### PR TITLE
handle errors emitted by rollup-watch

### DIFF
--- a/bin/src/handleError.js
+++ b/bin/src/handleError.js
@@ -42,7 +42,7 @@ const handlers = {
 	}
 };
 
-export default function handleError ( err ) {
+export default function handleError ( err, recover ) {
 	const handler = handlers[ err && err.code ];
 
 	if ( handler ) {
@@ -57,5 +57,5 @@ export default function handleError ( err ) {
 
 	stderr( `Type ${chalk.cyan( 'rollup --help' )} for help, or visit https://github.com/rollup/rollup/wiki` );
 
-	process.exit( 1 );
+	if ( !recover ) process.exit( 1 );
 }

--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -152,6 +152,10 @@ function execute ( options, command ) {
 							stderr( 'bundled in ' + event.duration + 'ms. Watching for changes...' );
 							break;
 
+						case 'ERROR':
+							handleError( event.error, true );
+							break;
+
 						default:
 							stderr( 'unknown event', event );
 					}


### PR DESCRIPTION
closes #712 (though it'd be nice to improve the logging eventually, i.e. show snippet surrounding a parse error etc)