### PR TITLE
Add a failing test for #672.

### DIFF
--- a/src/Statement.js
+++ b/src/Statement.js
@@ -63,6 +63,14 @@ export default class Statement {
 					module.magicString.overwrite( node.start, node.end, 'undefined' );
 				}
 
+				// rewrite `foo[bar]()` as `(0,foo[bar])()` if `foo` is an imported namespace
+				if ( node.type === 'CallExpression' && node.callee.type === 'MemberExpression' && node.callee.object.type === 'Identifier' && node.callee.computed ) {
+					const declaration = module.imports[ node.callee.object.name ];
+					if ( declaration && declaration.name === '*' ) {
+						module.magicString.insertRight( node.callee.start, '(0,' ).insertLeft( node.callee.end, ')' );
+					}
+				}
+
 				if ( node._scope ) scope = node._scope;
 				if ( /^Function/.test( node.type ) ) contextDepth += 1;
 

--- a/test/function/namespace-context/_config.js
+++ b/test/function/namespace-context/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	solo: true,
+	description: 'namespace method call context should not be the namespace object'
+};

--- a/test/function/namespace-context/_config.js
+++ b/test/function/namespace-context/_config.js
@@ -1,4 +1,3 @@
 module.exports = {
-	solo: true,
 	description: 'namespace method call context should not be the namespace object'
 };

--- a/test/function/namespace-context/foo.js
+++ b/test/function/namespace-context/foo.js
@@ -1,0 +1,3 @@
+export function self() {
+	return this;
+}

--- a/test/function/namespace-context/main.js
+++ b/test/function/namespace-context/main.js
@@ -1,0 +1,3 @@
+import * as foo from './foo.js';
+
+assert.notStrictEqual( foo[ 'self' ](), foo );


### PR DESCRIPTION
I'm not sure where the namespace stuff is handled. My proposed solution was to rewrite all namespaces where we couldn't simply eliminate the namespace object from the method call from `ns['self']()` to `(0, ns['self'])()`.
