### PR TITLE
Allow reassignments

### DIFF
--- a/bin/help.md
+++ b/bin/help.md
@@ -5,15 +5,16 @@ Usage: rollup [options] <entry file>
 
 Basic options:
 
--v, --version            Show version number
--h, --help               Show this help message
--i, --input              Input (alternative to <entry file>)
--o, --output <output>    Output (if absent, prints to stdout)
--f, --format [umd]       Type of output (amd, cjs, es6, iife, umd)
--e, --external           Comma-separate list of module IDs to exclude
--n, --name               Name for UMD export
--u, --id                 ID for AMD module (default is anonymous)
--m, --sourcemap          Generate sourcemap (`-m inline` for inline map)
+-v, --version               Show version number
+-h, --help                  Show this help message
+-i, --input                 Input (alternative to <entry file>)
+-o, --output <output>       Output (if absent, prints to stdout)
+-f, --format [umd]          Type of output (amd, cjs, es6, iife, umd)
+-e, --external              Comma-separate list of module IDs to exclude
+-n, --name                  Name for UMD export
+-u, --id                    ID for AMD module (default is anonymous)
+-m, --sourcemap             Generate sourcemap (`-m inline` for inline map)
+-r, --allow-reassignments   Allow imported bindings to be altered
 
 
 Example:

--- a/bin/rollup
+++ b/bin/rollup
@@ -13,7 +13,8 @@ command = minimist( process.argv.slice( 2 ), {
 		m: 'sourcemap',
 		n: 'name',
 		u: 'id',
-		e: 'external'
+		e: 'external',
+		r: 'allow-reassignments'
 	}
 });
 

--- a/bin/runRollup.js
+++ b/bin/runRollup.js
@@ -35,7 +35,8 @@ function bundle ( options, method ) {
 
 	return rollup.rollup({
 		entry: options.input,
-		external: options.external && options.external.split( ',' )
+		external: options.external && options.external.split( ',' ),
+		allowReassignments: options[ 'allow-reassignments' ]
 	}).then( function ( bundle ) {
 		var generateOptions = {
 			dest: options.output,

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -35,6 +35,8 @@ export default class Bundle {
 		this.varExports = blank();
 		this.toExport = null;
 
+		this.allowReassignments = !!options.allowReassignments;
+
 		this.modulePromises = blank();
 		this.statements = [];
 		this.externalModules = [];

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -111,7 +111,9 @@ export default class Statement {
 					if ( node._scope ) scope = node._scope;
 
 					this.checkForReads( scope, node, parent );
-					this.checkForWrites( scope, node );
+					this.checkForWrites( scope, node, {
+						allowReassignments: this.module.bundle.allowReassignments
+					});
 				},
 				leave: ( node ) => {
 					if ( node._scope ) scope = scope.parent;
@@ -144,7 +146,7 @@ export default class Statement {
 		}
 	}
 
-	checkForWrites ( scope, node ) {
+	checkForWrites ( scope, node, { allowReassignments }) {
 		const addNode = ( node, isAssignment ) => {
 			let depth = 0; // determine whether we're illegally modifying a binding or namespace
 
@@ -157,7 +159,7 @@ export default class Statement {
 			if ( isAssignment ) {
 				const importSpecifier = this.module.imports[ node.name ];
 
-				if ( importSpecifier && !scope.contains( node.name ) ) {
+				if ( !allowReassignments && importSpecifier && !scope.contains( node.name ) ) {
 					const minDepth = importSpecifier.name === '*' ?
 						2 : // cannot do e.g. `namespace.foo = bar`
 						1;  // cannot do e.g. `foo = bar`, but `foo.bar = bar` is fine


### PR DESCRIPTION
Quick hack in service of an experiment, which may turn out to be more generally useful so I'm leaving it here for future me to consider merging.

The spec disallows this sort of thing...

```js
import { uid } from './foo';

export class Bar {
  constructor () {
    this.id = uid++; // can't update or assign to an imported binding
  }
}
```

...but the equivalent ES5 is used in the wild in libraries like three.js (`THREE.GeometryIdCount++` and so on). Allowing reassignments may be the easiest way to help transition existing codebases to ES6.