### PR TITLE
expand shorthand properties (#61)

### DIFF
--- a/src/Statement.js
+++ b/src/Statement.js
@@ -337,18 +337,28 @@ export default class Statement {
 					replacementStack.push( newNames );
 				}
 
-				// We want to rewrite identifiers (that aren't property names etc)
 				if ( node.type !== 'Identifier' ) return;
+
+				// if there's no replacement, or it's the same, there's nothing more to do
+				const name = names[ node.name ];
+				if ( !name || name === node.name ) return;
+
+				// shorthand properties (`obj = { foo }`) need to be expanded
+				if ( parent.type === 'Property' && parent.shorthand ) {
+					magicString.insert( node.end, `: ${name}` );
+					parent.key._skip = true;
+					parent.value._skip = true; // redundant, but defensive
+					return;
+				}
+
+				// property names etc can be disregarded
 				if ( parent.type === 'MemberExpression' && !parent.computed && node !== parent.object ) return;
 				if ( parent.type === 'Property' && node !== parent.value ) return;
 				if ( parent.type === 'MethodDefinition' && node === parent.key ) return;
 				// TODO others...?
 
-				const name = names[ node.name ];
-
-				if ( name && name !== node.name ) {
-					magicString.overwrite( node.start, node.end, name );
-				}
+				// all other identifiers should be overwritten
+				magicString.overwrite( node.start, node.end, name );
 			},
 
 			leave ( node ) {

--- a/test/function/shorthand-properties/_config.js
+++ b/test/function/shorthand-properties/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'expands shorthand properties as necessary (#61)'
+};

--- a/test/function/shorthand-properties/foo.js
+++ b/test/function/shorthand-properties/foo.js
@@ -1,0 +1,7 @@
+function bar () {
+	return 'foo-bar';
+}
+
+export var foo = {
+	bar
+};

--- a/test/function/shorthand-properties/main.js
+++ b/test/function/shorthand-properties/main.js
@@ -1,0 +1,8 @@
+import { foo } from './foo';
+
+function bar () {
+	return 'main-bar';
+}
+
+assert.equal( bar(), 'main-bar' );
+assert.equal( foo.bar(), 'foo-bar' );


### PR DESCRIPTION
This fixes #61 by rewriting `var foo = { bar }` as `var foo = { bar: _bar }` as necessary