### PR TITLE
Allow external files to be non-existent, relative files. Fixes #532.

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -178,8 +178,15 @@ export default class Bundle {
 		return mapSequence( module.sources, source => {
 			return this.resolveId( source, module.id )
 				.then( resolvedId => {
-					// If the `resolvedId` is supposed to be external, make it so.
-					const forcedExternal = resolvedId && ~this.external.indexOf( resolvedId.replace( /[\/\\]/g, '/' ) );
+					let externalName;
+					if ( resolvedId ) {
+						// If the `resolvedId` is supposed to be external, make it so.
+						externalName = resolvedId.replace( /[\/\\]/g, '/' );
+					} else if ( isRelative( source ) ) {
+						// This could be an external, relative dependency, based on the current module's parent dir.
+						externalName = resolve( module.id, '..', source );
+					}
+					const forcedExternal = externalName && ~this.external.indexOf( externalName );
 
 					if ( !resolvedId || forcedExternal ) {
 						if ( !forcedExternal ) {

--- a/test/function/configure-relative-external-module/_config.js
+++ b/test/function/configure-relative-external-module/_config.js
@@ -1,0 +1,21 @@
+var assert = require( 'assert' );
+var path = require( 'path' );
+
+var mockedValue = {
+	val: 'A value'
+};
+
+module.exports = {
+	description: 'allows a nonexistent relative module to be configured as external',
+	options: {
+		external: [ path.join( __dirname, './nonexistent-relative-dependency.js') ]
+	},
+	context: {
+		require: function() {
+			return mockedValue;
+		}
+	},
+	exports: function () {
+		assert.equal( mockedValue.wasAltered, true );
+	}
+};

--- a/test/function/configure-relative-external-module/main.js
+++ b/test/function/configure-relative-external-module/main.js
@@ -1,0 +1,3 @@
+import relativeDep from './nonexistent-relative-dependency.js';
+
+relativeDep.wasAltered = true;


### PR DESCRIPTION
See #532 for a detailed explanation of the problem this pull requests solves, and also the use case for non-existent, relative files to be treated as external dependencies.