### PR TITLE
fix `var exports.foo`

### DIFF
--- a/test/form/object-destructuring-default-values/_config.js
+++ b/test/form/object-destructuring-default-values/_config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  description: 'object destructuring default values are preserved'
+	description: 'object destructuring default values are preserved'
 };

--- a/test/function/deconstructed-exported-vars/_config.js
+++ b/test/function/deconstructed-exported-vars/_config.js
@@ -1,0 +1,10 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'allows destructuring in exported variable declarations, synthetic or otherwise',
+	babel: true,
+	exports: function ( exports ) {
+		assert.equal( exports.a, 1 );
+		assert.equal( exports.d, 4 );
+	}
+};

--- a/test/function/deconstructed-exported-vars/main.js
+++ b/test/function/deconstructed-exported-vars/main.js
@@ -1,0 +1,11 @@
+let { a, b } = c(), [ d, e ] = f();
+
+function c () {
+	return { a: 1, b: 2 };
+}
+
+function f () {
+	return [ 4, 5 ];
+}
+
+export { a, d };

--- a/test/function/removes-empty-exported-vars/_config.js
+++ b/test/function/removes-empty-exported-vars/_config.js
@@ -1,0 +1,8 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'removes empty exported var declarations',
+	exports: function ( exports ) {
+		assert.equal( exports.foo, 42 );
+	}
+};

--- a/test/function/removes-empty-exported-vars/main.js
+++ b/test/function/removes-empty-exported-vars/main.js
@@ -1,0 +1,4 @@
+var foo;
+foo = 42;
+
+export { foo };


### PR DESCRIPTION
#426. Turns out there was a semi-related bug involving destructuring syntax, which is also fixed by this PR.