### PR TITLE
Revert "expand shorthand properties (#61)"

### DIFF
--- a/src/Statement.js
+++ b/src/Statement.js
@@ -327,28 +327,18 @@ export default class Statement {
 					replacementStack.push( newNames );
 				}
 
+				// We want to rewrite identifiers (that aren't property names etc)
 				if ( node.type !== 'Identifier' ) return;
-
-				// if there's no replacement, or it's the same, there's nothing more to do
-				const name = names[ node.name ];
-				if ( !name || name === node.name ) return;
-
-				// shorthand properties (`obj = { foo }`) need to be expanded
-				if ( parent.type === 'Property' && parent.shorthand ) {
-					magicString.insert( node.end, `: ${name}` );
-					parent.key._skip = true;
-					parent.value._skip = true; // redundant, but defensive
-					return;
-				}
-
-				// property names etc can be disregarded
 				if ( parent.type === 'MemberExpression' && !parent.computed && node !== parent.object ) return;
 				if ( parent.type === 'Property' && node !== parent.value ) return;
 				if ( parent.type === 'MethodDefinition' && node === parent.key ) return;
 				// TODO others...?
 
-				// all other identifiers should be overwritten
-				magicString.overwrite( node.start, node.end, name );
+				const name = names[ node.name ];
+
+				if ( name && name !== node.name ) {
+					magicString.overwrite( node.start, node.end, name );
+				}
 			},
 
 			leave ( node ) {

--- a/test/function/shorthand-properties/_config.js
+++ b/test/function/shorthand-properties/_config.js
@@ -1,3 +1,0 @@
-module.exports = {
-	description: 'expands shorthand properties as necessary (#61)'
-};

--- a/test/function/shorthand-properties/foo.js
+++ b/test/function/shorthand-properties/foo.js
@@ -1,7 +1,0 @@
-function bar () {
-	return 'foo-bar';
-}
-
-export var foo = {
-	bar
-};

--- a/test/function/shorthand-properties/main.js
+++ b/test/function/shorthand-properties/main.js
@@ -1,8 +1,0 @@
-import { foo } from './foo';
-
-function bar () {
-	return 'main-bar';
-}
-
-assert.equal( bar(), 'main-bar' );
-assert.equal( foo.bar(), 'foo-bar' );


### PR DESCRIPTION
Reverts rollup/rollup#63.

After merging #64 I re-ran the tests on Travis. I thought they'd take the changes for #64 into account, which they didn't. The result was test that failed when testing locally. Had #63 been rebased on current master, the failing test `unused-var-d` would have been detected.