### PR TITLE
Add a failing test that illustrates a problem with RSVP.

### DIFF
--- a/test/function/top-level-side-effects-are-preserved/_config.js
+++ b/test/function/top-level-side-effects-are-preserved/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'top level side effects are preserved'
+};

--- a/test/function/top-level-side-effects-are-preserved/asap.js
+++ b/test/function/top-level-side-effects-are-preserved/asap.js
@@ -1,0 +1,1 @@
+export default function asap() {}

--- a/test/function/top-level-side-effects-are-preserved/config.js
+++ b/test/function/top-level-side-effects-are-preserved/config.js
@@ -1,0 +1,1 @@
+export const config = {};

--- a/test/function/top-level-side-effects-are-preserved/defer.js
+++ b/test/function/top-level-side-effects-are-preserved/defer.js
@@ -1,0 +1,5 @@
+import { config } from './config';
+
+export default function defer() {
+  config.async();
+}

--- a/test/function/top-level-side-effects-are-preserved/main.js
+++ b/test/function/top-level-side-effects-are-preserved/main.js
@@ -1,0 +1,3 @@
+import { defer } from './rsvp';
+
+defer();

--- a/test/function/top-level-side-effects-are-preserved/rsvp.js
+++ b/test/function/top-level-side-effects-are-preserved/rsvp.js
@@ -1,0 +1,7 @@
+import { config } from './config';
+import asap from './asap';
+import defer from './defer';
+
+config.async = asap;
+
+export { defer };


### PR DESCRIPTION
I ran into this trying to use rollup with [LGTM](https://github.com/square/lgtm) where I bundle only the parts of RSVP that I need. The problem is that rollup seems not to consider the side effect of setting `config.async = asap;` worth preserving because the file that contains is pretty much just passes an import directly into an export.

Perhaps rollup should consider the statement referenced above worth preserving if it uses something that is also used by any of its exports, namely `defer`.

For reference, this is the output that rollup generates:

```js
'use strict';

const config = {};

function defer() {
  config.async();
}

defer();
```