### PR TITLE
Convert `get` and `set` shorthand to longhand when creating export default object

### DIFF
--- a/test/function/default-exports-get-set/_config.js
+++ b/test/function/default-exports-get-set/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	solo: true,
+	show: true,
+	description: 'handles get/set keywords when converting `export default` to object'
+};

--- a/test/function/default-exports-get-set/foo.js
+++ b/test/function/default-exports-get-set/foo.js
@@ -1,0 +1,15 @@
+let foo = 'FOO';
+
+function get () {
+	return foo;
+}
+
+function set ( x ) {
+	foo = x;
+}
+
+function jet () {}
+function net () {}
+function wet () {}
+
+export default { get, set, jet, net, wet };

--- a/test/function/default-exports-get-set/main.js
+++ b/test/function/default-exports-get-set/main.js
@@ -1,0 +1,3 @@
+import foo from './foo';
+
+assert.equal( foo.get(), 'FOO' );


### PR DESCRIPTION
**not ready for merge**, just a failing test for now