### PR TITLE
add write hook for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ node_modules
 dist
 _actual
 coverage
+test-out
 .commithash
 .idea

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "pretest": "npm run build",
-    "test": "mocha",
+    "test": "mocha && rm -rf test-out/",
     "pretest-coverage": "npm run build",
     "test-coverage": "rm -rf coverage/* && istanbul cover --report json node_modules/.bin/_mocha -- -u exports -R spec test/test.js",
     "posttest-coverage": "remap-istanbul -i coverage/coverage-final.json -o coverage/coverage-remapped.json -b dist && remap-istanbul -i coverage/coverage-final.json -o coverage/coverage-remapped.lcov -t lcovonly -b dist && remap-istanbul -i coverage/coverage-final.json -o coverage/coverage-remapped -t html -b dist",

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -16,6 +16,7 @@ import collapseSourcemaps from './utils/collapseSourcemaps.js';
 import SOURCEMAPPING_URL from './utils/sourceMappingURL.js';
 import callIfFunction from './utils/callIfFunction.js';
 import { isRelative, resolve } from './utils/path.js';
+import { getMethod } from './utils/plugin.js';
 
 export default class Bundle {
 	constructor ( options ) {
@@ -37,20 +38,12 @@ export default class Bundle {
 		);
 
 		this.load = first(
-			this.plugins
-				.map( plugin => plugin.load )
-				.filter( Boolean )
-				.concat( load )
+			getMethod( this.plugins, 'load' ).concat( load )
 		);
 
-		this.transformers = this.plugins
-			.map( plugin => plugin.transform )
-			.filter( Boolean );
+		this.transformers = getMethod( this.plugins, 'transform' );
 
-		this.bundleTransformers = this.plugins
-			.map( plugin => plugin.transformBundle )
-			.filter( Boolean );
-
+		this.bundleTransformers = getMethod( this.plugins, 'transformBundle' );
 		this.moduleById = blank();
 		this.modules = [];
 

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -53,12 +53,10 @@ export function rollup ( options ) {
 			}),
 
 			generate: options => {
-				let rendered = bundle.render( options );
-				let result = Promise.all(
+				let result = bundle.render( options );
+				result.ongenerate = Promise.all(
 					executeMethod( bundle.plugins, 'ongenerate', null, [options] )
 				);
-				result.code = rendered.code;
-				result.map = rendered.map;
 				return result;
 			},
 

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -84,7 +84,7 @@ export function rollup ( options ) {
 				}
 
 				promises.push( writeFile( dest, code ) );
-				promises.push( executeMethod( bundle.plugins, 'onwrite', null, [dest] ));
+				promises.push( executeMethod( bundle.plugins, 'onwrite', null, [options] ));
 				return Promise.all( promises );
 			}
 		};

--- a/src/utils/plugin.js
+++ b/src/utils/plugin.js
@@ -1,0 +1,7 @@
+export function getMethod ( plugins, name ) {
+	return plugins.map( plugin => plugin[ name ] ).filter( Boolean );
+}
+
+export function executeMethod ( plugins, name, scope, args ) {
+	return Promise.all( getMethod( plugins, name ).map( fn => fn.apply( scope, args || [] )));
+}

--- a/test/fixtures/main.js
+++ b/test/fixtures/main.js
@@ -1,0 +1,1 @@
+export default true;

--- a/test/function/plugin-event-hooks/_config.js
+++ b/test/function/plugin-event-hooks/_config.js
@@ -1,0 +1,21 @@
+var assert = require( 'assert' );
+var generateTestVal = false;
+
+var ongenerateValue = 'b';
+
+
+module.exports = {
+	description: 'plugins can hook ongenerate',
+	options: {
+		plugins: [
+			{
+				ongenerate: function () {
+					generateTestVal = ongenerateValue;
+				}
+			}
+		]
+	},
+	exports: function () {
+		assert.equal( generateTestVal, ongenerateValue );
+	}
+};

--- a/test/function/plugin-event-hooks/main.js
+++ b/test/function/plugin-event-hooks/main.js
@@ -1,0 +1,1 @@
+export default true;

--- a/test/function/plugins-can-manipulate-options/_config.js
+++ b/test/function/plugins-can-manipulate-options/_config.js
@@ -15,4 +15,4 @@ module.exports = {
 	exports: function ( answer ) {
 		assert.equal( answer, 42 );
 	}
-}
+};

--- a/test/test.js
+++ b/test/test.js
@@ -125,6 +125,22 @@ describe( 'rollup', function () {
 				}, /You must supply options\.moduleName for IIFE bundles/ );
 			});
 		});
+
+		it( 'triggers onwrite plugin hooks', function () {
+			var testValue = false;
+			return rollup.rollup({
+				entry: 'test/fixtures/main.js',
+				plugins: [{
+					onwrite: function () { testValue = true; }
+				}]
+			}).then( function ( bundle ) {
+				return bundle.write({
+					dest: 'test-out/bundle.js'
+				}).then( function () {
+					assert.equal( testValue, true);
+				});
+			});
+		});
 	});
 
 	describe( 'function', function () {


### PR DESCRIPTION
I would like to be able to create an import plugin that returns information about an object during the generate process and then outputs data accumulated through the generate process to a file outside of the destination JS file. Concatenated CSS is one example;  I would like use imports to keep componentized css, but then output a single CSS file as part of the build.  

The following pull request adds the ability for a plugin to expose a 'write' method that is called in the bundle.write method.