### PR TITLE
prevent resolution of external IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
+!test/node_modules
 .gobble*
 dist
 _actual

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -31,9 +31,8 @@ export default class Bundle {
 		this.entryModule = null;
 
 		this.resolveId = first(
-			this.plugins
-				.map( plugin => plugin.resolveId )
-				.filter( Boolean )
+			[ id => ~this.external.indexOf( id ) ? false : null ]
+				.concat( this.plugins.map( plugin => plugin.resolveId ).filter( Boolean ) )
 				.concat( resolveId )
 		);
 
@@ -264,7 +263,7 @@ export default class Bundle {
 			if ( this.transformers.length || this.bundleTransformers.length ) {
 				map = collapseSourcemaps( map, usedModules, bundleSourcemapChain );
 			}
-			
+
 			map.sources = map.sources.map( unixizePath );
 		}
 

--- a/test/function/external-ids-not-resolved/_config.js
+++ b/test/function/external-ids-not-resolved/_config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	description: 'does not attempt to resolve external IDs',
+	options: {
+		external: [ 'external' ],
+		plugins: [
+			{
+				resolveId: function ( importee ) {
+					if ( importee === 'external' ) {
+						throw new Error( 'Attempted to resolve external module ID' );
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/function/external-ids-not-resolved/main.js
+++ b/test/function/external-ids-not-resolved/main.js
@@ -1,0 +1,2 @@
+import foo from 'external';
+assert.ok( foo.external );

--- a/test/node_modules/external.js
+++ b/test/node_modules/external.js
@@ -1,0 +1,3 @@
+module.exports = {
+	external: true
+};


### PR DESCRIPTION
See #410. This ensures that Rollup doesn't attempt to resolve IDs that are in `options.external`.