### PR TITLE
add bundle.modules - fixes #128

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -17,6 +17,9 @@ export function rollup ( options ) {
 		return {
 			imports: bundle.externalModules.map( module => module.id ),
 			exports: keys( bundle.entryModule.exports ),
+			modules: bundle.orderedModules.map( module => {
+				return { id: module.id };
+			}),
 
 			generate: options => bundle.render( options ),
 			write: options => {

--- a/test/function/has-modules-array/_config.js
+++ b/test/function/has-modules-array/_config.js
@@ -1,0 +1,13 @@
+var path = require( 'path' );
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'user-facing bundle has modules array',
+	bundle: function ( bundle ) {
+		assert.ok( bundle.modules );
+		assert.deepEqual( bundle.modules, [
+			{ id: path.resolve( __dirname, 'foo.js' ) },
+			{ id: path.resolve( __dirname, 'main.js' ) }
+		]);
+	}
+};

--- a/test/function/has-modules-array/foo.js
+++ b/test/function/has-modules-array/foo.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/function/has-modules-array/main.js
+++ b/test/function/has-modules-array/main.js
@@ -1,0 +1,2 @@
+import foo from './foo';
+assert.equal( foo, 42 );

--- a/test/test.js
+++ b/test/test.js
@@ -128,9 +128,8 @@ describe( 'rollup', function () {
 								unintendedError = new Error( 'Expected an error while executing output' );
 							}
 
-							if ( config.exports ) {
-								config.exports( module.exports );
-							}
+							if ( config.exports ) config.exports( module.exports );
+							if ( config.bundle ) config.bundle( bundle );
 						} catch ( err ) {
 							if ( config.error ) {
 								config.error( err );


### PR DESCRIPTION
This PR adds a `bundle.modules` property, where each module is an object with an `id` property (which in normal circumstances is the module's resolved path), and room for future growth. See #128