### PR TITLE
allow resolved module IDs to be non-strings

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -191,10 +191,14 @@ export default class Module {
 	}
 
 	basename () {
-		const base = basename( this.id );
-		const ext = extname( this.id );
+		if ( typeof this.id === 'string' ) {
+			const base = basename( this.id );
+			const ext = extname( this.id );
 
-		return makeLegalIdentifier( ext ? base.slice( 0, -ext.length ) : base );
+			return makeLegalIdentifier( ext ? base.slice( 0, -ext.length ) : base );
+		}
+
+		return 'module';
 	}
 
 	bindAliases () {
@@ -224,18 +228,18 @@ export default class Module {
 				const specifier = specifiers[ name ];
 
 				const id = this.resolvedIds[ specifier.source ];
-				specifier.module = this.bundle.moduleById[ id ];
+				specifier.module = this.bundle.moduleById.get( id );
 			});
 		});
 
 		this.exportAllModules = this.exportAllSources.map( source => {
 			const id = this.resolvedIds[ source ];
-			return this.bundle.moduleById[ id ];
+			return this.bundle.moduleById.get( id );
 		});
 
 		this.sources.forEach( source => {
 			const id = this.resolvedIds[ source ];
-			const module = this.bundle.moduleById[ id ];
+			const module = this.bundle.moduleById.get( id );
 
 			if ( !module.isExternal ) this.dependencies.push( module );
 		});

--- a/test/function/custom-resolver-non-string/_config.js
+++ b/test/function/custom-resolver-non-string/_config.js
@@ -1,0 +1,15 @@
+const FOO = {};
+
+module.exports = {
+	description: 'allows resolveId to return a non-string',
+	options: {
+		plugins: [{
+			resolveId: importee => {
+				if ( importee === 'foo' ) return FOO;
+			},
+			load: id => {
+				if ( id === FOO ) return 'export default 42';
+			}
+		}]
+	}
+};

--- a/test/function/custom-resolver-non-string/main.js
+++ b/test/function/custom-resolver-non-string/main.js
@@ -1,0 +1,2 @@
+import foo from 'foo';
+assert.equal( foo, 42 );


### PR DESCRIPTION
The purpose of this is to allow plugins like rollup-plugin-commonjs and rollup-plugin-babel to supply 'helper' modules (which transformed modules then depend on) without having to use daft string IDs like `__babelHelpers__` and hoping that there are no collisions.

The larger goal is to make it easier for to plugins to be stateless, which advances the goal of incremental rebuilds (see https://github.com/rollup/rollup/pull/658#issuecomment-224107907).