### PR TITLE
Fix module ordering

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -345,7 +345,7 @@ export default class Bundle {
 
 						findParent( this.entryModule );
 
-						throw new Error(
+						this.onwarn(
 							`Module ${a.id} may be unable to evaluate without ${b.id}, but is included first due to a cyclical dependency. Consider swapping the import statements in ${parent} to ensure correct ordering`
 						);
 					}

--- a/src/Module.js
+++ b/src/Module.js
@@ -566,11 +566,11 @@ export default class Module {
 		return magicString.trim();
 	}
 
-	run ( safe ) {
+	run () {
 		let marked = false;
 
 		this.statements.forEach( statement => {
-			marked = statement.run( this.strongDependencies, safe ) || marked;
+			marked = statement.run( this.strongDependencies ) || marked;
 		});
 
 		return marked;

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -130,11 +130,11 @@ export default class Statement {
 		});
 	}
 
-	run ( strongDependencies, safe ) {
+	run ( strongDependencies ) {
 		if ( ( this.ran && this.isIncluded ) || this.isImportDeclaration || this.isFunctionDeclaration ) return;
 		this.ran = true;
 
-		if ( run( this.node, this.scope, this, strongDependencies, false, safe ) ) {
+		if ( run( this.node, this.scope, this, strongDependencies, false ) ) {
 			this.mark();
 			return true;
 		}

--- a/src/utils/pureFunctions.js
+++ b/src/utils/pureFunctions.js
@@ -1,0 +1,42 @@
+let pureFunctions = {};
+
+const arrayTypes = 'Array Int8Array Uint8Array Uint8ClampedArray Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array'.split( ' ' );
+const simdTypes = 'Int8x16 Int16x8 Int32x4 Float32x4 Float64x2'.split( ' ' );
+const simdMethods = 'abs add and bool check div equal extractLane fromFloat32x4 fromFloat32x4Bits fromFloat64x2 fromFloat64x2Bits fromInt16x8Bits fromInt32x4 fromInt32x4Bits fromInt8x16Bits greaterThan greaterThanOrEqual lessThan lessThanOrEqual load max maxNum min minNum mul neg not notEqual or reciprocalApproximation reciprocalSqrtApproximation replaceLane select selectBits shiftLeftByScalar shiftRightArithmeticByScalar shiftRightLogicalByScalar shuffle splat sqrt store sub swizzle xor'.split( ' ' );
+let allSimdMethods = [];
+simdTypes.forEach( t => {
+	simdMethods.forEach( m => {
+		allSimdMethods.push( `SIMD.${t}.${m}` );
+	});
+});
+
+[
+	'Array.isArray',
+	'Error', 'EvalError', 'InternalError', 'RangeError', 'ReferenceError', 'SyntaxError', 'TypeError', 'URIError',
+	'isFinite', 'isNaN', 'parseFloat', 'parseInt', 'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'escape', 'unescape',
+	'Object', 'Object.create', 'Object.getNotifier', 'Object.getOwn', 'Object.getOwnPropertyDescriptor', 'Object.getOwnPropertyNames', 'Object.getOwnPropertySymbols', 'Object.getPrototypeOf', 'Object.is', 'Object.isExtensible', 'Object.isFrozen', 'Object.isSealed', 'Object.keys',
+	'Function', 'Boolean',
+	'Number', 'Number.isFinite', 'Number.isInteger', 'Number.isNaN', 'Number.isSafeInteger', 'Number.parseFloat', 'Number.parseInt',
+	'Symbol', 'Symbol.for', 'Symbol.keyFor',
+	'Math.abs', 'Math.acos', 'Math.acosh', 'Math.asin', 'Math.asinh', 'Math.atan', 'Math.atan2', 'Math.atanh', 'Math.cbrt', 'Math.ceil', 'Math.clz32', 'Math.cos', 'Math.cosh', 'Math.exp', 'Math.expm1', 'Math.floor', 'Math.fround', 'Math.hypot', 'Math.imul', 'Math.log', 'Math.log10', 'Math.log1p', 'Math.log2', 'Math.max', 'Math.min', 'Math.pow', 'Math.random', 'Math.round', 'Math.sign', 'Math.sin', 'Math.sinh', 'Math.sqrt', 'Math.tan', 'Math.tanh', 'Math.trunc',
+	'Date', 'Date.UTC', 'Date.now', 'Date.parse',
+	'String', 'String.fromCharCode', 'String.fromCodePoint', 'String.raw',
+	'RegExp',
+	'Map', 'Set', 'WeakMap', 'WeakSet',
+	'ArrayBuffer', 'ArrayBuffer.isView',
+	'DataView',
+	'JSON.parse', 'JSON.stringify',
+	'Promise', 'Promise.all', 'Promise.race', 'Promise.reject', 'Promise.resolve',
+	'Intl.Collator', 'Intl.Collator.supportedLocalesOf', 'Intl.DateTimeFormat', 'Intl.DateTimeFormat.supportedLocalesOf', 'Intl.NumberFormat', 'Intl.NumberFormat.supportedLocalesOf'
+
+	// TODO properties of e.g. window...
+].concat(
+	arrayTypes,
+	arrayTypes.map( t => `${t}.from` ),
+	arrayTypes.map( t => `${t}.of` ),
+	simdTypes.map( t => `SIMD.${t}` ),
+	allSimdMethods
+).forEach( name => pureFunctions[ name ] = true );
+	// TODO add others to this list from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
+
+export default pureFunctions;

--- a/src/utils/run.js
+++ b/src/utils/run.js
@@ -2,67 +2,24 @@ import { walk } from 'estree-walker';
 import modifierNodes, { isModifierNode } from '../ast/modifierNodes.js';
 import isReference from '../ast/isReference.js';
 import flatten from '../ast/flatten';
-
-let pureFunctions = {};
-
-const arrayTypes = 'Array Int8Array Uint8Array Uint8ClampedArray Int16Array Uint16Array Int32Array Uint32Array Float32Array Float64Array'.split( ' ' );
-const simdTypes = 'Int8x16 Int16x8 Int32x4 Float32x4 Float64x2'.split( ' ' );
-const simdMethods = 'abs add and bool check div equal extractLane fromFloat32x4 fromFloat32x4Bits fromFloat64x2 fromFloat64x2Bits fromInt16x8Bits fromInt32x4 fromInt32x4Bits fromInt8x16Bits greaterThan greaterThanOrEqual lessThan lessThanOrEqual load max maxNum min minNum mul neg not notEqual or reciprocalApproximation reciprocalSqrtApproximation replaceLane select selectBits shiftLeftByScalar shiftRightArithmeticByScalar shiftRightLogicalByScalar shuffle splat sqrt store sub swizzle xor'.split( ' ' );
-let allSimdMethods = [];
-simdTypes.forEach( t => {
-	simdMethods.forEach( m => {
-		allSimdMethods.push( `SIMD.${t}.${m}` );
-	});
-});
-
-[
-	'Array.isArray',
-	'Error', 'EvalError', 'InternalError', 'RangeError', 'ReferenceError', 'SyntaxError', 'TypeError', 'URIError',
-	'isFinite', 'isNaN', 'parseFloat', 'parseInt', 'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'escape', 'unescape',
-	'Object', 'Object.create', 'Object.getNotifier', 'Object.getOwn', 'Object.getOwnPropertyDescriptor', 'Object.getOwnPropertyNames', 'Object.getOwnPropertySymbols', 'Object.getPrototypeOf', 'Object.is', 'Object.isExtensible', 'Object.isFrozen', 'Object.isSealed', 'Object.keys',
-	'Function', 'Boolean',
-	'Number', 'Number.isFinite', 'Number.isInteger', 'Number.isNaN', 'Number.isSafeInteger', 'Number.parseFloat', 'Number.parseInt',
-	'Symbol', 'Symbol.for', 'Symbol.keyFor',
-	'Math.abs', 'Math.acos', 'Math.acosh', 'Math.asin', 'Math.asinh', 'Math.atan', 'Math.atan2', 'Math.atanh', 'Math.cbrt', 'Math.ceil', 'Math.clz32', 'Math.cos', 'Math.cosh', 'Math.exp', 'Math.expm1', 'Math.floor', 'Math.fround', 'Math.hypot', 'Math.imul', 'Math.log', 'Math.log10', 'Math.log1p', 'Math.log2', 'Math.max', 'Math.min', 'Math.pow', 'Math.random', 'Math.round', 'Math.sign', 'Math.sin', 'Math.sinh', 'Math.sqrt', 'Math.tan', 'Math.tanh', 'Math.trunc',
-	'Date', 'Date.UTC', 'Date.now', 'Date.parse',
-	'String', 'String.fromCharCode', 'String.fromCodePoint', 'String.raw',
-	'RegExp',
-	'Map', 'Set', 'WeakMap', 'WeakSet',
-	'ArrayBuffer', 'ArrayBuffer.isView',
-	'DataView',
-	'JSON.parse', 'JSON.stringify',
-	'Promise', 'Promise.all', 'Promise.race', 'Promise.reject', 'Promise.resolve',
-	'Intl.Collator', 'Intl.Collator.supportedLocalesOf', 'Intl.DateTimeFormat', 'Intl.DateTimeFormat.supportedLocalesOf', 'Intl.NumberFormat', 'Intl.NumberFormat.supportedLocalesOf'
-
-	// TODO properties of e.g. window...
-].concat(
-	arrayTypes,
-	arrayTypes.map( t => `${t}.from` ),
-	arrayTypes.map( t => `${t}.of` ),
-	simdTypes.map( t => `SIMD.${t}` ),
-	allSimdMethods
-).forEach( name => pureFunctions[ name ] = true );
-	// TODO add others to this list from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects
+import pureFunctions from './pureFunctions.js';
 
 function call ( callee, scope, statement, strongDependencies ) {
-	let hasSideEffect;
-
 	while ( callee.type === 'ParenthesizedExpression' ) callee = callee.expression;
 
 	if ( callee.type === 'Identifier' ) {
 		const declaration = scope.findDeclaration( callee.name ) ||
 							statement.module.trace( callee.name );
 
-		if ( declaration ) {
-			if ( declaration.run( strongDependencies ) ) {
-				hasSideEffect = true;
-			}
-		} else if ( !pureFunctions[ callee.name ] ) {
-			hasSideEffect = true;
-		}
+		if ( declaration ) return declaration.run( strongDependencies );
+		return !pureFunctions[ callee.name ];
 	}
 
-	else if ( callee.type === 'MemberExpression' ) {
+	if ( /FunctionExpression/.test( callee.type ) ) {
+		return run( callee.body, scope, statement, strongDependencies );
+	}
+
+	if ( callee.type === 'MemberExpression' ) {
 		const flattened = flatten( callee );
 
 		if ( flattened ) {
@@ -70,29 +27,13 @@ function call ( callee, scope, statement, strongDependencies ) {
 			// TODO make pureFunctions configurable
 			const declaration = scope.findDeclaration( flattened.name ) || statement.module.trace( flattened.name );
 
-			if ( !!declaration || !pureFunctions[ flattened.keypath ] ) {
-				hasSideEffect = true;
-			}
-		} else {
-			// is not a keypath like `foo.bar.baz` – could be e.g.
-			// `foo[bar].baz()`. Err on the side of caution
-			hasSideEffect = true;
+			return ( !!declaration || !pureFunctions[ flattened.keypath ] );
 		}
 	}
 
-	else if ( /FunctionExpression/.test( callee.type ) ) {
-		if ( run( callee.body, scope, statement, strongDependencies ) ) {
-			hasSideEffect = true;
-		}
-	}
-
-	else {
-		// huh?
-		console.log( 'callee', callee )
-		throw new Error( 'Cannot call a non-function' );
-	}
-
-	return hasSideEffect;
+	// complex case like `( a ? b : c )()` or foo[bar].baz()`
+	// – err on the side of caution
+	return true;
 }
 
 export default function run ( node, scope, statement, strongDependencies, force ) {

--- a/test/form/side-effect-n/_config.js
+++ b/test/form/side-effect-n/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'detects side-effects in complex call expressions'
+};

--- a/test/form/side-effect-n/_expected/amd.js
+++ b/test/form/side-effect-n/_expected/amd.js
@@ -1,0 +1,13 @@
+define(function () { 'use strict';
+
+	function foo () {
+		console.log( 'foo' );
+	}
+
+	function bar () {
+		console.log( 'bar' );
+	}
+
+	( Math.random() < 0.5 ? foo : bar )();
+
+});

--- a/test/form/side-effect-n/_expected/cjs.js
+++ b/test/form/side-effect-n/_expected/cjs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function foo () {
+	console.log( 'foo' );
+}
+
+function bar () {
+	console.log( 'bar' );
+}
+
+( Math.random() < 0.5 ? foo : bar )();

--- a/test/form/side-effect-n/_expected/es6.js
+++ b/test/form/side-effect-n/_expected/es6.js
@@ -1,0 +1,9 @@
+function foo () {
+	console.log( 'foo' );
+}
+
+function bar () {
+	console.log( 'bar' );
+}
+
+( Math.random() < 0.5 ? foo : bar )();

--- a/test/form/side-effect-n/_expected/iife.js
+++ b/test/form/side-effect-n/_expected/iife.js
@@ -1,0 +1,14 @@
+(function () {
+	'use strict';
+
+	function foo () {
+		console.log( 'foo' );
+	}
+
+	function bar () {
+		console.log( 'bar' );
+	}
+
+	( Math.random() < 0.5 ? foo : bar )();
+
+}());

--- a/test/form/side-effect-n/_expected/umd.js
+++ b/test/form/side-effect-n/_expected/umd.js
@@ -1,0 +1,17 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, function () { 'use strict';
+
+	function foo () {
+		console.log( 'foo' );
+	}
+
+	function bar () {
+		console.log( 'bar' );
+	}
+
+	( Math.random() < 0.5 ? foo : bar )();
+
+}));

--- a/test/form/side-effect-n/main.js
+++ b/test/form/side-effect-n/main.js
@@ -1,0 +1,9 @@
+function foo () {
+	console.log( 'foo' );
+}
+
+function bar () {
+	console.log( 'bar' );
+}
+
+( Math.random() < 0.5 ? foo : bar )();

--- a/test/form/side-effect-o/_config.js
+++ b/test/form/side-effect-o/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'detects side-effects in complex call expressions'
+};

--- a/test/form/side-effect-o/_expected/amd.js
+++ b/test/form/side-effect-o/_expected/amd.js
@@ -1,0 +1,17 @@
+define(function () { 'use strict';
+
+	function fn () {
+		return Math.random() < 0.5 ? foo : bar;
+	}
+
+	function foo () {
+		console.log( 'foo' );
+	}
+
+	function bar () {
+		console.log( 'bar' );
+	}
+
+	fn()();
+
+});

--- a/test/form/side-effect-o/_expected/cjs.js
+++ b/test/form/side-effect-o/_expected/cjs.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function fn () {
+	return Math.random() < 0.5 ? foo : bar;
+}
+
+function foo () {
+	console.log( 'foo' );
+}
+
+function bar () {
+	console.log( 'bar' );
+}
+
+fn()();

--- a/test/form/side-effect-o/_expected/es6.js
+++ b/test/form/side-effect-o/_expected/es6.js
@@ -1,0 +1,13 @@
+function fn () {
+	return Math.random() < 0.5 ? foo : bar;
+}
+
+function foo () {
+	console.log( 'foo' );
+}
+
+function bar () {
+	console.log( 'bar' );
+}
+
+fn()();

--- a/test/form/side-effect-o/_expected/iife.js
+++ b/test/form/side-effect-o/_expected/iife.js
@@ -1,0 +1,18 @@
+(function () {
+	'use strict';
+
+	function fn () {
+		return Math.random() < 0.5 ? foo : bar;
+	}
+
+	function foo () {
+		console.log( 'foo' );
+	}
+
+	function bar () {
+		console.log( 'bar' );
+	}
+
+	fn()();
+
+}());

--- a/test/form/side-effect-o/_expected/umd.js
+++ b/test/form/side-effect-o/_expected/umd.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, function () { 'use strict';
+
+	function fn () {
+		return Math.random() < 0.5 ? foo : bar;
+	}
+
+	function foo () {
+		console.log( 'foo' );
+	}
+
+	function bar () {
+		console.log( 'bar' );
+	}
+
+	fn()();
+
+}));

--- a/test/form/side-effect-o/main.js
+++ b/test/form/side-effect-o/main.js
@@ -1,0 +1,13 @@
+function fn () {
+	return Math.random() < 0.5 ? foo : bar;
+}
+
+function foo () {
+	console.log( 'foo' );
+}
+
+function bar () {
+	console.log( 'bar' );
+}
+
+fn()();

--- a/test/function/cycles-pathological/_config.js
+++ b/test/function/cycles-pathological/_config.js
@@ -1,18 +1,17 @@
 var assert = require( 'assert' );
 
+var warned;
+
 module.exports = {
 	description: 'resolves pathological cyclical dependencies gracefully',
 	babel: true,
-	exports: function ( exports ) {
-		assert.ok( exports.a.isA );
-		assert.ok( exports.b1.isA );
-		assert.ok( exports.b1.isB );
-		assert.ok( exports.b2.isA );
-		assert.ok( exports.b2.isB );
-		assert.ok( exports.c1.isC );
-		assert.ok( exports.c1.isD );
-		assert.ok( exports.c2.isC );
-		assert.ok( exports.c2.isD );
-		assert.ok( exports.d.isD );
+	options: {
+		onwarn: function ( message ) {
+			assert.ok( /Module .+B\.js may be unable to evaluate without .+A\.js, but is included first due to a cyclical dependency. Consider swapping the import statements in .+main\.js to ensure correct ordering/.test( message ) );
+			warned = true;
+		}
+	},
+	runtimeError: function () {
+		assert.ok( warned );
 	}
 };

--- a/test/function/iife-comments/_config.js
+++ b/test/function/iife-comments/_config.js
@@ -5,4 +5,4 @@ module.exports = {
 	exports: function ( exports ) {
 		assert.equal( exports, 42 );
 	}
-}
+};

--- a/test/function/iife-strong-dependencies/_config.js
+++ b/test/function/iife-strong-dependencies/_config.js
@@ -1,15 +1,16 @@
 var assert = require( 'assert' );
 
+var warned;
+
 module.exports = {
 	description: 'does not treat references inside IIFEs as weak dependencies', // edge case encountered in THREE.js codebase
-	exports: function ( exports ) {
-		assert.ok( exports.a1.isA );
-		assert.ok( exports.b1.isB );
-		assert.ok( exports.c1.isC );
-		assert.ok( exports.d1.isD );
-		assert.ok( exports.a2.isA );
-		assert.ok( exports.b2.isB );
-		assert.ok( exports.c2.isC );
-		assert.ok( exports.d2.isD );
+	options: {
+		onwarn: function ( message ) {
+			assert.ok( /Module .+D\.js may be unable to evaluate without .+C\.js, but is included first due to a cyclical dependency. Consider swapping the import statements in .+main\.js to ensure correct ordering/.test( message ) );
+			warned = true;
+		}
+	},
+	runtimeError: function () {
+		assert.ok( warned );
 	}
 };


### PR DESCRIPTION
This PR addresses #435 and #440. Possibly not the most elegant code in the world, but it makes the ordering of modules adhere to the spec without sacrificing information needed to determine that the resulting bundle may not run.

A future improvement (besides better code) could be to illustrate the actual lines containing the import statements that need to be swapped.