### PR TITLE
Disregard re-export statements

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -344,7 +344,7 @@ export default class Module {
 
 				if ( declaration ) {
 					declaration.addReference( reference );
-				} else if ( statement.node.type !== 'ExportNamedDeclaration' || !this.reexports[ reference.name ] ) {
+				} else {
 					// TODO handle globals
 					this.bundle.assumedGlobals[ reference.name ] = true;
 				}

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -100,6 +100,9 @@ export default class Statement {
 					module.bundle.onwarn( `Use of \`eval\` (in ${module.id}) is discouraged, as it may cause issues with minification. See https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval for more details` );
 				}
 
+				// skip re-export declarations
+				if ( node.type === 'ExportNamedDeclaration' && node.source ) return this.skip();
+
 				if ( node.type === 'TemplateElement' ) stringLiteralRanges.push([ node.start, node.end ]);
 				if ( node.type === 'Literal' && typeof node.value === 'string' && /\n/.test( node.raw ) ) {
 					stringLiteralRanges.push([ node.start + 1, node.end - 1 ]);

--- a/test/function/export-from-no-local-binding-var/_config.js
+++ b/test/function/export-from-no-local-binding-var/_config.js
@@ -1,5 +1,8 @@
 var assert = require( 'assert' );
 
 module.exports = {
-	description: 'export from does not create a local binding'
+	description: 'export from does not create a local binding',
+	runtimeError: function ( err ) {
+		assert.ok( /foo is not defined/.test( err.message ) );
+	}
 };

--- a/test/function/export-from-no-local-binding-var/_config.js
+++ b/test/function/export-from-no-local-binding-var/_config.js
@@ -1,0 +1,5 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'export from does not create a local binding'
+};

--- a/test/function/export-from-no-local-binding-var/foo.js
+++ b/test/function/export-from-no-local-binding-var/foo.js
@@ -1,0 +1,1 @@
+export default function() {}

--- a/test/function/export-from-no-local-binding-var/main.js
+++ b/test/function/export-from-no-local-binding-var/main.js
@@ -1,0 +1,3 @@
+export {default as foo} from './foo';
+
+export var foo1 = foo(); // This should fail as foo lacks a local binding.


### PR DESCRIPTION
Because `export { x as y } from './whatever.js'` doesn't create a local binding, we need to ignore it when analysing statements. This PR is based off #270