### PR TITLE
Implemented export * from ...

### DIFF
--- a/src/Statement.js
+++ b/src/Statement.js
@@ -31,6 +31,7 @@ export default class Statement {
 		// some facts about this statement...
 		this.isImportDeclaration = node.type === 'ImportDeclaration';
 		this.isExportDeclaration = /^Export/.test( node.type );
+		this.isExportAllDeclaration = /^ExportAll/.test( node.type );
 	}
 
 	analyse () {

--- a/src/utils/promise.js
+++ b/src/utils/promise.js
@@ -20,3 +20,23 @@ export function sequence ( arr, callback ) {
 
 	return promise.then( () => results );
 }
+
+
+export function first ( arr, fail, callback ) {
+	const len = arr.length;
+
+	let promise = Promise.reject( fail );
+
+	function next ( i ) {
+		return promise
+			.catch(() => callback( arr[i], i ));
+	}
+
+	let i;
+
+	for ( i = 0; i < len; i += 1 ) {
+		promise = next( i );
+	}
+
+	return promise;
+}

--- a/test/function/export-all/_config.js
+++ b/test/function/export-all/_config.js
@@ -1,0 +1,5 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'allows export *'
+};

--- a/test/function/export-all/main.js
+++ b/test/function/export-all/main.js
@@ -1,0 +1,2 @@
+import { wat } from './wat';
+assert.equal( wat(), 4711 );

--- a/test/function/export-all/wat-impl.js
+++ b/test/function/export-all/wat-impl.js
@@ -1,0 +1,1 @@
+export function wat () { return 4711; }

--- a/test/function/export-all/wat.js
+++ b/test/function/export-all/wat.js
@@ -1,0 +1,1 @@
+export * from './wat-impl';


### PR DESCRIPTION
Discovering esperanto and then rollup has been very exciting. I always felt that it should be possible bundle ES modules more efficiently than compiling them to CommonJS and bundling with Browserify. I'm really drawn towards this project.

I gave implementing `export * from '...'` a go, as per #44. I added the example I presented there as a test, and got it passing. I'm not sure I entirely understand the bundling process, but I'm sure you can oblige me with some pointers if something's amiss.