### PR TITLE
omit side effects in unreachable modules (#551)

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -92,6 +92,9 @@ export default class Bundle {
 					declaration.use();
 				});
 
+				// mark modules that should appear in the bundle
+				entryModule.use();
+
 				// mark statements that should appear in the bundle
 				let settled = false;
 				while ( !settled ) {

--- a/src/ExternalModule.js
+++ b/src/ExternalModule.js
@@ -25,7 +25,9 @@ export default class ExternalModule {
 			this.name = name;
 		}
 	}
-
+	use () {
+			// noop
+	}
 	traceExport ( name ) {
 		if ( name !== 'default' && name !== '*' ) {
 			this.exportsNames = true;

--- a/src/Module.js
+++ b/src/Module.js
@@ -59,6 +59,7 @@ export default class Module {
 		this.analyse();
 
 		this.strongDependencies = [];
+		this.used = false;
 	}
 
 	addExport ( statement ) {
@@ -598,6 +599,8 @@ export default class Module {
 	run () {
 		let marked = false;
 
+		if (!this.used) return marked;
+
 		this.statements.forEach( statement => {
 			marked = statement.run( this.strongDependencies ) || marked;
 		});
@@ -610,7 +613,7 @@ export default class Module {
 		if ( name in this.imports ) {
 			const importDeclaration = this.imports[ name ];
 			const otherModule = importDeclaration.module;
-
+			otherModule.use();
 			if ( importDeclaration.name === '*' && !otherModule.isExternal ) {
 				return otherModule.namespace();
 			}
@@ -657,5 +660,9 @@ export default class Module {
 
 			if ( declaration ) return declaration;
 		}
+	}
+
+	use () {
+		this.used = true;
 	}
 }

--- a/src/Statement.js
+++ b/src/Statement.js
@@ -125,7 +125,7 @@ export default class Statement {
 	mark () {
 		if ( this.isIncluded ) return; // prevent infinite loops
 		this.isIncluded = true;
-
+		this.module.use();
 		this.references.forEach( reference => {
 			if ( reference.declaration ) reference.declaration.use();
 		});

--- a/test/function/side-effects-in-unreached-modules/_config.js
+++ b/test/function/side-effects-in-unreached-modules/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'side effects in unreached modules are not executed'
+};

--- a/test/function/side-effects-in-unreached-modules/circle.js
+++ b/test/function/side-effects-in-unreached-modules/circle.js
@@ -1,0 +1,3 @@
+export function circle(r) {
+  return Math.PI * r * r;
+}

--- a/test/function/side-effects-in-unreached-modules/cube.js
+++ b/test/function/side-effects-in-unreached-modules/cube.js
@@ -1,0 +1,7 @@
+import square2 from './square2';
+
+function cubic(x) {
+  return cubic.square(x) * x;
+}
+export var cube = cubic;
+cube.square = square2;

--- a/test/function/side-effects-in-unreached-modules/main.js
+++ b/test/function/side-effects-in-unreached-modules/main.js
@@ -1,0 +1,3 @@
+import {cube} from './maths.js';
+
+console.log(cube(3));

--- a/test/function/side-effects-in-unreached-modules/maths.js
+++ b/test/function/side-effects-in-unreached-modules/maths.js
@@ -1,0 +1,5 @@
+export {cube} from './cube';
+
+export {square} from './square';
+
+export {circle} from './circle';

--- a/test/function/side-effects-in-unreached-modules/square.js
+++ b/test/function/side-effects-in-unreached-modules/square.js
@@ -1,0 +1,9 @@
+export function square(x) {
+  return x * x;
+}
+
+Object.defineProperty(square, "test", {
+  get: function() { throw new Error('should not import square'); },
+  set: function( arg ) {}
+});
+square.test();

--- a/test/function/side-effects-in-unreached-modules/square2.js
+++ b/test/function/side-effects-in-unreached-modules/square2.js
@@ -1,0 +1,5 @@
+var square2 = function  (x) {
+  return x * x;
+}
+
+export default square2;


### PR DESCRIPTION
the idea is that if you don't actually import anything from a module (i.e. because everything that imported it has been shaken out of the tree) then don't include it's side effects.

This would be very helpful for situations where you have something like a lodash or other utility thing that people are going to only one one or 2 functions out of.  So if you want `_.pluck` it shouldn't matter to you that `_.somethignWeird` depends on `giantModuleWithSideEffects`.
