### PR TITLE
report files causing transform errors

### DIFF
--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -39,5 +39,10 @@ export default function transform ( source, id, transformers ) {
 
 	}, Promise.resolve( source.code ) )
 
-	.then( code => ({ code, originalCode, ast, sourceMapChain }) );
+	.then( code => ({ code, originalCode, ast, sourceMapChain }) )
+	.catch( err => {
+		err.id = id;
+		err.message = `Error loading ${id}: ${err.message}`;
+		throw err;
+	});
 }

--- a/test/function/report-transform-error-file/_config.js
+++ b/test/function/report-transform-error-file/_config.js
@@ -1,0 +1,17 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'reports which file caused a transform error',
+	options: {
+		plugins: [{
+			transform: function ( code, id ) {
+				if ( /foo/.test( id ) ) {
+					throw new Error( 'nope' );
+				}
+			}
+		}]
+	},
+	error: function ( err ) {
+		assert.ok( ~err.message.indexOf( 'foo.js' ) );
+	}
+};

--- a/test/function/report-transform-error-file/foo.js
+++ b/test/function/report-transform-error-file/foo.js
@@ -1,0 +1,3 @@
+export default function () {
+	console.log( 'foo' );
+}

--- a/test/function/report-transform-error-file/main.js
+++ b/test/function/report-transform-error-file/main.js
@@ -1,0 +1,3 @@
+import foo from './foo.js';
+
+foo();


### PR DESCRIPTION
Does what it says on the tin – if a transform fails on a particular file, this PR augments the error message to include the filename. An `id` property is also added to the error object.

Thoughts on whether this is the right approach?