### PR TITLE
Load 'index.js' from the supplied module directory if it exists and the module doesn't

### DIFF
--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -7,10 +7,17 @@ export function load ( id ) {
 }
 
 function addJsExtensionIfNecessary ( file ) {
+	let originalFileName;
+
 	if ( isFile( file ) ) return file;
+
+	originalFileName = file;
 
 	file += '.js';
 	if ( isFile( file ) ) return file;
+
+	originalFileName += '/index.js';
+	if ( isFile( originalFileName ) ) return originalFileName;
 
 	return null;
 }

--- a/test/function/import-index-from-directory/_config.js
+++ b/test/function/import-index-from-directory/_config.js
@@ -1,0 +1,8 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'imports the index file from a relative dir if the file to import does not exist',
+	exports: function ( exports ) {
+		assert.equal( exports, 42 );
+	}
+};

--- a/test/function/import-index-from-directory/first/index.js
+++ b/test/function/import-index-from-directory/first/index.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/function/import-index-from-directory/main.js
+++ b/test/function/import-index-from-directory/main.js
@@ -1,0 +1,3 @@
+import first from './first';
+
+export default first;


### PR DESCRIPTION
If you have a file structure similar to the following, and attempt to import `./first` from `main`, then a `"Could not resolve ./first"` error will be thrown by Rollup. In node (and Browserify!), this will resolve to `./first/index.js` if the file exists.

```
src
├──main.js
└──first
	└──index.js
```
