### PR TITLE
Add globals option to rollup executable.

### DIFF
--- a/bin/help.md
+++ b/bin/help.md
@@ -9,17 +9,21 @@ Basic options:
 -h, --help               Show this help message
 -i, --input              Input (alternative to <entry file>)
 -o, --output <output>    Output (if absent, prints to stdout)
--f, --format [umd]       Type of output (amd, cjs, es6, iife, umd)
+-f, --format [es6]       Type of output (amd, cjs, es6, iife, umd)
 -e, --external           Comma-separate list of module IDs to exclude
+-g, --globals            Comma-separate list of `module ID:Global` pairs
+                            Any module IDs defined here are added to external
 -n, --name               Name for UMD export
 -u, --id                 ID for AMD module (default is anonymous)
 -m, --sourcemap          Generate sourcemap (`-m inline` for inline map)
 
 
-Example:
+Examples:
 
 rollup --format=cjs --output=bundle.js -- src/main.js
 
+rollup -f iife --globals jquery:jQuery,angular:ng \
+  -i src/app.js -o build/app.js -m build/app.js.map
 
 Notes:
 

--- a/bin/rollup
+++ b/bin/rollup
@@ -5,15 +5,16 @@ var minimist = require( 'minimist' ),
 
 command = minimist( process.argv.slice( 2 ), {
 	alias: {
-		i: 'input',
-		o: 'output',
-		v: 'version',
-		h: 'help',
+		e: 'external',
 		f: 'format',
+		g: 'globals',
+		h: 'help',
+		i: 'input',
 		m: 'sourcemap',
 		n: 'name',
+		o: 'output',
 		u: 'id',
-		e: 'external'
+		v: 'version'
 	}
 });
 


### PR DESCRIPTION
Also:
* Sorted minimalist aliases alphabetically
* Updated help.md to include correct format default (ES6).
* Removed unused requires and variables from `bin/runRollup.js`.
* Added missing definition of `map` for outputting inline source maps.
* Grabs external names from globals option. These are equivalent:

```
rollup -f iife --globals lodash:_,jquery:jQuery
rollup -f iife --globals lodash:_,jquery:jQuery --external lodash,jquery
```