### PR TITLE
Add build target for ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.31.2",
   "description": "Next-generation ES6 module bundler",
   "main": "dist/rollup.js",
-  "jsnext:main": "src/rollup.js",
+  "jsnext:main": "dist/rollup.es.js",
   "bin": {
     "rollup": "./bin/rollup"
   },
@@ -14,7 +14,7 @@
     "test-coverage": "rm -rf coverage/* && istanbul cover --report json node_modules/.bin/_mocha -- -u exports -R spec test/test.js",
     "posttest-coverage": "remap-istanbul -i coverage/coverage-final.json -o coverage/coverage-remapped.json -b dist && remap-istanbul -i coverage/coverage-final.json -o coverage/coverage-remapped.lcov -t lcovonly -b dist && remap-istanbul -i coverage/coverage-final.json -o coverage/coverage-remapped -t html -b dist",
     "ci": "npm run test-coverage && codecov < coverage/coverage-remapped.lcov",
-    "build": "git rev-parse HEAD > .commithash && rollup -c -o dist/rollup.js",
+    "build": "git rev-parse HEAD > .commithash && rollup -c",
     "build:cli": "rollup -c rollup.config.cli.js",
     "build:browser": "git rev-parse HEAD > .commithash && rollup -c rollup.config.browser.js -o dist/rollup.browser.js",
     "prepublish": "npm run lint && npm test && npm run build:browser",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,6 @@ var banner = readFileSync( 'src/banner.js', 'utf-8' )
 
 export default {
 	entry: 'src/rollup.js',
-	format: 'cjs',
 	plugins: [
 		buble({
 			include: [ 'src/**', 'node_modules/acorn/**' ]
@@ -40,5 +39,9 @@ export default {
 	external: [ 'fs' ],
 	banner: banner,
 	sourceMap: true,
-	moduleName: 'rollup'
+	moduleName: 'rollup',
+	targets: [
+		{ dest: 'dist/rollup.js', format: 'cjs' },
+		{ dest: 'dist/rollup.es.js', format: 'es6' }
+	]
 };


### PR DESCRIPTION
Fixes #725 by adding a build target for ES modules, and pointing the `jsnext:main` field to it.