### PR TITLE
Informative error message when namespace property doesn't exist

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -76,6 +76,14 @@ class SyntheticNamespaceDeclaration {
 
 			const original = this.originals[ reference.name ];
 
+			// throw with an informative error message if the reference doesn't exist.
+			if ( !original ) {
+				const err = new Error( `Export '${reference.name}' is not defined by '${this.module.id}'` );
+				err.code = 'MISSING_EXPORT';
+				err.file = this.id;
+				throw err;
+			}
+
 			original.addReference( reference );
 			return;
 		}

--- a/src/Module.js
+++ b/src/Module.js
@@ -80,7 +80,7 @@ class SyntheticNamespaceDeclaration {
 			if ( !original ) {
 				const err = new Error( `Export '${reference.name}' is not defined by '${this.module.id}'` );
 				err.code = 'MISSING_EXPORT';
-				err.file = this.id;
+				err.file = this.module.id;
 				throw err;
 			}
 

--- a/test/function/namespace-missing-export/_config.js
+++ b/test/function/namespace-missing-export/_config.js
@@ -1,12 +1,9 @@
 var assert = require( 'assert' );
+var path = require( 'path' );
 
 module.exports = {
-	solo: true,
-
 	error: function ( err ) {
-		console.log( err.message );
-		// assert.equal( path.normalize(err.file), path.resolve( __dirname, 'main.js' ) );
-		// assert.deepEqual( err.loc, { line: 8, column: 0 });
-		assert.ok( /Export "foo" is not defined by/.test( err.message ) );
+		assert.equal( path.normalize( err.file ), path.resolve( __dirname, 'empty.js' ) );
+		assert.ok( /Export 'foo' is not defined by/.test( err.message ) );
 	}
 };

--- a/test/function/namespace-missing-export/_config.js
+++ b/test/function/namespace-missing-export/_config.js
@@ -1,0 +1,12 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	solo: true,
+
+	error: function ( err ) {
+		console.log( err.message );
+		// assert.equal( path.normalize(err.file), path.resolve( __dirname, 'main.js' ) );
+		// assert.deepEqual( err.loc, { line: 8, column: 0 });
+		assert.ok( /Export "foo" is not defined by/.test( err.message ) );
+	}
+};

--- a/test/function/namespace-missing-export/main.js
+++ b/test/function/namespace-missing-export/main.js
@@ -1,0 +1,3 @@
+import * as mod from './empty.js';
+
+mod.foo();


### PR DESCRIPTION
`Error: Export 'foo' is not defined by '<module name>'`, instead of
`TypeError: Cannot read property 'addReference' of undefined`.