### PR TITLE
Fixes #379

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -9,24 +9,21 @@ import Bundle from './Bundle.js';
 export const VERSION = '<@VERSION@>';
 
 const ALLOWED_KEYS = [
-	'entry',
-	'dest',
-	'plugins',
-	'external',
-	'onwarn',
-	'indent',
-	'format',
-	'moduleName',
-	'sourceMap',
-	'intro',
-	'outro',
 	'banner',
+	'dest',
+	'entry',
+	'external',
 	'footer',
+	'format',
 	'globals',
-	'transform',
-	'load',
-	'resolveId',
-	'resolveExternal'
+	'indent',
+	'intro',
+	'moduleId',
+	'moduleName',
+	'onwarn',
+	'outro',
+	'plugins',
+	'sourceMap'
 ];
 
 export function rollup ( options ) {

--- a/test/test.js
+++ b/test/test.js
@@ -74,7 +74,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( function () {
 				throw new Error( 'Missing expected error' );
 			}, function ( err ) {
-				assert.equal( 'Unexpected key \'plUgins\' found, expected one of: entry, dest, plugins, external, onwarn, indent, format, moduleName, sourceMap, intro, outro, banner, footer, globals, transform, load, resolveId, resolveExternal', err.message );
+				assert.equal( 'Unexpected key \'plUgins\' found, expected one of: banner, dest, entry, external, footer, format, globals, indent, intro, moduleId, moduleName, onwarn, outro, plugins, sourceMap', err.message );
 			});
 		});
 	});


### PR DESCRIPTION
* Add missing `moduleId` key.
* Remove deprecated `transform`, `load`, `resolveId` and `resolveExternal`