### PR TITLE
Add code coverage with Istanbul and Codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .gobble*
 dist
 _actual
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ node_js:
 env:
   global:
     - BUILD_TIMEOUT=10000
+install: npm install --ignore-scripts
+script: npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "iojs"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ node_js:
 env:
   global:
     - BUILD_TIMEOUT=10000
-install: npm install --ignore-scripts
+install: npm install
 script: npm run ci

--- a/gobblefile.js
+++ b/gobblefile.js
@@ -8,7 +8,8 @@ var node = src
 		entry: 'rollup.js',
 		dest: 'rollup.js',
 		format: 'cjs',
-		external: [ 'sander', 'acorn' ]
+		external: [ 'sander', 'acorn' ],
+		sourceMap: true
 	})
 	.transform( 'babel' );
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "rollup": "./bin/rollup"
   },
   "scripts": {
+    "pretest": "npm run build",
     "test": "mocha",
+    "pretest-coverage": "npm run build",
     "test-coverage": "istanbul cover --report cobertura node_modules/.bin/_mocha -- -u exports -R spec test/test.js",
     "ci": "npm run test-coverage && codecov < coverage/cobertura-coverage.xml",
-    "pretest": "npm run build",
     "build": "gobble build -f dist",
     "prepublish": "npm test",
     "lint": "eslint src"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "pretest": "npm run build",
     "test": "mocha",
     "pretest-coverage": "npm run build",
-    "test-coverage": "istanbul cover --report cobertura node_modules/.bin/_mocha -- -u exports -R spec test/test.js",
-    "ci": "npm run test-coverage && codecov < coverage/cobertura-coverage.xml",
+    "test-coverage": "istanbul cover --report json node_modules/.bin/_mocha -- -u exports -R spec test/test.js",
+    "posttest-coverage": "remap-istanbul -i coverage/coverage-final.json -o coverage/coverage-remapped.json -b dist",
+    "ci": "npm run test-coverage && codecov < coverage/coverage-remapped.json",
     "build": "gobble build -f dist",
     "prepublish": "npm test",
     "lint": "eslint src"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   },
   "scripts": {
     "test": "mocha",
+    "test-coverage": "istanbul cover --report cobertura node_modules/.bin/_mocha -- -u exports -R spec test/test.js",
+    "ci": "npm run test-coverage && codecov < coverage/cobertura-coverage.xml",
     "pretest": "npm run build",
     "build": "gobble build -f dist",
     "prepublish": "npm test",
@@ -37,6 +39,7 @@
   "devDependencies": {
     "babel": "^5.8.21",
     "babel-core": "^5.5.8",
+    "codecov.io": "^0.1.6",
     "console-group": "^0.1.2",
     "eslint": "^1.1.0",
     "gobble": "^0.10.1",
@@ -46,6 +49,7 @@
     "gobble-esperanto-bundle": "^0.2.0",
     "gobble-rollup": "^0.8.0",
     "gobble-rollup-babel": "^0.1.0",
+    "istanbul": "^0.3.20",
     "mocha": "^2.2.4",
     "source-map": "^0.4.4"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gobble-rollup-babel": "^0.1.0",
     "istanbul": "^0.3.20",
     "mocha": "^2.2.4",
+    "remap-istanbul": "^0.2.0",
     "source-map": "^0.4.4"
   },
   "dependencies": {

--- a/src/Module.js
+++ b/src/Module.js
@@ -6,6 +6,7 @@ import walk from './ast/walk';
 import { blank, keys } from './utils/object';
 import getLocation from './utils/getLocation';
 import makeLegalIdentifier from './utils/makeLegalIdentifier';
+import SOURCEMAPPING_URL from './utils/sourceMappingUrl';
 
 function isEmptyExportedVarDeclaration ( node, exports, toExport ) {
 	if ( node.type !== 'VariableDeclaration' || node.declarations[0].init ) return false;
@@ -18,9 +19,10 @@ function isEmptyExportedVarDeclaration ( node, exports, toExport ) {
 }
 
 function removeSourceMappingURLComments ( source, magicString ) {
-	const pattern = /\/\/#\s+sourceMappingURL=.+\n?/g;
+	const SOURCEMAPPING_URL_PATTERN = new RegExp( `\\/\\/#\\s+${SOURCEMAPPING_URL}=.+\\n?`, 'g' );
 	let match;
-	while ( match = pattern.exec( source ) ) {
+
+	while ( match = SOURCEMAPPING_URL_PATTERN.exec( source ) ) {
 		magicString.remove( match.index, match.index + match[0].length );
 	}
 }

--- a/src/Module.js
+++ b/src/Module.js
@@ -6,7 +6,7 @@ import walk from './ast/walk';
 import { blank, keys } from './utils/object';
 import getLocation from './utils/getLocation';
 import makeLegalIdentifier from './utils/makeLegalIdentifier';
-import SOURCEMAPPING_URL from './utils/sourceMappingUrl';
+import SOURCEMAPPING_URL from './utils/sourceMappingURL';
 
 function isEmptyExportedVarDeclaration ( node, exports, toExport ) {
 	if ( node.type !== 'VariableDeclaration' || node.declarations[0].init ) return false;

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -1,7 +1,7 @@
 import { basename } from './utils/path';
 import { writeFile } from 'sander';
 import { keys } from './utils/object';
-import SOURCEMAPPING_URL from './utils/sourceMappingUrl';
+import SOURCEMAPPING_URL from './utils/sourceMappingURL';
 import Bundle from './Bundle';
 
 export function rollup ( options ) {

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -1,10 +1,8 @@
 import { basename } from './utils/path';
 import { writeFile } from 'sander';
 import { keys } from './utils/object';
+import SOURCEMAPPING_URL from './utils/sourceMappingUrl';
 import Bundle from './Bundle';
-
-let SOURCEMAPPING_URL = 'sourceMa';
-SOURCEMAPPING_URL += 'ppingURL';
 
 export function rollup ( options ) {
 	if ( !options || !options.entry ) {

--- a/src/utils/sourceMappingURL.js
+++ b/src/utils/sourceMappingURL.js
@@ -1,0 +1,6 @@
+// this looks ridiculous, but it prevents sourcemap tooling from mistaking
+// this for an actual sourceMappingURL
+let SOURCEMAPPING_URL = 'sourceMa';
+SOURCEMAPPING_URL += 'ppingURL';
+
+export default SOURCEMAPPING_URL;


### PR DESCRIPTION
https://codecov.io/github/rollup/rollup?branch=istanbul

This PR adds code coverage reports via [Istanbul](https://gotwarlost.github.io/istanbul/) and [codecov.io](https://codecov.io). Couple of questions/things to consider before merging:

* It instruments the built file (dist/rollup.js), not the src files, which is ignored in this repo – meaning we can't actually *see* on codecov.io which bits aren't covered
* Is there some sourcemap magic that'll fix that? I don't know
* Should dist/rollup.js be checked in? Should the coverage reports be generated on `npm test` automatically and checked in, so they can be viewed on GitHub? Or is that daft?
* `npm install` inexplicably runs `prepublish` scripts, meaning that Travis CI ends up having to run the build and tests twice. This is an inexplicably bad decision. I really hope npm fixes that.