### PR TITLE
More eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,9 +16,6 @@
 		"mocha": true,
 		"node": true
 	},
-	"globals": {
-		"Promise": false
-	},
 	"extends": "eslint:recommended",
 	"ecmaFeatures": {
 		"modules": true

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,9 @@
 		"mocha": true,
 		"node": true
 	},
+	"globals": {
+		"Promise": false
+	},
 	"extends": "eslint:recommended",
 	"ecmaFeatures": {
 		"modules": true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "rollup": "./bin/rollup"
   },
   "scripts": {
-    "pretest": "eslint src/**/*.js && npm run build",
+    "pretest": "npm run lint && npm run build",
     "test": "mocha",
     "pretest-coverage": "npm run build",
     "test-coverage": "rm -rf coverage/* && istanbul cover --report json node_modules/.bin/_mocha -- -u exports -R spec test/test.js",
@@ -17,7 +17,7 @@
     "build": "git rev-parse HEAD > .commithash && rollup -c -o dist/rollup.js",
     "build:browser": "git rev-parse HEAD > .commithash && rollup -c rollup.config.browser.js -o dist/rollup.browser.js",
     "prepublish": "npm test && npm run build:browser",
-    "lint": "eslint src"
+    "lint": "eslint src browser"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "rollup": "./bin/rollup"
   },
   "scripts": {
-    "pretest": "npm run build",
+    "pretest": "eslint src/**/*.js && npm run build",
     "test": "mocha",
     "pretest-coverage": "npm run build",
     "test-coverage": "rm -rf coverage/* && istanbul cover --report json node_modules/.bin/_mocha -- -u exports -R spec test/test.js",

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -1,5 +1,5 @@
 import { isFile, readFileSync } from './fs.js';
-import { dirname, extname, isAbsolute, resolve } from './path.js';
+import { dirname, isAbsolute, resolve } from './path.js';
 
 export function load ( id ) {
 	return readFileSync( id, 'utf-8' );
@@ -28,5 +28,5 @@ export function resolveId ( importee, importer ) {
 }
 
 export function onwarn ( msg ) {
-	console.error( msg );
+	console.error( msg ); //eslint-disable-line no-console
 }

--- a/src/utils/first.js
+++ b/src/utils/first.js
@@ -9,5 +9,5 @@ export default function first ( candidates ) {
 				result :
 				Promise.resolve( candidate( ...args ) ) );
 		}, Promise.resolve() );
-	}
+	};
 }


### PR DESCRIPTION
* Lint before test
* Lint browser source files
* Fix lint errors

~~Setting the `Promise` global to `false` should prevent us from forgetting to import it again.~~

I misunderstood the .eslintrc setting.