### PR TITLE
treat missing relative imports as error not warning - fixes #321

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -161,6 +161,7 @@ export default class Bundle {
 			return Promise.resolve( this.resolveId( source, module.id ) )
 				.then( resolvedId => {
 					if ( !resolvedId ) {
+						if ( source[0] === '.' ) throw new Error( `Could not resolve ${source} from ${module.id}` );
 						if ( !~this.external.indexOf( source ) ) this.onwarn( `Treating '${source}' as external dependency` );
 						module.resolvedIds[ source ] = source;
 

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -13,6 +13,7 @@ import { unixizePath } from './utils/normalizePlatform.js';
 import transform from './utils/transform.js';
 import collapseSourcemaps from './utils/collapseSourcemaps.js';
 import callIfFunction from './utils/callIfFunction.js';
+import { isRelative } from './utils/path.js';
 
 export default class Bundle {
 	constructor ( options ) {
@@ -161,7 +162,7 @@ export default class Bundle {
 			return Promise.resolve( this.resolveId( source, module.id ) )
 				.then( resolvedId => {
 					if ( !resolvedId ) {
-						if ( source[0] === '.' ) throw new Error( `Could not resolve ${source} from ${module.id}` );
+						if ( isRelative( source ) ) throw new Error( `Could not resolve ${source} from ${module.id}` );
 						if ( !~this.external.indexOf( source ) ) this.onwarn( `Treating '${source}' as external dependency` );
 						module.resolvedIds[ source ] = source;
 

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,9 +1,14 @@
 // TODO does this all work on windows?
 
 export const absolutePath = /^(?:\/|(?:[A-Za-z]:)?[\\|\/])/;
+export const relativePath = /^\.?\.\//;
 
 export function isAbsolute ( path ) {
 	return absolutePath.test( path );
+}
+
+export function isRelative ( path ) {
+	return relativePath.test( path );
 }
 
 export function basename ( path ) {

--- a/test/function/no-relative-external/_config.js
+++ b/test/function/no-relative-external/_config.js
@@ -1,0 +1,8 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'missing relative imports are an error, not a warning',
+	error: function ( err ) {
+		assert.ok( /Could not resolve \.\/missing\.js from/.test( err.message ) );
+	}
+};

--- a/test/function/no-relative-external/main.js
+++ b/test/function/no-relative-external/main.js
@@ -1,0 +1,1 @@
+import missing from './missing.js';


### PR DESCRIPTION
#321 