### PR TITLE
Handle options.external is a function.

### DIFF
--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -95,8 +95,15 @@ const equivalents = {
 };
 
 function execute ( options, command ) {
-	let external = ( options.external || [] )
-		.concat( command.external ? command.external.split( ',' ) : []  );
+	let external = command.external ?
+		typeof options.external === 'function' ?
+		((fn, a) => {
+			return function (id) {
+				return fn() || a.indexOf(id) !== -1;
+			};
+		})(options.external, command.external.split(',')) :
+		(options.external || []).concat(command.external.split(',')) :
+		options.external;
 
 	if ( command.globals ) {
 		let globals = Object.create( null );

--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -99,7 +99,7 @@ function execute ( options, command ) {
 		typeof options.external === 'function' ?
 		((fn, a) => {
 			return function (id) {
-				return fn() || a.indexOf(id) !== -1;
+				return fn(id) || a.indexOf(id) !== -1;
 			};
 		})(options.external, command.external.split(',')) :
 		(options.external || []).concat(command.external.split(',')) :

--- a/test/cli/config-external-function/_config.js
+++ b/test/cli/config-external-function/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'external option gets passed from config',
+	command: 'rollup -c -e assert,external-module'
+};

--- a/test/cli/config-external-function/_expected.js
+++ b/test/cli/config-external-function/_expected.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var ___config_js = require('./_config.js');
+var assert = require('assert');
+var externalModule = require('external-module');
+
+assert.ok( ___config_js.execute );
+externalModule.method();

--- a/test/cli/config-external-function/main.js
+++ b/test/cli/config-external-function/main.js
@@ -1,0 +1,6 @@
+import { execute } from './_config.js';
+import { ok } from 'assert';
+import { method } from 'external-module';
+
+ok( execute );
+method();

--- a/test/cli/config-external-function/rollup.config.js
+++ b/test/cli/config-external-function/rollup.config.js
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import { resolve, sep } from 'path';
+
+var config = resolve( './_config.js' ).split(sep).join('/');
+
+export default {
+	entry: 'main.js',
+	format: 'cjs',
+
+	external: function (id) {
+		if (id === config) {
+			return true;
+		}
+
+		return false;
+	},
+
+	plugins: [
+		{
+			load: function ( id ) {
+				assert.notEqual( id, config );
+			}
+		}
+	]
+};


### PR DESCRIPTION
Rollup generate TypeError when options.external is a function in rollup.config.js

bin/rollup:746:4
```
TypeError: (options.external || []).concat is not a function
```