### PR TITLE
Import search path

### DIFF
--- a/bin/src/help.md
+++ b/bin/src/help.md
@@ -11,6 +11,7 @@ Basic options:
                            is unspecified, defaults to rollup.config.js)
 -w, --watch              Watch files in bundle and rebuild on changes
 -i, --input              Input (alternative to <entry file>)
+-I <path>                Add a directory to the import search path
 -o, --output <output>    Output (if absent, prints to stdout)
 -f, --format [es6]       Type of output (amd, cjs, es6, iife, umd)
 -e, --external           Comma-separate list of module IDs to exclude

--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -15,6 +15,7 @@ const command = minimist( process.argv.slice( 2 ), {
 		f: 'format',
 		g: 'globals',
 		h: 'help',
+		I: 'importSearchPath',
 		i: 'input',
 		m: 'sourcemap',
 		n: 'name',

--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -84,6 +84,7 @@ const equivalents = {
 	format: 'format',
 	globals: 'globals',
 	id: 'moduleId',
+	importSearchPath: 'importSearchPath',
 	indent: 'indent',
 	input: 'entry',
 	intro: 'intro',
@@ -120,6 +121,10 @@ function execute ( options, command ) {
 
 	options.noConflict = command.conflict === false;
 	delete command.conflict;
+
+	if ( command.importSearchPath && !Array.isArray( command.importSearchPath ) ) {
+		command.importSearchPath = command.importSearchPath.split( ',' ).filter( x => x != '' );
+	}
 
 	// Use any options passed through the CLI as overrides.
 	Object.keys( equivalents ).forEach( cliOption => {

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -34,6 +34,8 @@ export default class Bundle {
 			}
 		});
 
+		let importSearchPath = options.importSearchPath;
+
 		this.entry = unixizePath( options.entry );
 		this.entryId = null;
 		this.entryModule = null;
@@ -43,7 +45,7 @@ export default class Bundle {
 		this.resolveId = first(
 			[ id => this.isExternal( id ) ? false : null ]
 				.concat( this.plugins.map( plugin => plugin.resolveId ).filter( Boolean ) )
-				.concat( resolveId )
+				.concat( ( a, b ) => resolveId( a, b, importSearchPath ) )
 		);
 
 		this.load = first(

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -17,6 +17,7 @@ const ALLOWED_KEYS = [
 	'footer',
 	'format',
 	'globals',
+	'importSearchPath',
 	'indent',
 	'intro',
 	'moduleId',

--- a/test/cli/import-search-path/_config.js
+++ b/test/cli/import-search-path/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'allows the module search path to be specified with -I <path>',
+	command: 'rollup main.js -I .'
+};

--- a/test/cli/import-search-path/_expected.js
+++ b/test/cli/import-search-path/_expected.js
@@ -1,0 +1,3 @@
+const magic = 42;
+
+console.log(magic);

--- a/test/cli/import-search-path/import.js
+++ b/test/cli/import-search-path/import.js
@@ -1,0 +1,1 @@
+export const magic = 42;

--- a/test/cli/import-search-path/main.js
+++ b/test/cli/import-search-path/main.js
@@ -1,0 +1,3 @@
+import { magic } from 'import';
+
+console.log(magic);

--- a/test/test.js
+++ b/test/test.js
@@ -76,7 +76,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( function () {
 				throw new Error( 'Missing expected error' );
 			}, function ( err ) {
-				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: banner, cache, dest, entry, exports, external, footer, format, globals, indent, intro, moduleId, moduleName, noConflict, onwarn, outro, plugins, preferConst, sourceMap, targets, treeshake, useStrict' );
+				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: banner, cache, dest, entry, exports, external, footer, format, globals, importSearchPath, indent, intro, moduleId, moduleName, noConflict, onwarn, outro, plugins, preferConst, sourceMap, targets, treeshake, useStrict' );
 			});
 		});
 	});


### PR DESCRIPTION
This adds a new `-I` cli option (and `importSearchPath` key for the rollup.config.js) to specify module search path(s).  (I appreciate that plugins can handle it as well but it's easier to do it via a command-line flag than dealing with plugins and config files.)