### PR TITLE
Exported __esModule when bundling to CJS or UMD in named mode.

### DIFF
--- a/src/finalisers/cjs.js
+++ b/src/finalisers/cjs.js
@@ -1,4 +1,5 @@
 import getExportBlock from './shared/getExportBlock.js';
+import esModuleExport from './shared/esModuleExport.js';
 
 export default function cjs ( bundle, magicString, { exportMode }, options ) {
 	let intro = options.useStrict === false ? `` : `'use strict';\n\n`;
@@ -35,7 +36,7 @@ export default function cjs ( bundle, magicString, { exportMode }, options ) {
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
 
 	if (exportMode === 'named') {
-		magicString.append('\n\nexports.__esModule = true;\n\n');
+		magicString.append(esModuleExport);
 	}
 
 	return magicString;

--- a/src/finalisers/cjs.js
+++ b/src/finalisers/cjs.js
@@ -34,5 +34,9 @@ export default function cjs ( bundle, magicString, { exportMode }, options ) {
 	const exportBlock = getExportBlock( bundle.entryModule, exportMode, 'module.exports =' );
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
 
+	if (exportMode === 'named') {
+		magicString.append('\n\nexports.__esModule = true;\n\n');
+	}
+
 	return magicString;
 }

--- a/src/finalisers/shared/esModuleExport.js
+++ b/src/finalisers/shared/esModuleExport.js
@@ -1,0 +1,4 @@
+export default '\n\n' +
+	'Object.defineProperty(exports, "__esModule", {\n' +
+	'	value: true\n' +
+	'});\n\n';

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -3,6 +3,7 @@ import { getName, quoteId, req } from '../utils/map-helpers.js';
 import getInteropBlock from './shared/getInteropBlock.js';
 import getExportBlock from './shared/getExportBlock.js';
 import getGlobalNameMaker from './shared/getGlobalNameMaker.js';
+import esModuleExport from './shared/esModuleExport.js';
 
 function setupNamespace ( name ) {
 	const parts = name.split( '.' );
@@ -70,7 +71,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
 
 	if (exportMode === 'named') {
-		magicString.append('\n\nexports.__esModule = true;\n\n');
+		magicString.append(esModuleExport);
 	}
 
 	return magicString

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -69,6 +69,10 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 	const exportBlock = getExportBlock( bundle.entryModule, exportMode );
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
 
+	if (exportMode === 'named') {
+		magicString.append('\n\nexports.__esModule = true;\n\n');
+	}
+
 	return magicString
 		.trim()
 		.indent( indentString )

--- a/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
@@ -2,3 +2,5 @@
 
 exports.Foo = class Foo {}
 exports.Foo = lol( exports.Foo );
+
+exports.__esModule = true;

--- a/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
@@ -3,4 +3,6 @@
 exports.Foo = class Foo {}
 exports.Foo = lol( exports.Foo );
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/assignment-to-exports-class-declaration/_expected/umd.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/umd.js
@@ -7,4 +7,6 @@
 	exports.Foo = class Foo {}
 	exports.Foo = lol( exports.Foo );
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/assignment-to-exports-class-declaration/_expected/umd.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/umd.js
@@ -7,6 +7,8 @@
 	exports.Foo = class Foo {}
 	exports.Foo = lol( exports.Foo );
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/computed-properties/_expected/cjs.js
+++ b/test/form/computed-properties/_expected/cjs.js
@@ -15,3 +15,5 @@ class X {
 
 exports.x = x;
 exports.X = X;
+
+exports.__esModule = true;

--- a/test/form/computed-properties/_expected/cjs.js
+++ b/test/form/computed-properties/_expected/cjs.js
@@ -16,4 +16,6 @@ class X {
 exports.x = x;
 exports.X = X;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/computed-properties/_expected/umd.js
+++ b/test/form/computed-properties/_expected/umd.js
@@ -20,6 +20,8 @@
 	exports.x = x;
 	exports.X = X;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/computed-properties/_expected/umd.js
+++ b/test/form/computed-properties/_expected/umd.js
@@ -20,4 +20,6 @@
 	exports.x = x;
 	exports.X = X;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/dedupes-external-imports/_expected/cjs.js
+++ b/test/form/dedupes-external-imports/_expected/cjs.js
@@ -30,3 +30,5 @@ const baz = new Baz();
 exports.foo = foo;
 exports.bar = bar;
 exports.baz = baz;
+
+exports.__esModule = true;

--- a/test/form/dedupes-external-imports/_expected/cjs.js
+++ b/test/form/dedupes-external-imports/_expected/cjs.js
@@ -31,4 +31,6 @@ exports.foo = foo;
 exports.bar = bar;
 exports.baz = baz;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/dedupes-external-imports/_expected/umd.js
+++ b/test/form/dedupes-external-imports/_expected/umd.js
@@ -33,6 +33,8 @@
 	exports.bar = bar;
 	exports.baz = baz;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/dedupes-external-imports/_expected/umd.js
+++ b/test/form/dedupes-external-imports/_expected/umd.js
@@ -33,4 +33,6 @@
 	exports.bar = bar;
 	exports.baz = baz;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/export-all-from-internal/_expected/cjs.js
+++ b/test/form/export-all-from-internal/_expected/cjs.js
@@ -6,4 +6,6 @@ const b = 2;
 exports.a = a;
 exports.b = b;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/export-all-from-internal/_expected/cjs.js
+++ b/test/form/export-all-from-internal/_expected/cjs.js
@@ -5,3 +5,5 @@ const b = 2;
 
 exports.a = a;
 exports.b = b;
+
+exports.__esModule = true;

--- a/test/form/export-all-from-internal/_expected/umd.js
+++ b/test/form/export-all-from-internal/_expected/umd.js
@@ -10,4 +10,6 @@
 	exports.a = a;
 	exports.b = b;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/export-all-from-internal/_expected/umd.js
+++ b/test/form/export-all-from-internal/_expected/umd.js
@@ -10,6 +10,8 @@
 	exports.a = a;
 	exports.b = b;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/export-default-import/_expected/cjs.js
+++ b/test/form/export-default-import/_expected/cjs.js
@@ -7,3 +7,5 @@ var x = _interopDefault(require('x'));
 
 
 exports.x = x;
+
+exports.__esModule = true;

--- a/test/form/export-default-import/_expected/cjs.js
+++ b/test/form/export-default-import/_expected/cjs.js
@@ -8,4 +8,6 @@ var x = _interopDefault(require('x'));
 
 exports.x = x;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/export-default-import/_expected/umd.js
+++ b/test/form/export-default-import/_expected/umd.js
@@ -10,4 +10,6 @@
 
 	exports.x = x;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/export-default-import/_expected/umd.js
+++ b/test/form/export-default-import/_expected/umd.js
@@ -10,6 +10,8 @@
 
 	exports.x = x;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/exports-at-end-if-possible/_expected/cjs.js
+++ b/test/form/exports-at-end-if-possible/_expected/cjs.js
@@ -7,3 +7,5 @@ console.log( FOO );
 console.log( FOO );
 
 exports.FOO = FOO;
+
+exports.__esModule = true;

--- a/test/form/exports-at-end-if-possible/_expected/cjs.js
+++ b/test/form/exports-at-end-if-possible/_expected/cjs.js
@@ -8,4 +8,6 @@ console.log( FOO );
 
 exports.FOO = FOO;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/exports-at-end-if-possible/_expected/umd.js
+++ b/test/form/exports-at-end-if-possible/_expected/umd.js
@@ -12,4 +12,6 @@
 
 	exports.FOO = FOO;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/exports-at-end-if-possible/_expected/umd.js
+++ b/test/form/exports-at-end-if-possible/_expected/umd.js
@@ -12,6 +12,8 @@
 
 	exports.FOO = FOO;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/multiple-exports/_expected/cjs.js
+++ b/test/form/multiple-exports/_expected/cjs.js
@@ -6,4 +6,6 @@ var bar = 2;
 exports.foo = foo;
 exports.bar = bar;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/multiple-exports/_expected/cjs.js
+++ b/test/form/multiple-exports/_expected/cjs.js
@@ -5,3 +5,5 @@ var bar = 2;
 
 exports.foo = foo;
 exports.bar = bar;
+
+exports.__esModule = true;

--- a/test/form/multiple-exports/_expected/umd.js
+++ b/test/form/multiple-exports/_expected/umd.js
@@ -10,4 +10,6 @@
 	exports.foo = foo;
 	exports.bar = bar;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/multiple-exports/_expected/umd.js
+++ b/test/form/multiple-exports/_expected/umd.js
@@ -10,6 +10,8 @@
 	exports.foo = foo;
 	exports.bar = bar;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/namespaced-named-exports/_expected/cjs.js
+++ b/test/form/namespaced-named-exports/_expected/cjs.js
@@ -3,3 +3,5 @@
 var answer = 42;
 
 exports.answer = answer;
+
+exports.__esModule = true;

--- a/test/form/namespaced-named-exports/_expected/cjs.js
+++ b/test/form/namespaced-named-exports/_expected/cjs.js
@@ -4,4 +4,6 @@ var answer = 42;
 
 exports.answer = answer;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/namespaced-named-exports/_expected/umd.js
+++ b/test/form/namespaced-named-exports/_expected/umd.js
@@ -8,4 +8,6 @@
 
 	exports.answer = answer;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/namespaced-named-exports/_expected/umd.js
+++ b/test/form/namespaced-named-exports/_expected/umd.js
@@ -8,6 +8,8 @@
 
 	exports.answer = answer;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/no-treeshake/_expected/cjs.js
+++ b/test/form/no-treeshake/_expected/cjs.js
@@ -23,3 +23,5 @@ exports.baz = baz;
 exports.create = create;
 exports.getPrototypeOf = getPrototypeOf;
 exports.strange = quux;
+
+exports.__esModule = true;

--- a/test/form/no-treeshake/_expected/cjs.js
+++ b/test/form/no-treeshake/_expected/cjs.js
@@ -24,4 +24,6 @@ exports.create = create;
 exports.getPrototypeOf = getPrototypeOf;
 exports.strange = quux;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/no-treeshake/_expected/umd.js
+++ b/test/form/no-treeshake/_expected/umd.js
@@ -26,6 +26,8 @@
 	exports.getPrototypeOf = getPrototypeOf;
 	exports.strange = quux;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/no-treeshake/_expected/umd.js
+++ b/test/form/no-treeshake/_expected/umd.js
@@ -26,4 +26,6 @@
 	exports.getPrototypeOf = getPrototypeOf;
 	exports.strange = quux;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/preserves-comments-after-imports/_expected/cjs.js
+++ b/test/form/preserves-comments-after-imports/_expected/cjs.js
@@ -7,3 +7,5 @@ var number = 5;
 var obj = { number };
 
 exports.obj = obj;
+
+exports.__esModule = true;

--- a/test/form/preserves-comments-after-imports/_expected/cjs.js
+++ b/test/form/preserves-comments-after-imports/_expected/cjs.js
@@ -8,4 +8,6 @@ var obj = { number };
 
 exports.obj = obj;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/preserves-comments-after-imports/_expected/umd.js
+++ b/test/form/preserves-comments-after-imports/_expected/umd.js
@@ -12,6 +12,8 @@
 
 	exports.obj = obj;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/preserves-comments-after-imports/_expected/umd.js
+++ b/test/form/preserves-comments-after-imports/_expected/umd.js
@@ -12,4 +12,6 @@
 
 	exports.obj = obj;
 
+	exports.__esModule = true;
+
 }));

--- a/test/form/umd-noconflict/_expected/cjs.js
+++ b/test/form/umd-noconflict/_expected/cjs.js
@@ -11,3 +11,5 @@ var setting = 'no';
 exports.doThings = doThings;
 exports.number = number;
 exports.setting = setting;
+
+exports.__esModule = true;

--- a/test/form/umd-noconflict/_expected/cjs.js
+++ b/test/form/umd-noconflict/_expected/cjs.js
@@ -12,4 +12,6 @@ exports.doThings = doThings;
 exports.number = number;
 exports.setting = setting;
 
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});

--- a/test/form/umd-noconflict/_expected/umd.js
+++ b/test/form/umd-noconflict/_expected/umd.js
@@ -21,6 +21,8 @@
 	exports.number = number;
 	exports.setting = setting;
 
-	exports.__esModule = true;
+	Object.defineProperty(exports, "__esModule", {
+		value: true
+	});
 
 }));

--- a/test/form/umd-noconflict/_expected/umd.js
+++ b/test/form/umd-noconflict/_expected/umd.js
@@ -21,4 +21,6 @@
 	exports.number = number;
 	exports.setting = setting;
 
+	exports.__esModule = true;
+
 }));

--- a/test/function/deconflicts-exports/_config.js
+++ b/test/function/deconflicts-exports/_config.js
@@ -3,7 +3,7 @@ var assert = require( 'assert' );
 module.exports = {
 	description: 'renames variables named `exports` if necessary',
 	exports: function ( exports ) {
-		assert.deepEqual( Object.keys( exports ), [ 'a', 'b', '__esModule' ] );
+		assert.deepEqual( Object.keys( exports ), [ 'a', 'b' ] );
 		assert.equal( exports.a, 'A' );
 		assert.equal( exports.b, 42 );
 	}

--- a/test/function/deconflicts-exports/_config.js
+++ b/test/function/deconflicts-exports/_config.js
@@ -3,7 +3,7 @@ var assert = require( 'assert' );
 module.exports = {
 	description: 'renames variables named `exports` if necessary',
 	exports: function ( exports ) {
-		assert.deepEqual( Object.keys( exports ), [ 'a', 'b' ] );
+		assert.deepEqual( Object.keys( exports ), [ 'a', 'b', '__esModule' ] );
 		assert.equal( exports.a, 'A' );
 		assert.equal( exports.b, 42 );
 	}

--- a/test/function/export-destruction/_config.js
+++ b/test/function/export-destruction/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 	babel: true,
 
 	exports: function ( exports ) {
-		assert.deepEqual( Object.keys( exports ), [ 'baz', 'quux' ] );
+		assert.deepEqual( Object.keys( exports ), [ 'baz', 'quux', '__esModule' ] );
 		assert.equal( exports.baz, 5 );
 		assert.equal( exports.quux, 17 );
 	}

--- a/test/function/export-destruction/_config.js
+++ b/test/function/export-destruction/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 	babel: true,
 
 	exports: function ( exports ) {
-		assert.deepEqual( Object.keys( exports ), [ 'baz', 'quux', '__esModule' ] );
+		assert.deepEqual( Object.keys( exports ), [ 'baz', 'quux' ] );
 		assert.equal( exports.baz, 5 );
 		assert.equal( exports.quux, 17 );
 	}


### PR DESCRIPTION
This is a follow-up PR for issue https://github.com/rollup/rollup/issues/650.

One thing that I'm not sure about is if I have broken sourcemaps. Since I have just added to the end of the output, the mapping should still be valid. But can somebody who is more knowledgeable confirm that I have not?

Also, should I add new test cases to explicitly test this behaviour?

EDIT: I see that [magic-string] takes care of keeping source maps correct.

[magic-string]: https://github.com/Rich-Harris/magic-string