### PR TITLE
Preserve comments ahead of import statements.

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -451,6 +451,11 @@ export default class Module {
 
 		this.statements.forEach( statement => {
 			if ( !statement.isIncluded ) {
+				if ( statement.node.type === 'ImportDeclaration' ) {
+					magicString.remove( statement.node.start, statement.next );
+					return;
+				}
+
 				magicString.remove( statement.start, statement.next );
 				return;
 			}


### PR DESCRIPTION
This should allow comments to stay above the imported module code when bundled. I did this so that my file name and code coverage specific comments would be preserved.