### PR TITLE
Hooks

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -1,6 +1,7 @@
 import { basename } from './utils/path.js';
 import { writeFile } from './utils/fs.js';
 import { assign, keys } from './utils/object.js';
+import { mapSequence } from './utils/promise.js';
 import validateKeys from './utils/validateKeys.js';
 import SOURCEMAPPING_URL from './utils/sourceMappingURL.js';
 import Bundle from './Bundle.js';
@@ -96,7 +97,13 @@ export function rollup ( options ) {
 				}
 
 				promises.push( writeFile( dest, code ) );
-				return Promise.all( promises );
+				return Promise.all( promises ).then( () => {
+					return mapSequence( bundle.plugins.filter( plugin => plugin.onwrite ), plugin => {
+						return Promise.resolve( plugin.onwrite( assign({
+							bundle: result
+						}, options )));
+					});
+				});
 			}
 		};
 

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,18 @@ function loadConfig ( path ) {
 	}
 }
 
+function loader ( modules ) {
+	return {
+		resolveId ( id ) {
+			return id;
+		},
+
+		load ( id ) {
+			return modules[ id ];
+		}
+	};
+}
+
 describe( 'rollup', function () {
 	this.timeout( 10000 );
 
@@ -530,6 +542,36 @@ describe( 'rollup', function () {
 			}).then( bundle => {
 				assert.equal( calls, 3 );
 				assert.equal( executeBundle( bundle ), 43 );
+			});
+		});
+	});
+
+	describe( 'hooks', () => {
+		it( 'calls ongenerate hooks in sequence', () => {
+			var result = [];
+
+			return rollup.rollup({
+				entry: 'entry',
+				plugins: [
+					loader({ entry: `alert('hello')` }),
+					{
+						ongenerate ( info ) {
+							result.push({ a: info.format });
+						}
+					},
+					{
+						ongenerate ( info ) {
+							result.push({ b: info.format });
+						}
+					}
+				]
+			}).then( bundle => {
+				bundle.generate({ format: 'cjs' });
+
+				assert.deepEqual( result, [
+					{ a: 'cjs' },
+					{ b: 'cjs' }
+				]);
 			});
 		});
 	});


### PR DESCRIPTION
This implements hooks as discussed in #353, with a couple of differences – the result of `bundle.generate(...)` is unchanged, and `ongenerate` hooks can't do anything asynchronously (well, they can, but Rollup won't wait for them).

The `onwrite` hook can return a promise. Both it and `ongenerate` are passed a copy of the `options` object with an additional `bundle` property (the same object that `rollup.rollup(...)` resolves with). `onwrite` handlers are called in sequence, not in parallel.

I'm a little unsure about the naming of `onwrite`, since it's weird for an event handler to be asynchronous. Am open to alternative suggestions.

Feedback welcome!