### PR TITLE
Using Rollup on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+# http://www.appveyor.com/docs/appveyor-yml
+
+version: "{build}"
+
+clone_depth: 10
+
+init:
+  - git config --global core.autocrlf true
+
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: 0.10
+    - nodejs_version: 0.12
+    # io.js
+    - nodejs_version: 1
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+build: off
+
+test_script:
+  - node --version && npm --version
+  - npm test
+
+matrix:
+  fast_finish: false
+
+cache:
+  - C:\Users\appveyor\AppData\Roaming\npm-cache -> package.json     # npm cache
+  - node_modules -> package.json                                    # local npm modules

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,6 +1,6 @@
 // TODO does this all work on windows?
 
-export const absolutePath = /^(?:\/|(?:[A-Za-z]:)?\\)/;
+export const absolutePath = /^(?:\/|(?:[A-Za-z]:)?[\\|\/])/;
 
 export function isAbsolute ( path ) {
 	return absolutePath.test( path );


### PR DESCRIPTION
Hi,

I started using Rollup recently, but encountered some issues that __were__ initially preventing me from using its full range of capabilities. _(I'm using Windows because I'm a bit of a masochist.)_

When there is an external module to load like so:

```javascript
// src/main.js
import Evil from "@pandora/box";
```

It fails with this error:

```sh
>> rollup -f cjs -i src/main.js -o build/main.js

Cannot read property '0' of null
TypeError: Cannot read property '0' of null
    at Object.defaultExternalResolver [as resolveExternal]
    (F:\Sourcecode\JavaScript\evil\node_modules\rollup\dist\rollup.js:2692:40)
...
```

Browserify + Babelify handles this without problems. JSHint doesn't shout at me either.  

The Rollup CLI creates __valid bundles__ for me on Windows when there are __no__ modules to import. So I figured that there might be a Windows-specific bug somewhere in [resolveId](https://github.com/rollup/rollup/blob/master/src/utils/resolveId.js) and thus in [path logic](https://github.com/rollup/rollup/blob/master/src/utils/path.js).

I then tried the JavaScript API instead of the CLI, but got the same ```Cannot read property '0' of null``` error at first. __However, after overriding the ```defaultResolver``` it worked__ even though I wasn't using any black magic. [Here](https://gist.github.com/vanruesc/88853128c9fcda7d8691) is a Gist if you're interested in the details.

This helped me find the problematic code:

```javascript
// src/utils/path.js
export const absolutePath = /^(?:\/|(?:[A-Za-z]:)?\\)/;
```

I saw that on Windows, the ```importer``` parameter in ```resolveExternal()``` contains strings like these:

```sh
F:/Sourcecode/JavaScript/myProject/src/main.js
```

The obvious solution was to add normal slashes to the regular expression:

```javascript
/^(?:\/|(?:[A-Za-z]:)?[\\|\/])/
```

When I tried to build the project myself to test this, it straight out faceplanted like an overly enthusiastic skateboarder. It's strange that nobody has pointed this out before, but Rollup cannot be [built on Windows](https://ci.appveyor.com/project/vanruesc/rollup/build/job/rqjxpra71a1cm0wu) at the moment. The main reason for this is that it uses itself internally during the build process. Since I can't build it locally like this, I directly modified ```node_modules/rollup/dist/rollup.js``` in my projects and got it to work. __The CLI works on Windows with this little change.__

_If you want to try building Rollup yourself on Windows, you could use this [config](https://github.com/vanruesc/rollup/blob/master/appveyor.yml). Appveyor is pretty similar to travis-ci._
 