### PR TITLE
Initialize member in constructor, fixes #813

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -218,7 +218,6 @@ export default class Bundle {
 				this.moduleById.set( id, module );
 
 				return this.fetchAllDependencies( module ).then( () => {
-					module.exportsAll = blank();
 					keys( module.exports ).forEach( name => {
 						module.exportsAll[name] = module.id;
 					});

--- a/src/Module.js
+++ b/src/Module.js
@@ -35,6 +35,7 @@ export default class Module {
 		// imports and exports, indexed by local name
 		this.imports = blank();
 		this.exports = blank();
+		this.exportsAll = blank();
 		this.reexports = blank();
 
 		this.exportAllSources = [];


### PR DESCRIPTION
This might do the trick.
But since fetchAllDependencies() and fetchModule() call each other, this may just hide the real bug / introduce new ones... not sure.