### PR TITLE
warn if default and named exports are used together in auto mode

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -241,7 +241,7 @@ export default class Bundle {
 		const format = options.format || 'es6';
 
 		// Determine export mode - 'default', 'named', 'none'
-		const exportMode = getExportMode( this, options.exports );
+		const exportMode = getExportMode( this, options.exports, options.moduleName );
 
 		let magicString = new MagicString.Bundle({ separator: '\n\n' });
 		let usedModules = [];

--- a/src/utils/getExportMode.js
+++ b/src/utils/getExportMode.js
@@ -4,7 +4,7 @@ function badExports ( option, keys ) {
 	throw new Error( `'${option}' was specified for options.exports, but entry module has following exports: ${keys.join(', ')}` );
 }
 
-export default function getExportMode ( bundle, exportMode ) {
+export default function getExportMode ( bundle, exportMode, moduleName ) {
 	const exportKeys = keys( bundle.entryModule.exports )
 		.concat( keys( bundle.entryModule.reexports ) )
 		.concat( bundle.entryModule.exportAllSources ); // not keys, but makes our job easier this way
@@ -23,6 +23,9 @@ export default function getExportMode ( bundle, exportMode ) {
 		} else if ( exportKeys.length === 1 && exportKeys[0] === 'default' ) {
 			exportMode = 'default';
 		} else {
+			if ( bundle.entryModule.exports.default ) {
+				bundle.onwarn( `Using named and default exports together. Consumers of your bundle will have to use ${moduleName || 'bundle'}['default'] to access the default export, which may not be what you want. Use \`exports: 'named'\` to disable this warning. See https://github.com/rollup/rollup/wiki/JavaScript-API#exports for more information` );
+			}
 			exportMode = 'named';
 		}
 	}

--- a/test/function/confused-default-identifier/_config.js
+++ b/test/function/confused-default-identifier/_config.js
@@ -2,9 +2,7 @@ var assert = require( 'assert' );
 
 module.exports = {
 	description: 'Rollup should not get confused and allow "default" as an identifier name',
-	warnings: function ( warnings ) {
-		// ignore pending gh-587
-	}
+	warnings: function () {} // suppress
 };
 
 // https://github.com/rollup/rollup/issues/215

--- a/test/function/warn-on-auto-named-default-exports/_config.js
+++ b/test/function/warn-on-auto-named-default-exports/_config.js
@@ -1,0 +1,10 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'warns if default and named exports are used in auto mode',
+	warnings: function ( warnings ) {
+		assert.deepEqual( warnings, [
+			'Using named and default exports together. Consumers of your bundle will have to use bundle[\'default\'] to access the default export, which may not be what you want. Use `exports: \'named\'` to disable this warning. See https://github.com/rollup/rollup/wiki/JavaScript-API#exports for more information'
+		]);
+	}
+};

--- a/test/function/warn-on-auto-named-default-exports/main.js
+++ b/test/function/warn-on-auto-named-default-exports/main.js
@@ -1,0 +1,10 @@
+function foo () {
+	console.log( 'foo' );
+}
+
+function bar () {
+	console.log( 'bar' );
+}
+
+export default foo;
+export { bar };


### PR DESCRIPTION
Addresses #587. If you have an entry module like this...

```js
function foo () {
  console.log( 'foo' );
}

function bar () {
  console.log( 'bar' );
}

export default foo;
export { bar };
```

...and you don't specify an export mode, you'll end up with the dreaded `exports['default'] = foo` if you're creating anything other than an ES2015 bundle, which is bad for interoperability.

This PR adds a warning if that situation is encountered, pointing to the relevant documentation.