### PR TITLE
Reexport fs functions directly

### DIFF
--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -2,12 +2,7 @@ import Promise from 'es6-promise/lib/es6-promise/promise.js';
 import * as fs from 'fs';
 import { dirname } from './path.js';
 
-export {
-	lstatSync,
-	readdirSync,
-	readFileSync,
-	realpathSync
-} from 'fs';
+export * from 'fs';
 
 function mkdirpath ( path ) {
 	const dir = dirname( path );

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -2,6 +2,13 @@ import Promise from 'es6-promise/lib/es6-promise/promise.js';
 import * as fs from 'fs';
 import { dirname } from './path.js';
 
+export {
+	lstatSync,
+	readdirSync,
+	readFileSync,
+	realpathSync
+} from 'fs';
+
 function mkdirpath ( path ) {
 	const dir = dirname( path );
 	try {
@@ -25,8 +32,3 @@ export function writeFile ( dest, data ) {
 		});
 	});
 }
-
-export const lstatSync = fs.lstatSync;
-export const readdirSync = fs.readdirSync;
-export const readFileSync = fs.readFileSync;
-export const realpathSync = fs.realpathSync;


### PR DESCRIPTION
#450 is looking good. :+1:

The only eye-sore I see are all the `export const xxx = fs.xxx`s at the bottom of `fs.js`. Let's just re-export them. :smile: 