### PR TITLE
rewrite top-level this as undefined

### DIFF
--- a/src/Statement.js
+++ b/src/Statement.js
@@ -41,7 +41,7 @@ export default class Statement {
 		// find references
 		const statement = this;
 		let { module, references, scope, stringLiteralRanges } = this;
-		let readDepth = 0;
+		let contextDepth = 0;
 
 		walk( this.node, {
 			enter ( node, parent, prop ) {
@@ -59,8 +59,12 @@ export default class Statement {
 					stringLiteralRanges.push([ node.start + 1, node.end - 1 ]);
 				}
 
+				if ( node.type === 'ThisExpression' && contextDepth === 0 ) {
+					module.magicString.overwrite( node.start, node.end, 'undefined' );
+				}
+
 				if ( node._scope ) scope = node._scope;
-				if ( /Function/.test( node.type ) ) readDepth += 1;
+				if ( /^Function/.test( node.type ) ) contextDepth += 1;
 
 				let isReassignment;
 
@@ -121,7 +125,7 @@ export default class Statement {
 			},
 			leave ( node ) {
 				if ( node._scope ) scope = scope.parent;
-				if ( /Function/.test( node.type ) ) readDepth -= 1;
+				if ( /^Function/.test( node.type ) ) contextDepth -= 1;
 			}
 		});
 	}

--- a/test/form/this-is-undefined/_config.js
+++ b/test/form/this-is-undefined/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'top-level `this` expression is rewritten as `undefined`'
+};

--- a/test/form/this-is-undefined/_expected/amd.js
+++ b/test/form/this-is-undefined/_expected/amd.js
@@ -1,0 +1,21 @@
+define(function () { 'use strict';
+
+	const fooContext = {};
+
+	function foo () {
+		// inside a function, `this` should be untouched...
+		assert.strictEqual( this, fooContext );
+	}
+
+	const bar = () => {
+		// ...unless it's an arrow function
+		assert.strictEqual( undefined, undefined );
+	}
+
+	foo.call( fooContext );
+	bar.call( {} );
+
+	// outside a function, `this` is undefined
+	assert.strictEqual( undefined, undefined );
+
+});

--- a/test/form/this-is-undefined/_expected/cjs.js
+++ b/test/form/this-is-undefined/_expected/cjs.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const fooContext = {};
+
+function foo () {
+	// inside a function, `this` should be untouched...
+	assert.strictEqual( this, fooContext );
+}
+
+const bar = () => {
+	// ...unless it's an arrow function
+	assert.strictEqual( undefined, undefined );
+}
+
+foo.call( fooContext );
+bar.call( {} );
+
+// outside a function, `this` is undefined
+assert.strictEqual( undefined, undefined );

--- a/test/form/this-is-undefined/_expected/es6.js
+++ b/test/form/this-is-undefined/_expected/es6.js
@@ -1,0 +1,17 @@
+const fooContext = {};
+
+function foo () {
+	// inside a function, `this` should be untouched...
+	assert.strictEqual( this, fooContext );
+}
+
+const bar = () => {
+	// ...unless it's an arrow function
+	assert.strictEqual( undefined, undefined );
+}
+
+foo.call( fooContext );
+bar.call( {} );
+
+// outside a function, `this` is undefined
+assert.strictEqual( undefined, undefined );

--- a/test/form/this-is-undefined/_expected/iife.js
+++ b/test/form/this-is-undefined/_expected/iife.js
@@ -1,0 +1,22 @@
+(function () {
+	'use strict';
+
+	const fooContext = {};
+
+	function foo () {
+		// inside a function, `this` should be untouched...
+		assert.strictEqual( this, fooContext );
+	}
+
+	const bar = () => {
+		// ...unless it's an arrow function
+		assert.strictEqual( undefined, undefined );
+	}
+
+	foo.call( fooContext );
+	bar.call( {} );
+
+	// outside a function, `this` is undefined
+	assert.strictEqual( undefined, undefined );
+
+}());

--- a/test/form/this-is-undefined/_expected/umd.js
+++ b/test/form/this-is-undefined/_expected/umd.js
@@ -1,0 +1,25 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, function () { 'use strict';
+
+	const fooContext = {};
+
+	function foo () {
+		// inside a function, `this` should be untouched...
+		assert.strictEqual( this, fooContext );
+	}
+
+	const bar = () => {
+		// ...unless it's an arrow function
+		assert.strictEqual( undefined, undefined );
+	}
+
+	foo.call( fooContext );
+	bar.call( {} );
+
+	// outside a function, `this` is undefined
+	assert.strictEqual( undefined, undefined );
+
+}));

--- a/test/form/this-is-undefined/main.js
+++ b/test/form/this-is-undefined/main.js
@@ -1,4 +1,4 @@
-const fooContext = {}
+const fooContext = {};
 
 function foo () {
 	// inside a function, `this` should be untouched...

--- a/test/function/this-is-undefined/_config.js
+++ b/test/function/this-is-undefined/_config.js
@@ -1,4 +1,0 @@
-module.exports = {
-	description: 'this at top level is undefined',
-	babel: true
-};


### PR DESCRIPTION
We didn't catch that this wasn't already happening (pretty sure it did at one point), because Babel was doing it for us in the test (and we needed Babel, because we need to test behaviour inside arrow functions...)