### PR TITLE
Export all bugs

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -690,17 +690,20 @@ export default class Module {
 				return otherModule.namespace();
 			}
 
-			return otherModule.traceExport( importDeclaration.name, this );
+			const declaration = otherModule.traceExport( importDeclaration.name );
+
+			if ( !declaration ) throw new Error( `Module ${otherModule.id} does not export ${importDeclaration.name} (imported by ${this.id})` );
+			return declaration;
 		}
 
 		return null;
 	}
 
-	traceExport ( name, importer ) {
+	traceExport ( name ) {
 		// export { foo } from './other'
 		const reexportDeclaration = this.reexports[ name ];
 		if ( reexportDeclaration ) {
-			return reexportDeclaration.module.traceExport( reexportDeclaration.localName, this );
+			return reexportDeclaration.module.traceExport( reexportDeclaration.localName );
 		}
 
 		const exportDeclaration = this.exports[ name ];
@@ -710,14 +713,9 @@ export default class Module {
 
 		for ( let i = 0; i < this.exportAllModules.length; i += 1 ) {
 			const module = this.exportAllModules[i];
-			const declaration = module.traceExport( name, this );
+			const declaration = module.traceExport( name );
 
 			if ( declaration ) return declaration;
 		}
-
-		let errorMessage = `Module ${this.id} does not export ${name}`;
-		if ( importer ) errorMessage += ` (imported by ${importer.id})`;
-
-		throw new Error( errorMessage );
 	}
 }

--- a/test/function/export-all-multiple/_config.js
+++ b/test/function/export-all-multiple/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'allows multiple export * statements'
+};

--- a/test/function/export-all-multiple/bar.js
+++ b/test/function/export-all-multiple/bar.js
@@ -1,0 +1,1 @@
+export const BAR = 2;

--- a/test/function/export-all-multiple/bar.js
+++ b/test/function/export-all-multiple/bar.js
@@ -1,1 +1,1 @@
-export const BAR = 2;
+export var BAR = 2;

--- a/test/function/export-all-multiple/foo.js
+++ b/test/function/export-all-multiple/foo.js
@@ -1,0 +1,1 @@
+export const FOO = 1;

--- a/test/function/export-all-multiple/foo.js
+++ b/test/function/export-all-multiple/foo.js
@@ -1,1 +1,1 @@
-export const FOO = 1;
+export var FOO = 1;

--- a/test/function/export-all-multiple/main.js
+++ b/test/function/export-all-multiple/main.js
@@ -1,0 +1,2 @@
+export * from './foo.js';
+export * from './bar.js';

--- a/test/function/namespace-missing-export/_config.js
+++ b/test/function/namespace-missing-export/_config.js
@@ -2,8 +2,9 @@ var assert = require( 'assert' );
 var path = require( 'path' );
 
 module.exports = {
-	error: function ( err ) {
-		assert.equal( path.normalize( err.file ), path.resolve( __dirname, 'empty.js' ) );
-		assert.ok( /Export 'foo' is not defined by/.test( err.message ) );
+	options: {
+		onwarn: function ( msg ) {
+			assert.ok( /Export 'foo' is not defined by/.test( msg ) );
+		}
 	}
 };

--- a/test/function/namespace-missing-export/empty.js
+++ b/test/function/namespace-missing-export/empty.js
@@ -1,0 +1,1 @@
+// this space left intentionally blank

--- a/test/function/namespace-missing-export/main.js
+++ b/test/function/namespace-missing-export/main.js
@@ -1,3 +1,3 @@
 import * as mod from './empty.js';
 
-mod.foo();
+assert.equal( typeof mod.foo, 'undefined' );


### PR DESCRIPTION
Found a couple of bugs while trying to use Rollup on Babel 6 (because I'm having some startup performance issues with it, which I'm fairly sure are related to the level of modularisation combined with the fact that [require is dog slow](https://kev.inburke.com/kevin/node-require-is-dog-slow/) – other people are [experiencing similar issues](https://news.ycombinator.com/item?id=10474175), though it looks as though npm 3 may help a lot).

1. you can't have multiple `export *` declarations in a module
2. missing namespace exports are treated as an error, when they should really be treated as a warning, I think