### PR TITLE
feat: support tree-shaking of classes instantiated at the top level of a module

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -13,6 +13,12 @@ export default class Declaration {
 			} else if ( node.type === 'VariableDeclarator' && node.init && /FunctionExpression/.test( node.init.type ) ) {
 				this.isFunctionDeclaration = true;
 				this.functionNode = node.init;
+			} else if ( node.type === 'ClassDeclaration') {
+				this.isClassDeclaration = true;
+				const constructorNode = node.body.body.find(node => node.kind === 'constructor');
+				if (constructorNode) {
+					this.hasConstructor = true;
+				}
 			}
 		}
 
@@ -48,8 +54,10 @@ export default class Declaration {
 	run ( strongDependencies ) {
 		if ( this.tested ) return this.hasSideEffects;
 
-
-		if ( !this.functionNode ) {
+		if ( this.isClassDeclaration && !this.hasConstructor ) {
+			// class declaration without a constructor has no side-effects
+			this.hasSideEffects = false;
+		} else if ( !this.functionNode ) {
 			this.hasSideEffects = true; // err on the side of caution. TODO handle unambiguous `var x; x = y => z` cases
 		} else {
 			if ( this.running ) return true; // short-circuit infinite loop

--- a/test/form/side-effect-p/_config.js
+++ b/test/form/side-effect-p/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'discards declarations new-ing up an otherwise unused class',
+	options: {
+		moduleName: 'myBundle'
+	}
+};

--- a/test/form/side-effect-p/_expected/amd.js
+++ b/test/form/side-effect-p/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+  class PublicClass {}
+
+  return PublicClass;
+
+});

--- a/test/form/side-effect-p/_expected/cjs.js
+++ b/test/form/side-effect-p/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+class PublicClass {}
+
+module.exports = PublicClass;

--- a/test/form/side-effect-p/_expected/es6.js
+++ b/test/form/side-effect-p/_expected/es6.js
@@ -1,0 +1,3 @@
+class PublicClass {}
+
+export default PublicClass;

--- a/test/form/side-effect-p/_expected/iife.js
+++ b/test/form/side-effect-p/_expected/iife.js
@@ -1,0 +1,8 @@
+var myBundle = (function () {
+  'use strict';
+
+  class PublicClass {}
+
+  return PublicClass;
+
+}());

--- a/test/form/side-effect-p/_expected/umd.js
+++ b/test/form/side-effect-p/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global.myBundle = factory());
+}(this, function () { 'use strict';
+
+  class PublicClass {}
+
+  return PublicClass;
+
+}));

--- a/test/form/side-effect-p/main.js
+++ b/test/form/side-effect-p/main.js
@@ -1,0 +1,12 @@
+class ClassWithNoConstructor {
+}
+
+
+// TODO support tree shaking this in the future
+class ClassWithConstructor {
+  constructor() { }
+}
+
+const unusedInstance = new ClassWithNoConstructor();
+
+export default class PublicClass {}


### PR DESCRIPTION
Only classes without constructors are currently supported because we can't
easily detect side-effect free constructors without a bigger refactoring.
