### PR TITLE
allow options.globals to be a function, warn on miss

### DIFF
--- a/src/finalisers/iife.js
+++ b/src/finalisers/iife.js
@@ -2,6 +2,7 @@ import { blank } from '../utils/object.js';
 import { getName } from '../utils/map-helpers.js';
 import getInteropBlock from './shared/getInteropBlock.js';
 import getExportBlock from './shared/getExportBlock.js';
+import getGlobalNameMaker from './shared/getGlobalNameMaker.js';
 
 function setupNamespace ( keypath ) {
 	let parts = keypath.split( '.' ); // TODO support e.g. `foo['something-hyphenated']`?
@@ -16,13 +17,12 @@ function setupNamespace ( keypath ) {
 }
 
 export default function iife ( bundle, magicString, { exportMode, indentString }, options ) {
-	const globalNames = options.globals || blank();
+	const globalNameMaker = getGlobalNameMaker( options.globals || blank(), bundle.onwarn );
+
 	const name = options.moduleName;
 	const isNamespaced = name && ~name.indexOf( '.' );
 
-	let dependencies = bundle.externalModules.map( module => {
-		return globalNames[ module.id ] || module.name;
-	});
+	let dependencies = bundle.externalModules.map( globalNameMaker );
 
 	let args = bundle.externalModules.map( getName );
 

--- a/src/finalisers/shared/getGlobalNameMaker.js
+++ b/src/finalisers/shared/getGlobalNameMaker.js
@@ -1,0 +1,11 @@
+export default function getGlobalNameMaker ( globals, onwarn ) {
+	const fn = typeof globals === 'function' ? globals : id => globals[ id ];
+
+	return function ( module ) {
+		const name = fn( module.id );
+		if ( name ) return name;
+
+		onwarn( `No name was provided for external module '${module.id}' in options.globals – guessing '${module.name}'` );
+		return module.name;
+	};
+}

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -2,6 +2,7 @@ import { blank } from '../utils/object.js';
 import { getName, quoteId, req } from '../utils/map-helpers.js';
 import getInteropBlock from './shared/getInteropBlock.js';
 import getExportBlock from './shared/getExportBlock.js';
+import getGlobalNameMaker from './shared/getGlobalNameMaker.js';
 
 function setupNamespace ( name ) {
 	const parts = name.split( '.' );
@@ -19,13 +20,11 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 		throw new Error( 'You must supply options.moduleName for UMD bundles' );
 	}
 
-	const globalNames = options.globals || blank();
+	const globalNameMaker = getGlobalNameMaker( options.globals || blank(), bundle.onwarn );
 
 	let amdDeps = bundle.externalModules.map( quoteId );
 	let cjsDeps = bundle.externalModules.map( req );
-	let globalDeps = bundle.externalModules.map( module => {
-		return 'global.' + (globalNames[ module.id ] || module.name);
-	});
+	let globalDeps = bundle.externalModules.map( module => `global.${globalNameMaker( module )}` );
 
 	let args = bundle.externalModules.map( getName );
 

--- a/test/form/external-imports-custom-names-function/_config.js
+++ b/test/form/external-imports-custom-names-function/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'allows globals to be specified as a function',
+	options: {
+		globals: function ( id ) {
+			return id.replace( /-/g, '_' );
+		}
+	}
+};

--- a/test/form/external-imports-custom-names-function/_expected/amd.js
+++ b/test/form/external-imports-custom-names-function/_expected/amd.js
@@ -1,0 +1,5 @@
+define(['a-b-c'], function (aBC) { 'use strict';
+
+	aBC.foo();
+
+});

--- a/test/form/external-imports-custom-names-function/_expected/cjs.js
+++ b/test/form/external-imports-custom-names-function/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var aBC = require('a-b-c');
+
+aBC.foo();

--- a/test/form/external-imports-custom-names-function/_expected/es6.js
+++ b/test/form/external-imports-custom-names-function/_expected/es6.js
@@ -1,0 +1,3 @@
+import { foo } from 'a-b-c';
+
+foo();

--- a/test/form/external-imports-custom-names-function/_expected/iife.js
+++ b/test/form/external-imports-custom-names-function/_expected/iife.js
@@ -1,0 +1,5 @@
+(function (aBC) { 'use strict';
+
+	aBC.foo();
+
+})(a_b_c);

--- a/test/form/external-imports-custom-names-function/_expected/umd.js
+++ b/test/form/external-imports-custom-names-function/_expected/umd.js
@@ -1,0 +1,9 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('a-b-c')) :
+	typeof define === 'function' && define.amd ? define(['a-b-c'], factory) :
+	(factory(global.a_b_c));
+}(this, function (aBC) { 'use strict';
+
+	aBC.foo();
+
+}));

--- a/test/form/external-imports-custom-names-function/main.js
+++ b/test/form/external-imports-custom-names-function/main.js
@@ -1,0 +1,2 @@
+import { foo } from 'a-b-c';
+foo();


### PR DESCRIPTION
Follow-up to #293. Allows `options.globals` to be a function as opposed to an object. In addition, if a global name isn't provided for an external module (in IIFE or UMD mode), Rollup will print a warning along these lines:

```
No name was provided for external module 'my-lib' in options.globals – guessing 'MyLib'
```

The 'guess' is based on how the external library is referenced in the bundle – if the code has something like...

```js
import MyLib from 'my-lib';
```

...it's a pretty safe bet that `MyLib` is the correct name. But in cases like this...

```js
import { foo } from 'named-only';
```

...we're forced to guess on the basis of the module ID. Either way, the recommendation is to be explicit.