### PR TITLE
Test that top-level side effects involving imports are preserved.

### DIFF
--- a/test/function/top-level-side-effect-on-imported/_config.js
+++ b/test/function/top-level-side-effect-on-imported/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'top level function calls are preserved'
+};

--- a/test/function/top-level-side-effect-on-imported/lib.js
+++ b/test/function/top-level-side-effect-on-imported/lib.js
@@ -1,0 +1,5 @@
+import obj from './obj';
+
+obj.value = 'augmented';
+
+export default obj;

--- a/test/function/top-level-side-effect-on-imported/main.js
+++ b/test/function/top-level-side-effect-on-imported/main.js
@@ -1,0 +1,3 @@
+import lib from './lib';
+
+assert.strictEqual(lib.value, 'augmented');

--- a/test/function/top-level-side-effect-on-imported/obj.js
+++ b/test/function/top-level-side-effect-on-imported/obj.js
@@ -1,0 +1,1 @@
+export default { value: 'original' };

--- a/test/function/top-level-side-effects-are-preserved/_config.js
+++ b/test/function/top-level-side-effects-are-preserved/_config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	description: 'top level side effects are preserved'
+	description: 'top level side effects on imports are preserved'
 };


### PR DESCRIPTION
With the current implementation of rollup, this test fails. To make it pass, you can replace `import obj from './obj;` in lib.js with `var obj = {};`, suggesting that it's the import itself that somehow confuses rollup.