### PR TITLE
allow plugins to manipulate options

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -17,10 +17,16 @@ import { isRelative } from './utils/path.js';
 
 export default class Bundle {
 	constructor ( options ) {
+		this.plugins = ensureArray( options.plugins );
+
+		this.plugins.forEach( plugin => {
+			if ( plugin.options ) {
+				options = plugin.options( options ) || options;
+			}
+		});
+
 		this.entry = options.entry;
 		this.entryModule = null;
-
-		this.plugins = ensureArray( options.plugins );
 
 		this.resolveId = first(
 			this.plugins

--- a/test/function/plugins-can-manipulate-options/_config.js
+++ b/test/function/plugins-can-manipulate-options/_config.js
@@ -1,0 +1,18 @@
+var path = require( 'path' );
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'plugins can manipulate the options object',
+	options: {
+		plugins: [
+			{
+				options: function ( options ) {
+					options.entry = path.resolve( __dirname, 'answer.js' );
+				}
+			}
+		]
+	},
+	exports: function ( answer ) {
+		assert.equal( answer, 42 );
+	}
+}

--- a/test/function/plugins-can-manipulate-options/answer.js
+++ b/test/function/plugins-can-manipulate-options/answer.js
@@ -1,0 +1,1 @@
+export default 42;


### PR DESCRIPTION
Follow-up to @eventualbuddha's idea on #345 – allows plugins to register an `options` hook that either manipulates the `options` object, or return a replacement one.