### PR TITLE
handle filenames with .foo, where foo is not an extension

### DIFF
--- a/browser/fs.js
+++ b/browser/fs.js
@@ -1,5 +1,6 @@
 const nope = method => `Cannot use fs.${method} inside browser`;
 
+export const isFile = () => false;
 export const readdirSync = nope( 'readdirSync' );
 export const readFileSync = nope( 'readFileSync' );
 export const writeFile = nope( 'writeFile' );

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -1,26 +1,30 @@
-import { readFileSync } from './fs.js';
+import { isFile, readFileSync } from './fs.js';
 import { dirname, extname, isAbsolute, resolve } from './path.js';
 
 export function load ( id ) {
 	return readFileSync( id, 'utf-8' );
 }
 
-function addExt ( id ) {
-	if ( !extname( id ) ) id += '.js';
-	return id;
+function addJsExtensionIfNecessary ( file ) {
+	if ( isFile( file ) ) return file;
+
+	file += '.js';
+	if ( isFile( file ) ) return file;
+
+	return null;
 }
 
 export function resolveId ( importee, importer ) {
 	// absolute paths are left untouched
-	if ( isAbsolute( importee ) ) return addExt( importee );
+	if ( isAbsolute( importee ) ) return addJsExtensionIfNecessary( importee );
 
 	// if this is the entry point, resolve against cwd
-	if ( importer === undefined ) return resolve( process.cwd(), addExt( importee ) );
+	if ( importer === undefined ) return addJsExtensionIfNecessary( resolve( process.cwd(), importee ) );
 
 	// external modules are skipped at this stage
 	if ( importee[0] !== '.' ) return null;
 
-	return resolve( dirname( importer ), addExt( importee ) );
+	return addJsExtensionIfNecessary( resolve( dirname( importer ), importee ) );
 }
 
 export function onwarn ( msg ) {

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -12,6 +12,15 @@ function mkdirpath ( path ) {
 	}
 }
 
+export function isFile ( file ) {
+	try {
+		const stats = fs.statSync( file );
+		return stats.isFile();
+	} catch ( err ) {
+		return false;
+	}
+}
+
 export function writeFile ( dest, data ) {
 	return new Promise( ( fulfil, reject ) => {
 		mkdirpath( dest );

--- a/test/function/non-extension-dot/_config.js
+++ b/test/function/non-extension-dot/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'adds .js to module paths with non-extension dots in them'
+};

--- a/test/function/non-extension-dot/foo.bar.js
+++ b/test/function/non-extension-dot/foo.bar.js
@@ -1,0 +1,1 @@
+export default 'fubar';

--- a/test/function/non-extension-dot/main.js
+++ b/test/function/non-extension-dot/main.js
@@ -1,0 +1,2 @@
+import status from './foo.bar';
+assert.equal( status, 'fubar' );


### PR DESCRIPTION
This PR changes the behaviour of the default resolver such that it checks whether a path exists at resolution time rather than waiting for failure at load time. This allows us to add `.js` to an import path like `./foo.bar` (where previously `.bar` was assumed to be the extension), thereby working around the ongoing consequences of Node's biggest design flaw (allowing extensions to be omitted).