### PR TITLE
Fix UMD global export

### DIFF
--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -50,7 +50,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 		`(function (global, factory) {
 			typeof exports === 'object' && typeof module !== 'undefined' ? ${cjsExport}factory(${cjsDeps.join( ', ' )}) :
 			typeof define === 'function' && define.amd ? define(${amdParams}factory) :
-			${defaultExport}factory(${globalDeps});
+			(${defaultExport}factory(${globalDeps}));
 		}(this, function (${args}) {${useStrict}
 
 		`.replace( /^\t\t/gm, '' ).replace( /^\t/gm, magicString.getIndentString() );

--- a/test/cli/config/_expected.js
+++ b/test/cli/config/_expected.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/cli/indent-none/_expected.js
+++ b/test/cli/indent-none/_expected.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 assert.equal( 1 + 1, 2 );

--- a/test/cli/module-name/_expected.js
+++ b/test/cli/module-name/_expected.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/banner-and-footer-plugin/_expected/umd.js
+++ b/test/form/banner-and-footer-plugin/_expected/umd.js
@@ -3,7 +3,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	console.log( 1 + 1 );

--- a/test/form/banner-and-footer/_expected/umd.js
+++ b/test/form/banner-and-footer/_expected/umd.js
@@ -2,7 +2,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	console.log( 'hello world' );

--- a/test/form/block-comments/_expected/umd.js
+++ b/test/form/block-comments/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/dedupes-external-imports/_expected/umd.js
+++ b/test/form/dedupes-external-imports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('external')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'external'], factory) :
-	factory((global.myBundle = {}),global.external);
+	(factory((global.myBundle = {}),global.external));
 }(this, function (exports,external) { 'use strict';
 
 	class Foo extends external.Component {

--- a/test/form/exclude-unnecessary-modifications/_expected/umd.js
+++ b/test/form/exclude-unnecessary-modifications/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var foo = {};

--- a/test/form/export-all-from-internal/_expected/umd.js
+++ b/test/form/export-all-from-internal/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.exposedInternals = {}));
+	(factory((global.exposedInternals = {})));
 }(this, function (exports) { 'use strict';
 
 	const a = 1;

--- a/test/form/export-default-2/_expected/umd.js
+++ b/test/form/export-default-2/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var bar = 1;

--- a/test/form/export-default-3/_expected/umd.js
+++ b/test/form/export-default-3/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var bar = 1;

--- a/test/form/export-default/_expected/umd.js
+++ b/test/form/export-default/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/export-multiple-vars/_expected/umd.js
+++ b/test/form/export-multiple-vars/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var a = 1;

--- a/test/form/exports-at-end-if-possible/_expected/umd.js
+++ b/test/form/exports-at-end-if-possible/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myBundle = {}));
+	(factory((global.myBundle = {})));
 }(this, function (exports) { 'use strict';
 
 	var FOO = 'foo';

--- a/test/form/external-imports-custom-names/_expected/umd.js
+++ b/test/form/external-imports-custom-names/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery')) :
 	typeof define === 'function' && define.amd ? define(['jquery'], factory) :
-	factory(global.jQuery);
+	(factory(global.jQuery));
 }(this, function ($) { 'use strict';
 
 	$ = 'default' in $ ? $['default'] : $;

--- a/test/form/external-imports/_expected/umd.js
+++ b/test/form/external-imports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('factory'), require('baz'), require('shipping-port'), require('alphabet')) :
 	typeof define === 'function' && define.amd ? define(['factory', 'baz', 'shipping-port', 'alphabet'], factory) :
-	factory(global.factory,global.baz,global.containers,global.alphabet);
+	(factory(global.factory,global.baz,global.containers,global.alphabet));
 }(this, function (factory,baz,containers,alphabet) { 'use strict';
 
 	factory = 'default' in factory ? factory['default'] : factory;

--- a/test/form/indent-false/_expected/umd.js
+++ b/test/form/indent-false/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.foo = factory();
+	(global.foo = factory());
 }(this, function () { 'use strict';
 
 function foo () {

--- a/test/form/indent-true-spaces/_expected/umd.js
+++ b/test/form/indent-true-spaces/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
   typeof define === 'function' && define.amd ? define(factory) :
-  global.foo = factory();
+  (global.foo = factory());
 }(this, function () { 'use strict';
 
   function foo () {

--- a/test/form/indent-true/_expected/umd.js
+++ b/test/form/indent-true/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.foo = factory();
+	(global.foo = factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/internal-conflict-resolution/_expected/umd.js
+++ b/test/form/internal-conflict-resolution/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var bar$1 = 42;

--- a/test/form/intro-and-outro/_expected/umd.js
+++ b/test/form/intro-and-outro/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	/* this is an intro */

--- a/test/form/multiple-exports/_expected/umd.js
+++ b/test/form/multiple-exports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myBundle = {}));
+	(factory((global.myBundle = {})));
 }(this, function (exports) { 'use strict';
 
 	var foo = 1;

--- a/test/form/namespace-optimization-b/_expected/umd.js
+++ b/test/form/namespace-optimization-b/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/namespace-optimization/_expected/umd.js
+++ b/test/form/namespace-optimization/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function a () {}

--- a/test/form/namespaced-default-exports/_expected/umd.js
+++ b/test/form/namespaced-default-exports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.foo = global.foo || {}, global.foo.bar = global.foo.bar || {}, global.foo.bar.baz = factory();
+	(global.foo = global.foo || {}, global.foo.bar = global.foo.bar || {}, global.foo.bar.baz = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/namespaced-named-exports/_expected/umd.js
+++ b/test/form/namespaced-named-exports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.foo = global.foo || {}, global.foo.bar = global.foo.bar || {}, global.foo.bar.baz = {}));
+	(factory((global.foo = global.foo || {}, global.foo.bar = global.foo.bar || {}, global.foo.bar.baz = {})));
 }(this, function (exports) { 'use strict';
 
 	var answer = 42;

--- a/test/form/no-imports-or-exports/_expected/umd.js
+++ b/test/form/no-imports-or-exports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	console.log( 'this is it' );

--- a/test/form/object-destructuring-default-values/_expected/umd.js
+++ b/test/form/object-destructuring-default-values/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	const a = 1;

--- a/test/form/preserves-comments-after-imports/_expected/umd.js
+++ b/test/form/preserves-comments-after-imports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myBundle = {}));
+	(factory((global.myBundle = {})));
 }(this, function (exports) { 'use strict';
 
 	/** A comment for a number */

--- a/test/form/removes-existing-sourcemap-comments/_expected/umd.js
+++ b/test/form/removes-existing-sourcemap-comments/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/self-contained-bundle/_expected/umd.js
+++ b/test/form/self-contained-bundle/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/shorthand-properties/_expected/umd.js
+++ b/test/form/shorthand-properties/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function x () {

--- a/test/form/side-effect-b/_expected/umd.js
+++ b/test/form/side-effect-b/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/side-effect-c/_expected/umd.js
+++ b/test/form/side-effect-c/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/side-effect-d/_expected/umd.js
+++ b/test/form/side-effect-d/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/side-effect-e/_expected/umd.js
+++ b/test/form/side-effect-e/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/side-effect-f/_expected/umd.js
+++ b/test/form/side-effect-f/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/side-effect-g/_expected/umd.js
+++ b/test/form/side-effect-g/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/side-effect-h/_expected/umd.js
+++ b/test/form/side-effect-h/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var main = 42;

--- a/test/form/side-effect-i/_expected/umd.js
+++ b/test/form/side-effect-i/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	if ( !ok ) {

--- a/test/form/side-effect-j/_expected/umd.js
+++ b/test/form/side-effect-j/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	var augment;

--- a/test/form/side-effect-k/_expected/umd.js
+++ b/test/form/side-effect-k/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myBundle = factory();
+	(global.myBundle = factory());
 }(this, function () { 'use strict';
 
 	function augment ( x ) {

--- a/test/form/side-effect-l/_expected/umd.js
+++ b/test/form/side-effect-l/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 

--- a/test/form/side-effect/_expected/umd.js
+++ b/test/form/side-effect/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var foo = 42;

--- a/test/form/sourcemaps-inline/_expected/umd.js
+++ b/test/form/sourcemaps-inline/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/sourcemaps/_expected/umd.js
+++ b/test/form/sourcemaps/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function foo () {

--- a/test/form/spacing-after-function-with-semicolon/_expected/umd.js
+++ b/test/form/spacing-after-function-with-semicolon/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	function x () { return 'x' };

--- a/test/form/string-indentation-b/_expected/umd.js
+++ b/test/form/string-indentation-b/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
     typeof define === 'function' && define.amd ? define(factory) :
-    factory();
+    (factory());
 }(this, function () { 'use strict';
 
     var a = 'a';

--- a/test/form/string-indentation/_expected/umd.js
+++ b/test/form/string-indentation/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var a = '1\

--- a/test/form/unmodified-default-exports-function-argument/_expected/umd.js
+++ b/test/form/unmodified-default-exports-function-argument/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var foo = function () {

--- a/test/form/unmodified-default-exports/_expected/umd.js
+++ b/test/form/unmodified-default-exports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var Foo = function () {

--- a/test/form/unused-default-exports/_expected/umd.js
+++ b/test/form/unused-default-exports/_expected/umd.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory();
+	(factory());
 }(this, function () { 'use strict';
 
 	var foo = { value: 1 };


### PR DESCRIPTION
This wraps the comma expression generated when using a namespaced global module name; e.g.: `Foo.bar`. Previously the generated code would fail in a CommonJS or AMD module environment.

See: https://github.com/rollup/rollup/issues/378#issuecomment-168063404