### PR TITLE
prevent stack overflow with mutual strong dependencies – fixes #425

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -335,19 +335,25 @@ export default class Bundle {
 			let unordered = ordered;
 			ordered = [];
 
+			let placed = blank();
+
 			// unordered is actually semi-ordered, as [ fewer dependencies ... more dependencies ]
 			unordered.forEach( module => {
 				// ensure strong dependencies of `module` that don't strongly depend on `module` go first
 				strongDeps[ module.id ].forEach( place );
 
 				function place ( dep ) {
-					if ( !stronglyDependsOn[ dep.id ][ module.id ] && !~ordered.indexOf( dep ) ) {
+					if ( placed[ dep.id ] ) return;
+					placed[ dep.id ] = true;
+
+					if ( !stronglyDependsOn[ dep.id ][ module.id ] ) {
 						strongDeps[ dep.id ].forEach( place );
 						ordered.push( dep );
 					}
 				}
 
 				if ( !~ordered.indexOf( module ) ) {
+					placed[ module.id ] = true;
 					ordered.push( module );
 				}
 			});

--- a/test/function/cycles-stack-overflow/_config.js
+++ b/test/function/cycles-stack-overflow/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not stack overflow on crazy cyclical dependencies'
+};

--- a/test/function/cycles-stack-overflow/b.js
+++ b/test/function/cycles-stack-overflow/b.js
@@ -1,0 +1,11 @@
+import { C } from './c.js';
+
+export function B () {};
+
+B.prototype = {
+	c: function () {
+		return function () {
+			new C();
+		};
+	}()
+};

--- a/test/function/cycles-stack-overflow/c.js
+++ b/test/function/cycles-stack-overflow/c.js
@@ -1,0 +1,13 @@
+import { D } from './d.js';
+
+export function C () {
+	this.x = 'x';
+}
+
+C.prototype = {
+	d: function () {
+		return function () {
+			new D();
+		};
+	}()
+};

--- a/test/function/cycles-stack-overflow/d.js
+++ b/test/function/cycles-stack-overflow/d.js
@@ -1,0 +1,12 @@
+import { B } from './b.js';
+import { C } from './c.js';
+
+export function D () {};
+
+D.prototype = {
+	c: function () {
+		return function () {
+			new C();
+		};
+	}()
+};

--- a/test/function/cycles-stack-overflow/main.js
+++ b/test/function/cycles-stack-overflow/main.js
@@ -1,0 +1,3 @@
+import { C } from './c.js';
+
+assert.equal( new C().x, 'x' );


### PR DESCRIPTION
This does raise the question of *why* the modules in question are being identified as mutual strong dependencies (references inside the returned function expressions should presumably be *weak* dependencies), but I'll leave that for an occasion when I have a bit more time to scratch my head.