### PR TITLE
Fix #53

### DIFF
--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -11,15 +11,19 @@ export function basename ( path ) {
 }
 
 export function dirname ( path ) {
-	const match = /(\/|\\)[^\/\\]+$/.exec( path );
+	const match = /(\/|\\)[^\/\\]*$/.exec( path );
 	if ( !match ) return '.';
-	return path.slice( 0, -match[0].length );
+
+	const dir = path.slice( 0, -match[0].length );
+
+	// If `dir` is the empty string, we're at root.
+	return dir ? dir : '/';
 }
 
 export function extname ( path ) {
 	const match = /\.[^\.]+$/.exec( path );
 	if ( !match ) return '';
-	return match[0]
+	return match[0];
 }
 
 export function relative ( from, to ) {


### PR DESCRIPTION
See issue #53 for explaination. This PR fixes `dirname` to handle the root (empty string) case.