### PR TITLE
Allow 'exports' key

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -12,6 +12,7 @@ const ALLOWED_KEYS = [
 	'banner',
 	'dest',
 	'entry',
+	'exports',
 	'external',
 	'footer',
 	'format',

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -14,7 +14,6 @@ const ALLOWED_KEYS = [
 	'entry',
 	'exports',
 	'external',
-	'exports',
 	'footer',
 	'format',
 	'globals',

--- a/test/function/exports-flag-allowed-in-options/_config.js
+++ b/test/function/exports-flag-allowed-in-options/_config.js
@@ -1,0 +1,12 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'exports flag is passed through to bundle options',
+	options: {
+		exports: 'named'
+	},
+	exports: function ( exports ) {
+		assert.equal( exports.y, 42 );
+		assert.ok( !( 'x' in exports ) );
+	}
+};

--- a/test/function/exports-flag-allowed-in-options/foo.js
+++ b/test/function/exports-flag-allowed-in-options/foo.js
@@ -1,0 +1,1 @@
+export var x = 42;

--- a/test/function/exports-flag-allowed-in-options/main.js
+++ b/test/function/exports-flag-allowed-in-options/main.js
@@ -1,0 +1,1 @@
+export { x as y } from './foo';

--- a/test/test.js
+++ b/test/test.js
@@ -76,7 +76,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( function () {
 				throw new Error( 'Missing expected error' );
 			}, function ( err ) {
-				assert.equal( 'Unexpected key \'plUgins\' found, expected one of: banner, dest, entry, external, footer, format, globals, indent, intro, moduleId, moduleName, onwarn, outro, plugins, sourceMap', err.message );
+				assert.equal( 'Unexpected key \'plUgins\' found, expected one of: banner, dest, entry, exports, external, footer, format, globals, indent, intro, moduleId, moduleName, onwarn, outro, plugins, sourceMap', err.message );
 			});
 		});
 	});
@@ -149,6 +149,7 @@ describe( 'rollup', function () {
 
 						// try to generate output
 						try {
+							if(config.bundleOptions) { console.log(config.bundleOptions); }
 							var result = bundle.generate( extend( {}, config.bundleOptions, {
 								format: 'cjs'
 							}));


### PR DESCRIPTION
Apparently this isn't used much, but we need it whitelisted for our gulp-rollup plugin integration.