### PR TITLE
Ensure namespace imports are not combined with other import types.

### DIFF
--- a/test/form/external-imports/_expected/amd.js
+++ b/test/form/external-imports/_expected/amd.js
@@ -4,7 +4,7 @@ define(['factory', 'baz', 'shipping-port', 'alphabet'], function (factory, baz, 
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );
-	baz.foo( baz.bar );
+	baz.foo( baz.bar, containers.port );
 	containers.forEach( console.log, console );
 	console.log( alphabet.a );
 	console.log( alphabet__default.length );

--- a/test/form/external-imports/_expected/cjs.js
+++ b/test/form/external-imports/_expected/cjs.js
@@ -8,7 +8,7 @@ var alphabet = require('alphabet');
 var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 factory( null );
-baz.foo( baz.bar );
+baz.foo( baz.bar, containers.port );
 containers.forEach( console.log, console );
 console.log( alphabet.a );
 console.log( alphabet__default.length );

--- a/test/form/external-imports/_expected/es6.js
+++ b/test/form/external-imports/_expected/es6.js
@@ -1,10 +1,11 @@
 import factory from 'factory';
 import { bar, foo } from 'baz';
+import { port } from 'shipping-port';
 import * as containers from 'shipping-port';
 import alphabet, { a } from 'alphabet';
 
 factory( null );
-foo( bar );
+foo( bar, port );
 containers.forEach( console.log, console );
 console.log( a );
 console.log( alphabet.length );

--- a/test/form/external-imports/_expected/iife.js
+++ b/test/form/external-imports/_expected/iife.js
@@ -4,7 +4,7 @@
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );
-	baz.foo( baz.bar );
+	baz.foo( baz.bar, containers.port );
 	containers.forEach( console.log, console );
 	console.log( alphabet.a );
 	console.log( alphabet__default.length );

--- a/test/form/external-imports/_expected/umd.js
+++ b/test/form/external-imports/_expected/umd.js
@@ -8,7 +8,7 @@
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );
-	baz.foo( baz.bar );
+	baz.foo( baz.bar, containers.port );
 	containers.forEach( console.log, console );
 	console.log( alphabet.a );
 	console.log( alphabet__default.length );

--- a/test/form/external-imports/main.js
+++ b/test/form/external-imports/main.js
@@ -1,10 +1,11 @@
 import factory from 'factory';
 import { foo, bar } from 'baz';
 import * as containers from 'shipping-port';
+import { port } from 'shipping-port';
 import alphabet, { a, b } from 'alphabet';
 
 factory( null );
-foo( bar );
+foo( bar, port );
 containers.forEach( console.log, console );
 console.log( a );
 console.log( alphabet.length );


### PR DESCRIPTION
It is a syntax error to combine namespace import specifiers with named or default specifiers.

Fixes #355.