### PR TITLE
Prevent namespace abuse by freezing them

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -111,7 +111,7 @@ class SyntheticNamespaceDeclaration {
 			return `${indentString}${name}: ${original.render()}`;
 		});
 
-		return `var ${this.render()} = {\n${members.join( ',\n' )}\n};\n\n`;
+		return `var ${this.render()} = Object.freeze({\n${members.join( ',\n' )}\n});\n\n`;
 	}
 
 	render () {

--- a/test/function/namespaces-are-frozen/_config.js
+++ b/test/function/namespaces-are-frozen/_config.js
@@ -1,0 +1,35 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'namespaces should be non-extensible and its properties immutatable and non-configurable',
+
+	exports: function ( exports ) {
+		const ns = exports.ns;
+
+		function extend ( obj ) {
+			'use strict';
+			obj.newProperty = true;
+		}
+
+		function reconfigure ( obj ) {
+			Object.defineProperty( obj, 'a', { value: null } );
+		}
+
+		function mutate ( obj ) {
+			'use strict';
+			obj.a = 2;
+		}
+
+		assert.throws(function () {
+			extend( ns );
+		});
+
+		assert.throws(function () {
+			reconfigure( ns );
+		});
+
+		assert.throws(function () {
+			mutate( ns );
+		});
+	}
+};

--- a/test/function/namespaces-are-frozen/main.js
+++ b/test/function/namespaces-are-frozen/main.js
@@ -1,0 +1,5 @@
+// import * as ns from './mod';
+
+// export { ns };
+
+export var ns = Object.freeze({ a: 1, b: 2 });

--- a/test/function/namespaces-are-frozen/mod.js
+++ b/test/function/namespaces-are-frozen/mod.js
@@ -1,0 +1,2 @@
+export var a = 1;
+export var b = 2;


### PR DESCRIPTION
Fixes #202

I discovered another bug while adding this test.

`main.js` currently looks like
```js
// import * as ns from './mod';

// export { ns };

export var ns = Object.freeze({ a: 1, b: 2 });
```

Writing it how we want
```js
// export * as ns from './mod';
import * as ns from './mod';
export { ns };
```

yields nothing but

```js
'use strict';

var ns = Object.freeze({
	a: a,
	b: b
});

exports.ns = ns;
```
resulting in a `ReferenceError: a is not defined`