### PR TITLE
Fix #43

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -418,7 +418,9 @@ export default class Bundle {
 
 				keys( statement.modifies ).forEach( name => {
 					const definingStatement = module.definitions[ name ];
-					const exportDeclaration = module.exports[ name ];
+					const exportDeclaration = module.exports[ name ] || (
+						module.exports.default && module.exports.default.identifier === name && module.exports.default
+					);
 
 					const shouldMark = ( definingStatement && definingStatement.isIncluded ) ||
 					                   ( exportDeclaration && exportDeclaration.isUsed );

--- a/src/Module.js
+++ b/src/Module.js
@@ -412,6 +412,7 @@ export default class Module {
 						});
 					}
 
+					exportDeclaration.isUsed = true;
 					return module.mark( exportDeclaration.localName );
 				});
 		}

--- a/test/function/top-level-side-effect-on-imported/_config.js
+++ b/test/function/top-level-side-effect-on-imported/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'top level function calls are preserved'
+};

--- a/test/function/top-level-side-effect-on-imported/lib.js
+++ b/test/function/top-level-side-effect-on-imported/lib.js
@@ -1,0 +1,5 @@
+import obj from './obj';
+
+obj.value = 'augmented';
+
+export default obj;

--- a/test/function/top-level-side-effect-on-imported/main.js
+++ b/test/function/top-level-side-effect-on-imported/main.js
@@ -1,0 +1,3 @@
+import lib from './lib';
+
+assert.strictEqual(lib.value, 'augmented');

--- a/test/function/top-level-side-effect-on-imported/obj.js
+++ b/test/function/top-level-side-effect-on-imported/obj.js
@@ -1,0 +1,1 @@
+export default { value: 'original' };

--- a/test/function/top-level-side-effects-are-preserved/_config.js
+++ b/test/function/top-level-side-effects-are-preserved/_config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	description: 'top level side effects are preserved'
+	description: 'top level side effects on imports are preserved'
 };

--- a/test/function/top-level-side-effects-are-preserved/_config.js
+++ b/test/function/top-level-side-effects-are-preserved/_config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	description: 'top level side effects on imports are preserved'
+	description: 'top level side effects are preserved'
 };


### PR DESCRIPTION
Fix for #43. A couple of things were going wrong:

* the code that scans statements to see if they're used elsewhere in the bundle wasn't handling default exports
* no export declarations were actually being marked as `isUsed`. Not quite sure how that happened, must have borked a commit