### PR TITLE
Windows...

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -27,7 +27,7 @@ export default class Bundle {
 			}
 		});
 
-		this.entry = options.entry;
+		this.entry = unixizePath( options.entry );
 		this.entryModule = null;
 
 		this.resolveId = first(


### PR DESCRIPTION
Just spent about three hours trying to find out why some Ractive tests are failing for me and passing on Travis... Eventually I found out rollup was including the whole Ractive code twice in one file, which caused some `instanceof` checks to fail... Luckily, after identifying it was a problem with rollup, I found the offending code in two minutes :smile: 