### PR TITLE
guard against undefined `this` in post-processed UMD bundle - fixes #109

### DIFF
--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -40,7 +40,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 			typeof exports === 'object' && typeof module !== 'undefined' ? ${cjsExport}factory(${cjsDeps.join( ', ' )}) :
 			typeof define === 'function' && define.amd ? define(${amdParams}factory) :
 			${defaultExport}factory(${globalDeps});
-		}(this, function (${args}) {${useStrict}
+		}(this || (typeof window !== 'undefined' && window), function (${args}) {${useStrict}
 
 		`.replace( /^\t\t/gm, '' ).replace( /^\t/gm, magicString.getIndentString() );
 

--- a/test/cli/module-name/_expected.js
+++ b/test/cli/module-name/_expected.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.myBundle = factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var main = 42;
 

--- a/test/form/banner-and-footer/_expected/umd.js
+++ b/test/form/banner-and-footer/_expected/umd.js
@@ -3,7 +3,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	console.log( 'hello world' );
 

--- a/test/form/block-comments/_expected/umd.js
+++ b/test/form/block-comments/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	function foo () {
 		return embiggen( 6, 7 );

--- a/test/form/dedupes-external-imports/_expected/umd.js
+++ b/test/form/dedupes-external-imports/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
 	factory(global.external);
-}(this, function (external) { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function (external) { 'use strict';
 
 	class Foo extends external.Component {
 		constructor () {

--- a/test/form/exclude-unnecessary-modifications/_expected/umd.js
+++ b/test/form/exclude-unnecessary-modifications/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var foo = {};
 

--- a/test/form/export-all-from-internal/_expected/umd.js
+++ b/test/form/export-all-from-internal/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
 	factory((global.exposedInternals = {}));
-}(this, function (exports) { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function (exports) { 'use strict';
 
 	const a = 1;
 	const b = 2;

--- a/test/form/export-default/_expected/umd.js
+++ b/test/form/export-default/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.myBundle = factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var main = 42;
 

--- a/test/form/exports-at-end-if-possible/_expected/umd.js
+++ b/test/form/exports-at-end-if-possible/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
 	factory((global.myBundle = {}));
-}(this, function (exports) { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function (exports) { 'use strict';
 
 	var FOO = 'foo';
 

--- a/test/form/external-imports-custom-names/_expected/umd.js
+++ b/test/form/external-imports-custom-names/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery')) :
 	typeof define === 'function' && define.amd ? define(['jquery'], factory) :
 	factory(global.jQuery);
-}(this, function ($) { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function ($) { 'use strict';
 
 	$ = 'default' in $ ? $['default'] : $;
 

--- a/test/form/external-imports/_expected/umd.js
+++ b/test/form/external-imports/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('factory'), require('baz'), require('shipping-port'), require('alphabet')) :
 	typeof define === 'function' && define.amd ? define(['factory', 'baz', 'shipping-port', 'alphabet'], factory) :
 	factory(global.factory,global.baz,global.containers,global.alphabet);
-}(this, function (factory,baz,containers,alphabet) { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function (factory,baz,containers,alphabet) { 'use strict';
 
 	factory = 'default' in factory ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;

--- a/test/form/indent-false/_expected/umd.js
+++ b/test/form/indent-false/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.foo = factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 function foo () {
 	console.log( 'indented with tabs' );

--- a/test/form/indent-true-spaces/_expected/umd.js
+++ b/test/form/indent-true-spaces/_expected/umd.js
@@ -2,7 +2,7 @@
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
   global.foo = factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
   function foo () {
     console.log( 'indented with spaces' );

--- a/test/form/indent-true/_expected/umd.js
+++ b/test/form/indent-true/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.foo = factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	function foo () {
 		console.log( 'indented with tabs' );

--- a/test/form/internal-conflict-resolution/_expected/umd.js
+++ b/test/form/internal-conflict-resolution/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/form/multiple-exports/_expected/umd.js
+++ b/test/form/multiple-exports/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
 	factory((global.myBundle = {}));
-}(this, function (exports) { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function (exports) { 'use strict';
 
 	var foo = 1;
 	var bar = 2;

--- a/test/form/namespace-optimization/_expected/umd.js
+++ b/test/form/namespace-optimization/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	function a () {}
 

--- a/test/form/no-imports-or-exports/_expected/umd.js
+++ b/test/form/no-imports-or-exports/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	console.log( 'this is it' );
 

--- a/test/form/preserves-comments-after-imports/_expected/umd.js
+++ b/test/form/preserves-comments-after-imports/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
 	factory((global.myBundle = {}));
-}(this, function (exports) { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function (exports) { 'use strict';
 
 	/** A comment for a number */
 	var number = 5;

--- a/test/form/removes-existing-sourcemap-comments/_expected/umd.js
+++ b/test/form/removes-existing-sourcemap-comments/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	function foo () {
 		return 42;

--- a/test/form/self-contained-bundle/_expected/umd.js
+++ b/test/form/self-contained-bundle/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	function foo () {
 		return bar();

--- a/test/form/sourcemaps-inline/_expected/umd.js
+++ b/test/form/sourcemaps-inline/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	function foo () {
 		console.log( 'hello from foo.js' );

--- a/test/form/sourcemaps/_expected/umd.js
+++ b/test/form/sourcemaps/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	function foo () {
 		console.log( 'hello from foo.js' );

--- a/test/form/unmodified-default-exports-function-argument/_expected/umd.js
+++ b/test/form/unmodified-default-exports-function-argument/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var foo = function () {
 		return 42;

--- a/test/form/unmodified-default-exports/_expected/umd.js
+++ b/test/form/unmodified-default-exports/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var Foo = function () {
 		this.isFoo = true;

--- a/test/form/unused-default-exports/_expected/umd.js
+++ b/test/form/unused-default-exports/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var foo = { value: 1 };
 

--- a/test/form/unused-side-effect/_expected/umd.js
+++ b/test/form/unused-side-effect/_expected/umd.js
@@ -2,7 +2,7 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory();
-}(this, function () { 'use strict';
+}(this || (typeof window !== 'undefined' && window), function () { 'use strict';
 
 	var foo = 42;
 


### PR DESCRIPTION
Similar to #109, but a slightly more compact form.

For:

* keeps things working if a UMD bundle is subsequently processed with Babel, or something else that rewrites `this` as `undefined`.

Against:

* It adds extra bytes to the bundle
* Rollup isn't actually doing anything wrong here (in an ES5 environment, `this` is always the global object at the top level AFAIK), so it's really just masking a problem rather than fixing it

Any thoughts?