### PR TITLE
squelch duplicate warnings per-bundle (#362)

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -6,7 +6,7 @@ import Module from './Module.js';
 import ExternalModule from './ExternalModule.js';
 import finalisers from './finalisers/index.js';
 import ensureArray from './utils/ensureArray.js';
-import { load, onwarn, resolveId } from './utils/defaults.js';
+import { load, makeOnwarn, resolveId } from './utils/defaults.js';
 import getExportMode from './utils/getExportMode.js';
 import getIndentString from './utils/getIndentString.js';
 import { unixizePath } from './utils/normalizePlatform.js';
@@ -49,7 +49,7 @@ export default class Bundle {
 		this.assumedGlobals = blank();
 
 		this.external = options.external || [];
-		this.onwarn = options.onwarn || onwarn;
+		this.onwarn = options.onwarn || makeOnwarn();
 
 		// TODO strictly speaking, this only applies with non-ES6, non-default-only bundles
 		[ 'module', 'exports' ].forEach( global => this.assumedGlobals[ global ] = true );

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -1,5 +1,6 @@
 import { isFile, readFileSync } from './fs.js';
 import { dirname, isAbsolute, resolve } from './path.js';
+import { blank } from './object.js';
 
 export function load ( id ) {
 	return readFileSync( id, 'utf-8' );
@@ -27,6 +28,13 @@ export function resolveId ( importee, importer ) {
 	return addJsExtensionIfNecessary( resolve( dirname( importer ), importee ) );
 }
 
-export function onwarn ( msg ) {
-	console.error( msg ); //eslint-disable-line no-console
+
+export function makeOnwarn ( msg ) {
+	let warned = blank();
+
+	return msg => {
+		if ( msg in warned ) return;
+		console.error( msg ); //eslint-disable-line no-console
+		warned[ msg ] = true;
+	};
 }

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -29,7 +29,7 @@ export function resolveId ( importee, importer ) {
 }
 
 
-export function makeOnwarn ( msg ) {
+export function makeOnwarn () {
 	let warned = blank();
 
 	return msg => {


### PR DESCRIPTION
This fixes #362 by keeping track of what warnings a bundle emits