### PR TITLE
Fix test for windows

### DIFF
--- a/test/function/has-modules-array/_config.js
+++ b/test/function/has-modules-array/_config.js
@@ -5,9 +5,8 @@ module.exports = {
 	description: 'user-facing bundle has modules array',
 	bundle: function ( bundle ) {
 		assert.ok( bundle.modules );
-		assert.deepEqual( bundle.modules, [
-			{ id: path.resolve( __dirname, 'foo.js' ) },
-			{ id: path.resolve( __dirname, 'main.js' ) }
-		]);
+		assert.equal( bundle.modules.length, 2 );
+		assert.equal( path.relative(bundle.modules[0].id, path.resolve(__dirname, 'foo.js')), '' );
+		assert.equal( path.relative(bundle.modules[1].id, path.resolve(__dirname, 'main.js')), '' );
 	}
 };


### PR DESCRIPTION
both paths come out of rollup differently, with mixed seperators on windows..

```
  1) rollup function has-modules-array:

      AssertionError: [ { id: 'c:/git/rollup/test/function/has-modules-array/foo.js' },
  { id: 'c:\\git\\rollup\\test\\function/has-modules-array/mai deepEqual [ { id: 'c:\\git\\rollup\\test\\function\\has-modules-array\\foo.js' },
  { id: 'c:\\git\\rollup\\test\\function\\has-modules-ar
      + expected - actual

       [
         {
      -    "id": "c:/git/rollup/test/function/has-modules-array/foo.js"
      +    "id": "c:\\git\\rollup\\test\\function\\has-modules-array\\foo.js"
         }
         {
      -    "id": "c:\\git\\rollup\\test\\function/has-modules-array/main.js"
      +    "id": "c:\\git\\rollup\\test\\function\\has-modules-array\\main.js"
         }
       ]
```

The alternative fix would be to keep the test as-is but add some path normalization into rollup.

I went for the simplest fix for now.