### PR TITLE
use async versions of pulgin functions by default

### DIFF
--- a/browser/fs.js
+++ b/browser/fs.js
@@ -1,6 +1,5 @@
 const nope = method => `Cannot use fs.${method} inside browser`;
 
 export const isFile = () => false;
-export const readdirSync = nope( 'readdirSync' );
-export const readFileSync = nope( 'readFileSync' );
+export const readFile = nope( 'readFileSync' );
 export const writeFile = nope( 'writeFile' );

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -1,18 +1,25 @@
-import { isFile, readFileSync } from './fs.js';
+import { isFile, readFile } from './fs.js';
 import { dirname, isAbsolute, resolve } from './path.js';
 import { blank } from './object.js';
 
 export function load ( id ) {
-	return readFileSync( id, 'utf-8' );
+	return readFile( id, 'utf-8' );
 }
 
 function addJsExtensionIfNecessary ( file ) {
-	if ( isFile( file ) ) return file;
-
-	file += '.js';
-	if ( isFile( file ) ) return file;
-
-	return null;
+	return isFile( file )
+		.then( answer => {
+			if ( answer ) {
+				return file;
+			}
+			file += '.js';
+			return isFile(file).then( answer => {
+				if ( answer ) {
+					return file;
+				}
+				return null;
+			});
+		});
 }
 
 export function resolveId ( importee, importer ) {

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -2,30 +2,9 @@ import Promise from 'es6-promise/lib/es6-promise/promise.js';
 import * as fs from 'fs';
 import { dirname } from './path.js';
 
-function mkdirpath ( path ) {
-	const dir = dirname( path );
-	try {
-		fs.readdirSync( dir );
-	} catch ( err ) {
-		mkdirpath( dir );
-		fs.mkdirSync( dir );
-	}
-}
-
-export function isFile ( file ) {
-	try {
-		const stats = fs.statSync( file );
-		return stats.isFile();
-	} catch ( err ) {
-		return false;
-	}
-}
-
-export function writeFile ( dest, data ) {
+function readdir ( dir ) {
 	return new Promise( ( fulfil, reject ) => {
-		mkdirpath( dest );
-
-		fs.writeFile( dest, data, err => {
+		fs.readdir( dir, ( err ) => {
 			if ( err ) {
 				reject( err );
 			} else {
@@ -35,5 +14,67 @@ export function writeFile ( dest, data ) {
 	});
 }
 
-export const readdirSync = fs.readdirSync;
-export const readFileSync = fs.readFileSync;
+function mkdir ( dir ) {
+	return new Promise( ( fulfil, reject ) => {
+		fs.mkdir( dir, ( err ) => {
+			if ( err ) {
+				reject( err );
+			} else {
+				fulfil();
+			}
+		});
+	});
+}
+
+function mkdirpath ( path ) {
+	const dir = dirname( path );
+	return readdir( dir ).catch( () => {
+		return mkdirpath( dir ).then( () => {
+			return mkdir( dir ).catch( e => {
+				// race condition
+				if (e && e.code === 'EEXIST') {
+					return;
+				}
+				throw e;
+			});
+		});
+	});
+}
+
+export function isFile ( file ) {
+	return new Promise( ( fulfil ) => {
+		fs.stat( file, ( err, stats ) => {
+			if ( err ) {
+				fulfil( false );
+			} else {
+				fulfil( stats.isFile() );
+			}
+		});
+	});
+}
+
+export function writeFile ( dest, data ) {
+	return mkdirpath( dest ).then( ()=> {
+		return new Promise( ( fulfil, reject ) => {
+
+			fs.writeFile( dest, data, err => {
+				if ( err ) {
+					reject( err );
+				} else {
+					fulfil();
+				}
+			});
+		});
+	});
+}
+export function readFile ( id, enc ) {
+	return new Promise( ( fulfil, reject ) => {
+		fs.readFile( id, enc, ( err, data ) => {
+			if ( err ) {
+				reject( err );
+			} else {
+				fulfil( data );
+			}
+		});
+	});
+}


### PR DESCRIPTION
the docs suggest plugins should use async methods, the internal code should probably follow it's own advice. 