### PR TITLE
support --environment in CLI

### DIFF
--- a/bin/help.md
+++ b/bin/help.md
@@ -20,14 +20,23 @@ Basic options:
 -m, --sourcemap          Generate sourcemap (`-m inline` for inline map)
 --no-strict              Don't emit a `"use strict";` in the generated modules.
 --no-indent              Don't indent result
+--environment <values>   Settings passed to config file (see example)
 
 Examples:
 
+# use settings in config file
 rollup -c
 
+# in config file, process.env.INCLUDE_DEPS === 'true'
+# and process.env.BUILD === 'production'
+rollup -c --environment INCLUDE_DEPS,BUILD:production
+
+# create CommonJS bundle.js from src/main.js
 rollup --format=cjs --output=bundle.js -- src/main.js
 
-rollup -f iife --globals jquery:jQuery,angular:ng \
+# create self-executing IIFE using `window.jQuery`
+# and `window._` as external globals
+rollup -f iife --globals jquery:jQuery,lodash:_ \
   -i src/app.js -o build/app.js -m build/app.js.map
 
 Notes:

--- a/bin/runRollup.js
+++ b/bin/runRollup.js
@@ -20,6 +20,17 @@ module.exports = function ( command ) {
 		command.input = command._[0];
 	}
 
+	if ( command.environment ) {
+		command.environment.split( ',' ).forEach( function ( pair ) {
+			var index = pair.indexOf( ':' );
+			if ( ~index ) {
+				process.env[ pair.slice( 0, index ) ] = pair.slice( index + 1 );
+			} else {
+				process.env[ pair ] = true;
+			}
+		});
+	}
+
 	var config = command.config === true ? 'rollup.config.js' : command.config;
 
 	if ( config ) {

--- a/test/cli/config-env/_config.js
+++ b/test/cli/config-env/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'passes environment variables to config file',
+	command: 'rollup --config --environment PRODUCTION,FOO:bar',
+	execute: true
+};

--- a/test/cli/config-env/main.js
+++ b/test/cli/config-env/main.js
@@ -1,0 +1,2 @@
+assert.equal( '__ENVIRONMENT__', 'production' );
+assert.equal( '__FOO__', 'bar' );

--- a/test/cli/config-env/rollup.config.js
+++ b/test/cli/config-env/rollup.config.js
@@ -1,0 +1,12 @@
+var replace = require( 'rollup-plugin-replace' );
+
+module.exports = {
+	entry: 'main.js',
+	format: 'cjs',
+	plugins: [
+		replace({
+			__ENVIRONMENT__: process.env.PRODUCTION ? 'production' : 'development',
+			__FOO__: process.env.FOO
+		})
+	]
+};


### PR DESCRIPTION
Closes #376. Adds an `--environment` option to the CLI with the following syntax, modelled after the syntax for `-g`:

```bash
rollup -c --environment PRODUCTION,FOO:bar,BAZ:qux
```

This results in the following conditions inside the `rollup.config.js` file:

```js
process.env.PRODUCTION === 'true'; // all process.env properties must be strings
process.env.FOO === 'bar';
process.env.BAZ === 'qux';
```