### PR TITLE
Cannot read property 'node' of undefined when declaration is SyntheticGlobalDeclaration

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -189,6 +189,7 @@ export default class Module {
 			const declaration = this.declarations[ name ];
 			const statement = declaration.statement;
 
+			if ( !statement ) return;
 			if ( statement.node.type !== 'VariableDeclaration' ) return;
 
 			const init = statement.node.declarations[0].init;


### PR DESCRIPTION
Could not catch this in mocha tests. it seems like to crash only at compile time.