### PR TITLE
Changed the default deconfliction function to behave more like Babel.…

### DIFF
--- a/src/Scope.js
+++ b/src/Scope.js
@@ -27,9 +27,23 @@ function isntReference ( id ) {
 	return !( id instanceof Reference );
 }
 
-// Prefix the argument with '_'.
-function underscorePrefix ( x ) {
-	return '_' + x;
+// Returns a function that will prefix its argument with '_'
+// and append a number if called with the same argument more than once.
+function underscorePrefix () {
+	function number ( x ) {
+		if ( !( x in map ) ) {
+			map[ x ] = 0;
+			return '';
+		}
+
+		return map[ x ]++;
+	}
+
+	var map = blank();
+
+	return function ( x ) {
+		return '_' + x + number( x );
+	}
 }
 
 // ## Scope
@@ -51,7 +65,7 @@ export default class Scope {
 	// Deconflict all names within the scope,
 	// using the given renaming function.
 	// If no function is supplied, `underscorePrefix` is used.
-	deconflict ( rename = underscorePrefix ) {
+	deconflict ( rename = underscorePrefix() ) {
 		const names = this.used;
 
 		this.ids.filter( ref => ref instanceof Reference ).forEach( ref => {


### PR DESCRIPTION
… Should be much faster for many identical identifiers.

Deconflicting five `foo`s, yields
```
foo
_foo
_foo1
_foo2
_foo3
```
instead of
```
foo
_foo
__foo
___foo
____foo
```