### PR TITLE
support paths config

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -52,6 +52,12 @@ export default class Bundle {
 		this.hasLoaders = loaders.length !== 0;
 		this.load = first( loaders.concat( load ) );
 
+		this.getPath = typeof options.paths === 'function' ?
+			( id => options.paths( id ) || this.getPathRelativeToEntryDirname( id ) ) :
+			options.paths ?
+				( id => options.paths.hasOwnProperty( id ) ? options.paths[ id ] : this.getPathRelativeToEntryDirname( id ) ) :
+				id => this.getPathRelativeToEntryDirname( id );
+
 		this.moduleById = new Map();
 		this.modules = [];
 
@@ -243,7 +249,7 @@ export default class Bundle {
 						module.resolvedIds[ source ] = externalId;
 
 						if ( !this.moduleById.has( externalId ) ) {
-							const module = new ExternalModule( externalId, this.getPathRelativeToEntryDirname( externalId ) );
+							const module = new ExternalModule( externalId, this.getPath( externalId ) );
 							this.externalModules.push( module );
 							this.moduleById.set( externalId, module );
 						}

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -26,6 +26,7 @@ const ALLOWED_KEYS = [
 	'noConflict',
 	'onwarn',
 	'outro',
+	'paths',
 	'plugins',
 	'preferConst',
 	'sourceMap',

--- a/test/form/paths-function/_config.js
+++ b/test/form/paths-function/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'external paths (#754)',
+	options: {
+		paths: id => `https://npmcdn.com/${id}`
+	}
+};

--- a/test/form/paths-function/_expected/amd.js
+++ b/test/form/paths-function/_expected/amd.js
@@ -1,0 +1,7 @@
+define(['https://npmcdn.com/foo'], function (foo) { 'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+});

--- a/test/form/paths-function/_expected/cjs.js
+++ b/test/form/paths-function/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var foo = _interopDefault(require('https://npmcdn.com/foo'));
+
+assert.equal( foo, 42 );

--- a/test/form/paths-function/_expected/es.js
+++ b/test/form/paths-function/_expected/es.js
@@ -1,0 +1,3 @@
+import foo from 'https://npmcdn.com/foo';
+
+assert.equal( foo, 42 );

--- a/test/form/paths-function/_expected/iife.js
+++ b/test/form/paths-function/_expected/iife.js
@@ -1,0 +1,8 @@
+(function (foo) {
+	'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+}(foo));

--- a/test/form/paths-function/_expected/umd.js
+++ b/test/form/paths-function/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('https://npmcdn.com/foo')) :
+	typeof define === 'function' && define.amd ? define(['https://npmcdn.com/foo'], factory) :
+	(factory(global.foo));
+}(this, function (foo) { 'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+}));

--- a/test/form/paths-function/main.js
+++ b/test/form/paths-function/main.js
@@ -1,0 +1,3 @@
+import foo from 'foo';
+
+assert.equal( foo, 42 );

--- a/test/form/paths-relative/_config.js
+++ b/test/form/paths-relative/_config.js
@@ -1,0 +1,13 @@
+const { resolve } = require( 'path' );
+
+const resolved = resolve( __dirname, 'foo.js' );
+
+module.exports = {
+	description: 'external paths (#754)',
+	options: {
+		external: [ resolved ],
+		paths: {
+			[ resolved ]: '../foo'
+		}
+	}
+};

--- a/test/form/paths-relative/_expected/amd.js
+++ b/test/form/paths-relative/_expected/amd.js
@@ -1,0 +1,7 @@
+define(['../foo'], function (foo) { 'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+});

--- a/test/form/paths-relative/_expected/cjs.js
+++ b/test/form/paths-relative/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var foo = _interopDefault(require('../foo'));
+
+assert.equal( foo, 42 );

--- a/test/form/paths-relative/_expected/es.js
+++ b/test/form/paths-relative/_expected/es.js
@@ -1,0 +1,3 @@
+import foo from '../foo';
+
+assert.equal( foo, 42 );

--- a/test/form/paths-relative/_expected/iife.js
+++ b/test/form/paths-relative/_expected/iife.js
@@ -1,0 +1,8 @@
+(function (foo) {
+	'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+}(foo));

--- a/test/form/paths-relative/_expected/umd.js
+++ b/test/form/paths-relative/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../foo')) :
+	typeof define === 'function' && define.amd ? define(['../foo'], factory) :
+	(factory(global.foo));
+}(this, function (foo) { 'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+}));

--- a/test/form/paths-relative/main.js
+++ b/test/form/paths-relative/main.js
@@ -1,0 +1,3 @@
+import foo from './foo.js';
+
+assert.equal( foo, 42 );

--- a/test/form/paths/_config.js
+++ b/test/form/paths/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'external paths (#754)',
+	options: {
+		paths: {
+			foo: 'https://npmcdn.com/foo'
+		}
+	}
+};

--- a/test/form/paths/_expected/amd.js
+++ b/test/form/paths/_expected/amd.js
@@ -1,0 +1,7 @@
+define(['https://npmcdn.com/foo'], function (foo) { 'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+});

--- a/test/form/paths/_expected/cjs.js
+++ b/test/form/paths/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var foo = _interopDefault(require('https://npmcdn.com/foo'));
+
+assert.equal( foo, 42 );

--- a/test/form/paths/_expected/es.js
+++ b/test/form/paths/_expected/es.js
@@ -1,0 +1,3 @@
+import foo from 'https://npmcdn.com/foo';
+
+assert.equal( foo, 42 );

--- a/test/form/paths/_expected/iife.js
+++ b/test/form/paths/_expected/iife.js
@@ -1,0 +1,8 @@
+(function (foo) {
+	'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+}(foo));

--- a/test/form/paths/_expected/umd.js
+++ b/test/form/paths/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('https://npmcdn.com/foo')) :
+	typeof define === 'function' && define.amd ? define(['https://npmcdn.com/foo'], factory) :
+	(factory(global.foo));
+}(this, function (foo) { 'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
+
+	assert.equal( foo, 42 );
+
+}));

--- a/test/form/paths/main.js
+++ b/test/form/paths/main.js
@@ -1,0 +1,3 @@
+import foo from 'foo';
+
+assert.equal( foo, 42 );

--- a/test/test.js
+++ b/test/test.js
@@ -90,7 +90,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( function () {
 				throw new Error( 'Missing expected error' );
 			}, function ( err ) {
-				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, dest, entry, exports, external, footer, format, globals, indent, intro, moduleId, moduleName, noConflict, onwarn, outro, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
+				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, dest, entry, exports, external, footer, format, globals, indent, intro, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
 			});
 		});
 	});


### PR DESCRIPTION
closes #754. Allows you to specify the path of an external module, making it straightforward to (for example) create an AMD bundle that loads specific libraries from a CDN