### PR TITLE
Avoid lazy parsing by adding parens around factory

### DIFF
--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -59,7 +59,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 			typeof exports === 'object' && typeof module !== 'undefined' ? ${cjsExport}factory(${cjsDeps.join( ', ' )}) :
 			typeof define === 'function' && define.amd ? define(${amdParams}factory) :
 			${globalExport};
-		}(this, function (${args}) {${useStrict}
+		}(this, (function (${args}) {${useStrict}
 
 		`.replace( /^\t\t/gm, '' ).replace( /^\t/gm, magicString.getIndentString() );
 
@@ -77,6 +77,6 @@ export default function umd ( bundle, magicString, { exportMode, indentString },
 	return magicString
 		.trim()
 		.indent( indentString )
-		.append( '\n\n}));' )
+		.append( '\n\n})));' )
 		.prepend( intro );
 }


### PR DESCRIPTION
Most javascript engines do a lazy parsing optimization. For example if they see:

function X() {...}

They won't parse the contents of X until it is executed. However they often have to read the contents of X so that they can see if X uses any variables from the outer scope. Thus X ends up getting parsed twice.

Realizing that often one immediately executes a function, browser have optimized statements of the form:

(function X() {...})()

So that X is not parsed lazily. Traditionally this optimization looks for an open paren before the function. For example, here's the optimization in v8:

https://github.com/v8/v8/blob/203391bcc0e970d3cae27ba99afd337c1c5f6d42/src/parsing/parser.cc#L4256

Since the factory is immediately executed (at least in the commonJS and global export case), this change avoids the double parsing that comes with parsing the function lazily.