### PR TITLE
__esModule for AMD modules and CJS with cyclical dependencies

### DIFF
--- a/src/finalisers/amd.js
+++ b/src/finalisers/amd.js
@@ -1,6 +1,7 @@
 import { getName, quoteId } from '../utils/map-helpers.js';
 import getInteropBlock from './shared/getInteropBlock.js';
 import getExportBlock from './shared/getExportBlock.js';
+import esModuleExport from './shared/esModuleExport.js';
 
 export default function amd ( bundle, magicString, { exportMode, indentString }, options ) {
 	let deps = bundle.externalModules.map( quoteId );
@@ -24,6 +25,10 @@ export default function amd ( bundle, magicString, { exportMode, indentString },
 
 	const exportBlock = getExportBlock( bundle.entryModule, exportMode );
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
+
+	if ( exportMode === 'named' ) {
+		magicString.append( `\n\n${esModuleExport}` );
+	}
 
 	return magicString
 		.indent( indentString )

--- a/src/finalisers/cjs.js
+++ b/src/finalisers/cjs.js
@@ -2,7 +2,8 @@ import getExportBlock from './shared/getExportBlock.js';
 import esModuleExport from './shared/esModuleExport.js';
 
 export default function cjs ( bundle, magicString, { exportMode }, options ) {
-	let intro = options.useStrict === false ? `` : `'use strict';\n\n`;
+	let intro = ( options.useStrict === false ? `` : `'use strict';\n\n` ) +
+	            ( exportMode === 'named' ? `${esModuleExport}\n\n` : '' );
 
 	const hasDefaultImport = bundle.externalModules.some( mod => mod.declarations.default);
 
@@ -34,10 +35,6 @@ export default function cjs ( bundle, magicString, { exportMode }, options ) {
 
 	const exportBlock = getExportBlock( bundle.entryModule, exportMode, 'module.exports =' );
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
-
-	if (exportMode === 'named') {
-		magicString.append(esModuleExport);
-	}
 
 	return magicString;
 }

--- a/src/finalisers/shared/esModuleExport.js
+++ b/src/finalisers/shared/esModuleExport.js
@@ -1,4 +1,1 @@
-export default '\n\n' +
-	'Object.defineProperty(exports, "__esModule", {\n' +
-	'	value: true\n' +
-	'});\n\n';
+export default `Object.defineProperty(exports, '__esModule', { value: true });`;

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -71,7 +71,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
 
 	if (exportMode === 'named') {
-		magicString.append(esModuleExport);
+		magicString.append( `\n\n${esModuleExport}` );
 	}
 
 	return magicString

--- a/test/form/assignment-to-exports-class-declaration/_expected/amd.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/amd.js
@@ -3,4 +3,6 @@ define(['exports'], function (exports) { 'use strict';
 	exports.Foo = class Foo {}
 	exports.Foo = lol( exports.Foo );
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/cjs.js
@@ -1,8 +1,6 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 exports.Foo = class Foo {}
 exports.Foo = lol( exports.Foo );
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/assignment-to-exports-class-declaration/_expected/umd.js
+++ b/test/form/assignment-to-exports-class-declaration/_expected/umd.js
@@ -7,8 +7,6 @@
 	exports.Foo = class Foo {}
 	exports.Foo = lol( exports.Foo );
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/computed-properties/_expected/amd.js
+++ b/test/form/computed-properties/_expected/amd.js
@@ -16,4 +16,6 @@ define(['exports'], function (exports) { 'use strict';
 	exports.x = x;
 	exports.X = X;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/computed-properties/_expected/cjs.js
+++ b/test/form/computed-properties/_expected/cjs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 var foo = 'foo';
 var bar = 'bar';
 var baz = 'baz';
@@ -15,7 +17,3 @@ class X {
 
 exports.x = x;
 exports.X = X;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/computed-properties/_expected/umd.js
+++ b/test/form/computed-properties/_expected/umd.js
@@ -20,8 +20,6 @@
 	exports.x = x;
 	exports.X = X;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/dedupes-external-imports/_expected/amd.js
+++ b/test/form/dedupes-external-imports/_expected/amd.js
@@ -29,4 +29,6 @@ define(['exports', 'external'], function (exports, external) { 'use strict';
 	exports.bar = bar;
 	exports.baz = baz;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/dedupes-external-imports/_expected/cjs.js
+++ b/test/form/dedupes-external-imports/_expected/cjs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 var external = require('external');
 
 class Foo extends external.Component {
@@ -30,7 +32,3 @@ const baz = new Baz();
 exports.foo = foo;
 exports.bar = bar;
 exports.baz = baz;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/dedupes-external-imports/_expected/umd.js
+++ b/test/form/dedupes-external-imports/_expected/umd.js
@@ -33,8 +33,6 @@
 	exports.bar = bar;
 	exports.baz = baz;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/export-all-from-internal/_expected/amd.js
+++ b/test/form/export-all-from-internal/_expected/amd.js
@@ -6,4 +6,6 @@ define(['exports'], function (exports) { 'use strict';
 	exports.a = a;
 	exports.b = b;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/export-all-from-internal/_expected/cjs.js
+++ b/test/form/export-all-from-internal/_expected/cjs.js
@@ -1,11 +1,9 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 const a = 1;
 const b = 2;
 
 exports.a = a;
 exports.b = b;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/export-all-from-internal/_expected/umd.js
+++ b/test/form/export-all-from-internal/_expected/umd.js
@@ -10,8 +10,6 @@
 	exports.a = a;
 	exports.b = b;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/export-default-import/_expected/amd.js
+++ b/test/form/export-default-import/_expected/amd.js
@@ -6,4 +6,6 @@ define(['exports', 'x'], function (exports, x) { 'use strict';
 
 	exports.x = x;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/export-default-import/_expected/cjs.js
+++ b/test/form/export-default-import/_expected/cjs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
 var x = _interopDefault(require('x'));
@@ -7,7 +9,3 @@ var x = _interopDefault(require('x'));
 
 
 exports.x = x;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/export-default-import/_expected/umd.js
+++ b/test/form/export-default-import/_expected/umd.js
@@ -10,8 +10,6 @@
 
 	exports.x = x;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/exports-at-end-if-possible/_expected/amd.js
+++ b/test/form/exports-at-end-if-possible/_expected/amd.js
@@ -8,4 +8,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	exports.FOO = FOO;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/exports-at-end-if-possible/_expected/cjs.js
+++ b/test/form/exports-at-end-if-possible/_expected/cjs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 var FOO = 'foo';
 
 console.log( FOO );
@@ -7,7 +9,3 @@ console.log( FOO );
 console.log( FOO );
 
 exports.FOO = FOO;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/exports-at-end-if-possible/_expected/umd.js
+++ b/test/form/exports-at-end-if-possible/_expected/umd.js
@@ -12,8 +12,6 @@
 
 	exports.FOO = FOO;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/multiple-exports/_expected/amd.js
+++ b/test/form/multiple-exports/_expected/amd.js
@@ -6,4 +6,6 @@ define(['exports'], function (exports) { 'use strict';
 	exports.foo = foo;
 	exports.bar = bar;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/multiple-exports/_expected/cjs.js
+++ b/test/form/multiple-exports/_expected/cjs.js
@@ -1,11 +1,9 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 var foo = 1;
 var bar = 2;
 
 exports.foo = foo;
 exports.bar = bar;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/multiple-exports/_expected/umd.js
+++ b/test/form/multiple-exports/_expected/umd.js
@@ -10,8 +10,6 @@
 	exports.foo = foo;
 	exports.bar = bar;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/namespaced-named-exports/_expected/amd.js
+++ b/test/form/namespaced-named-exports/_expected/amd.js
@@ -4,4 +4,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	exports.answer = answer;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/namespaced-named-exports/_expected/cjs.js
+++ b/test/form/namespaced-named-exports/_expected/cjs.js
@@ -1,9 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 var answer = 42;
 
 exports.answer = answer;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/namespaced-named-exports/_expected/umd.js
+++ b/test/form/namespaced-named-exports/_expected/umd.js
@@ -8,8 +8,6 @@
 
 	exports.answer = answer;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/no-treeshake/_expected/amd.js
+++ b/test/form/no-treeshake/_expected/amd.js
@@ -22,4 +22,6 @@ define(['exports', 'external'], function (exports, external) { 'use strict';
 	exports.getPrototypeOf = getPrototypeOf;
 	exports.strange = quux;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/no-treeshake/_expected/cjs.js
+++ b/test/form/no-treeshake/_expected/cjs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 var external = require('external');
 
 var foo = 'unused';
@@ -23,7 +25,3 @@ exports.baz = baz;
 exports.create = create;
 exports.getPrototypeOf = getPrototypeOf;
 exports.strange = quux;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/no-treeshake/_expected/umd.js
+++ b/test/form/no-treeshake/_expected/umd.js
@@ -26,8 +26,6 @@
 	exports.getPrototypeOf = getPrototypeOf;
 	exports.strange = quux;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/preserves-comments-after-imports/_expected/amd.js
+++ b/test/form/preserves-comments-after-imports/_expected/amd.js
@@ -8,4 +8,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	exports.obj = obj;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/preserves-comments-after-imports/_expected/cjs.js
+++ b/test/form/preserves-comments-after-imports/_expected/cjs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 /** A comment for a number */
 var number = 5;
 
@@ -7,7 +9,3 @@ var number = 5;
 var obj = { number };
 
 exports.obj = obj;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/preserves-comments-after-imports/_expected/umd.js
+++ b/test/form/preserves-comments-after-imports/_expected/umd.js
@@ -12,8 +12,6 @@
 
 	exports.obj = obj;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));

--- a/test/form/umd-noconflict/_expected/amd.js
+++ b/test/form/umd-noconflict/_expected/amd.js
@@ -12,4 +12,6 @@ define(['exports'], function (exports) { 'use strict';
 	exports.number = number;
 	exports.setting = setting;
 
+	Object.defineProperty(exports, '__esModule', { value: true });
+
 });

--- a/test/form/umd-noconflict/_expected/cjs.js
+++ b/test/form/umd-noconflict/_expected/cjs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+Object.defineProperty(exports, '__esModule', { value: true });
+
 function doThings() {
 	console.log( 'doing things...' );
 }
@@ -11,7 +13,3 @@ var setting = 'no';
 exports.doThings = doThings;
 exports.number = number;
 exports.setting = setting;
-
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});

--- a/test/form/umd-noconflict/_expected/umd.js
+++ b/test/form/umd-noconflict/_expected/umd.js
@@ -21,8 +21,6 @@
 	exports.number = number;
 	exports.setting = setting;
 
-	Object.defineProperty(exports, "__esModule", {
-		value: true
-	});
+	Object.defineProperty(exports, '__esModule', { value: true });
 
 }));


### PR DESCRIPTION
This is based on #652, but applies it to AMD modules (see https://github.com/rollup/rollup/pull/652#issuecomment-219398441), and moves the block to the top of a CJS file to handle cyclical dependencies.

It also makes the style consistent with other statements inserted by Rollup (single line, single quotes).

Unfortunately I don't think it's possible to handle the cyclical dependency case (https://github.com/rollup/rollup/pull/652#issuecomment-219315359) in AMD modules. Because of that, I think it makes sense to keep the `__esModule` block at the bottom of UMD modules, because augmenting `exports` before any `require` statements take place would yield inconsistent behaviour between AMD and CJS environments. In practical terms, cyclical dependencies between bundles are rather rare, so I don't think this is a major issue.

Before we merge this, we need to be aware that this will break support for IE8. Not that IE8 should guide our decisions, but something to be aware of – for my understanding, what is the actual issue that `__esModule` solves, and is solving it a higher priority than preserving IE8 support? I have to confess I'm not entirely clear on why we need it – its absence has never been an issue for me. (cc @guybedford)