### PR TITLE
exclude plugin helpers from sourcemaps

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -25,6 +25,7 @@ export default class Module {
 
 		this.bundle = bundle;
 		this.id = id;
+		this.excludeFromSourcemap = /\0/.test( id );
 
 		// all dependencies
 		this.sources = [];
@@ -42,7 +43,7 @@ export default class Module {
 		// By default, `id` is the filename. Custom resolvers and loaders
 		// can change that, but it makes sense to use it for the source filename
 		this.magicString = new MagicString( code, {
-			filename: id,
+			filename: this.excludeFromSourcemap ? null : id, // don't include plugin helpers in sourcemap
 			indentExclusionRanges: []
 		});
 

--- a/src/utils/collapseSourcemaps.js
+++ b/src/utils/collapseSourcemaps.js
@@ -98,7 +98,7 @@ class Link {
 }
 
 export default function collapseSourcemaps ( file, map, modules, bundleSourcemapChain ) {
-	const moduleSources = modules.map( module => {
+	const moduleSources = modules.filter( module => !module.excludeFromSourcemap ).map( module => {
 		let sourceMapChain = module.sourceMapChain;
 
 		let source;

--- a/test/sourcemaps/excludes-plugin-helpers/_config.js
+++ b/test/sourcemaps/excludes-plugin-helpers/_config.js
@@ -1,0 +1,28 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+const assert = require( 'assert' );
+
+const HELPER = '\0helper';
+
+module.exports = {
+	description: 'excludes plugin helpers from sources',
+	options: {
+		format: 'cjs',
+		plugins: [{
+			resolveId ( id ) {
+				if ( id === HELPER ) return id;
+			},
+
+			load ( id ) {
+				if ( id === HELPER ) {
+					return fs.readFileSync( path.join( __dirname, 'helper.js' ), 'utf-8' );
+				}
+			}
+		}]
+	},
+	test: ( code, map ) => {
+		assert.equal( map.sources.length, 1 );
+		assert.equal( map.sourcesContent.length, 1 );
+		assert.ok( /main/.test( map.sources[0] ) );
+	}
+};

--- a/test/sourcemaps/excludes-plugin-helpers/helper.js
+++ b/test/sourcemaps/excludes-plugin-helpers/helper.js
@@ -1,0 +1,3 @@
+export default function foo ( input ) {
+	assert.equal( input, 42 );
+}

--- a/test/sourcemaps/excludes-plugin-helpers/main.js
+++ b/test/sourcemaps/excludes-plugin-helpers/main.js
@@ -1,0 +1,3 @@
+import foo from '\0helper';
+
+foo( 42 );


### PR DESCRIPTION
Via https://github.com/rollup/rollup-plugin-babel/issues/64 – including helpers (e.g. `babelHelpers`) in sourcemaps causes all sorts of chaos. It makes more sense to exclude these virtual modules from the sourcemap.

In magic-string, you can exclude a source from the `sources` array by not giving it a filename, so this just filters out sources that have the `\0` character (convention to indicate plugin helpers/virtual modules).