### PR TITLE
Browser-friendly version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,8 +5,8 @@
 		"es6.classes",
 		"es6.constants",
 		"es6.destructuring",
-		"es6.parameters.default",
 		"es6.parameters.rest",
+		"es6.parameters.default",
 		"es6.properties.shorthand",
 		"es6.spread",
 		"es6.templateLiterals"

--- a/.babelrc
+++ b/.babelrc
@@ -5,8 +5,7 @@
 		"es6.classes",
 		"es6.constants",
 		"es6.destructuring",
-		"es6.parameters.rest",
-		"es6.parameters.default",
+		"es6.parameters",
 		"es6.properties.shorthand",
 		"es6.spread",
 		"es6.templateLiterals"

--- a/browser/sander.js
+++ b/browser/sander.js
@@ -1,0 +1,13 @@
+export function readFile () {
+	throw new Error( 'Cannot use sander.readFile inside browser' );
+}
+
+export function readFileSync () {
+	throw new Error( 'Cannot use sander.readFileSync inside browser' );
+}
+
+export function writeFile () {
+	throw new Error( 'Cannot use sander.writeFile inside browser' );
+}
+
+export const Promise = window.Promise;

--- a/gobblefile.js
+++ b/gobblefile.js
@@ -1,20 +1,38 @@
 var gobble = require( 'gobble' );
+var fs = require( 'fs' );
 
-var selfhost = 1;
+var src = gobble( 'src' );
 
-module.exports = selfhost ?
-	gobble( 'src' )
-		.transform( 'babel' )
-		.transform( 'rollup', {
-			entry: 'rollup.js',
-			format: 'cjs',
-			external: [ 'sander', 'path', 'acorn', 'magic-string' ]
-		}) :
+var node = src
+	.transform( 'rollup', {
+		entry: 'rollup.js',
+		dest: 'rollup.js',
+		format: 'cjs',
+		external: [ 'sander', 'path', 'acorn', 'magic-string' ]
+	})
+	.transform( 'babel' );
 
-	gobble( 'src' )
-		.transform( 'babel' )
-		.transform( 'esperanto-bundle', {
-			entry: 'rollup',
-			type: 'cjs',
-			strict: true
-		});
+var absolutePath = /^(?:\/|(?:[A-Za-z]:)?\\)/;
+
+var browserPlaceholders = {
+	sander: fs.readFileSync( 'browser/sander.js' ).toString()
+};
+
+var browser = src
+	.transform( 'rollup-babel', {
+		entry: 'rollup.js',
+		dest: 'rollup.browser.js',
+		format: 'cjs',
+		load: function ( id ) {
+			if ( ~id.indexOf( 'sander.js' ) ) return browserPlaceholders.sander;
+			return fs.readFileSync( id ).toString();
+		},
+		external: [ 'acorn', 'magic-string' ]
+	})
+	.transform( 'browserify', {
+		entries: [ './rollup.browser' ],
+		dest: 'rollup.browser.js',
+		standalone: 'rollup'
+	});
+
+module.exports = gobble([ node, browser ]);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "console-group": "^0.1.2",
     "gobble": "^0.10.1",
     "gobble-babel": "^5.5.8",
+    "gobble-browserify": "^0.6.1",
     "gobble-cli": "^0.4.2",
     "gobble-esperanto-bundle": "^0.2.0",
     "gobble-rollup": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "gobble-browserify": "^0.6.1",
     "gobble-cli": "^0.4.2",
     "gobble-esperanto-bundle": "^0.2.0",
-    "gobble-rollup": "^0.3.1",
+    "gobble-rollup": "^0.5.0",
+    "gobble-rollup-babel": "^0.1.0",
     "mocha": "^2.2.4",
     "source-map": "^0.1.40"
   },

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -1,4 +1,4 @@
-import { basename, dirname, extname, relative } from 'path';
+import { basename, dirname, extname, relative } from './utils/path';
 import { Promise } from 'sander';
 import MagicString from 'magic-string';
 import { blank, keys } from './utils/object';
@@ -495,6 +495,7 @@ export default class Bundle {
 			// make sources relative. TODO fix this upstream?
 			const dir = dirname( map.file );
 			map.sources = map.sources.map( source => {
+				// TODO is unixizePath still necessary, given internal helper rather than node builtin?
 				return source ? unixizePath( relative( dir, source ) ) : null;
 			});
 		}

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -1,4 +1,4 @@
-import { basename, dirname, extname, relative } from './utils/path';
+import { basename, extname } from './utils/path';
 import { Promise } from 'sander';
 import MagicString from 'magic-string';
 import { blank, keys } from './utils/object';
@@ -486,18 +486,14 @@ export default class Bundle {
 		let map = null;
 
 		if ( options.sourceMap ) {
+			const file = options.sourceMapFile || options.dest;
 			map = magicString.generateMap({
 				includeContent: true,
-				file: options.sourceMapFile || options.dest
+				file
 				// TODO
 			});
 
-			// make sources relative. TODO fix this upstream?
-			const dir = dirname( map.file );
-			map.sources = map.sources.map( source => {
-				// TODO is unixizePath still necessary, given internal helper rather than node builtin?
-				return source ? unixizePath( relative( dir, source ) ) : null;
-			});
+			map.sources = map.sources.map( unixizePath );
 		}
 
 		return { code, map };

--- a/src/Module.js
+++ b/src/Module.js
@@ -1,4 +1,4 @@
-import { dirname } from 'path';
+import { dirname } from './utils/path';
 import { Promise } from 'sander';
 import { parse } from 'acorn';
 import MagicString from 'magic-string';

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -1,4 +1,4 @@
-import { basename } from 'path';
+import { basename } from './utils/path';
 import { writeFile } from 'sander';
 import Bundle from './Bundle';
 

--- a/src/utils/normalizePlatform.js
+++ b/src/utils/normalizePlatform.js
@@ -1,6 +1,3 @@
-import { sep } from "path";
-
-export function unixizePath(path) {
-    if (sep==="/") return path;
-    return path.split(sep).join("/");
+export function unixizePath( path ) {
+    return path.split( /[\/\\]/ ).join( '/' );
 }

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,0 +1,73 @@
+// TODO does this all work on windows?
+
+export const absolutePath = /^(?:\/|(?:[A-Za-z]:)?\\)/;
+
+export function isAbsolute ( path ) {
+	return absolutePath.test( path );
+}
+
+export function basename ( path ) {
+	return path.split( /(\/|\\)/ ).pop();
+}
+
+export function dirname ( path ) {
+	const match = /(\/|\\)[^\/\\]+$/.exec( path );
+	if ( !match ) return '.';
+	return path.slice( 0, -match[0].length );
+}
+
+export function extname ( path ) {
+	const match = /\.[^\.]+$/.exec( path );
+	if ( !match ) return '';
+	return match[0]
+}
+
+export function relative ( from, to ) {
+	const fromParts = from.split( /[\/\\]/ );
+	const toParts = to.split( /[\/\\]/ );
+
+	while ( fromParts[0] && toParts[0] && fromParts[0] === toParts[0] ) {
+		fromParts.shift();
+		toParts.shift();
+	}
+
+	while ( toParts[0] && toParts[0][0] === '.' ) {
+		if ( toParts[0] === '.' ) {
+			toParts.shift();
+		} else if ( toParts[0] === '..' ) {
+			fromParts.pop();
+		} else {
+			throw new Error( `Unexpected path part (${toParts[0]})` );
+		}
+	}
+
+	while ( fromParts.pop() ) {
+		toParts.unshift( '..' );
+	}
+
+	return toParts.join( '/' );
+}
+
+export function resolve ( ...paths ) {
+	let resolvedParts = paths.shift().split( /[\/\\]/ );
+
+	paths.forEach( path => {
+		if ( isAbsolute( path ) ) {
+			resolvedParts = path.split( /[\/\\]/ );
+		} else {
+			const parts = path.split( /[\/\\]/ );
+
+			while ( parts[0] && parts[0][0] === '.' ) {
+				if ( parts[0] === '.' ) {
+					parts.shift();
+				} else if ( parts[0] === '..' ) {
+					resolvedParts.pop();
+				}
+			}
+
+			resolvedParts.push.apply( resolvedParts, parts );
+		}
+	});
+
+	return resolvedParts.join( '/' ); // TODO windows...
+}

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -32,12 +32,11 @@ export function relative ( from, to ) {
 	}
 
 	while ( toParts[0] && toParts[0][0] === '.' ) {
-		if ( toParts[0] === '.' ) {
-			toParts.shift();
-		} else if ( toParts[0] === '..' ) {
+		const toPart = toParts.shift();
+		if ( toPart === '..' ) {
 			fromParts.pop();
-		} else {
-			throw new Error( `Unexpected path part (${toParts[0]})` );
+		} else if ( toPart !== '.' ) {
+			throw new Error( `Unexpected path part (${toPart})` );
 		}
 	}
 
@@ -58,10 +57,11 @@ export function resolve ( ...paths ) {
 			const parts = path.split( /[\/\\]/ );
 
 			while ( parts[0] && parts[0][0] === '.' ) {
-				if ( parts[0] === '.' ) {
-					parts.shift();
-				} else if ( parts[0] === '..' ) {
+				const part = parts.shift();
+				if ( part === '..' ) {
 					resolvedParts.pop();
+				} else if ( part !== '.' ) {
+					throw new Error( `Unexpected path part (${part})` );
 				}
 			}
 

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -23,8 +23,8 @@ export function extname ( path ) {
 }
 
 export function relative ( from, to ) {
-	const fromParts = from.split( /[\/\\]/ );
-	const toParts = to.split( /[\/\\]/ );
+	const fromParts = from.split( /[\/\\]/ ).filter( Boolean );
+	const toParts = to.split( /[\/\\]/ ).filter( Boolean );
 
 	while ( fromParts[0] && toParts[0] && fromParts[0] === toParts[0] ) {
 		fromParts.shift();

--- a/src/utils/resolveId.js
+++ b/src/utils/resolveId.js
@@ -1,14 +1,12 @@
-import { dirname, resolve } from 'path';
+import { absolutePath, dirname, isAbsolute, resolve } from './path';
 import { readFileSync } from 'sander';
-
-const absolutePath = /^(?:\/|(?:[A-Za-z]:)?\\)/;
 
 export function defaultResolver ( importee, importer, options ) {
 	// absolute paths are left untouched
-	if ( absolutePath.test( importee ) ) return importee;
+	if ( isAbsolute( importee ) ) return importee;
 
 	// if this is the entry point, resolve against cwd
-	if ( importer === undefined ) return resolve( importee );
+	if ( importer === undefined ) return resolve( process.cwd(), importee );
 
 	// we try to resolve external modules
 	if ( importee[0] !== '.' ) {


### PR DESCRIPTION
This is a first crack at #25. Could possibly be simplified further (Browserify seems to include a lot of unnecessary gubbins, need to investigate), but it works (am building https://github.com/rollup/rollupjs.org with it... work-in-progress), at least on OS X.

Will need to check that the path utils continue to work on Windows. Though I suppose an alternative option would be to continue using node's built-in path utils in node, and only use our own in the browser bundle.