### PR TITLE
fix #26

### DIFF
--- a/test/function/statement-order/_config.js
+++ b/test/function/statement-order/_config.js
@@ -1,0 +1,15 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'correct statement order is preserved even in weird edge cases',
+	context: {
+		getAnswer: function ( obj ) {
+			return obj.answer;
+		}
+	},
+	exports: function ( exports ) {
+		assert.equal( exports, 'right' );
+	},
+	solo: true,
+	show: true
+};

--- a/test/function/statement-order/_config.js
+++ b/test/function/statement-order/_config.js
@@ -9,7 +9,5 @@ module.exports = {
 	},
 	exports: function ( exports ) {
 		assert.equal( exports, 'right' );
-	},
-	solo: true,
-	show: true
+	}
 };

--- a/test/function/statement-order/answer.js
+++ b/test/function/statement-order/answer.js
@@ -1,0 +1,17 @@
+var prop,
+answer;
+
+var foo = { answer: 'wrong' };
+var bar = { answer: 'right' };
+
+if ( typeof bar === "object" ) {
+	for ( prop in bar ) {
+		if ( bar.hasOwnProperty(prop) ) {
+			foo[prop] = bar[prop];
+		}
+	}
+}
+
+answer = getAnswer( foo );
+
+export default answer;

--- a/test/function/statement-order/main.js
+++ b/test/function/statement-order/main.js
@@ -1,0 +1,3 @@
+import answer from './answer';
+var answer2 = answer;
+export default answer2;


### PR DESCRIPTION
If top-level var declarations are encountered immediately after the initial parse, they are split apart:

```js
// this...
var foo, bar;

// ...becomes this:
var foo;
var bar;
```

Otherwise, code that depended on `foo` would cause anything that modified `bar` to also be included. In the worst case (see #26), the order of statements would be confused as a result.