### PR TITLE
Apply resolve hook to entry module

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -1,3 +1,4 @@
+import { dirname } from 'path';
 import { Promise } from 'sander';
 import { parse } from 'acorn';
 import MagicString from 'magic-string';
@@ -251,7 +252,7 @@ export default class Module {
 	getCanonicalName ( localName ) {
 		// Special case
 		if ( localName === 'default' && this.exports.default && this.exports.default.isModified ) {
-			let canonicalName = makeLegalIdentifier( this.path.replace( this.bundle.base + '/', '' ).replace( /\.js$/, '' ) );
+			let canonicalName = makeLegalIdentifier( this.path.replace( dirname( this.bundle.entryModule.path ) + '/', '' ).replace( /\.js$/, '' ) );
 			while ( this.definitions[ canonicalName ] ) {
 				canonicalName = `_${canonicalName}`;
 			}

--- a/src/utils/resolvePath.js
+++ b/src/utils/resolvePath.js
@@ -7,6 +7,9 @@ export function defaultResolver ( importee, importer, options ) {
 	// absolute paths are left untouched
 	if ( absolutePath.test( importee ) ) return importee;
 
+	// if this is the entry point, resolve against cwd
+	if ( importer === undefined ) return resolve( importee );
+
 	// we try to resolve external modules
 	if ( importee[0] !== '.' ) {
 		// unless we want to keep it external, that is

--- a/test/function/custom-path-resolver-async/_config.js
+++ b/test/function/custom-path-resolver-async/_config.js
@@ -1,3 +1,4 @@
+var path = require( 'path' );
 var assert = require( 'assert' );
 
 module.exports = {
@@ -7,8 +8,10 @@ module.exports = {
 			var Promise = require( 'sander' ).Promise;
 			var resolved;
 
+			if ( importee === path.resolve( __dirname, 'main.js' ) ) return importee;
+
 			if ( importee === 'foo' ) {
-				resolved = require( 'path' ).resolve( __dirname, 'bar.js' );
+				resolved = path.resolve( __dirname, 'bar.js' );
 			} else {
 				resolved = false;
 			}

--- a/test/function/custom-path-resolver-on-entry/_config.js
+++ b/test/function/custom-path-resolver-on-entry/_config.js
@@ -1,0 +1,35 @@
+var path = require( 'path' );
+var fs = require( 'fs' );
+var assert = require( 'assert' );
+
+var cachedModules = {
+	'@main.js': 'import foo from "./foo"; export default foo();'
+};
+
+module.exports = {
+	description: 'applies custom resolver to entry point',
+	//solo: true,
+	options: {
+		resolvePath: function ( importee, importer ) {
+			if ( importer === undefined ) {
+				return '@' + path.relative( __dirname, importee );
+			}
+
+			if ( importer[0] === '@' ) {
+				return path.resolve( __dirname, importee ) + '.js';
+			}
+
+			return path.resolve( path.dirname( importer ), importee ) + '.js';
+		},
+		load: function ( moduleId ) {
+			if ( moduleId[0] === '@' ) {
+				return cachedModules[ moduleId ];
+			}
+
+			return fs.readFileSync( moduleId, 'utf-8' );
+		}
+	},
+	exports: function ( exports ) {
+		assert.equal( exports, 42 );
+	}
+};

--- a/test/function/custom-path-resolver-on-entry/bar.js
+++ b/test/function/custom-path-resolver-on-entry/bar.js
@@ -1,0 +1,3 @@
+export default function () {
+	return 21;
+}

--- a/test/function/custom-path-resolver-on-entry/foo.js
+++ b/test/function/custom-path-resolver-on-entry/foo.js
@@ -1,0 +1,5 @@
+import bar from './bar';
+
+export default function () {
+	return bar() * 2;
+}

--- a/test/function/custom-path-resolver-sync/_config.js
+++ b/test/function/custom-path-resolver-sync/_config.js
@@ -1,12 +1,12 @@
+var path = require( 'path' );
 var assert = require( 'assert' );
 
 module.exports = {
 	description: 'uses a custom path resolver (synchronous)',
 	options: {
 		resolvePath: function ( importee, importer ) {
-			if ( importee === 'foo' ) {
-				return require( 'path' ).resolve( __dirname, 'bar.js' );
-			}
+			if ( importee === path.resolve( __dirname, 'main.js' ) ) return importee;
+			if ( importee === 'foo' ) return path.resolve( __dirname, 'bar.js' );
 
 			return false;
 		}


### PR DESCRIPTION
**not ready for merge**

This enables #30, and by extension #25 (eventually), by applying the `resolvePath` hook to `options.entry`. `resolvePath` is now a misnomer; it should become `resolveId` or something similar, and there are a few other bits of internal terminology that will probably need updating as well.

Something to note: `bundle.entryPath` and `bundle.base` no longer exist. These were used for the purposes of generating non-conflicting identifiers by restricting the 'available' path parts to those within the source directory (i.e. `_foo` to deconflict with `foo`, rather than `Users_rharris_code_someProject_src_foo`) - for now, that's being worked around, but it'll need a more robust approach eventually.

* [ ] fix internal terminology
* [ ] alternative approach to `bundle.base`
* [ ] update docs