### PR TITLE
Introduce eslint to tests.  Complaints are fixed, but none of them major.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,6 @@
     "env": {
         "es6": true,
         "browser": true,
-        "mocha": true,
         "node": true
     },
     "extends": "eslint:recommended",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:cli": "rollup -c rollup.config.cli.js",
     "build:browser": "git rev-parse HEAD > .commithash && rollup -c rollup.config.browser.js -o dist/rollup.browser.js",
     "prepublish": "npm run lint && npm test && npm run build:browser",
-    "lint": "eslint src browser"
+    "lint": "eslint src browser test/test.js test/utils test/**/_config.js"
   },
   "repository": {
     "type": "git",

--- a/src/utils/collapseSourcemaps.js
+++ b/src/utils/collapseSourcemaps.js
@@ -21,7 +21,9 @@ class Link {
 	}
 
 	traceMappings () {
-		let sources = [], sourcesContent = [], names = [];
+		let sources = [];
+		let sourcesContent = [];
+		let names = [];
 
 		const mappings = this.mappings.map( line => {
 			let tracedLine = [];
@@ -31,7 +33,8 @@ class Link {
 				const traced = source.traceSegment( segment[2], segment[3], this.names[ segment[4] ] );
 
 				if ( traced ) {
-					let sourceIndex = null, nameIndex = null;
+					let sourceIndex = null;
+					let nameIndex = null;
 					segment = [
 						segment[0],
 						null,

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,9 @@
+{
+    "rules": {
+        "no-console": [ 0 ],
+        "no-unused-vars": [ "error", { "vars": "all", "args": "none" } ]
+    },
+    "env": {
+        "mocha": true
+    }
+}

--- a/test/cli/config-cwd-case-insensitive/_config.js
+++ b/test/cli/config-cwd-case-insensitive/_config.js
@@ -1,13 +1,13 @@
 var os = require( 'os' );
 
 function toggleCase ( s ) {
-  return ( s == s.toLowerCase() ) ? s.toUpperCase() : s.toLowerCase();
+	return ( s == s.toLowerCase() ) ? s.toUpperCase() : s.toLowerCase();
 }
 
 module.exports = {
-  skip: os.platform() !== 'win32',
+	skip: os.platform() !== 'win32',
 	description: "can load config with cwd that doesn't match realpath",
 	command: 'rollup -c',
-  cwd: __dirname.replace( /^[A-Z]:\\/i, toggleCase ),
+	cwd: __dirname.replace( /^[A-Z]:\\/i, toggleCase ),
 	execute: true
 };

--- a/test/cli/external-modules-auto-global/_config.js
+++ b/test/cli/external-modules-auto-global/_config.js
@@ -1,5 +1,3 @@
-const assert = require( 'assert' );
-
 module.exports = {
 	description: 'populates options.external with --global keys',
 	command: 'rollup main.js --format iife --globals mathematics:Math',

--- a/test/cli/indent-none/_config.js
+++ b/test/cli/indent-none/_config.js
@@ -1,5 +1,3 @@
-var assert = require( 'assert' );
-
 module.exports = {
 	description: 'disables indentation with --no-indent',
 	command: 'rollup main.js --format umd --no-indent'

--- a/test/form/banner-and-footer-plugin/_config.js
+++ b/test/form/banner-and-footer-plugin/_config.js
@@ -12,4 +12,4 @@ module.exports = {
 			}
 		]
 	}
-}
+};

--- a/test/form/transform-bundle-plugin/_config.js
+++ b/test/form/transform-bundle-plugin/_config.js
@@ -14,4 +14,4 @@ module.exports = {
 			}
 		]
 	}
-}
+};

--- a/test/form/umd-noconflict/_config.js
+++ b/test/form/umd-noconflict/_config.js
@@ -1,5 +1,3 @@
-var assert = require( 'assert' );
-
 module.exports = {
 	description: 'exports noConflict method for default umd when requested',
 	options: {

--- a/test/function/configure-relative-external-module/_config.js
+++ b/test/function/configure-relative-external-module/_config.js
@@ -11,7 +11,7 @@ module.exports = {
 		external: [ path.join( __dirname, './nonexistent-relative-dependency.js') ]
 	},
 	context: {
-		require: function() {
+		require: function () {
 			return mockedValue;
 		}
 	},

--- a/test/function/confused-default-identifier/_config.js
+++ b/test/function/confused-default-identifier/_config.js
@@ -1,5 +1,3 @@
-var assert = require( 'assert' );
-
 module.exports = {
 	description: 'Rollup should not get confused and allow "default" as an identifier name',
 	warnings: function () {} // suppress

--- a/test/function/consistent-renaming-e/_config.js
+++ b/test/function/consistent-renaming-e/_config.js
@@ -1,3 +1,3 @@
 module.exports = {
 	description: 'consistent renaming test e'
-}
+};

--- a/test/function/custom-path-resolver-plural-b/_config.js
+++ b/test/function/custom-path-resolver-plural-b/_config.js
@@ -9,7 +9,7 @@ module.exports = {
 					throw new Error( 'nope' );
 				},
 				load: function ( id ) {
-					if ( id === 'main' ) return 'assert.ok( false );'
+					if ( id === 'main' ) return 'assert.ok( false );';
 				}
 			},
 			{

--- a/test/function/default-export-is-not-bound-b/_config.js
+++ b/test/function/default-export-is-not-bound-b/_config.js
@@ -4,6 +4,6 @@ module.exports = {
 	description: 'does not move default export statement above earlier statements',
 	exports: function ( exports ) {
 		assert.equal( exports.bar, 42 );
-	},
+	}
 	// solo: true
 };

--- a/test/function/delete/_config.js
+++ b/test/function/delete/_config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  description: '`delete` operator at the top level is preserved'
+	description: '`delete` operator at the top level is preserved'
 };

--- a/test/function/export-as/_config.js
+++ b/test/function/export-as/_config.js
@@ -1,5 +1,3 @@
-var assert = require( 'assert' );
-
 module.exports = {
 	description: 'allows export { x as y }'
 };

--- a/test/function/export-from-no-local-binding/_config.js
+++ b/test/function/export-from-no-local-binding/_config.js
@@ -1,5 +1,3 @@
-var assert = require( 'assert' );
-
 module.exports = {
 	description: 'export from does not create a local binding'
 };

--- a/test/function/member-expression-assignment-in-function/_config.js
+++ b/test/function/member-expression-assignment-in-function/_config.js
@@ -7,4 +7,4 @@ module.exports = {
 		assert.equal( code.indexOf( 'set("bar", 2);' ) >= 0, true, code );
 		assert.equal( code.indexOf( 'set("qux", 3);' ) >= 0, true, code );
 	}
-}
+};

--- a/test/function/namespace-missing-export/_config.js
+++ b/test/function/namespace-missing-export/_config.js
@@ -1,5 +1,4 @@
 var assert = require( 'assert' );
-var path = require( 'path' );
 
 module.exports = {
 	options: {

--- a/test/function/newline-after-comment/_config.js
+++ b/test/function/newline-after-comment/_config.js
@@ -4,6 +4,6 @@ module.exports = {
 	description: 'inserts newline after comment',
 	exports: function ( exports ) {
 		assert.equal( exports(), 42 );
-	},
+	}
 	// solo: true
 };

--- a/test/function/object-dynamic-properties/_config.js
+++ b/test/function/object-dynamic-properties/_config.js
@@ -1,5 +1,3 @@
-var assert = require('assert');
-
 module.exports = {
 	description: 'dynamic object assignments should be imported'
 };

--- a/test/function/plugins-can-manipulate-options/_config.js
+++ b/test/function/plugins-can-manipulate-options/_config.js
@@ -15,4 +15,4 @@ module.exports = {
 	exports: function ( answer ) {
 		assert.equal( answer, 42 );
 	}
-}
+};

--- a/test/function/resolves-namespace-default/_config.js
+++ b/test/function/resolves-namespace-default/_config.js
@@ -1,9 +1,9 @@
 var assert = require('assert');
 
 module.exports = {
-  description: "namespace's 'default' properties should be available",
+	description: "namespace's 'default' properties should be available",
 
-  exports: function ( exports ) {
-    assert.equal( exports, 42 );
-  }
+	exports: function ( exports ) {
+		assert.equal( exports, 42 );
+	}
 };

--- a/test/function/skips-dead-branches-b/_config.js
+++ b/test/function/skips-dead-branches-b/_config.js
@@ -5,4 +5,4 @@ module.exports = {
 	code: function ( code ) {
 		assert.equal( code.indexOf( 'obj.foo = function' ), -1, code );
 	}
-}
+};

--- a/test/function/skips-dead-branches-c/_config.js
+++ b/test/function/skips-dead-branches-c/_config.js
@@ -5,4 +5,4 @@ module.exports = {
 	code: function ( code ) {
 		assert.equal( code.indexOf( 'obj.foo = function' ), -1, code );
 	}
-}
+};

--- a/test/function/skips-dead-branches-d/_config.js
+++ b/test/function/skips-dead-branches-d/_config.js
@@ -5,4 +5,4 @@ module.exports = {
 	code: function ( code ) {
 		assert.equal( code.indexOf( 'obj.foo = function' ), -1, code );
 	}
-}
+};

--- a/test/function/skips-dead-branches-e/_config.js
+++ b/test/function/skips-dead-branches-e/_config.js
@@ -5,4 +5,4 @@ module.exports = {
 	code: function ( code ) {
 		assert.equal( code.indexOf( 'obj.foo = function' ), -1, code );
 	}
-}
+};

--- a/test/function/skips-dead-branches-f/_config.js
+++ b/test/function/skips-dead-branches-f/_config.js
@@ -5,4 +5,4 @@ module.exports = {
 	code: function ( code ) {
 		assert.equal( code.indexOf( 'obj.foo = function' ), -1, code );
 	}
-}
+};

--- a/test/function/skips-dead-branches-g/_config.js
+++ b/test/function/skips-dead-branches-g/_config.js
@@ -1,9 +1,9 @@
 var assert = require( 'assert' );
 
 module.exports = {
-  description: 'skips a dead conditional expression branch (g)',
-  code: function ( code ) {
-    assert.ok( code.indexOf( 'var c = a;' ) >= 0, code );
-    assert.ok( code.indexOf( 'var d = b;' ) >= 0, code );
-  }
+	description: 'skips a dead conditional expression branch (g)',
+	code: function ( code ) {
+		assert.ok( code.indexOf( 'var c = a;' ) >= 0, code );
+		assert.ok( code.indexOf( 'var d = b;' ) >= 0, code );
+	}
 };

--- a/test/function/skips-dead-branches/_config.js
+++ b/test/function/skips-dead-branches/_config.js
@@ -5,4 +5,4 @@ module.exports = {
 	code: function ( code ) {
 		assert.equal( code.indexOf( 'obj.foo = function' ), -1, code );
 	}
-}
+};

--- a/test/function/transformer-multiple/_config.js
+++ b/test/function/transformer-multiple/_config.js
@@ -22,4 +22,4 @@ module.exports = {
 	exports: function ( exports ) {
 		assert.equal( exports.magicNumber, 6 );
 	}
-}
+};

--- a/test/function/transformer-single/_config.js
+++ b/test/function/transformer-single/_config.js
@@ -12,4 +12,4 @@ module.exports = {
 	exports: function ( exports ) {
 		assert.equal( exports.magicNumber, 3 );
 	}
-}
+};

--- a/test/function/warn-on-eval/_config.js
+++ b/test/function/warn-on-eval/_config.js
@@ -1,4 +1,3 @@
-var path = require( 'path' );
 var assert = require( 'assert' );
 
 var warned = false;

--- a/test/sourcemaps/basic-support/_config.js
+++ b/test/sourcemaps/basic-support/_config.js
@@ -1,4 +1,3 @@
-var path = require( 'path' );
 var assert = require( 'assert' );
 var getLocation = require( '../../utils/getLocation' );
 var SourceMapConsumer = require( 'source-map' ).SourceMapConsumer;

--- a/test/sourcemaps/loaders/_config.js
+++ b/test/sourcemaps/loaders/_config.js
@@ -39,16 +39,18 @@ module.exports = {
 	},
 	test: function ( code, map ) {
 		var smc = new SourceMapConsumer( map );
+		var generatedLoc;
+		var originalLoc;
 
-		var generatedLoc = getLocation( code, code.indexOf( '22' ) );
-		var originalLoc = smc.originalPositionFor( generatedLoc );
+		generatedLoc = getLocation( code, code.indexOf( '22' ) );
+		originalLoc = smc.originalPositionFor( generatedLoc );
 
 		assert.equal( originalLoc.source, '../foo.js' );
 		assert.equal( originalLoc.line, 1 );
 		assert.equal( originalLoc.column, 32 );
 
-		var generatedLoc = getLocation( code, code.indexOf( '20' ) );
-		var originalLoc = smc.originalPositionFor( generatedLoc );
+		generatedLoc = getLocation( code, code.indexOf( '20' ) );
+		originalLoc = smc.originalPositionFor( generatedLoc );
 
 		assert.equal( originalLoc.source, '../bar.js' );
 		assert.equal( originalLoc.line, 1 );

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,6 @@ require( 'source-map-support' ).install();
 require( 'console-group' ).install();
 
 var path = require( 'path' );
-var os = require( 'os' );
 var sander = require( 'sander' );
 var assert = require( 'assert' );
 var exec = require( 'child_process' ).exec;
@@ -314,12 +313,16 @@ describe( 'rollup', function () {
 								try {
 									actualMap = JSON.parse( sander.readFileSync( FORM, dir, '_actual', profile.format + '.js.map' ).toString() );
 									actualMap.sourcesContent = actualMap.sourcesContent.map( normaliseOutput );
-								} catch ( err ) {}
+								} catch ( err ) {
+									assert.equal( err.code, 'ENOENT' );
+								}
 
 								try {
 									expectedMap = JSON.parse( sander.readFileSync( FORM, dir, '_expected', profile.format + '.js.map' ).toString() );
 									expectedMap.sourcesContent = expectedMap.sourcesContent.map( normaliseOutput );
-								} catch ( err ) {}
+								} catch ( err ) {
+									assert.equal( err.code, 'ENOENT' );
+								}
 
 								if ( config.show ) {
 									console.log( actualCode + '\n\n\n' );

--- a/test/utils/getLocation.js
+++ b/test/utils/getLocation.js
@@ -19,4 +19,4 @@ module.exports = function getLocation ( source, search ) {
 	}
 
 	throw new Error( 'Could not determine location of character' );
-}
+};


### PR DESCRIPTION
This includes the tab changes that I was going to do in #760.

Probably the most controversial thing is relaxing the use of unused function arguments, but it's only restricted to the tests directory.  I don't understand why you would want to delete arguments when they're useful documentation about the function's interface.