### PR TITLE
Add Dockunit file since Travis doesn't test node 4.2.x

### DIFF
--- a/Dockunit.json
+++ b/Dockunit.json
@@ -3,7 +3,7 @@
     {
       "prettyName": "nodejs 4.2.1",
       "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-4.2.1",
-      "testCommand": "mocha",
+      "testCommand": "npm test",
       "beforeScripts": [
         "npm install",
         "npm run build"
@@ -12,7 +12,7 @@
     {
       "prettyName": "nodejs 0.12.7",
       "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.12.7",
-      "testCommand": "mocha",
+      "testCommand": "npm test",
       "beforeScripts": [
         "npm install",
         "npm run build"
@@ -21,7 +21,7 @@
     {
       "prettyName": "nodejs 0.10.40",
       "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.10.40",
-      "testCommand": "mocha",
+      "testCommand": "npm test",
       "beforeScripts": [
         "npm install",
         "npm run build"

--- a/Dockunit.json
+++ b/Dockunit.json
@@ -1,0 +1,31 @@
+{
+  "containers": [
+    {
+      "prettyName": "nodejs 4.2.1",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-4.2.1",
+      "testCommand": "mocha",
+      "beforeScripts": [
+        "npm install",
+        "npm run build"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.12.7",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.12.7",
+      "testCommand": "mocha",
+      "beforeScripts": [
+        "npm install",
+        "npm run build"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.10.40",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.10.40",
+      "testCommand": "mocha",
+      "beforeScripts": [
+        "npm install",
+        "npm run build"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[Dockunit](https://dockunit.io) is a continuous integration service built to be container based. It is super helpful because you can build and distribute your test environments from scratch and run tests locally with ease.

This PR tests Rollup in Node.js 4.2.1, 0.12.7, and 0.10.40. 4.2.x is not available yet on Travis CI. Assuming the PR is accepted, I'll send another with the Dockunit status badge for the README.md. You can see the [current Dockunit status of Rollup here](https://dockunit.io/projects/tlovett1/rollup). Right now, the module is failing in Node.js 0.10.40. If you don't want to support that version, I can remove it from the `Dockunit.json` file.