### PR TITLE
Add root: true to eslint config.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+	"root": true,
 	"rules": {
 		"indent": [ 2, "tab", { "SwitchCase": 1 } ],
 		"quotes": [ 2, "single" ],


### PR DESCRIPTION
This prevents eslint from taking user's eslint config files that are
higher in the directory structure into consideration.