### PR TITLE
[RFC] add --config option to CLI (#226)

### DIFF
--- a/bin/help.md
+++ b/bin/help.md
@@ -7,6 +7,8 @@ Basic options:
 
 -v, --version            Show version number
 -h, --help               Show this help message
+-c, --config             Use this config file (if argument is used but value
+                           is unspecified, defaults to rollup.config.js)
 -i, --input              Input (alternative to <entry file>)
 -o, --output <output>    Output (if absent, prints to stdout)
 -f, --format [es6]       Type of output (amd, cjs, es6, iife, umd)
@@ -20,6 +22,8 @@ Basic options:
 --no-indent              Don't indent result
 
 Examples:
+
+rollup -c
 
 rollup --format=cjs --output=bundle.js -- src/main.js
 

--- a/bin/rollup
+++ b/bin/rollup
@@ -9,6 +9,7 @@ command = minimist( process.argv.slice( 2 ), {
 		strict: 'useStrict',
 
 		// Short options
+		c: 'config',
 		d: 'indent',
 		e: 'external',
 		f: 'format',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "magic-string": "^0.8.0",
     "mocha": "^2.3.3",
     "remap-istanbul": "^0.3.1",
+    "rollup-plugin-replace": "^1.0.1",
     "sander": "^0.4.0",
     "source-map": "^0.5.1"
   },

--- a/test/cli/config-es6/_config.js
+++ b/test/cli/config-es6/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'uses ES6 module config file',
+	command: 'rollup --config rollup.config.js',
+	execute: true
+};

--- a/test/cli/config-es6/main.js
+++ b/test/cli/config-es6/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/config-es6/rollup.config.js
+++ b/test/cli/config-es6/rollup.config.js
@@ -1,0 +1,9 @@
+import replace from 'rollup-plugin-replace';
+
+export default {
+	entry: 'main.js',
+	format: 'cjs',
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};

--- a/test/cli/config-override/_config.js
+++ b/test/cli/config-override/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'overrides config file with command line arguments',
+	command: 'rollup -c -i main.js -f cjs',
+	execute: true
+};

--- a/test/cli/config-override/main.js
+++ b/test/cli/config-override/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/config-override/rollup.config.js
+++ b/test/cli/config-override/rollup.config.js
@@ -1,0 +1,9 @@
+import replace from 'rollup-plugin-replace';
+
+export default {
+	entry: 'nope.js',
+	format: 'amd',
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};

--- a/test/cli/config-true/_config.js
+++ b/test/cli/config-true/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'defaults to rollup.config.js',
+	command: 'rollup -c',
+	execute: true
+};

--- a/test/cli/config-true/main.js
+++ b/test/cli/config-true/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/config-true/rollup.config.js
+++ b/test/cli/config-true/rollup.config.js
@@ -1,0 +1,9 @@
+import replace from 'rollup-plugin-replace';
+
+export default {
+	entry: 'main.js',
+	format: 'cjs',
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};

--- a/test/cli/config/_config.js
+++ b/test/cli/config/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'uses config file',
+	command: 'rollup --config rollup.config.js',
+	execute: true
+};

--- a/test/cli/config/_expected.js
+++ b/test/cli/config/_expected.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	global.myBundle = factory();
+}(this, function () { 'use strict';
+
+	var main = 42;
+
+	return main;
+
+}));

--- a/test/cli/config/main.js
+++ b/test/cli/config/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/config/rollup.config.js
+++ b/test/cli/config/rollup.config.js
@@ -1,0 +1,9 @@
+var replace = require( 'rollup-plugin-replace' );
+
+module.exports = {
+	entry: 'main.js',
+	format: 'cjs',
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};


### PR DESCRIPTION
This adds support for a `--config` option in the CLI, which, by extension, enables support for plugins (#226).

`rollup -c` or `rollup --config` will load options from a `rollup.config.js` config file in the current directory. You can override this file with `rollup -c some.other.file.js`.

Any additional arguments will override those specified in the config file (i.e. `rollup -c -f umd` will create a UMD build regardless of the config file.)

The config file is processed with Rollup before being required, so it can look like this...

```js
import babel from 'rollup-plugin-babel';

export default {
  entry: 'src/main.js',
  plugins: [ babel() ],
  format: 'umd'
};
```

...or this:

```js
var babel = require( 'rollup-plugin-babel' );

module.exports = {
  entry: 'src/main.js',
  plugins: [ babel() ],
  format: 'umd'
};
```

Thoughts welcome.