### PR TITLE
Release 0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rollup changelog
 
+## 0.19.2
+
+* Fix exporting namespaces to include all of their exports ([#204](https://github.com/rollup/rollup/issues/204))
+* Namespace exotic objects are frozen to ensure that its properties cannot be modified, reconfigured, redefined or deleted ([#203](https://github.com/rollup/rollup/pulls/203))
+* Fix `ReferenceError: Promise is not defined` in node v0.10 ([#189](https://github.com/rollup/rollup/issues/189))
+
 ## 0.19.1
 
 * Fix `module.basename()` when used with custom `resolveId` function

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Next-generation ES6 module bundler",
   "main": "dist/rollup.js",
   "jsnext:main": "src/rollup.js",


### PR DESCRIPTION
We might as well release 0.19.2 to include these fixes (#203, #205) along with the Promise related `ReferenceError` for those running node v0.10 (#189).