### PR TITLE
RFC: Resolver fallbacks

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -1,5 +1,6 @@
 import { Promise } from 'sander';
 import MagicString from 'magic-string';
+import attempt from './utils/attempt.js';
 import { blank, keys } from './utils/object';
 import Module from './Module';
 import ExternalModule from './ExternalModule';
@@ -17,12 +18,16 @@ export default class Bundle {
 		this.entry = options.entry;
 		this.entryModule = null;
 
-		this.resolveId = options.resolveId || defaultResolver;
-		this.load = options.load || defaultLoader;
+		this.resolveId = ensureArray( options.resolveId )
+			.reduce( attempt, defaultResolver );
+
+		this.load = ensureArray( options.load )
+			.reduce( attempt, defaultLoader );
 
 		this.resolveOptions = {
 			external: ensureArray( options.external ),
-			resolveExternal: options.resolveExternal || defaultExternalResolver
+			resolveExternal: ensureArray( options.resolveExternal )
+				.reduce( attempt, defaultExternalResolver )
 		};
 
 		this.loadOptions = {

--- a/src/utils/attempt.js
+++ b/src/utils/attempt.js
@@ -1,0 +1,11 @@
+// Given a `fallback` and a `preferred` function,
+// return a function that attempts to call the `preferred`.
+// If it fails, or returns undefined, call the fallback and return its value.
+export default function attempt ( fallback, preferred ) {
+	return function ( ...args ) {
+		const boundFallback = () => fallback( ...args );
+
+		return Promise.resolve( preferred( ...args ) )
+			.then( res => res === undefined ? boundFallback() : res, boundFallback );
+	};
+}

--- a/test/function/custom-path-resolver-on-entry/_config.js
+++ b/test/function/custom-path-resolver-on-entry/_config.js
@@ -18,8 +18,6 @@ module.exports = {
 			if ( importer[0] === '@' ) {
 				return path.resolve( __dirname, importee ) + '.js';
 			}
-
-			return path.resolve( path.dirname( importer ), importee ) + '.js';
 		},
 		load: function ( moduleId ) {
 			if ( moduleId[0] === '@' ) {

--- a/test/function/custom-path-resolver-plural/_config.js
+++ b/test/function/custom-path-resolver-plural/_config.js
@@ -1,0 +1,23 @@
+var path = require( 'path' );
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'uses custom path resolvers (plural)',
+	options: {
+		resolveId: [
+			function ( importee ) {
+				if ( importee[0] === '@' )
+					return path.resolve( __dirname, 'globals-' + importee.slice( 1 ).toLowerCase() + '.js' );
+			},
+			function ( importee ) {
+				if ( importee[0] === '!' ) return '<empty>';
+			}
+		],
+		load: function ( id ) {
+			if ( id === '<empty>' ) return '';
+		}
+	},
+	exports: function ( exports ) {
+		assert.strictEqual( exports.res, 0 );
+	}
+};

--- a/test/function/custom-path-resolver-plural/globals-math.js
+++ b/test/function/custom-path-resolver-plural/globals-math.js
@@ -1,0 +1,2 @@
+export var sin = Math.sin;
+export var cos = Math.cos;

--- a/test/function/custom-path-resolver-plural/main.js
+++ b/test/function/custom-path-resolver-plural/main.js
@@ -1,0 +1,4 @@
+import { sin } from '@Math';
+import '!path';
+
+export var res = sin( 0 );


### PR DESCRIPTION
It would be really nice to be able to "fall back" to some other implementation of `resolveId`, `resolveExternal` etc. This PR (which should be considered an RFC) includes one possible way to implement this in a backwards-compatible manner.

Let the resolvers handle what they can, and delegate everything else to some other function. It may not do anything to help #107, but could be something in the right direction. Thought?

Fixes #108 