### PR TITLE
ensure name suggestions are legal identifiers

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -1,4 +1,5 @@
 import { blank, forOwn, keys } from './utils/object.js';
+import makeLegalIdentifier from './utils/makeLegalIdentifier.js';
 import run from './utils/run.js';
 import { SyntheticReference } from './Reference.js';
 
@@ -17,7 +18,7 @@ export default class Declaration {
 		}
 
 		this.statement = statement;
-		this.name = null;
+		this.name = node.id ? node.id.name : node.name;
 		this.exportName = null;
 		this.isParam = isParam;
 
@@ -33,7 +34,10 @@ export default class Declaration {
 
 	addReference ( reference ) {
 		reference.declaration = this;
-		this.name = reference.name; // TODO handle differences of opinion
+
+		if ( reference.name !== this.name ) {
+			this.name = makeLegalIdentifier( reference.name ); // TODO handle differences of opinion
+		}
 
 		if ( reference.isReassignment ) this.isReassigned = true;
 	}

--- a/test/function/legal-suggested-names/_config.js
+++ b/test/function/legal-suggested-names/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'illegal name suggestions are ignored'
+};

--- a/test/function/legal-suggested-names/bar.js
+++ b/test/function/legal-suggested-names/bar.js
@@ -1,0 +1,5 @@
+import * as helpers from './helpers.js';
+
+export default function bar ( a ) {
+	return helpers.typeof( a );
+}

--- a/test/function/legal-suggested-names/foo.js
+++ b/test/function/legal-suggested-names/foo.js
@@ -1,0 +1,5 @@
+import * as helpers from './helpers.js';
+
+export default function foo ( a ) {
+	return helpers.typeof( a );
+}

--- a/test/function/legal-suggested-names/helpers.js
+++ b/test/function/legal-suggested-names/helpers.js
@@ -1,0 +1,5 @@
+var _typeof = function ( thing ) {
+	return typeof thing;
+};
+
+export { _typeof as typeof };

--- a/test/function/legal-suggested-names/main.js
+++ b/test/function/legal-suggested-names/main.js
@@ -1,0 +1,8 @@
+import * as helpers from './helpers.js';
+import foo from './foo.js';
+import bar from './bar.js';
+
+assert.equal( helpers.typeof( foo ), 'function' );
+assert.equal( helpers.typeof( bar ), 'function' );
+assert.equal( foo( 1 ), 'number' );
+assert.equal( bar( 2 ), 'number' );


### PR DESCRIPTION
This fixes a bug exposed by https://github.com/rollup/rollup-plugin-babel/issues/55 – it's possible for a module to export a binding that is a reserved word, and for another module to import that reserved word, without ever writing a syntax error...

```js
// helpers.js
var _typeof = x => typeof x;
export { _typeof as typeof };

// main.js
import * as helpers from './helpers.js';
console.log( helpers.typeof( 1 ) );
```

(The export from `helpers.js` might be against spec, I'm not sure. That would be a separate issue if it is.)

This PR ensures that the use of `helpers.typeof` doesn't cause the `var _typeof` to be rewritten as `var typeof`.