### PR TITLE
Use fs.realpathSync() rather than path.resolve() on the config path

### DIFF
--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { realpathSync } from 'fs';
 import relative from 'require-relative';
 import handleError from './handleError';
 import SOURCEMAPPING_URL from './sourceMappingUrl.js';
@@ -54,7 +54,8 @@ export default function runRollup ( command ) {
 				}
 			}
 		} else {
-			config = resolve( config );
+			// find real path of config so it matches what Node provides to callbacks in require.extensions
+			config = realpathSync( config );
 		}
 
 		rollup.rollup({
@@ -79,7 +80,7 @@ export default function runRollup ( command ) {
 			};
 
 			try {
-				const options = require( resolve( config ) );
+				const options = require( config );
 				if ( Object.keys( options ).length === 0 ) {
 					handleError({ code: 'MISSING_CONFIG' });
 				}

--- a/rollup.config.cli.js
+++ b/rollup.config.cli.js
@@ -22,6 +22,7 @@ export default {
 		})
 	],
 	external: [
+		'fs',
 		'path',
 		'module',
 		'source-map-support'

--- a/test/cli/config-cwd-case-insensitive/_config.js
+++ b/test/cli/config-cwd-case-insensitive/_config.js
@@ -1,0 +1,13 @@
+var os = require( 'os' );
+
+function toggleCase ( s ) {
+  return ( s == s.toLowerCase() ) ? s.toUpperCase() : s.toLowerCase();
+}
+
+module.exports = {
+  skip: os.platform() !== 'win32',
+	description: "can load config with cwd that doesn't match realpath",
+	command: 'rollup -c',
+  cwd: process.cwd().replace( /^[A-Z]:\\/ig, toggleCase ),
+	execute: true
+};

--- a/test/cli/config-cwd-case-insensitive/_config.js
+++ b/test/cli/config-cwd-case-insensitive/_config.js
@@ -8,6 +8,6 @@ module.exports = {
   skip: os.platform() !== 'win32',
 	description: "can load config with cwd that doesn't match realpath",
 	command: 'rollup -c',
-  cwd: process.cwd().replace( /^[A-Z]:\\/ig, toggleCase ),
+  cwd: __dirname.replace( /^[A-Z]:\\/i, toggleCase ),
 	execute: true
 };

--- a/test/cli/config-cwd-case-insensitive/main.js
+++ b/test/cli/config-cwd-case-insensitive/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/config-cwd-case-insensitive/rollup.config.js
+++ b/test/cli/config-cwd-case-insensitive/rollup.config.js
@@ -1,0 +1,9 @@
+var replace = require( 'rollup-plugin-replace' );
+
+module.exports = {
+	entry: 'main.js',
+	format: 'cjs',
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};

--- a/test/sourcemaps/relative-paths/_config.js
+++ b/test/sourcemaps/relative-paths/_config.js
@@ -1,13 +1,11 @@
 var path = require( 'path' );
 var assert = require( 'assert' );
 
-var pathRelativeToCwd = path.relative( process.cwd(), path.resolve( __dirname, '_actual/bundle.js' ) );
-
 module.exports = {
-	description: 'source paths are relative (#344)',
+	description: 'source paths are relative with relative dest (#344)',
 	options: {
 		moduleName: 'myModule',
-		dest: pathRelativeToCwd
+		dest: path.resolve( '_actual/bundle.js' )
 	},
 	test: function ( code, map ) {
 		assert.deepEqual( map.sources, [ '../main.js' ]);

--- a/test/test.js
+++ b/test/test.js
@@ -338,6 +338,7 @@ describe( 'rollup', function () {
 			if ( dir[0] === '.' ) return; // .DS_Store...
 
 			describe( dir, function () {
+				process.chdir( SOURCEMAPS + '/' + dir );
 				var config = loadConfig( SOURCEMAPS + '/' + dir + '/_config.js' );
 
 				var entry = path.resolve( SOURCEMAPS, dir, 'main.js' );
@@ -349,6 +350,7 @@ describe( 'rollup', function () {
 
 				PROFILES.forEach( function ( profile ) {
 					( config.skip ? it.skip : config.solo ? it.only : it )( 'generates ' + profile.format, function () {
+						process.chdir( SOURCEMAPS + '/' + dir );
 						return rollup.rollup( options ).then( function ( bundle ) {
 							var options = extend( {}, {
 								format: profile.format,

--- a/test/test.js
+++ b/test/test.js
@@ -376,7 +376,7 @@ describe( 'rollup', function () {
 				var config = loadConfig( CLI + '/' + dir + '/_config.js' );
 
 				( config.skip ? it.skip : config.solo ? it.only : it )( dir, function ( done ) {
-					process.chdir( path.resolve( CLI, dir ) );
+					process.chdir( config.cwd || path.resolve( CLI, dir ) );
 
 					const command = 'node ' + path.resolve( __dirname, '../bin' ) + path.sep + config.command;
 


### PR DESCRIPTION
It's possible for the require.extensions['.js'] override to fail on Windows because path.resolve(...) might return "c:\..." while fs.realpath(...) returns "C:\...", and the exact match fails.