### PR TITLE
Add failing testcase for #68

### DIFF
--- a/test/function/named-external-method-in-prototype/_config.js
+++ b/test/function/named-external-method-in-prototype/_config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	description: 'method of external named import used inside prototype method',
+	context: {
+		// override require here, making "foo" appear as a global module
+		require: function ( name ) {
+			if ( name === 'bar' ) {
+				return require( './bar' );
+			}
+			return require( name );
+		}
+	},
+	options: {
+		external: [ 'bar' ]
+	},
+};

--- a/test/function/named-external-method-in-prototype/bar.js
+++ b/test/function/named-external-method-in-prototype/bar.js
@@ -1,0 +1,5 @@
+exports.bar = {
+	foobar: function () {
+		return 42;
+	}
+};

--- a/test/function/named-external-method-in-prototype/foo.js
+++ b/test/function/named-external-method-in-prototype/foo.js
@@ -1,0 +1,16 @@
+import { bar } from 'bar';
+
+export default function Foo() {
+	// XXX: one does not even have to call the method, simply having it defined
+	// on the prototype triggers the failure
+	//return this.bar();
+	return bar.foobar();
+}
+
+// XXX: this prototype definition throws it of, comment it out and it at least
+// fails at runtime because it generates wrong code
+Foo.prototype.bar = function () {
+	// XXX: it also has to be a nested function, simply calling `bar()` here
+	// works, or at least it fails ar runtime like the case above
+	return bar.foobar();
+};

--- a/test/function/named-external-method-in-prototype/main.js
+++ b/test/function/named-external-method-in-prototype/main.js
@@ -1,0 +1,5 @@
+// XXX: it has to be an imported module, otherwise it compiles and fails at
+// runtime
+import Foo from './foo.js';
+
+assert.equal( new Foo(), 42 );


### PR DESCRIPTION
I managed to reduce the failure from #68, with some comments about some observations I made trying to reduce the testcase.

In summary:
you have a relative default import that exports a typical constructor/prototype pattern, where one of the prototype methods is calling a property on a named external import.

* if we do not call the property of the named import but the named import itself, it compiles but generates wrong code
* if we do not define the prototype method but call the property of the named import in the constructor function it compiles but generates wrong code
* if we do not use a relative local import but copy-paste the code right into the `main.js` it compiles but generates wrong code

The compile error is like this:
```
TypeError: Cannot read property 'bar' of undefined
 at .gobble-build/01-rollup/1/rollup.js:1975:48
```