### PR TITLE
fix #34, albeit kludgily

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -247,6 +247,16 @@ export default class Bundle {
 		let previousIndex = -1;
 		let previousMargin = 0;
 
+		this.statements.forEach( ( statement, i ) => {
+			statement.bundleIndex = i;
+		});
+
+		this.statements.sort( ( a, b ) => {
+			return a.module !== b.module ?
+				a.bundleIndex - b.bundleIndex :
+				a.index - b.index;
+		});
+
 		this.statements.forEach( statement => {
 			// skip `export { foo, bar, baz }`
 			if ( statement.node.type === 'ExportNamedDeclaration' && statement.node.specifiers.length ) {

--- a/test/form/block-comments/_expected/amd.js
+++ b/test/form/block-comments/_expected/amd.js
@@ -1,5 +1,9 @@
 define(function () { 'use strict';
 
+	function foo () {
+		return embiggen( 6, 7 );
+	}
+
 	/**
 	 * Embiggens a number
 	 * @param {number} num - the number to embiggen
@@ -8,10 +12,6 @@ define(function () { 'use strict';
 	 */
 	function embiggen ( num, factor ) {
 		return num * factor;
-	}
-
-	function foo () {
-		return embiggen( 6, 7 );
 	}
 
 	alert( foo() );

--- a/test/form/block-comments/_expected/cjs.js
+++ b/test/form/block-comments/_expected/cjs.js
@@ -1,5 +1,9 @@
 'use strict';
 
+function foo () {
+	return embiggen( 6, 7 );
+}
+
 /**
  * Embiggens a number
  * @param {number} num - the number to embiggen
@@ -8,10 +12,6 @@
  */
 function embiggen ( num, factor ) {
 	return num * factor;
-}
-
-function foo () {
-	return embiggen( 6, 7 );
 }
 
 alert( foo() );

--- a/test/form/block-comments/_expected/es6.js
+++ b/test/form/block-comments/_expected/es6.js
@@ -1,3 +1,7 @@
+function foo () {
+	return embiggen( 6, 7 );
+}
+
 /**
  * Embiggens a number
  * @param {number} num - the number to embiggen
@@ -6,10 +10,6 @@
  */
 function embiggen ( num, factor ) {
 	return num * factor;
-}
-
-function foo () {
-	return embiggen( 6, 7 );
 }
 
 alert( foo() );

--- a/test/form/block-comments/_expected/iife.js
+++ b/test/form/block-comments/_expected/iife.js
@@ -1,5 +1,9 @@
 (function () { 'use strict';
 
+	function foo () {
+		return embiggen( 6, 7 );
+	}
+
 	/**
 	 * Embiggens a number
 	 * @param {number} num - the number to embiggen
@@ -8,10 +12,6 @@
 	 */
 	function embiggen ( num, factor ) {
 		return num * factor;
-	}
-
-	function foo () {
-		return embiggen( 6, 7 );
 	}
 
 	alert( foo() );

--- a/test/form/block-comments/_expected/umd.js
+++ b/test/form/block-comments/_expected/umd.js
@@ -4,6 +4,10 @@
 	factory();
 }(this, function () { 'use strict';
 
+	function foo () {
+		return embiggen( 6, 7 );
+	}
+
 	/**
 	 * Embiggens a number
 	 * @param {number} num - the number to embiggen
@@ -12,10 +16,6 @@
 	 */
 	function embiggen ( num, factor ) {
 		return num * factor;
-	}
-
-	function foo () {
-		return embiggen( 6, 7 );
 	}
 
 	alert( foo() );

--- a/test/form/self-contained-bundle/_expected/amd.js
+++ b/test/form/self-contained-bundle/_expected/amd.js
@@ -5,12 +5,12 @@ define(function () { 'use strict';
 	console.log( 1 );
 	console.log( 2 ); // comment alongside 2
 
-	function bar () {
-		return 42;
-	}
-
 	function foo () {
 		return bar();
+	}
+
+	function bar () {
+		return 42;
 	}
 
 	foo();

--- a/test/form/self-contained-bundle/_expected/cjs.js
+++ b/test/form/self-contained-bundle/_expected/cjs.js
@@ -5,12 +5,12 @@
 console.log( 1 );
 console.log( 2 ); // comment alongside 2
 
-function bar () {
-	return 42;
-}
-
 function foo () {
 	return bar();
+}
+
+function bar () {
+	return 42;
 }
 
 foo();

--- a/test/form/self-contained-bundle/_expected/es6.js
+++ b/test/form/self-contained-bundle/_expected/es6.js
@@ -3,12 +3,12 @@
 console.log( 1 );
 console.log( 2 ); // comment alongside 2
 
-function bar () {
-	return 42;
-}
-
 function foo () {
 	return bar();
+}
+
+function bar () {
+	return 42;
 }
 
 foo();

--- a/test/form/self-contained-bundle/_expected/iife.js
+++ b/test/form/self-contained-bundle/_expected/iife.js
@@ -5,12 +5,12 @@
 	console.log( 1 );
 	console.log( 2 ); // comment alongside 2
 
-	function bar () {
-		return 42;
-	}
-
 	function foo () {
 		return bar();
+	}
+
+	function bar () {
+		return 42;
 	}
 
 	foo();

--- a/test/form/self-contained-bundle/_expected/umd.js
+++ b/test/form/self-contained-bundle/_expected/umd.js
@@ -9,12 +9,12 @@
 	console.log( 1 );
 	console.log( 2 ); // comment alongside 2
 
-	function bar () {
-		return 42;
-	}
-
 	function foo () {
 		return bar();
+	}
+
+	function bar () {
+		return 42;
 	}
 
 	foo();

--- a/test/function/retains-sort-order/_config.js
+++ b/test/function/retains-sort-order/_config.js
@@ -1,0 +1,8 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'sorts statements according to their original order within modules',
+	exports: function ( exports ) {
+		assert.equal( exports, 'GREAT SUCCESS' );
+	}
+};

--- a/test/function/retains-sort-order/baz.js
+++ b/test/function/retains-sort-order/baz.js
@@ -1,0 +1,1 @@
+export default 'GREAT SUCCESS';

--- a/test/function/retains-sort-order/foobar.js
+++ b/test/function/retains-sort-order/foobar.js
@@ -1,0 +1,15 @@
+import baz from './baz';
+
+export function Foo () {}
+
+Foo.prototype.test = function () {
+	return 'nope';
+};
+
+export function Bar () {}
+
+Bar.prototype = Object.create( Foo.prototype );
+
+Bar.prototype.test = function () {
+	return baz;
+};

--- a/test/function/retains-sort-order/main.js
+++ b/test/function/retains-sort-order/main.js
@@ -1,0 +1,4 @@
+import { Foo, Bar } from './foobar';
+
+new Foo();
+export default new Bar().test();


### PR DESCRIPTION
This is a potential fix for #34. It simply sorts statements within a bundle according to their original order with a module. It feels like a filthy hack though, so I'm just going to leave it here and not merge until alternatives have been explored.

In particular, a hypothetical bundle that looked like this...

```js
[
  { module: 'a', index: 1 },
  { module: 'b', index: 1 },
  { module: 'b', index: 0 },
  { module: 'a', index: 0 }
]
```

...wouldn't be sorted in such a way that the first in the list appeared after the last in the list. I'm not sure if such a situation could arise though.