### PR TITLE
Force external

### DIFF
--- a/bin/runRollup.js
+++ b/bin/runRollup.js
@@ -88,7 +88,8 @@ var equivalents = {
 };
 
 function execute ( options, command ) {
-	var external = command.external ? command.external.split( ',' ) : [];
+	var external = ( options.external || [] )
+		.concat( command.external ? command.external.split( ',' ) : []  );
 
 	if ( command.globals ) {
 		var globals = Object.create( null );

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -172,9 +172,14 @@ export default class Bundle {
 		const promises = module.dependencies.map( source => {
 			return Promise.resolve( this.resolveId( source, module.id ) )
 				.then( resolvedId => {
-					if ( !resolvedId ) {
-						if ( isRelative( source ) ) throw new Error( `Could not resolve ${source} from ${module.id}` );
-						if ( !~this.external.indexOf( source ) ) this.onwarn( `Treating '${source}' as external dependency` );
+					// If the `resolvedId` is supposed to be exteral, make it so.
+					const forcedExternal = ~this.external.indexOf( resolvedId );
+
+					if ( !resolvedId || forcedExternal ) {
+						if ( !forcedExternal ) {
+							if ( isRelative( source ) ) throw new Error( `Could not resolve ${source} from ${module.id}` );
+							if ( !~this.external.indexOf( source ) ) this.onwarn( `Treating '${source}' as external dependency` );
+						}
 						module.resolvedIds[ source ] = source;
 
 						if ( !this.moduleById[ source ] ) {

--- a/test/cli/config-external/_config.js
+++ b/test/cli/config-external/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'external option gets passed from config',
+	command: 'rollup -c'
+};

--- a/test/cli/config-external/_expected.js
+++ b/test/cli/config-external/_expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var ___config_js = require('./_config.js');
+var assert = require('assert');
+
+assert.ok( ___config_js.execute );

--- a/test/cli/config-external/main.js
+++ b/test/cli/config-external/main.js
@@ -1,0 +1,4 @@
+import { execute } from './_config.js';
+import { ok } from 'assert';
+
+ok( execute );

--- a/test/cli/config-external/rollup.config.js
+++ b/test/cli/config-external/rollup.config.js
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import { resolve } from 'path';
+
+var config = resolve( './_config.js' );
+
+export default {
+	entry: 'main.js',
+	format: 'cjs',
+
+	external: [ 'assert', config ],
+
+	plugins: [
+		{
+			load: function ( id ) {
+				assert.notEqual( id, config );
+			}
+		}
+	]
+};


### PR DESCRIPTION
Force ids specified in `external` to actually _be_ external.
    
Fixes #410
Builds on top of #417