### PR TITLE
Plugins can be passed as functions

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -19,7 +19,8 @@ import { isRelative, resolve } from './utils/path.js';
 
 export default class Bundle {
 	constructor ( options ) {
-		this.plugins = ensureArray( options.plugins );
+		this.plugins = ensureArray( options.plugins )
+			.map( plugin => typeof plugin === 'function' ? plugin() : plugin );
 
 		this.plugins.forEach( plugin => {
 			if ( plugin.options ) {

--- a/test/function/plugins-can-be-passed-as-functions/_config.js
+++ b/test/function/plugins-can-be-passed-as-functions/_config.js
@@ -1,0 +1,20 @@
+var path = require( 'path' );
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'plugins can be passed as functions',
+	options: {
+		plugins: [
+			function () {
+				return {
+					options: function ( options ) {
+						options.entry = path.resolve( __dirname, 'answer.js' );
+					}
+				}
+			}
+		]
+	},
+	exports: function ( answer ) {
+		assert.equal( answer, 42 );
+	}
+}

--- a/test/function/plugins-can-be-passed-as-functions/answer.js
+++ b/test/function/plugins-can-be-passed-as-functions/answer.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,7 @@ function loadConfig ( path ) {
 	try {
 		return require( path );
 	} catch ( err ) {
+		console.log( err );
 		throw new Error( 'Failed to load ' + path + '. An old test perhaps? You should probably delete the directory' );
 	}
 }


### PR DESCRIPTION
Don't like plugins with empty parentheses. Think this looks much nicer.

```js
{
  plugins: [
    eslint,
    commonjs({ jsnext: true })
    babel,
    uglify
  ]
}
```