### PR TITLE
Dynamically defined object properties

### DIFF
--- a/src/Statement.js
+++ b/src/Statement.js
@@ -175,10 +175,24 @@ export default class Statement {
 	}
 
 	checkForWrites ( scope, node ) {
+		const parent = node;
+
 		const addNode = ( node, isAssignment ) => {
 			let depth = 0; // determine whether we're illegally modifying a binding or namespace
 
 			while ( node.type === 'MemberExpression' ) {
+
+				// In a situation like that below, make sure the assignments
+				// depend on `a` and `b`.
+				//
+				//    var a = 1, b = 0;
+				//
+				//    arr[a] = arr[b] = true;
+				//
+				if ( node.computed ) {
+					this.checkForReads( scope, node.property, parent, true );
+				}
+
 				node = node.object;
 				depth += 1;
 			}

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -250,7 +250,7 @@ export default class Statement {
 	}
 
 	mark () {
-		if ( this.included ) return; // prevent infinite loops
+		if ( this.isIncluded ) return; // prevent infinite loops
 		this.isIncluded = true;
 
 		const dependencies = Object.keys( this.dependsOn );

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -134,7 +134,7 @@ export default class Statement {
 					}
 
 					this.checkForReads( scope, node, parent, !depth );
-					this.checkForWrites( scope, node );
+					this.checkForWrites( scope, node, !depth );
 				},
 				leave: ( node, parent ) => {
 					if ( node._scope ) {
@@ -174,7 +174,7 @@ export default class Statement {
 		}
 	}
 
-	checkForWrites ( scope, node ) {
+	checkForWrites ( scope, node, strong ) {
 		const parent = node;
 
 		const addNode = ( node, isAssignment ) => {
@@ -183,14 +183,14 @@ export default class Statement {
 			while ( node.type === 'MemberExpression' ) {
 
 				// In a situation like that below, make sure the assignments
-				// depend on `a` and `b`.
+				// to arr depend on `a` and `b`.
 				//
 				//    var a = 1, b = 0;
 				//
 				//    arr[a] = arr[b] = true;
 				//
 				if ( node.computed ) {
-					this.checkForReads( scope, node.property, parent, true );
+					this.checkForReads( scope, node.property, parent, strong );
 				}
 
 				node = node.object;

--- a/test/function/object-dynamic-properties/_config.js
+++ b/test/function/object-dynamic-properties/_config.js
@@ -1,0 +1,5 @@
+var assert = require('assert');
+
+module.exports = {
+	description: 'dynamic object assignments should be imported'
+};

--- a/test/function/object-dynamic-properties/main.js
+++ b/test/function/object-dynamic-properties/main.js
@@ -1,4 +1,5 @@
 import tags from './tags';
 
-assert(tags['[object Object]'], true);
-assert(Object.keys(tags).length, 6);
+assert.equal(tags['[object Object]'], true);
+assert.equal(tags['[object Number]'], false);
+assert.equal(Object.keys(tags).length, 6);

--- a/test/function/object-dynamic-properties/main.js
+++ b/test/function/object-dynamic-properties/main.js
@@ -1,0 +1,3 @@
+import tags from './tags';
+
+assert(tags['[object Object]'], true);

--- a/test/function/object-dynamic-properties/main.js
+++ b/test/function/object-dynamic-properties/main.js
@@ -1,3 +1,4 @@
 import tags from './tags';
 
 assert(tags['[object Object]'], true);
+assert(Object.keys(tags).length, 6);

--- a/test/function/object-dynamic-properties/tags.js
+++ b/test/function/object-dynamic-properties/tags.js
@@ -1,13 +1,13 @@
 // Emulates a piece of Lodash source code.
 // The tag strings are not imported, and a runtime error ensues.
 
-let objTag = '[object Object]';
-let arrTag = '[object Array]';
-let fnTag = '[object Function]';
-let dateTag = '[object Date]';
+var objTag = '[object Object]';
+var arrTag = '[object Array]';
+var fnTag = '[object Function]';
+var dateTag = '[object Date]';
 
-let strTag = '[object String]';
-let numTag = '[object Number]';
+var strTag = '[object String]';
+var numTag = '[object Number]';
 
 // Only the code below is included in the bundle.
 

--- a/test/function/object-dynamic-properties/tags.js
+++ b/test/function/object-dynamic-properties/tags.js
@@ -1,0 +1,21 @@
+// Emulates a piece of Lodash source code.
+// The tag strings are not imported, and a runtime error ensues.
+
+let objTag = '[object Object]';
+let arrTag = '[object Array]';
+let fnTag = '[object Function]';
+let dateTag = '[object Date]';
+
+let strTag = '[object String]';
+let numTag = '[object Number]';
+
+// Only the code below is included in the bundle.
+
+var tags = {};
+
+tags[objTag] = tags[arrTag] =
+tags[fnTag] = tags[dateTag] = true;
+
+tags[strTag] = tags[numTag] = false;
+
+export default tags;


### PR DESCRIPTION
When I bundled some code with a few functions of a modern, ES build of Lodash (similar to the README example), I encountered a ReferenceError at runtime.

It is caused by Lodash defining a number of variables with string tags, which are used to populate an object. Extract from Lodash [here](https://github.com/lodash/lodash/blob/master/lodash.js#L49) and [here](https://github.com/lodash/lodash/blob/master/lodash.js#L168):

```js
/** `Object#toString` result references. */
  var argsTag = '[object Arguments]',
      arrayTag = '[object Array]',
      boolTag = '[object Boolean]',
      ...

// Later...

/** Used to identify `toStringTag` values supported by `_.clone`. */
  var cloneableTags = {};
  cloneableTags[argsTag] = cloneableTags[arrayTag] =
  cloneableTags[arrayBufferTag] = cloneableTags[boolTag] =
  cloneableTags[dateTag] = cloneableTags[float32Tag] =
  cloneableTags[float64Tag] = cloneableTags[int8Tag] =
  cloneableTags[int16Tag] = cloneableTags[int32Tag] =
  cloneableTags[numberTag] = cloneableTags[objectTag] =
  cloneableTags[regexpTag] = cloneableTags[stringTag] =
  cloneableTags[uint8Tag] = cloneableTags[uint8ClampedTag] =
  cloneableTags[uint16Tag] = cloneableTags[uint32Tag] = true;
  cloneableTags[errorTag] = cloneableTags[funcTag] =
  cloneableTags[mapTag] = cloneableTags[setTag] =
  cloneableTags[weakMapTag] = false;

```
The assignment statements to `clonableTags` do not recognize the tag variables as dependencies, so the definitions of the tags are not included resulting in a ReferenceError. This PR solves this issue, by checking for reads in computed member expressions.

Since I could not find any references to `BinaryExpression` in the sources, I was unsure whether expressions like
```js
var n = 'Number';

clonableTags['[object ' + n + ']'] = true;
```
would work for the same reason, but they appear to work just fine even without the fix. Could you point out how it is handled?

Bundle for tests before PR:
```js
// Only the code below is included in the bundle.

var tags = {};

tags[objTag] = tags[arrTag] =
tags[fnTag] = tags[dateTag] = true;

tags[strTag] = tags[numTag] = false;

assert.equal(tags['[object Object]'], true);
assert.equal(tags['[object Number]'], false);
assert.equal(Object.keys(tags).length, 6);
```
After:
```js
// Emulates a piece of Lodash source code.
// The tag strings are not imported, and a runtime error ensues.

var objTag = '[object Object]';
var arrTag = '[object Array]';
var fnTag = '[object Function]';
var dateTag = '[object Date]';

var strTag = '[object String]';
var numTag = '[object Number]';


// Only the code below is included in the bundle.

var tags = {};

tags[objTag] = tags[arrTag] =
tags[fnTag] = tags[dateTag] = true;

tags[strTag] = tags[numTag] = false;

assert.equal(tags['[object Object]'], true);
assert.equal(tags['[object Number]'], false);
assert.equal(Object.keys(tags).length, 6);
```