### PR TITLE
Give ongenerate/onwrite more access

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -60,7 +60,7 @@ export function rollup ( options ) {
 				if ( plugin.ongenerate ) {
 					plugin.ongenerate( assign({
 						bundle: result
-					}, options ));
+					}, options ), rendered);
 				}
 			});
 
@@ -79,7 +79,8 @@ export function rollup ( options ) {
 				}
 
 				const dest = options.dest;
-				let { code, map } = generate( options );
+				let output = generate( options );
+				let { code, map } = output;
 
 				let promises = [];
 
@@ -101,7 +102,7 @@ export function rollup ( options ) {
 					return mapSequence( bundle.plugins.filter( plugin => plugin.onwrite ), plugin => {
 						return Promise.resolve( plugin.onwrite( assign({
 							bundle: result
-						}, options )));
+						}, options ), output));
 					});
 				});
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -550,6 +550,32 @@ describe( 'rollup', function () {
 	});
 
 	describe( 'hooks', () => {
+		it( 'passes bundle & output object to ongenerate & onwrite hooks', () => {
+			var dest = path.join( __dirname, 'tmp/bundle.js' );
+			
+			return rollup.rollup({
+				entry: 'entry',
+				plugins: [
+					loader({ entry: `alert('hello')` }),
+					{
+						ongenerate ( bundle, out ) {
+							out.ongenerate = true;
+						},
+
+						onwrite (bundle, out ) {
+							assert.equal(out.ongenerate, true);
+						}
+					}
+				]
+			}).then( bundle => {
+				return bundle.write({
+					dest
+				});
+			}).then( () => {
+				return sander.unlink( dest );
+			});
+		});
+
 		it( 'calls ongenerate hooks in sequence', () => {
 			var result = [];
 


### PR DESCRIPTION
This proposal came out of the conversation in #742 to try and pass a bit more information along to `ongenerate`/`onwrite` so that they can be more useful. Specifically trying to make it so that `ongenerate` is able to add values to the output of `.generate()` so that `onwrite` or API users can see it. This would allow me to clean up some gross stuff I'm doing in the `modular-css` rollup plugin, and hopefully will allow clearer differentiation between the use-cases for `ongenerate` and `onwrite`.

@Rich-Harris @TrySound would love your thoughts on whether or not this improves things. It's a small change & all tests still pass w/o modification.