### PR TITLE
Add an option to add noConflict method to umd global

### DIFF
--- a/bin/help.md
+++ b/bin/help.md
@@ -21,6 +21,7 @@ Basic options:
 --no-strict              Don't emit a `"use strict";` in the generated modules.
 --no-indent              Don't indent result
 --environment <values>   Settings passed to config file (see example)
+--no-conflict            Generate a noConflict method for UMD globals
 --intro                  Content to insert at top of bundle (inside wrapper)
 --outro                  Content to insert at end of bundle (inside wrapper)
 --banner                 Content to insert at top of bundle (outside wrapper)

--- a/bin/runRollup.js
+++ b/bin/runRollup.js
@@ -115,6 +115,8 @@ function execute ( options, command ) {
 	options.external = external;
 	options.indent = command.indent !== false;
 
+	options.noConflict = command.conflict === false;
+
 	Object.keys( equivalents ).forEach( function ( cliOption ) {
 		if ( command[ cliOption ] ) {
 			options[ equivalents[ cliOption ] ] = command[ cliOption ];

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -51,7 +51,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 				var exports = factory(${globalDeps});
 				global.${options.moduleName} = exports;
 				exports.noConflict = function() { global.${options.moduleName} = current; return exports; };
-			})()` : `(${defaultExport}factory(${globalDeps}))`
+			})()` : `(${defaultExport}factory(${globalDeps}))`;
 
 	const intro =
 		`(function (global, factory) {

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -45,11 +45,19 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 
 	const useStrict = options.useStrict !== false ? ` 'use strict';` : ``;
 
+	const globalExport = options.noConflict === true ?
+		`(function() {
+				var current = global.${options.moduleName};
+				var exports = factory(${globalDeps});
+				global.${options.moduleName} = exports;
+				exports.noConflict = function() { global.${options.moduleName} = current; return exports; };
+			})()` : `(${defaultExport}factory(${globalDeps}))`
+
 	const intro =
 		`(function (global, factory) {
 			typeof exports === 'object' && typeof module !== 'undefined' ? ${cjsExport}factory(${cjsDeps.join( ', ' )}) :
 			typeof define === 'function' && define.amd ? define(${amdParams}factory) :
-			(${defaultExport}factory(${globalDeps}));
+			${globalExport};
 		}(this, function (${args}) {${useStrict}
 
 		`.replace( /^\t\t/gm, '' ).replace( /^\t/gm, magicString.getIndentString() );

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -21,6 +21,7 @@ const ALLOWED_KEYS = [
 	'intro',
 	'moduleId',
 	'moduleName',
+	'noConflict',
 	'onwarn',
 	'outro',
 	'plugins',

--- a/test/form/umd-noconflict/_config.js
+++ b/test/form/umd-noconflict/_config.js
@@ -1,0 +1,10 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'exports noConflict method for default umd when requested',
+	options: {
+		noConflict: true,
+		moduleName: 'FooBar'
+	}
+};
+

--- a/test/form/umd-noconflict/_expected/amd.js
+++ b/test/form/umd-noconflict/_expected/amd.js
@@ -1,0 +1,15 @@
+define(['exports'], function (exports) { 'use strict';
+
+	function doThings() {
+		console.log( 'doing things...' );
+	}
+
+	const number = 42;
+
+	var setting = 'no';
+
+	exports.doThings = doThings;
+	exports.number = number;
+	exports.setting = setting;
+
+});

--- a/test/form/umd-noconflict/_expected/cjs.js
+++ b/test/form/umd-noconflict/_expected/cjs.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function doThings() {
+	console.log( 'doing things...' );
+}
+
+const number = 42;
+
+var setting = 'no';
+
+exports.doThings = doThings;
+exports.number = number;
+exports.setting = setting;

--- a/test/form/umd-noconflict/_expected/es6.js
+++ b/test/form/umd-noconflict/_expected/es6.js
@@ -1,0 +1,9 @@
+function doThings() {
+	console.log( 'doing things...' );
+}
+
+const number = 42;
+
+var setting = 'no';
+
+export { doThings, number, setting };

--- a/test/form/umd-noconflict/_expected/iife.js
+++ b/test/form/umd-noconflict/_expected/iife.js
@@ -1,0 +1,16 @@
+(function (exports) {
+	'use strict';
+
+	function doThings() {
+		console.log( 'doing things...' );
+	}
+
+	const number = 42;
+
+	var setting = 'no';
+
+	exports.doThings = doThings;
+	exports.number = number;
+	exports.setting = setting;
+
+}((this.FooBar = this.FooBar || {})));

--- a/test/form/umd-noconflict/_expected/umd.js
+++ b/test/form/umd-noconflict/_expected/umd.js
@@ -1,0 +1,24 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(function() {
+		var current = global.FooBar;
+		var exports = factory((global.FooBar = global.FooBar || {}));
+		global.FooBar = exports;
+		exports.noConflict = function() { global.FooBar = current; return exports; };
+	})();
+}(this, function (exports) { 'use strict';
+
+	function doThings() {
+		console.log( 'doing things...' );
+	}
+
+	const number = 42;
+
+	var setting = 'no';
+
+	exports.doThings = doThings;
+	exports.number = number;
+	exports.setting = setting;
+
+}));

--- a/test/form/umd-noconflict/main.js
+++ b/test/form/umd-noconflict/main.js
@@ -1,0 +1,7 @@
+export function doThings() {
+	console.log( 'doing things...' );
+}
+
+export const number = 42;
+
+export var setting = 'no';

--- a/test/test.js
+++ b/test/test.js
@@ -76,7 +76,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( function () {
 				throw new Error( 'Missing expected error' );
 			}, function ( err ) {
-				assert.equal( 'Unexpected key \'plUgins\' found, expected one of: banner, dest, entry, exports, external, footer, format, globals, indent, intro, moduleId, moduleName, onwarn, outro, plugins, sourceMap', err.message );
+				assert.equal( 'Unexpected key \'plUgins\' found, expected one of: banner, dest, entry, exports, external, footer, format, globals, indent, intro, moduleId, moduleName, noConflict, onwarn, outro, plugins, sourceMap', err.message );
 			});
 		});
 	});


### PR DESCRIPTION
I don't know if this was even something on the radar for rollup, but it seemed like a better solution than regexp hacking build output. So feel free to ignore this if it's not something rollup should handle :smile:

This _should_ only affect UMD modules when they're used as a global. I'm not 100% sure this is the best way to handle it, or if I've even put all the right things in the right places, but I did do a test build with this with Ractive and it seems to work as intended. 

Linking - ractivejs/ractive#2066