### PR TITLE
Babel 6-ify

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,20 +1,3 @@
 {
-	"whitelist": [
-		"es6.arrowFunctions",
-		"es6.blockScoping",
-		"es6.classes",
-		"es6.constants",
-		"es6.destructuring",
-		"es6.modules",
-		"es6.parameters",
-		"es6.properties.shorthand",
-		"es6.spread",
-		"es6.templateLiterals"
-	],
-	"loose": [
-		"es6.classes",
-		"es6.destructuring"
-	],
-	"compact": false,
-	"sourceMap": true
+	"presets": [ "es2015-rollup" ]
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
   "homepage": "https://github.com/rollup/rollup",
   "devDependencies": {
     "acorn": "^2.6.4",
-    "babel-core": "^5.8.32",
+    "babel-core": "^6.3.26",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-es2015-rollup": "^1.0.0",
+    "babel-runtime": "^6.3.19",
     "codecov.io": "^0.1.6",
     "console-group": "^0.1.2",
     "es6-promise": "^3.0.2",
@@ -50,9 +53,9 @@
     "istanbul": "^0.4.0",
     "magic-string": "^0.10.0",
     "mocha": "^2.3.3",
-    "remap-istanbul": "^0.4.0",
-    "rollup": "^0.20.2",
-    "rollup-plugin-babel": "^1.0.0",
+    "remap-istanbul": "^0.5.1",
+    "rollup": "^0.22.0",
+    "rollup-plugin-babel": "^2.2.0",
     "rollup-plugin-npm": "^1.0.0",
     "rollup-plugin-replace": "^1.0.1",
     "sander": "^0.4.0",
@@ -62,7 +65,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "minimist": "^1.2.0",
-    "source-map-support": "^0.3.2"
+    "source-map-support": "^0.4.0"
   },
   "files": [
     "src",

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -1,7 +1,7 @@
 import Promise from 'es6-promise/lib/es6-promise/promise.js';
 import MagicString from 'magic-string';
 import first from './utils/first.js';
-import { blank, keys } from './utils/object.js';
+import { assign, blank, keys } from './utils/object.js';
 import Module from './Module.js';
 import ExternalModule from './ExternalModule.js';
 import finalisers from './finalisers/index.js';
@@ -15,52 +15,52 @@ import collapseSourcemaps from './utils/collapseSourcemaps.js';
 import callIfFunction from './utils/callIfFunction.js';
 import { isRelative } from './utils/path.js';
 
-export default class Bundle {
-	constructor ( options ) {
-		this.plugins = ensureArray( options.plugins );
+export default function Bundle ( options ) {
+	this.plugins = ensureArray( options.plugins );
 
-		this.plugins.forEach( plugin => {
-			if ( plugin.options ) {
-				options = plugin.options( options ) || options;
-			}
-		});
+	this.plugins.forEach( plugin => {
+		if ( plugin.options ) {
+			options = plugin.options( options ) || options;
+		}
+	});
 
-		this.entry = options.entry;
-		this.entryModule = null;
+	this.entry = options.entry;
+	this.entryModule = null;
 
-		this.resolveId = first(
-			this.plugins
-				.map( plugin => plugin.resolveId )
-				.filter( Boolean )
-				.concat( resolveId )
-		);
+	this.resolveId = first(
+		this.plugins
+			.map( plugin => plugin.resolveId )
+			.filter( Boolean )
+			.concat( resolveId )
+	);
 
-		this.load = first(
-			this.plugins
-				.map( plugin => plugin.load )
-				.filter( Boolean )
-				.concat( load )
-		);
+	this.load = first(
+		this.plugins
+			.map( plugin => plugin.load )
+			.filter( Boolean )
+			.concat( load )
+	);
 
-		this.transformers = this.plugins
-			.map( plugin => plugin.transform )
-			.filter( Boolean );
+	this.transformers = this.plugins
+		.map( plugin => plugin.transform )
+		.filter( Boolean );
 
-		this.moduleById = blank();
-		this.modules = [];
+	this.moduleById = blank();
+	this.modules = [];
 
-		this.externalModules = [];
-		this.internalNamespaces = [];
+	this.externalModules = [];
+	this.internalNamespaces = [];
 
-		this.assumedGlobals = blank();
+	this.assumedGlobals = blank();
 
-		this.external = options.external || [];
-		this.onwarn = options.onwarn || makeOnwarn();
+	this.external = options.external || [];
+	this.onwarn = options.onwarn || makeOnwarn();
 
-		// TODO strictly speaking, this only applies with non-ES6, non-default-only bundles
-		[ 'module', 'exports' ].forEach( global => this.assumedGlobals[ global ] = true );
-	}
+	// TODO strictly speaking, this only applies with non-ES6, non-default-only bundles
+	[ 'module', 'exports' ].forEach( global => this.assumedGlobals[ global ] = true );
+}
 
+assign( Bundle.prototype, {
 	build () {
 		// Phase 1 – discovery. We load the entry module and find which
 		// modules it imports, and import those, until we have all
@@ -103,7 +103,7 @@ export default class Bundle {
 				this.orderedModules = this.sort();
 				this.deconflict();
 			});
-	}
+	},
 
 	deconflict () {
 		let used = blank();
@@ -135,7 +135,7 @@ export default class Bundle {
 				declaration.name = getSafeName( declaration.name );
 			});
 		});
-	}
+	},
 
 	fetchModule ( id, importer ) {
 		// short-circuit cycles
@@ -161,7 +161,7 @@ export default class Bundle {
 
 				return this.fetchAllDependencies( module ).then( () => module );
 			});
-	}
+	},
 
 	fetchAllDependencies ( module ) {
 		const promises = module.dependencies.map( source => {
@@ -191,7 +191,7 @@ export default class Bundle {
 		});
 
 		return Promise.all( promises );
-	}
+	},
 
 	render ( options = {} ) {
 		const format = options.format || 'es6';
@@ -258,7 +258,7 @@ export default class Bundle {
 		}
 
 		return { code, map };
-	}
+	},
 
 	sort () {
 		let seen = {};
@@ -340,4 +340,4 @@ export default class Bundle {
 
 		return ordered;
 	}
-}
+});

--- a/src/ExternalModule.js
+++ b/src/ExternalModule.js
@@ -1,21 +1,21 @@
-import { blank } from './utils/object.js';
+import { assign, blank } from './utils/object.js';
 import makeLegalIdentifier from './utils/makeLegalIdentifier.js';
 import { ExternalDeclaration } from './Declaration.js';
 
-export default class ExternalModule {
-	constructor ( id ) {
-		this.id = id;
-		this.name = makeLegalIdentifier( id );
+export default function ExternalModule ( id ) {
+	this.id = id;
+	this.name = makeLegalIdentifier( id );
 
-		this.nameSuggestions = blank();
-		this.mostCommonSuggestion = 0;
+	this.nameSuggestions = blank();
+	this.mostCommonSuggestion = 0;
 
-		this.isExternal = true;
-		this.declarations = blank();
+	this.isExternal = true;
+	this.declarations = blank();
 
-		this.exportsNames = false;
-	}
+	this.exportsNames = false;
+}
 
+assign( ExternalModule.prototype, {
 	suggestName ( name ) {
 		if ( !this.nameSuggestions[ name ] ) this.nameSuggestions[ name ] = 0;
 		this.nameSuggestions[ name ] += 1;
@@ -24,7 +24,7 @@ export default class ExternalModule {
 			this.mostCommonSuggestion = this.nameSuggestions[ name ];
 			this.name = name;
 		}
-	}
+	},
 
 	traceExport ( name ) {
 		if ( name !== 'default' && name !== '*' ) {
@@ -35,4 +35,4 @@ export default class ExternalModule {
 			this.declarations[ name ] = new ExternalDeclaration( this, name )
 		);
 	}
-}
+});

--- a/src/ast/Scope.js
+++ b/src/ast/Scope.js
@@ -1,4 +1,4 @@
-import { blank, keys } from '../utils/object.js';
+import { assign, blank, keys } from '../utils/object.js';
 import Declaration from '../Declaration.js';
 
 const extractors = {
@@ -34,26 +34,26 @@ function extractNames ( param ) {
 	return names;
 }
 
-export default class Scope {
-	constructor ( options ) {
-		options = options || {};
+export default function Scope ( options ) {
+	options = options || {};
 
-		this.parent = options.parent;
-		this.statement = options.statement || this.parent.statement;
-		this.isBlockScope = !!options.block;
-		this.isTopLevel = !this.parent || ( this.parent.isTopLevel && this.isBlockScope );
+	this.parent = options.parent;
+	this.statement = options.statement || this.parent.statement;
+	this.isBlockScope = !!options.block;
+	this.isTopLevel = !this.parent || ( this.parent.isTopLevel && this.isBlockScope );
 
-		this.declarations = blank();
+	this.declarations = blank();
 
-		if ( options.params ) {
-			options.params.forEach( param => {
-				extractNames( param ).forEach( name => {
-					this.declarations[ name ] = new Declaration( param, true, this.statement );
-				});
+	if ( options.params ) {
+		options.params.forEach( param => {
+			extractNames( param ).forEach( name => {
+				this.declarations[ name ] = new Declaration( param, true, this.statement );
 			});
-		}
+		});
 	}
+}
 
+assign( Scope.prototype, {
 	addDeclaration ( node, isBlockDeclaration, isVar ) {
 		if ( !isBlockDeclaration && this.isBlockScope ) {
 			// it's a `var` or function node, and this
@@ -64,21 +64,21 @@ export default class Scope {
 				this.declarations[ name ] = new Declaration( node, false, this.statement );
 			});
 		}
-	}
+	},
 
 	contains ( name ) {
 		return this.declarations[ name ] ||
 		       ( this.parent ? this.parent.contains( name ) : false );
-	}
+	},
 
 	eachDeclaration ( fn ) {
 		keys( this.declarations ).forEach( key => {
 			fn( key, this.declarations[ key ] );
 		});
-	}
+	},
 
 	findDeclaration ( name ) {
 		return this.declarations[ name ] ||
 		       ( this.parent && this.parent.findDeclaration( name ) );
 	}
-}
+});

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,5 +1,13 @@
 export const keys = Object.keys;
 
+export function assign ( source, target ) {
+	keys( target ).forEach( key => {
+		source[ key ] = target[ key ];
+	});
+
+	return target;
+}
+
 export function blank () {
 	return Object.create( null );
 }

--- a/test/sourcemaps/transforms/_config.js
+++ b/test/sourcemaps/transforms/_config.js
@@ -11,7 +11,7 @@ module.exports = {
 			{
 				transform: function ( source, id ) {
 					return babel.transform( source, {
-						blacklist: [ 'es6.modules' ],
+						presets: [ 'es2015-rollup' ],
 						sourceMap: true
 					});
 				}

--- a/test/test.js
+++ b/test/test.js
@@ -169,8 +169,7 @@ describe( 'rollup', function () {
 
 						if ( config.babel ) {
 							code = babel.transform( result.code, {
-								blacklist: [ 'es6.modules' ],
-								loose: [ 'es6.classes' ]
+								presets: [ 'es2015' ]
 							}).code;
 						} else {
 							code = result.code;
@@ -350,8 +349,7 @@ describe( 'rollup', function () {
 							try {
 								if ( config.babel ) {
 									code = babel.transform( code, {
-										blacklist: [ 'es6.modules' ],
-										loose: [ 'es6.classes' ]
+										presets: [ 'es2015' ]
 									}).code;
 								}
 


### PR DESCRIPTION
Replaces classes with functions, as per #384. Results in a bit of a slimming down, though we're still including `babelHelpers.createClass` because Acorn uses classes and we're bundling it.

**Not ready for merge**, until [this Babel issue](https://phabricator.babeljs.io/T6891) is resolved.