### PR TITLE
Disallow 'default' as an identifier name in `addReference`

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -25,7 +25,7 @@ class SyntheticDefaultDeclaration {
 
 	addReference ( reference ) {
 		// Don't change the name to `default`; it's not a valid identifier name.
-		if ( reference.name !== 'default' ) return;
+		if ( reference.name === 'default' ) return;
 
 		reference.declaration = this;
 		this.name = reference.name;

--- a/src/Module.js
+++ b/src/Module.js
@@ -24,6 +24,9 @@ class SyntheticDefaultDeclaration {
 	}
 
 	addReference ( reference ) {
+		// Don't change the name to `default`; it's not a valid identifier name.
+		if ( reference.name !== 'default' ) return;
+
 		reference.declaration = this;
 		this.name = reference.name;
 	}

--- a/test/function/confused-default-identifier/_config.js
+++ b/test/function/confused-default-identifier/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'Rollup should not get confused and allow "default" as an identifier name'
+};
+
+// https://github.com/rollup/rollup/issues/215

--- a/test/function/confused-default-identifier/foo.js
+++ b/test/function/confused-default-identifier/foo.js
@@ -1,0 +1,3 @@
+export default function Foo () {
+
+}

--- a/test/function/confused-default-identifier/main.js
+++ b/test/function/confused-default-identifier/main.js
@@ -1,0 +1,6 @@
+// export
+export {default as Foo} from './foo';
+
+export default function () {
+  // whatever
+}


### PR DESCRIPTION
Fixes #215 