### PR TITLE
Incremental rebuilds

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -19,8 +19,8 @@ import { dirname, isRelative, isAbsolute, relative, resolve } from './utils/path
 
 export default class Bundle {
 	constructor ( options ) {
-		if ( typeof options.bundle === 'object' ) {
-			this.cachedModules = options.bundle.modules.reduce((modules, module) => {
+		if ( typeof options.cache === 'object' ) {
+			this.cachedModules = options.cache.modules.reduce((modules, module) => {
 				modules[module.id] = module;
 				return modules;
 			}, {});

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -19,11 +19,11 @@ import { dirname, isRelative, isAbsolute, relative, resolve } from './utils/path
 
 export default class Bundle {
 	constructor ( options ) {
-		if ( typeof options.cache === 'object' ) {
-			this.cachedModules = options.cache.modules.reduce((modules, module) => {
-				modules[module.id] = module;
-				return modules;
-			}, {});
+		this.cachedModules = new Map();
+		if ( options.cache ) {
+			options.cache.modules.forEach( module => {
+				this.cachedModules.set( module.id, module );
+			});
 		}
 
 		this.plugins = ensureArray( options.plugins );
@@ -195,13 +195,11 @@ export default class Bundle {
 						ast: null
 					};
 				}
-				if (this.cachedModules && this.cachedModules[id] && this.cachedModules[id].originalCode === source.code) {
-					const { code, originalCode } = this.cachedModules[id];
-					return {
-						code,
-						originalCode
-					};
+
+				if ( this.cachedModules.has( id ) && this.cachedModules.get( id ).originalCode === source.code ) {
+					return this.cachedModules.get( id );
 				}
+
 				return transform( source, id, this.transformers );
 			})
 			.then( source => {

--- a/src/Module.js
+++ b/src/Module.js
@@ -53,7 +53,8 @@ export default class Module {
 		}
 
 		this.comments = [];
-		this.statements = this.parse( ast );
+		this.ast = ast;
+		this.statements = this.parse();
 
 		this.declarations = blank();
 		this.analyse();
@@ -298,13 +299,13 @@ export default class Module {
 		return this.declarations['*'];
 	}
 
-	parse ( ast ) {
+	parse () {
 		// The ast can be supplied programmatically (but usually won't be)
-		if ( !ast ) {
+		if ( !this.ast ) {
 			// Try to extract a list of top-level statements/declarations. If
 			// the parse fails, attach file info and abort
 			try {
-				ast = parse( this.code, {
+				this.ast = parse( this.code, {
 					ecmaVersion: 6,
 					sourceType: 'module',
 					onComment: ( block, text, start, end ) => this.comments.push({ block, text, start, end }),
@@ -318,7 +319,7 @@ export default class Module {
 			}
 		}
 
-		walk( ast, {
+		walk( this.ast, {
 			enter: node => {
 				// eliminate dead branches early
 				if ( node.type === 'IfStatement' ) {
@@ -354,7 +355,7 @@ export default class Module {
 		let lastChar = 0;
 		let commentIndex = 0;
 
-		ast.body.forEach( node => {
+		this.ast.body.forEach( node => {
 			if ( node.type === 'EmptyStatement' ) return;
 
 			if (
@@ -635,6 +636,15 @@ export default class Module {
 		});
 
 		return marked;
+	}
+
+	toJSON () {
+		return {
+			id: this.id,
+			code: this.code,
+			originalCode: this.originalCode,
+			ast: this.ast
+		};
 	}
 
 	trace ( name ) {

--- a/src/Module.js
+++ b/src/Module.js
@@ -643,7 +643,8 @@ export default class Module {
 			id: this.id,
 			code: this.code,
 			originalCode: this.originalCode,
-			ast: this.ast
+			ast: this.ast,
+			sourceMapChain: this.sourceMapChain
 		};
 	}
 

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -9,6 +9,7 @@ export const VERSION = '<@VERSION@>';
 
 const ALLOWED_KEYS = [
 	'banner',
+	'cache',
 	'dest',
 	'entry',
 	'exports',
@@ -28,8 +29,7 @@ const ALLOWED_KEYS = [
 	'sourceMap',
 	'targets',
 	'treeshake',
-	'useStrict',
-	'bundle'
+	'useStrict'
 ];
 
 export function rollup ( options ) {

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -53,7 +53,7 @@ export function rollup ( options ) {
 		return {
 			imports: bundle.externalModules.map( module => module.id ),
 			exports: keys( bundle.entryModule.exports ),
-			modules: bundle.orderedModules.map( ( { id, code, originalCode } ) => ( { id, code, originalCode } ) ),
+			modules: bundle.orderedModules.map( module => module.toJSON() ),
 
 			generate: options => bundle.render( options ),
 			write: options => {

--- a/test/incremental/not-transform-twice/expected.js
+++ b/test/incremental/not-transform-twice/expected.js
@@ -1,5 +1,0 @@
-function foo () {
-	console.log('foo');
-};
-
-foo();

--- a/test/incremental/not-transform-twice/foo.js
+++ b/test/incremental/not-transform-twice/foo.js
@@ -1,3 +1,0 @@
-export default function () {
-	console.log('foo');
-};

--- a/test/incremental/not-transform-twice/main.js
+++ b/test/incremental/not-transform-twice/main.js
@@ -1,3 +1,0 @@
-import foo from './foo.js';
-
-foo();

--- a/test/incremental/transform-changed/expected.js
+++ b/test/incremental/transform-changed/expected.js
@@ -1,5 +1,0 @@
-function foo () {
-	console.log('foo-changed');
-};
-
-foo();

--- a/test/incremental/transform-changed/foo-changed.js
+++ b/test/incremental/transform-changed/foo-changed.js
@@ -1,3 +1,0 @@
-export default function () {
-	console.log('foo-changed');
-};

--- a/test/incremental/transform-changed/foo.js
+++ b/test/incremental/transform-changed/foo.js
@@ -1,3 +1,0 @@
-export default function () {
-	console.log('foo');
-};

--- a/test/incremental/transform-changed/main.js
+++ b/test/incremental/transform-changed/main.js
@@ -1,3 +1,0 @@
-import foo from './foo.js';
-
-foo();

--- a/test/test.js
+++ b/test/test.js
@@ -431,7 +431,7 @@ describe( 'rollup', function () {
 							});
 							done( error );
 						}
-						
+
 						else {
 							var expected = sander.readFileSync( '_expected.js' ).toString();
 							try {
@@ -464,7 +464,7 @@ describe( 'rollup', function () {
 				return rollup.rollup({
 					entry: path.join( INCREMENTAL, 'not-transform-twice', 'main.js' ),
 					plugins: [counter],
-					bundle
+					cache: bundle
 				});
 			}).then( function ( bundle ) {
 				assert.equal( calls, 2 );
@@ -509,7 +509,7 @@ describe( 'rollup', function () {
 				return rollup.rollup({
 					entry: path.join( INCREMENTAL, 'transform-changed', 'main.js' ),
 					plugins: [counter],
-					bundle
+					cache: bundle
 				});
 			}).then( function ( bundle ) {
 				assert.equal( calls, 3 );


### PR DESCRIPTION
This builds on #658 (and is a PR to merge this into that branch) – a few small tweaks:

* I think the property should be `cache` rather than `bundle` – it's a lot more explicit about what it does, and I think it'll make more sense when we get round to serializing the cache object to disk for fast cold builds
* ASTs and sourcemap chains are preserved – this will allow us to skip parsing in many cases, and should mean sourcemaps are unaffected
* The tests were a little brittle for me – because they relied on resetting the state of the input files, any changes that resulted in tests failing would also cause the state of the test itself to get borked up. So now modules are served from memory rather than the filesystem when testing – makes life a bit easier

If @rollup/collaborators are on board I think we should merge this and #658 and release it, making it clear that this is still experimental. Once that's done, we can crack on with the following:

* [ ] Implementing `rollup --watch`. I think there should be a separate `rollup-watch` package that should handle the file watching, because in my experience file watchers are all horrible and it would be better not to pollute Rollup itself. If someone tries to do `rollup -w` without having installed `rollup-watch` (whether locally or globally, ideally locally) we can do that for them after a prompt. That's the best of both worlds in my view
* [ ] Handling stateful plugins (such as modular-css – see https://github.com/rollup/rollup/pull/658#issuecomment-224120273). I've done a quick survey of existing plugins, and stateful ones are definitely in the minority (I could only find modular-css). I think the best solution here (while promoting statelessness as far as possible) is to add a `this.disableCache()` method to the `transform` context to signal that a given file should *always* be transformed, cache or no cache
* [ ] Handle shadow dependency graphs – e.g. if a CSS file as `@import` statements that aren't converted to JavaScript `import` statements, we need a mechanism (e.g. `this.addDependency(id)`) for keeping track so that the file watcher can trigger rebuilds when those files change
* [ ] Serialization. This isn't *quite* as straightforward as jumping a JSON blob to `.rollup-cache.json` or whatever, because we need to invalidate the cache if the config changes (for example). Would be great to have though

...plus probably some other stuff.