### PR TITLE
Fix default exports

### DIFF
--- a/src/finalisers/es6.js
+++ b/src/finalisers/es6.js
@@ -47,7 +47,7 @@ export default function es6 ( bundle, magicString ) {
 
 	const defaultExport = module.exports.default || module.reexports.default;
 	if ( defaultExport ) {
-		exportBlock += `export default ${module.traceExport( 'default' ).name};`;
+		exportBlock += `export default ${module.traceExport( 'default' ).render( true )};`;
 	}
 
 	if ( exportBlock ) {

--- a/src/finalisers/shared/getExportBlock.js
+++ b/src/finalisers/shared/getExportBlock.js
@@ -1,6 +1,6 @@
 export default function getExportBlock ( entryModule, exportMode, mechanism = 'return' ) {
 	if ( exportMode === 'default' ) {
-		return `${mechanism} ${entryModule.declarations.default.render( false )};`;
+		return `${mechanism} ${entryModule.traceExport( 'default' ).render( false )};`;
 	}
 
 	return entryModule.getExports()

--- a/test/form/export-default-2/_config.js
+++ b/test/form/export-default-2/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 're-exporting a default export',
+	options: {
+		moduleName: 'myBundle'
+	}
+};

--- a/test/form/export-default-2/_expected/amd.js
+++ b/test/form/export-default-2/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var bar = 1;
+
+	return bar;
+
+});

--- a/test/form/export-default-2/_expected/cjs.js
+++ b/test/form/export-default-2/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var bar = 1;
+
+module.exports = bar;

--- a/test/form/export-default-2/_expected/es6.js
+++ b/test/form/export-default-2/_expected/es6.js
@@ -1,0 +1,3 @@
+var bar = 1;
+
+export default bar;

--- a/test/form/export-default-2/_expected/iife.js
+++ b/test/form/export-default-2/_expected/iife.js
@@ -1,0 +1,7 @@
+var myBundle = (function () { 'use strict';
+
+	var bar = 1;
+
+	return bar;
+
+})();

--- a/test/form/export-default-2/_expected/umd.js
+++ b/test/form/export-default-2/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	global.myBundle = factory();
+}(this, function () { 'use strict';
+
+	var bar = 1;
+
+	return bar;
+
+}));

--- a/test/form/export-default-2/bar.js
+++ b/test/form/export-default-2/bar.js
@@ -1,0 +1,3 @@
+var bar = 1;
+
+export default bar;

--- a/test/form/export-default-2/main.js
+++ b/test/form/export-default-2/main.js
@@ -1,0 +1,1 @@
+export { default as default } from './bar.js';

--- a/test/form/export-default-3/_config.js
+++ b/test/form/export-default-3/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 're-exporting a default export',
+	options: {
+		moduleName: 'myBundle'
+	}
+};

--- a/test/form/export-default-3/_expected/amd.js
+++ b/test/form/export-default-3/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var bar = 1;
+
+	return bar;
+
+});

--- a/test/form/export-default-3/_expected/cjs.js
+++ b/test/form/export-default-3/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var bar = 1;
+
+module.exports = bar;

--- a/test/form/export-default-3/_expected/es6.js
+++ b/test/form/export-default-3/_expected/es6.js
@@ -1,0 +1,3 @@
+var bar = 1;
+
+export default bar;

--- a/test/form/export-default-3/_expected/iife.js
+++ b/test/form/export-default-3/_expected/iife.js
@@ -1,0 +1,7 @@
+var myBundle = (function () { 'use strict';
+
+	var bar = 1;
+
+	return bar;
+
+})();

--- a/test/form/export-default-3/_expected/umd.js
+++ b/test/form/export-default-3/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	global.myBundle = factory();
+}(this, function () { 'use strict';
+
+	var bar = 1;
+
+	return bar;
+
+}));

--- a/test/form/export-default-3/bar.js
+++ b/test/form/export-default-3/bar.js
@@ -1,0 +1,3 @@
+var bar = 1;
+
+export default bar;

--- a/test/form/export-default-3/main.js
+++ b/test/form/export-default-3/main.js
@@ -1,0 +1,3 @@
+import foo from './bar.js';
+
+export default foo;


### PR DESCRIPTION
We should have used the same methods in `es6.js` and `getExportBlock.js`; they made one mistake each.

What we want: `module.traceExport( 'default' ).render( direct )`

Mistakes:

1. `module.declarations.default` instead of `module.traceExport( 'default' )`
1. `declaration.name` instead of `declaration.render( direct )`

Fixes #339 