### PR TITLE
Optimise multiple namespaces in a function

### DIFF
--- a/src/optimise/namespace-lookup.js
+++ b/src/optimise/namespace-lookup.js
@@ -39,7 +39,10 @@ export default function ( statement ) {
 					const id = statement.module.locals.lookup( localName );
 
 					// It only counts if it exists, is a module, and isn't external.
-					if ( !id || !id.isModule || id.isExternal ) return;
+					if ( !id || !id.isModule || id.isExternal ) {
+						topNode = null;
+						return;
+					}
 
 					namespace = id;
 				}

--- a/test/form/namespace-optimization-2/_config.js
+++ b/test/form/namespace-optimization-2/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'it does static lookup optimization of internal namespaces, coping with multiple namespaces in one function'
+};

--- a/test/form/namespace-optimization-2/_expected/amd.js
+++ b/test/form/namespace-optimization-2/_expected/amd.js
@@ -1,0 +1,15 @@
+define(function () { 'use strict';
+
+  function foo() {
+  }
+
+  function a() {
+    foo();
+    foo();
+    var a;
+    if (a.b) {
+    }
+  }
+  a();
+
+});

--- a/test/form/namespace-optimization-2/_expected/cjs.js
+++ b/test/form/namespace-optimization-2/_expected/cjs.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function foo() {
+}
+
+function a() {
+  foo();
+  foo();
+  var a;
+  if (a.b) {
+  }
+}
+a();

--- a/test/form/namespace-optimization-2/_expected/es6.js
+++ b/test/form/namespace-optimization-2/_expected/es6.js
@@ -1,0 +1,11 @@
+function foo() {
+}
+
+function a() {
+  foo();
+  foo();
+  var a;
+  if (a.b) {
+  }
+}
+a();

--- a/test/form/namespace-optimization-2/_expected/iife.js
+++ b/test/form/namespace-optimization-2/_expected/iife.js
@@ -1,0 +1,15 @@
+(function () { 'use strict';
+
+  function foo() {
+  }
+
+  function a() {
+    foo();
+    foo();
+    var a;
+    if (a.b) {
+    }
+  }
+  a();
+
+})();

--- a/test/form/namespace-optimization-2/_expected/umd.js
+++ b/test/form/namespace-optimization-2/_expected/umd.js
@@ -1,0 +1,19 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  factory();
+}(this, function () { 'use strict';
+
+  function foo() {
+  }
+
+  function a() {
+    foo();
+    foo();
+    var a;
+    if (a.b) {
+    }
+  }
+  a();
+
+}));

--- a/test/form/namespace-optimization-2/foo.js
+++ b/test/form/namespace-optimization-2/foo.js
@@ -1,0 +1,2 @@
+export function foo() {
+};

--- a/test/form/namespace-optimization-2/main.js
+++ b/test/form/namespace-optimization-2/main.js
@@ -1,0 +1,10 @@
+import * as foo from './foo';
+
+function a() {
+  foo.foo();
+  foo.foo();
+  var a;
+  if (a.b) {
+  }
+}
+a();


### PR DESCRIPTION
I hinted in #148 that I was getting many namespaces not optimised. I thought I'd take a look after @Victorystick 's work in #150 (which didn't fix the issue).

I've cherry-picked that PR into here - I suggest that you merge that first and then I'll rebase so you can see just my changes.

I wasn't 100% sure it was the right change - at first I thought the `topNode` logic was in reverse and it should be `node.object !== topNode` but that breaks an existing test and actually seems correct - the problem then appeared to be that it was assumed that a "statement" would only have one namespace optimisation in it - except a statement can be a function declaration, so as in the test any member expressions in the function causes it to not optimise.