### PR TITLE
warn on eval

### DIFF
--- a/src/Statement.js
+++ b/src/Statement.js
@@ -95,6 +95,11 @@ export default class Statement {
 
 		walk( this.node, {
 			enter ( node, parent ) {
+				// warn about eval
+				if ( node.type === 'CallExpression' && node.callee.name === 'eval' && !scope.contains( 'eval' ) ) {
+					module.bundle.onwarn( `Use of \`eval\` (in ${module.id}) is discouraged, as it may cause issues with minification. See https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval for more details` );
+				}
+
 				if ( node.type === 'TemplateElement' ) stringLiteralRanges.push([ node.start, node.end ]);
 				if ( node.type === 'Literal' && typeof node.value === 'string' && /\n/.test( node.raw ) ) {
 					stringLiteralRanges.push([ node.start + 1, node.end - 1 ]);

--- a/test/function/warn-on-eval/_config.js
+++ b/test/function/warn-on-eval/_config.js
@@ -8,7 +8,7 @@ module.exports = {
 	options: {
 		onwarn: function ( message ) {
 			warned = true;
-			assert.equal( message, 'Use of `eval` (in ' + path.resolve( __dirname, 'main.js' ) + ') is discouraged, as it may cause issues with minification. See https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval for more details' );
+			assert.ok( /Use of `eval` \(in .+?main\.js\) is discouraged, as it may cause issues with minification\. See https:\/\/github.com\/rollup\/rollup\/wiki\/Troubleshooting#avoiding-eval for more details/.test( message ) );
 		}
 	},
 	exports: function () {

--- a/test/function/warn-on-eval/_config.js
+++ b/test/function/warn-on-eval/_config.js
@@ -1,0 +1,17 @@
+var path = require( 'path' );
+var assert = require( 'assert' );
+
+var warned = false;
+
+module.exports = {
+	description: 'warns about use of eval',
+	options: {
+		onwarn: function ( message ) {
+			warned = true;
+			assert.equal( message, 'Use of `eval` (in ' + path.resolve( __dirname, 'main.js' ) + ') is discouraged, as it may cause issues with minification. See https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval for more details' );
+		}
+	},
+	exports: function () {
+		assert.ok( warned, 'did not warn' );
+	}
+};

--- a/test/function/warn-on-eval/main.js
+++ b/test/function/warn-on-eval/main.js
@@ -1,0 +1,1 @@
+var result = eval( '1 + 1' );


### PR DESCRIPTION
If Rollup sees `eval`, it will warn the user about it and suggest some [alternatives](https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval) – fixes #186. It turns out we don't need to warn about `with`, even though it has the same result with UglifyJS, because ES6 modules are always strict, and `with` is banned in strict mode.