### PR TITLE
Retain symbols of computed properties defined on classes.

### DIFF
--- a/src/ast/isReference.js
+++ b/src/ast/isReference.js
@@ -10,7 +10,10 @@ export default function isReference ( node, parent ) {
 		if ( !parent ) return true;
 
 		// TODO is this right?
-		if ( parent.type === 'MemberExpression' ) return parent.computed || node === parent.object;
+		if ( parent.type === 'MemberExpression' ||
+			parent.type === 'MethodDefinition' ) {
+			return parent.computed || node === parent.object;
+		}
 
 		// disregard the `bar` in `{ bar: foo }`, but keep it in `{ [bar]: foo }`
 		if ( parent.type === 'Property' ) return parent.computed || node === parent.value;

--- a/test/form/computed-properties/_expected/amd.js
+++ b/test/form/computed-properties/_expected/amd.js
@@ -1,9 +1,19 @@
 define(['exports'], function (exports) { 'use strict';
 
-	var foo = 'foo';
+  var foo = 'foo';
+  var bar = 'bar';
+  var baz = 'baz';
+  var bam = 'bam';
 
-	var x = {[foo]: 'bar'};
+  var x = {[foo]: 'bar'};
 
-	exports.x = x;
+  class X {
+    [bar]() {}
+    get [baz]() {}
+    set [bam](value) {}
+  }
+
+  exports.x = x;
+  exports.X = X;
 
 });

--- a/test/form/computed-properties/_expected/cjs.js
+++ b/test/form/computed-properties/_expected/cjs.js
@@ -1,7 +1,17 @@
 'use strict';
 
 var foo = 'foo';
+var bar = 'bar';
+var baz = 'baz';
+var bam = 'bam';
 
 var x = {[foo]: 'bar'};
 
+class X {
+  [bar]() {}
+  get [baz]() {}
+  set [bam](value) {}
+}
+
 exports.x = x;
+exports.X = X;

--- a/test/form/computed-properties/_expected/es6.js
+++ b/test/form/computed-properties/_expected/es6.js
@@ -1,5 +1,14 @@
 var foo = 'foo';
+var bar = 'bar';
+var baz = 'baz';
+var bam = 'bam';
 
 var x = {[foo]: 'bar'};
 
-export { x };
+class X {
+  [bar]() {}
+  get [baz]() {}
+  set [bam](value) {}
+}
+
+export { x, X };

--- a/test/form/computed-properties/_expected/iife.js
+++ b/test/form/computed-properties/_expected/iife.js
@@ -1,10 +1,20 @@
 (function (exports) {
-	'use strict';
+  'use strict';
 
-	var foo = 'foo';
+  var foo = 'foo';
+  var bar = 'bar';
+  var baz = 'baz';
+  var bam = 'bam';
 
-	var x = {[foo]: 'bar'};
+  var x = {[foo]: 'bar'};
 
-	exports.x = x;
+  class X {
+    [bar]() {}
+    get [baz]() {}
+    set [bam](value) {}
+  }
+
+  exports.x = x;
+  exports.X = X;
 
 }((this.computedProperties = {})));

--- a/test/form/computed-properties/_expected/umd.js
+++ b/test/form/computed-properties/_expected/umd.js
@@ -1,13 +1,23 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
-	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	(factory((global.computedProperties = {})));
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (factory((global.computedProperties = {})));
 }(this, function (exports) { 'use strict';
 
-	var foo = 'foo';
+  var foo = 'foo';
+  var bar = 'bar';
+  var baz = 'baz';
+  var bam = 'bam';
 
-	var x = {[foo]: 'bar'};
+  var x = {[foo]: 'bar'};
 
-	exports.x = x;
+  class X {
+    [bar]() {}
+    get [baz]() {}
+    set [bam](value) {}
+  }
+
+  exports.x = x;
+  exports.X = X;
 
 }));

--- a/test/form/computed-properties/main.js
+++ b/test/form/computed-properties/main.js
@@ -1,3 +1,12 @@
 var foo = 'foo';
+var bar = 'bar';
+var baz = 'baz';
+var bam = 'bam';
 
 export var x = {[foo]: 'bar'};
+
+export class X {
+  [bar]() {}
+  get [baz]() {}
+  set [bam](value) {}
+}


### PR DESCRIPTION
(fixes #504, similar fix as #439)