### PR TITLE
Module order side effects

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -281,7 +281,7 @@ export default class Bundle {
 		let seen = blank();
 
 		let ordered = [];
-		let hasCycles;
+		let hasCycles = false;
 
 		// Map from module id to list of modules.
 		let strongDeps = blank();

--- a/src/Module.js
+++ b/src/Module.js
@@ -359,7 +359,7 @@ export default class Module {
 	}
 
 	consolidateDependencies () {
-		let strongDependencies = blank();
+		const strongDependencies = blank();
 
 		function addDependency ( dependencies, declaration ) {
 			if ( declaration && declaration.module && !declaration.module.isExternal ) {
@@ -397,7 +397,7 @@ export default class Module {
 			}
 		});
 
-		let weakDependencies = blank();
+		const weakDependencies = blank();
 
 		this.statements.forEach( statement => {
 			keys( statement.dependsOn ).forEach( name => {
@@ -407,19 +407,22 @@ export default class Module {
 			});
 		});
 
+		// Make us weakly depend on all our dependencies.
+		// If we don't, these modules (and their side-effects) won't be included.
+		this.dependencies.forEach( source => {
+			const module = this.getModule( source );
+
+			if ( !module.isExternal ) {
+				weakDependencies[ module.id ] = module;
+			}
+		});
+
 		// Go through all our local and exported ids and make us depend on
-		// the defining modules as well as
-		this.exports.getIds().concat(this.locals.getIds()).forEach( id => {
+		// the defining modules.
+		this.exports.getIds().concat( this.locals.getIds() ).forEach( id => {
 			if ( id.module && !id.module.isExternal ) {
 				weakDependencies[ id.module.id ] = id.module;
 			}
-
-			if ( !id.modifierStatements ) return;
-
-			id.modifierStatements.forEach( statement => {
-				const module = statement.module;
-				weakDependencies[ module.id ] = module;
-			});
 		});
 
 		// `Bundle.sort` gets stuck in an infinite loop if a module has

--- a/test/function/import-of-unexported-fails/_config.js
+++ b/test/function/import-of-unexported-fails/_config.js
@@ -4,7 +4,7 @@ module.exports = {
 	description: 'marking an imported, but unexported, identifier should throw',
 
 	error: function ( err ) {
-		assert.equal( err.message.slice( 0, 50 ), 'The imported name "default" is never exported by "' );
+		assert.equal( err.message.slice( 0, 41 ), 'The name "default" is never exported by "' );
 		assert.equal( err.message.slice( -10 ), 'empty.js".' );
 	}
 };

--- a/test/function/module-sort-order/_config.js
+++ b/test/function/module-sort-order/_config.js
@@ -1,5 +1,3 @@
 module.exports = {
-	// solo: true,
-	// show: true,
 	description: 'module sorter is not confused by top-level call expressions'
 };

--- a/test/function/module-sort-order/_config.js
+++ b/test/function/module-sort-order/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	// solo: true,
+	// show: true,
+	description: 'module sorter is not confused by top-level call expressions'
+};

--- a/test/function/module-sort-order/a.js
+++ b/test/function/module-sort-order/a.js
@@ -1,0 +1,20 @@
+import { b } from './b';
+import z from './z';
+
+z();
+
+const p = {
+	q: function () {
+		b.nope();
+	}
+};
+
+(function () {
+	const p = {
+		q: function () {
+			b.nope();
+		}
+	};
+})();
+
+export default 42;

--- a/test/function/module-sort-order/a.js
+++ b/test/function/module-sort-order/a.js
@@ -3,14 +3,14 @@ import z from './z';
 
 z();
 
-const p = {
+var p = {
 	q: function () {
 		b.nope();
 	}
 };
 
 (function () {
-	const p = {
+	var p = {
 		q: function () {
 			b.nope();
 		}

--- a/test/function/module-sort-order/b.js
+++ b/test/function/module-sort-order/b.js
@@ -1,1 +1,1 @@
-export const b = function () {};
+export var b = function () {};

--- a/test/function/module-sort-order/b.js
+++ b/test/function/module-sort-order/b.js
@@ -1,0 +1,1 @@
+export const b = function () {};

--- a/test/function/module-sort-order/c.js
+++ b/test/function/module-sort-order/c.js
@@ -1,0 +1,3 @@
+import { b } from './b';
+
+export const c = function () {};

--- a/test/function/module-sort-order/c.js
+++ b/test/function/module-sort-order/c.js
@@ -1,3 +1,3 @@
 import { b } from './b';
 
-export const c = function () {};
+export var c = function () {};

--- a/test/function/module-sort-order/main.js
+++ b/test/function/module-sort-order/main.js
@@ -1,0 +1,4 @@
+import a from './a';
+import z from './z';
+
+z();

--- a/test/function/module-sort-order/z.js
+++ b/test/function/module-sort-order/z.js
@@ -1,0 +1,5 @@
+import { c } from './c';
+
+export default function () {
+	c();
+}


### PR DESCRIPTION
I've been all over with this. As I said in [one of the comments](https://github.com/rollup/rollup/issues/132#issuecomment-143752767), I'm not entirely sure what should be included in `weakDependencies`, but I think this should do it.

Adding the `dependencies` (the imported/re-exported modules) of the current module as weak dependencies, seems to do the trick. We make sure to include the modules we depend on (makes sense), and so on recursively. Any statements that have been marked within that traversal will be included.

The tests pass, but as we've discovered, they're not yet all that thorough at this point.
@Rich-Harris Does this get the Ractive build passing again? :pray: 

Fixes #132