### PR TITLE
create new scope for classes, with class expression ID (if any) as sole name

### DIFF
--- a/src/ast/attachScopes.js
+++ b/src/ast/attachScopes.js
@@ -29,7 +29,7 @@ export default function attachScopes ( statement ) {
 			let newScope;
 
 			// create new function scope
-			if ( /Function/.test( node.type ) ) {
+			if ( /(Function|Class)/.test( node.type ) ) {
 				newScope = new Scope({
 					parent: scope,
 					block: false,
@@ -38,7 +38,7 @@ export default function attachScopes ( statement ) {
 
 				// named function expressions - the name is considered
 				// part of the function's scope
-				if ( node.type === 'FunctionExpression' && node.id ) {
+				if ( /(Function|Class)Expression/.test( node.type ) && node.id ) {
 					newScope.addDeclaration( node, false, false );
 				}
 			}

--- a/test/form/assignment-to-exports-class-declaration/_config.js
+++ b/test/form/assignment-to-exports-class-declaration/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'does not rewrite class declaration IDs',
+	options: {
+		moduleName: 'myModule'
+	}
+};

--- a/test/form/assignment-to-exports-class-declaration/_expected/amd.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/amd.js
@@ -1,0 +1,6 @@
+define(['exports'], function (exports) { 'use strict';
+
+	exports.Foo = class Foo {}
+	exports.Foo = lol( exports.Foo );
+
+});

--- a/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+exports.Foo = class Foo {}
+exports.Foo = lol( exports.Foo );

--- a/test/form/assignment-to-exports-class-declaration/_expected/es6.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/es6.js
@@ -1,0 +1,4 @@
+Foo = class Foo {}
+Foo = lol( Foo );
+
+export { Foo };

--- a/test/form/assignment-to-exports-class-declaration/_expected/iife.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/iife.js
@@ -1,0 +1,7 @@
+(function (exports) {
+	'use strict';
+
+	exports.Foo = class Foo {}
+	exports.Foo = lol( exports.Foo );
+
+}((this.myModule = this.myModule || {})));

--- a/test/form/assignment-to-exports-class-declaration/_expected/umd.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.myModule = global.myModule || {})));
+}(this, function (exports) { 'use strict';
+
+	exports.Foo = class Foo {}
+	exports.Foo = lol( exports.Foo );
+
+}));

--- a/test/form/assignment-to-exports-class-declaration/main.js
+++ b/test/form/assignment-to-exports-class-declaration/main.js
@@ -1,0 +1,2 @@
+export let Foo = class Foo {}
+Foo = lol( Foo );


### PR DESCRIPTION
Fixes #626.

It works by creating a new scope for classes (declarations and expressions), so that if a class expression has an ID, the ID belongs to that scope:

```js
let Foo = 'nope';

let MyClass = class Foo {
  constructor () {
    assert.equal( this instanceof Foo );
  }
}
```

In other words, it behaves similarly to function expressions (except that the class expression ID is the only name that can belong directly to the scope, since any further declarations take place inside the class's methods).

As a side-effect, the `Foo` in `class Foo` isn't seen as a reference to an external declaration, and thus isn't erroneously rewritten.

I'm fairly sure this is semantically correct but will leave this here for a while in case anyone wants to correct me...