### PR TITLE
Make it possible for plugin loaders to provide sourcemaps.

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -17,9 +17,10 @@ import { emptyBlockStatement } from './ast/create.js';
 import extractNames from './ast/extractNames.js';
 
 export default class Module {
-	constructor ({ id, code, originalCode, ast, sourceMapChain, bundle }) {
+	constructor ({ id, code, originalCode, originalSourceMap, ast, sourceMapChain, bundle }) {
 		this.code = code;
 		this.originalCode = originalCode;
+		this.originalSourceMap = originalSourceMap;
 		this.sourceMapChain = sourceMapChain;
 
 		this.bundle = bundle;

--- a/src/utils/collapseSourcemaps.js
+++ b/src/utils/collapseSourcemaps.js
@@ -106,17 +106,21 @@ export default function collapseSourcemaps ( file, map, modules, bundleSourcemap
 			source = new Source( module.id, module.originalCode );
 		} else {
 			const sources = module.originalSourceMap.sources;
+
 			if ( sources == null || ( sources.length <= 1 && sources[0] == null ) ) {
 				source = new Source( module.id, module.originalCode );
 				sourceMapChain = [ module.originalSourceMap ].concat( sourceMapChain );
 			} else {
-				// TODO indiscriminately treating IDs and sources as normal paths is probably bad.
 				const sourcesContent = module.originalSourceMap.sourcesContent || [];
+
+				// TODO indiscriminately treating IDs and sources as normal paths is probably bad.
 				const directory = dirname( module.id ) || '.';
 				const sourceRoot = module.originalSourceMap.sourceRoot || '.';
+
 				const baseSources = sources.map( (source, i) => {
 					return new Source( resolve( directory, sourceRoot, source ), sourcesContent[i] );
 				});
+
 				source = new Link( module.originalSourceMap, baseSources );
 			}
 		}

--- a/src/utils/collapseSourcemaps.js
+++ b/src/utils/collapseSourcemaps.js
@@ -100,19 +100,18 @@ class Link {
 export default function collapseSourcemaps ( file, map, modules, bundleSourcemapChain ) {
 	const moduleSources = modules.map( module => {
 		let sourceMapChain = module.sourceMapChain;
-		
+
 		let source;
 		if ( module.originalSourceMap == null ) {
 			source = new Source( module.id, module.originalCode );
 		} else {
 			const sources = module.originalSourceMap.sources;
+			const sourcesContent = module.originalSourceMap.sourcesContent || [];
 
 			if ( sources == null || ( sources.length <= 1 && sources[0] == null ) ) {
-				source = new Source( module.id, module.originalCode );
+				source = new Source( module.id, sourcesContent[0] );
 				sourceMapChain = [ module.originalSourceMap ].concat( sourceMapChain );
 			} else {
-				const sourcesContent = module.originalSourceMap.sourcesContent || [];
-
 				// TODO indiscriminately treating IDs and sources as normal paths is probably bad.
 				const directory = dirname( module.id ) || '.';
 				const sourceRoot = module.originalSourceMap.sourceRoot || '.';

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -1,6 +1,8 @@
 export default function transform ( source, id, transformers ) {
 	let sourceMapChain = [];
 
+	const originalSourceMap = typeof source.map === 'string' ? JSON.parse( source.map ) : source.map;
+
 	let originalCode = source.code;
 	let ast = source.ast;
 
@@ -30,7 +32,7 @@ export default function transform ( source, id, transformers ) {
 
 	}, Promise.resolve( source.code ) )
 
-	.then( code => ({ code, originalCode, ast, sourceMapChain }) )
+	.then( code => ({ code, originalCode, originalSourceMap, ast, sourceMapChain }) )
 	.catch( err => {
 		err.id = id;
 		err.message = `Error loading ${id}: ${err.message}`;

--- a/src/utils/transformBundle.js
+++ b/src/utils/transformBundle.js
@@ -11,7 +11,7 @@ export default function transformBundle ( code, transformers, sourceMapChain ) {
 			};
 		}
 
-		const map = typeof result.map === 'string' ? JSON.parse( result.map ) : map;
+		const map = typeof result.map === 'string' ? JSON.parse( result.map ) : result.map;
 		sourceMapChain.push( map );
 
 		return result.code;

--- a/test/sourcemaps/loaders/_config.js
+++ b/test/sourcemaps/loaders/_config.js
@@ -21,8 +21,8 @@ module.exports = {
 						sourceMap: true
 					});
 
-					const sourceRoot = out.map.sources[0].slice( 0, out.map.sources[0].lastIndexOf( '/' ) );
-					out.map.sources = out.map.sources.map( source => '../' + source.slice( sourceRoot.length + 1 ) );
+					const slash = out.map.sources[0].lastIndexOf( '/' ) + 1;
+					out.map.sources = out.map.sources.map( source => '../' + source.slice( slash ) );
 					out.map.sourceRoot = 'fake';
 
 					return { code: out.code, map: out.map };

--- a/test/sourcemaps/loaders/_config.js
+++ b/test/sourcemaps/loaders/_config.js
@@ -24,7 +24,6 @@ module.exports = {
 
 					if ( id.endsWith( 'main.js' ) ) {
 						delete out.map.sources;
-						//throw new Error(JSON.stringify(out.code));
 					} else {
 						const slash = out.map.sources[0].lastIndexOf( '/' ) + 1;
 						out.map.sources = out.map.sources.map( source => '../' + source.slice( slash ) );

--- a/test/sourcemaps/loaders/_config.js
+++ b/test/sourcemaps/loaders/_config.js
@@ -10,20 +10,26 @@ module.exports = {
 		plugins: [
 			{
 				load: function ( id ) {
-					if ( id.endsWith( 'main.js' ) ) {
-						id = id.replace( /main.js$/, 'foo.js' );
-					} else {
-						id = id.replace( /foo.js$/, 'main.js' );
+					if ( id.endsWith( 'foo.js' ) ) {
+						id = id.replace( /foo.js$/, 'bar.js' );
+					} else if ( id.endsWith( 'bar.js' ) ) {
+						id = id.replace( /bar.js$/, 'foo.js' );
 					}
 
 					var out = babel.transformFileSync( id, {
 						blacklist: [ 'es6.modules' ],
-						sourceMap: true
+						sourceMap: true,
+						comments: false // misalign the columns
 					});
 
-					const slash = out.map.sources[0].lastIndexOf( '/' ) + 1;
-					out.map.sources = out.map.sources.map( source => '../' + source.slice( slash ) );
-					out.map.sourceRoot = 'fake';
+					if ( id.endsWith( 'main.js' ) ) {
+						delete out.map.sources;
+						//throw new Error(JSON.stringify(out.code));
+					} else {
+						const slash = out.map.sources[0].lastIndexOf( '/' ) + 1;
+						out.map.sources = out.map.sources.map( source => '../' + source.slice( slash ) );
+						out.map.sourceRoot = 'fake';
+					}
 
 					return { code: out.code, map: out.map };
 				}
@@ -33,18 +39,26 @@ module.exports = {
 	test: function ( code, map ) {
 		var smc = new SourceMapConsumer( map );
 
-		var generatedLoc = getLocation( code, code.indexOf( '42' ) );
+		var generatedLoc = getLocation( code, code.indexOf( '22' ) );
 		var originalLoc = smc.originalPositionFor( generatedLoc );
 
-		assert.equal( originalLoc.source, '../main.js' );
+		assert.equal( originalLoc.source, '../foo.js' );
 		assert.equal( originalLoc.line, 1 );
-		assert.equal( originalLoc.column, 25 );
+		assert.equal( originalLoc.column, 32 );
+
+		var generatedLoc = getLocation( code, code.indexOf( '20' ) );
+		var originalLoc = smc.originalPositionFor( generatedLoc );
+
+		assert.equal( originalLoc.source, '../bar.js' );
+		assert.equal( originalLoc.line, 1 );
+		assert.equal( originalLoc.column, 37 );
 
 		generatedLoc = getLocation( code, code.indexOf( 'log' ) );
 		originalLoc = smc.originalPositionFor( generatedLoc );
 
-		assert.equal( originalLoc.source, '../foo.js' );
-		assert.equal( originalLoc.line, 3 );
-		assert.equal( originalLoc.column, 8 );
+		assert.equal( originalLoc.source, '../main.js' );
+		assert.ok( /columns/.test( smc.sourceContentFor( '../main.js' ) ) );
+		assert.equal( originalLoc.line, 4 );
+		assert.equal( originalLoc.column, 19 );
 	}
 };

--- a/test/sourcemaps/loaders/_config.js
+++ b/test/sourcemaps/loaders/_config.js
@@ -10,9 +10,9 @@ module.exports = {
 		plugins: [
 			{
 				load: function ( id ) {
-					if ( id.endsWith( 'foo.js' ) ) {
+					if ( /foo.js$/.test( id ) ) {
 						id = id.replace( /foo.js$/, 'bar.js' );
-					} else if ( id.endsWith( 'bar.js' ) ) {
+					} else if ( /bar.js$/.test( id ) ) {
 						id = id.replace( /bar.js$/, 'foo.js' );
 					}
 
@@ -22,7 +22,7 @@ module.exports = {
 						comments: false // misalign the columns
 					});
 
-					if ( id.endsWith( 'main.js' ) ) {
+					if ( /main.js$/.test( id ) ) {
 						delete out.map.sources;
 					} else {
 						const slash = out.map.sources[0].lastIndexOf( '/' ) + 1;

--- a/test/sourcemaps/loaders/_config.js
+++ b/test/sourcemaps/loaders/_config.js
@@ -1,0 +1,50 @@
+var babel = require( 'babel-core' );
+var fs = require( 'fs' );
+var assert = require( 'assert' );
+var getLocation = require( '../../utils/getLocation' );
+var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;
+
+module.exports = {
+	description: 'preserves sourcemap chains when transforming',
+	options: {
+		plugins: [
+			{
+				load: function ( id ) {
+					if ( id.endsWith( 'main.js' ) ) {
+						id = id.replace( /main.js$/, 'foo.js' );
+					} else {
+						id = id.replace( /foo.js$/, 'main.js' );
+					}
+
+					var out = babel.transformFileSync( id, {
+						blacklist: [ 'es6.modules' ],
+						sourceMap: true
+					});
+
+					const sourceRoot = out.map.sources[0].slice( 0, out.map.sources[0].lastIndexOf( '/' ) );
+					out.map.sources = out.map.sources.map( source => '../' + source.slice( sourceRoot.length + 1 ) );
+					out.map.sourceRoot = 'fake';
+
+					return { code: out.code, map: out.map };
+				}
+			}
+		]
+	},
+	test: function ( code, map ) {
+		var smc = new SourceMapConsumer( map );
+
+		var generatedLoc = getLocation( code, code.indexOf( '42' ) );
+		var originalLoc = smc.originalPositionFor( generatedLoc );
+
+		assert.equal( originalLoc.source, '../main.js' );
+		assert.equal( originalLoc.line, 1 );
+		assert.equal( originalLoc.column, 25 );
+
+		generatedLoc = getLocation( code, code.indexOf( 'log' ) );
+		originalLoc = smc.originalPositionFor( generatedLoc );
+
+		assert.equal( originalLoc.source, '../foo.js' );
+		assert.equal( originalLoc.line, 3 );
+		assert.equal( originalLoc.column, 8 );
+	}
+};

--- a/test/sourcemaps/loaders/bar.js
+++ b/test/sourcemaps/loaders/bar.js
@@ -1,0 +1,1 @@
+/*misalign*/export const foo = () => 20;

--- a/test/sourcemaps/loaders/foo.js
+++ b/test/sourcemaps/loaders/foo.js
@@ -1,3 +1,1 @@
-import { foo } from './foo';
-
-console.log( `the answer is ${foo()}` );
+/*the*/export const bar = () => 22;

--- a/test/sourcemaps/loaders/foo.js
+++ b/test/sourcemaps/loaders/foo.js
@@ -1,0 +1,3 @@
+import { foo } from './foo';
+
+console.log( `the answer is ${foo()}` );

--- a/test/sourcemaps/loaders/main.js
+++ b/test/sourcemaps/loaders/main.js
@@ -1,0 +1,1 @@
+export const foo = () => 42;

--- a/test/sourcemaps/loaders/main.js
+++ b/test/sourcemaps/loaders/main.js
@@ -1,1 +1,4 @@
-export const foo = () => 42;
+import { foo } from './foo';
+import { bar } from './bar';
+
+/*columns*/console.log( `the answer is ${foo() + bar()}` );


### PR DESCRIPTION
With this pull request, a loader can return either a `code` string or a `{ code, map }` object, just like a transformer.

The sourcemap can reference whatever sources it wants, or it can provide no sources, in which case it will be assumed to have one source which is the same as the module's ID.

One source can be referenced by multiple modules' sourcemaps; if no sourcemap provides the source content or if some sourcemaps provide source content while others don't, that will work, but an error will be thrown if multiple sourcemaps provide conflicting content for one source.

Sources, source roots, and module IDs are all assumed to function like normal paths. I'm not sure that's a good way to handle them, since a plugin could produce a sourcemap referencing a URI or maybe even some exotic thingamajig none of us have even heard of. [Mozilla's algorithm for finding sourcemap sources is a fair bit more sophisticated.](https://github.com/mozilla/source-map/blob/master/lib/util.js#L125)