### PR TITLE
Support export { global }

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -1,7 +1,7 @@
 import Promise from 'es6-promise/lib/es6-promise/promise.js';
 import MagicString from 'magic-string';
 import first from './utils/first.js';
-import { blank, keys } from './utils/object.js';
+import { blank, forOwn, keys } from './utils/object.js';
 import Module from './Module.js';
 import ExternalModule from './ExternalModule.js';
 import finalisers from './finalisers/index.js';
@@ -130,15 +130,14 @@ export default class Bundle {
 
 			// ensure we don't shadow named external imports, if
 			// we're creating an ES6 bundle
-			keys( module.declarations ).forEach( name => {
-				const declaration = module.declarations[ name ];
+			forOwn( module.declarations, ( declaration, name ) => {
 				declaration.setSafeName( getSafeName( name ) );
 			});
 		});
 
 		this.modules.forEach( module => {
-			keys( module.declarations ).forEach( originalName => {
-				const declaration = module.declarations[ originalName ];
+			forOwn( module.declarations, ( declaration, originalName ) => {
+				if ( declaration.isGlobal ) return;
 
 				if ( originalName === 'default' ) {
 					if ( declaration.original && !declaration.original.isReassigned ) return;

--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -221,8 +221,8 @@ export class SyntheticNamespaceDeclaration {
 
 			// add synthetic references, in case of chained
 			// namespace imports
-			keys( this.originals ).forEach( name => {
-				this.originals[ name ].addReference( new SyntheticReference( name ) );
+			forOwn( this.originals, ( original, name ) => {
+				original.addReference( new SyntheticReference( name ) );
 			});
 		}
 
@@ -249,12 +249,7 @@ export class SyntheticNamespaceDeclaration {
 	}
 
 	use () {
-		// forOwn( this.originals, use );
-
-		keys( this.originals ).forEach( name => {
-			this.originals[ name ].use();
-		});
-
+		forOwn( this.originals, use );
 		this.aliases.forEach( use );
 	}
 }

--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -1,6 +1,8 @@
-import { blank, keys } from './utils/object.js';
+import { blank, forOwn, keys } from './utils/object.js';
 import run from './utils/run.js';
 import { SyntheticReference } from './Reference.js';
+
+const use = alias => alias.use();
 
 export default class Declaration {
 	constructor ( node, isParam, statement ) {
@@ -68,7 +70,7 @@ export default class Declaration {
 		this.isUsed = true;
 		if ( this.statement ) this.statement.mark();
 
-		this.aliases.forEach( alias => alias.use() );
+		this.aliases.forEach( use );
 	}
 }
 
@@ -129,7 +131,44 @@ export class SyntheticDefaultDeclaration {
 
 		if ( this.original ) this.original.use();
 
-		this.aliases.forEach( alias => alias.use() );
+		this.aliases.forEach( use );
+	}
+}
+
+export class SyntheticGlobalDeclaration {
+	constructor ( name ) {
+		this.name = name;
+		this.isExternal = true;
+		this.isGlobal = true;
+		this.isReassigned = false;
+
+		this.aliases = [];
+
+		this.isUsed = false;
+	}
+
+	addAlias ( declaration ) {
+		this.aliases.push( declaration );
+	}
+
+	addReference ( reference ) {
+		reference.declaration = this;
+		if ( reference.isReassignment ) this.isReassigned = true;
+	}
+
+	render () {
+		return this.name;
+	}
+
+	run () {
+		return true;
+	}
+
+	use () {
+		if ( this.isUsed ) return;
+		this.isUsed = true;
+
+		this.aliases.forEach( use );
 	}
 }
 
@@ -210,11 +249,13 @@ export class SyntheticNamespaceDeclaration {
 	}
 
 	use () {
+		// forOwn( this.originals, use );
+
 		keys( this.originals ).forEach( name => {
 			this.originals[ name ].use();
 		});
 
-		this.aliases.forEach( alias => alias.use() );
+		this.aliases.forEach( use );
 	}
 }
 

--- a/src/Module.js
+++ b/src/Module.js
@@ -7,7 +7,11 @@ import { basename, extname } from './utils/path.js';
 import getLocation from './utils/getLocation.js';
 import makeLegalIdentifier from './utils/makeLegalIdentifier.js';
 import SOURCEMAPPING_URL from './utils/sourceMappingURL.js';
-import { SyntheticDefaultDeclaration, SyntheticNamespaceDeclaration } from './Declaration.js';
+import {
+	SyntheticDefaultDeclaration,
+	SyntheticGlobalDeclaration,
+	SyntheticNamespaceDeclaration
+} from './Declaration.js';
 import { isFalsy, isTruthy } from './ast/conditions.js';
 import { emptyBlockStatement } from './ast/create.js';
 import extractNames from './ast/extractNames.js';
@@ -624,7 +628,13 @@ export default class Module {
 
 		const exportDeclaration = this.exports[ name ];
 		if ( exportDeclaration ) {
-			return this.trace( exportDeclaration.localName );
+			const name = exportDeclaration.localName;
+			const declaration = this.trace( name );
+
+			if ( declaration ) return declaration;
+
+			this.bundle.assumedGlobals[ name ] = true;
+			return ( this.declarations[ name ] = new SyntheticGlobalDeclaration( name ) );
 		}
 
 		for ( let i = 0; i < this.exportAllModules.length; i += 1 ) {

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -1,5 +1,9 @@
-export const keys = Object.keys;
+export const { keys } = Object;
 
 export function blank () {
 	return Object.create( null );
+}
+
+export function forOwn ( object, func ) {
+	Object.keys( object ).forEach( key => func( object[ key ], key ) );
 }

--- a/test/function/export-global/_config.js
+++ b/test/function/export-global/_config.js
@@ -1,0 +1,9 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'any global variables in scope can be re-exported',
+
+	exports: function ( exports ) {
+		assert.equal( exports.Buffer, Buffer );
+	}
+};

--- a/test/function/export-global/main.js
+++ b/test/function/export-global/main.js
@@ -1,0 +1,1 @@
+export { Buffer };


### PR DESCRIPTION
I encountered an error when attempting to export a global variable, like so:

```js
export { Promise };
```
```
TypeError: Cannot set property 'isExported' of null
  ...
```

Rollup requires each exported binding to have a corresponding Declaration. This PR introduces a SyntheticGlobalDeclaration to circumvent this problem.