### PR TITLE
error if namespace is called

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -134,6 +134,7 @@ export class SyntheticDefaultDeclaration {
 
 export class SyntheticNamespaceDeclaration {
 	constructor ( module ) {
+		this.isNamespace = true;
 		this.module = module;
 		this.name = null;
 
@@ -221,6 +222,7 @@ export class ExternalDeclaration {
 		this.module = module;
 		this.name = name;
 		this.isExternal = true;
+		this.isNamespace = name === '*';
 	}
 
 	addAlias () {

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -1,0 +1,9 @@
+export default function error ( props ) {
+	const err = new Error( props.message );
+
+	Object.keys( props ).forEach( key => {
+		err[ key ] = props[ key ];
+	});
+
+	throw err;
+}

--- a/test/function/cannot-call-external-namespace/_config.js
+++ b/test/function/cannot-call-external-namespace/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 	description: 'errors if code calls an external namespace',
 	error: function ( err ) {
 		assert.equal( err.message, 'Cannot call a namespace (\'foo\')' );
-		assert.equal( err.file, path.resolve( __dirname, 'main.js' ) );
+		assert.equal( err.file, path.resolve( __dirname, 'main.js' ).replace( /\//g, path.sep ) );
 		assert.equal( err.pos, 28 );
 		assert.deepEqual( err.loc, { line: 2, column: 0 });
 	}

--- a/test/function/cannot-call-external-namespace/_config.js
+++ b/test/function/cannot-call-external-namespace/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 	description: 'errors if code calls an external namespace',
 	error: function ( err ) {
 		assert.equal( err.message, 'Cannot call a namespace (\'foo\')' );
-		assert.equal( err.file, path.resolve( __dirname, 'main.js' ).replace( /\//g, path.sep ) );
+		assert.equal( err.file.replace( /\//g, path.sep ), path.resolve( __dirname, 'main.js' ) );
 		assert.equal( err.pos, 28 );
 		assert.deepEqual( err.loc, { line: 2, column: 0 });
 	}

--- a/test/function/cannot-call-external-namespace/_config.js
+++ b/test/function/cannot-call-external-namespace/_config.js
@@ -1,0 +1,12 @@
+var path = require( 'path' );
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'errors if code calls an external namespace',
+	error: function ( err ) {
+		assert.equal( err.message, 'Cannot call a namespace (\'foo\')' );
+		assert.equal( err.file, path.resolve( __dirname, 'main.js' ) );
+		assert.equal( err.pos, 28 );
+		assert.deepEqual( err.loc, { line: 2, column: 0 });
+	}
+};

--- a/test/function/cannot-call-external-namespace/main.js
+++ b/test/function/cannot-call-external-namespace/main.js
@@ -1,0 +1,2 @@
+import * as foo from 'foo';
+foo();

--- a/test/function/cannot-call-internal-namespace/_config.js
+++ b/test/function/cannot-call-internal-namespace/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 	description: 'errors if code calls an internal namespace',
 	error: function ( err ) {
 		assert.equal( err.message, 'Cannot call a namespace (\'foo\')' );
-		assert.equal( err.file, path.resolve( __dirname, 'main.js' ) );
+		assert.equal( err.file, path.resolve( __dirname, 'main.js' ).replace( /\//g, path.sep ) );
 		assert.equal( err.pos, 33 );
 		assert.deepEqual( err.loc, { line: 2, column: 0 });
 	}

--- a/test/function/cannot-call-internal-namespace/_config.js
+++ b/test/function/cannot-call-internal-namespace/_config.js
@@ -1,0 +1,12 @@
+var path = require( 'path' );
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'errors if code calls an internal namespace',
+	error: function ( err ) {
+		assert.equal( err.message, 'Cannot call a namespace (\'foo\')' );
+		assert.equal( err.file, path.resolve( __dirname, 'main.js' ) );
+		assert.equal( err.pos, 33 );
+		assert.deepEqual( err.loc, { line: 2, column: 0 });
+	}
+};

--- a/test/function/cannot-call-internal-namespace/_config.js
+++ b/test/function/cannot-call-internal-namespace/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 	description: 'errors if code calls an internal namespace',
 	error: function ( err ) {
 		assert.equal( err.message, 'Cannot call a namespace (\'foo\')' );
-		assert.equal( err.file, path.resolve( __dirname, 'main.js' ).replace( /\//g, path.sep ) );
+		assert.equal( err.file.replace( /\//g, path.sep ), path.resolve( __dirname, 'main.js' ) );
 		assert.equal( err.pos, 33 );
 		assert.deepEqual( err.loc, { line: 2, column: 0 });
 	}

--- a/test/function/cannot-call-internal-namespace/foo.js
+++ b/test/function/cannot-call-internal-namespace/foo.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/function/cannot-call-internal-namespace/main.js
+++ b/test/function/cannot-call-internal-namespace/main.js
@@ -1,0 +1,2 @@
+import * as foo from './foo.js';
+foo();


### PR DESCRIPTION
This PR fixes #446 (see also #442), whether the namespace is internal or external.

It also adds an `error` helper that makes it very slightly easier to deal with these sorts of errors, by adding properties like `file` and `loc`. We could perhaps make this helper specific to code-related errors and make it do more work, e.g. figuring out the location and including a snippet of the offending code in the error message, with a location marker. In an ideal world it would also handle sourcemap chains, so that it could show the location in the original code rather than transformed code. For now though I wanted to keep this PR focused on #446.