### PR TITLE
Fix double export of aliased names

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -87,7 +87,7 @@ export default class Bundle {
 				// mark all export statements
 				entryModule.getExports().forEach( name => {
 					const declaration = entryModule.traceExport( name );
-					declaration.isExported = true;
+					declaration.exportName = name;
 
 					declaration.use();
 				});

--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -16,6 +16,7 @@ export default class Declaration {
 
 		this.statement = statement;
 		this.name = null;
+		this.exportName = null;
 		this.isParam = isParam;
 
 		this.isReassigned = false;
@@ -37,9 +38,9 @@ export default class Declaration {
 
 	render ( es6 ) {
 		if ( es6 ) return this.name;
-		if ( !this.isReassigned || !this.isExported ) return this.name;
+		if ( !this.isReassigned || !this.exportName ) return this.name;
 
-		return `exports.${this.name}`;
+		return `exports.${this.exportName}`;
 	}
 
 	run ( strongDependencies ) {
@@ -78,7 +79,7 @@ export class SyntheticDefaultDeclaration {
 		this.name = name;
 
 		this.original = null;
-		this.isExported = false;
+		this.exportName = null;
 		this.aliases = [];
 	}
 

--- a/src/Module.js
+++ b/src/Module.js
@@ -439,7 +439,7 @@ export default class Module {
 				if ( declarator.id.type === 'Identifier' ) {
 					const declaration = this.declarations[ declarator.id.name ];
 
-					if ( declaration.isExported && declaration.isReassigned ) { // `var foo = ...` becomes `exports.foo = ...`
+					if ( declaration.exportName && declaration.isReassigned ) { // `var foo = ...` becomes `exports.foo = ...`
 						magicString.remove( statement.start, declarator.init ? declarator.start : statement.next );
 						return;
 					}
@@ -453,7 +453,7 @@ export default class Module {
 					extractNames( declarator.id ).forEach( name => {
 						const declaration = this.declarations[ name ];
 
-						if ( declaration.isExported && declaration.isReassigned ) {
+						if ( declaration.exportName && declaration.isReassigned ) {
 							magicString.insert( statement.end, `;\nexports.${name} = ${declaration.render( es6 )}` );
 						}
 					});
@@ -519,7 +519,7 @@ export default class Module {
 
 					if ( !declaration ) throw new Error( `Missing declaration for ${name}!` );
 
-					const end = declaration.isExported && declaration.isReassigned ?
+					const end = declaration.exportName && declaration.isReassigned ?
 						statement.node.declaration.declarations[0].start :
 						statement.node.declaration.start;
 
@@ -549,7 +549,7 @@ export default class Module {
 					const defaultName = defaultDeclaration.render();
 
 					// prevent `var undefined = sideEffectyDefault(foo)`
-					if ( !defaultDeclaration.isExported && !defaultDeclaration.isUsed ) {
+					if ( !defaultDeclaration.exportName && !defaultDeclaration.isUsed ) {
 						magicString.remove( statement.start, statement.node.declaration.start );
 						return;
 					}

--- a/test/function/aliased-not-exported-twice/_config.js
+++ b/test/function/aliased-not-exported-twice/_config.js
@@ -1,0 +1,12 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'does not export aliased binding under original name (#438)',
+	exports: function ( exports ) {
+		assert.equal( exports.number, 0 );
+		assert.equal( exports.incr(), 1 );
+		assert.equal( exports.number, 1 );
+
+		assert.ok( !( 'count' in exports ) );
+	}
+};

--- a/test/function/aliased-not-exported-twice/foo.js
+++ b/test/function/aliased-not-exported-twice/foo.js
@@ -1,0 +1,5 @@
+export var count = 0;
+
+export function incr () {
+	return ++count;
+}

--- a/test/function/aliased-not-exported-twice/main.js
+++ b/test/function/aliased-not-exported-twice/main.js
@@ -1,0 +1,1 @@
+export { count as number, incr } from './foo.js';


### PR DESCRIPTION
This fixes half of #438. There's a second bug which I've only got a failing test for, for now – PR inbound