### PR TITLE
Use config files installed in `node_modules`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
-node_modules
-!test/node_modules
+/node_modules
 .gobble*
 dist
 _actual

--- a/bin/src/handleError.js
+++ b/bin/src/handleError.js
@@ -9,6 +9,10 @@ const handlers = {
 		stderr( chalk.red( 'Config file must export an options object. See https://github.com/rollup/rollup/wiki/Command-Line-Interface#using-a-config-file' ) );
 	},
 
+	MISSING_EXTERNAL_CONFIG: err => {
+		stderr( chalk.red( `Could not resolve config file ${err.config}` ) );
+	},
+
 	MISSING_INPUT_OPTION: () => {
 		stderr( chalk.red( 'You must specify an --input (-i) option' ) );
 	},

--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -38,7 +38,24 @@ export default function runRollup ( command ) {
 	let config = command.config === true ? 'rollup.config.js' : command.config;
 
 	if ( config ) {
-		config = resolve( config );
+		if ( config.slice( 0, 5 ) === 'node:' ) {
+			const pkgName = config.slice( 5 );
+			try {
+				config = relative.resolve( pkgName, process.cwd() );
+			} catch ( err ) {
+				try {
+					config = relative.resolve( `rollup-config-${pkgName}`, process.cwd() );
+				} catch ( err ) {
+					if ( err.code === 'MODULE_NOT_FOUND' ) {
+						handleError({ code: 'MISSING_EXTERNAL_CONFIG', config });
+					}
+
+					throw err;
+				}
+			}
+		} else {
+			config = resolve( config );
+		}
 
 		rollup.rollup({
 			entry: config,

--- a/test/cli/node-config-auto-prefix/_config.js
+++ b/test/cli/node-config-auto-prefix/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'uses config file installed from npm',
+	command: 'rollup --config node:foo',
+	execute: true
+};

--- a/test/cli/node-config-auto-prefix/_expected.js
+++ b/test/cli/node-config-auto-prefix/_expected.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	global.myBundle = factory();
+}(this, function () { 'use strict';
+
+	var main = 42;
+
+	return main;
+
+}));

--- a/test/cli/node-config-auto-prefix/main.js
+++ b/test/cli/node-config-auto-prefix/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/node-config-auto-prefix/node_modules/rollup-config-foo/lib/config.js
+++ b/test/cli/node-config-auto-prefix/node_modules/rollup-config-foo/lib/config.js
@@ -1,0 +1,9 @@
+var replace = require( 'rollup-plugin-replace' );
+
+module.exports = {
+	entry: 'main.js',
+	format: 'cjs',
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};

--- a/test/cli/node-config-auto-prefix/node_modules/rollup-config-foo/package.json
+++ b/test/cli/node-config-auto-prefix/node_modules/rollup-config-foo/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "lib/config.js"
+}

--- a/test/cli/node-config/_config.js
+++ b/test/cli/node-config/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'uses config file installed from npm',
+	command: 'rollup --config node:foo',
+	execute: true
+};

--- a/test/cli/node-config/_expected.js
+++ b/test/cli/node-config/_expected.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	global.myBundle = factory();
+}(this, function () { 'use strict';
+
+	var main = 42;
+
+	return main;
+
+}));

--- a/test/cli/node-config/main.js
+++ b/test/cli/node-config/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/node-config/node_modules/foo/lib/config.js
+++ b/test/cli/node-config/node_modules/foo/lib/config.js
@@ -1,0 +1,9 @@
+var replace = require( 'rollup-plugin-replace' );
+
+module.exports = {
+	entry: 'main.js',
+	format: 'cjs',
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};

--- a/test/cli/node-config/node_modules/foo/package.json
+++ b/test/cli/node-config/node_modules/foo/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "lib/config.js"
+}


### PR DESCRIPTION
See #736. This PR allows you to do this...

```bash
rollup -c node:some-plugins-i-like -i src/main.js -o dist/bundle.js
```

...and as long as either `some-plugins-i-like` or `rollup-config-some-plugins-i-like` is a package that exports a [config file](https://github.com/rollup/rollup/wiki/Command-Line-Interface#using-a-config-file), Rollup will use it.