### PR TITLE
Fix for malformed output.

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -44,7 +44,7 @@ export default class Module {
 			});
 
 			this.statements = ast.body.map( node => {
-				const magicString = this.magicString.snip( node.start, node.end );
+				const magicString = this.magicString.snip( node.start, node.end ).append( '\n' );
 				return new Statement( node, magicString, this );
 			});
 		} catch ( err ) {

--- a/src/Module.js
+++ b/src/Module.js
@@ -44,7 +44,7 @@ export default class Module {
 			});
 
 			this.statements = ast.body.map( node => {
-				const magicString = this.magicString.snip( node.start, node.end ).append( '\n' );
+				const magicString = this.magicString.snip( node.start, node.end ).prepend( '\n' ).append( '\n' );
 				return new Statement( node, magicString, this );
 			});
 		} catch ( err ) {

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -248,7 +248,7 @@ export default class Statement {
 	}
 
 	replaceIdentifiers ( names ) {
-		const magicString = this.magicString.clone().trim();
+		const magicString = this.magicString.clone();
 		const replacementStack = [ names ];
 		const nameList = keys( names );
 

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -16,7 +16,7 @@ export default function umd ( bundle, magicString, exportMode, options ) {
 
 	if ( exportMode === 'named' ) {
 		amdDeps.unshift( `'exports'` );
-		cjsDeps.unshift( `'exports'` );
+		cjsDeps.unshift( `exports` );
 		globalDeps.unshift( `(global.${options.moduleName} = {})` );
 
 		args.unshift( 'exports' );


### PR DESCRIPTION
Without this change, you can get malformed stuff like this:

```js
var foo = function() {
  return "foo";
}var bar = function() {
  return "bar";
}
```

(Uncaught SyntaxError: Unexpected token var.)

By appending a newline, a semicolon is implicitly inserted between statements when necessary:

```js
var foo = function() {
  return "foo";
}
var bar = function() {
  return "bar";
}
```

The indentation as a result of this commit is off, but I’m not sure how to fix it because the build fails for me. (I tested this by editing dist directly.)