### PR TITLE
indicate source of transform error where possible, and downgrade non-sourcemap-generating transforms to a warning

### DIFF
--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,0 +1,7 @@
+export function find ( array, fn ) {
+	for ( let i = 0; i < array.length; i += 1 ) {
+		if ( fn( array[i], i ) ) return array[i];
+	}
+
+	return null;
+}

--- a/src/utils/collapseSourcemaps.js
+++ b/src/utils/collapseSourcemaps.js
@@ -15,8 +15,6 @@ class Source {
 
 class Link {
 	constructor ( map, sources ) {
-		if ( !map ) throw new Error( 'Cannot generate a sourcemap if non-sourcemap-generating transformers are used' );
-
 		this.sources = sources;
 		this.names = map.names;
 		this.mappings = decode( map.mappings );
@@ -97,7 +95,7 @@ class Link {
 	}
 }
 
-export default function collapseSourcemaps ( file, map, modules, bundleSourcemapChain ) {
+export default function collapseSourcemaps ( file, map, modules, bundleSourcemapChain, onwarn ) {
 	const moduleSources = modules.filter( module => !module.excludeFromSourcemap ).map( module => {
 		let sourceMapChain = module.sourceMapChain;
 
@@ -125,6 +123,15 @@ export default function collapseSourcemaps ( file, map, modules, bundleSourcemap
 		}
 
 		sourceMapChain.forEach( map => {
+			if ( map.missing ) {
+				onwarn( `Sourcemap is likely to be incorrect: a plugin${map.plugin ? ` ('${map.plugin}')` : ``} was used to transform files, but didn't generate a sourcemap for the transformation. Consult https://github.com/rollup/rollup/wiki/Troubleshooting and the plugin documentation for more information` );
+
+				map = {
+					names: [],
+					mappings: ''
+				};
+			}
+
 			source = new Link( map, [ source ]);
 		});
 

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -1,4 +1,4 @@
-export default function transform ( source, id, transformers ) {
+export default function transform ( source, id, plugins ) {
 	let sourceMapChain = [];
 
 	const originalSourceMap = typeof source.map === 'string' ? JSON.parse( source.map ) : source.map;
@@ -6,9 +6,11 @@ export default function transform ( source, id, transformers ) {
 	let originalCode = source.code;
 	let ast = source.ast;
 
-	return transformers.reduce( ( promise, transformer ) => {
+	return plugins.reduce( ( promise, plugin ) => {
 		return promise.then( previous => {
-			return Promise.resolve( transformer( previous, id ) ).then( result => {
+			if ( !plugin.transform ) return previous;
+
+			return Promise.resolve( plugin.transform( previous, id ) ).then( result => {
 				if ( result == null ) return previous;
 
 				if ( typeof result === 'string' ) {
@@ -23,19 +25,18 @@ export default function transform ( source, id, transformers ) {
 					result.map = JSON.parse( result.map );
 				}
 
-				sourceMapChain.push( result.map );
+				sourceMapChain.push( result.map || { missing: true, plugin: plugin.name }); // lil' bit hacky but it works
 				ast = result.ast;
 
 				return result.code;
 			});
+		}).catch( err => {
+			err.id = id;
+			err.plugin = plugin.name;
+			err.message = `Error transforming ${id}${plugin.name ? ` with '${plugin.name}' plugin` : ''}: ${err.message}`;
+			throw err;
 		});
-
 	}, Promise.resolve( source.code ) )
 
-	.then( code => ({ code, originalCode, originalSourceMap, ast, sourceMapChain }) )
-	.catch( err => {
-		err.id = id;
-		err.message = `Error loading ${id}: ${err.message}`;
-		throw err;
-	});
+	.then( code => ({ code, originalCode, originalSourceMap, ast, sourceMapChain }) );
 }

--- a/src/utils/transformBundle.js
+++ b/src/utils/transformBundle.js
@@ -1,6 +1,16 @@
-export default function transformBundle ( code, transformers, sourceMapChain ) {
-	return transformers.reduce( ( code, transformer ) => {
-		let result = transformer( code );
+export default function transformBundle ( code, plugins, sourceMapChain ) {
+	return plugins.reduce( ( code, plugin ) => {
+		if ( !plugin.transformBundle ) return code;
+
+		let result;
+
+		try {
+			result = plugin.transformBundle( code );
+		} catch ( err ) {
+			err.plugin = plugin.name;
+			err.message = `Error transforming bundle${plugin.name ? ` with '${plugin.name}' plugin` : ''}: ${err.message}`;
+			throw err;
+		}
 
 		if ( result == null ) return code;
 

--- a/test/sourcemaps/transform-without-sourcemap/_config.js
+++ b/test/sourcemaps/transform-without-sourcemap/_config.js
@@ -1,0 +1,26 @@
+const assert = require( 'assert' );
+
+let warnings = [];
+
+module.exports = {
+	description: 'preserves sourcemap chains when transforming',
+	before: () => warnings = [], // reset
+	options: {
+		plugins: [
+			{
+				name: 'fake plugin',
+				transform: function ( code ) {
+					return code;
+				}
+			}
+		],
+		onwarn ( msg ) {
+			warnings.push( msg );
+		}
+	},
+	test: () => {
+		assert.deepEqual( warnings, [
+			`Sourcemap is likely to be incorrect: a plugin ('fake plugin') was used to transform files, but didn't generate a sourcemap for the transformation. Consult https://github.com/rollup/rollup/wiki/Troubleshooting and the plugin documentation for more information`
+		]);
+	}
+};

--- a/test/sourcemaps/transform-without-sourcemap/main.js
+++ b/test/sourcemaps/transform-without-sourcemap/main.js
@@ -1,0 +1,1 @@
+console.log( 42 );

--- a/test/test.js
+++ b/test/test.js
@@ -358,6 +358,7 @@ describe( 'rollup', function () {
 
 							bundle.write( options );
 
+							if ( config.before ) config.before();
 							var result = bundle.generate( options );
 							config.test( result.code, result.map );
 						});


### PR DESCRIPTION
Ref #746. This PR does two things:

* If a sourcemap is requested but a transformer plugin failed to generate a sourcemap for its transformation, Rollup will warn that the sourcemap is likely to be incorrect, but won't fail the build
* If a plugin has a `name` property, it'll be used in warnings and errors where possible

No plugin (that I'm aware of!) currently has a `name` property, but we can add it to the ones owned by the rollup organisation. Eventually it'll probably make sense to print warnings for plugins that don't supply a name, to incentivise plugin authors to add it, but no reason to do that just yet.