### PR TITLE
allow user-specified acorn options

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -82,6 +82,7 @@ export default class Bundle {
 		[ 'module', 'exports', '_interopDefault' ].forEach( global => this.assumedGlobals[ global ] = true );
 
 		this.varOrConst = options.preferConst ? 'const' : 'var';
+		this.acornOptions = options.acorn || {};
 	}
 
 	build () {

--- a/src/Module.js
+++ b/src/Module.js
@@ -2,7 +2,7 @@ import { parse } from 'acorn/src/index.js';
 import MagicString from 'magic-string';
 import { walk } from 'estree-walker';
 import Statement from './Statement.js';
-import { blank, keys } from './utils/object.js';
+import { assign, blank, keys } from './utils/object.js';
 import { basename, extname } from './utils/path.js';
 import getLocation from './utils/getLocation.js';
 import makeLegalIdentifier from './utils/makeLegalIdentifier.js';
@@ -305,12 +305,12 @@ export default class Module {
 			// Try to extract a list of top-level statements/declarations. If
 			// the parse fails, attach file info and abort
 			try {
-				this.ast = parse( this.code, {
+				this.ast = parse( this.code, assign({
 					ecmaVersion: 6,
 					sourceType: 'module',
 					onComment: ( block, text, start, end ) => this.comments.push({ block, text, start, end }),
 					preserveParens: true
-				});
+				}, this.bundle.acornOptions ));
 			} catch ( err ) {
 				err.code = 'PARSE_ERROR';
 				err.file = this.id; // see above - not necessarily true, but true enough

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -8,6 +8,7 @@ import Bundle from './Bundle.js';
 export const VERSION = '<@VERSION@>';
 
 const ALLOWED_KEYS = [
+	'acorn',
 	'banner',
 	'cache',
 	'dest',

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -7,3 +7,13 @@ export function blank () {
 export function forOwn ( object, func ) {
 	Object.keys( object ).forEach( key => func( object[ key ], key ) );
 }
+
+export function assign ( target, ...sources ) {
+	sources.forEach( source => {
+		for ( let key in source ) {
+			if ( source.hasOwnProperty( key ) ) target[ key ] = source[ key ];
+		}
+	});
+
+	return target;
+}

--- a/test/function/allow-reserved/_config.js
+++ b/test/function/allow-reserved/_config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	solo: true,
+	description: 'allow reserved identifiers via custom acorn options',
+	options: {
+		acorn: {
+			allowReserved: true
+		}
+	}
+};

--- a/test/function/allow-reserved/main.js
+++ b/test/function/allow-reserved/main.js
@@ -1,0 +1,2 @@
+var x = function await () {}
+assert.equal( x.name, 'await' );


### PR DESCRIPTION
One way to fix #564 – allow arbitrary options to be passed through to acorn