### PR TITLE
Leave it up to resolveId to normalize the entry path.

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -34,7 +34,7 @@ export default class Bundle {
 			}
 		});
 
-		this.entry = normalize( options.entry );
+		this.entry = options.entry;
 		this.entryId = null;
 		this.entryModule = null;
 

--- a/test/function/does-not-mangle-entry-point/_config.js
+++ b/test/function/does-not-mangle-entry-point/_config.js
@@ -1,0 +1,26 @@
+var path = require( 'path' );
+var fs = require( 'fs' );
+var assert = require( 'assert' );
+
+var modules = {
+	'x\\y': 'export default 42;',
+	'x/y': 'export default 24;'
+};
+
+module.exports = {
+	description: 'does not mangle entry point',
+	options: {
+		entry: 'x\\y',
+		plugins: [{
+			resolveId: function ( importee ) {
+				return importee;
+			},
+			load: function ( moduleId ) {
+				return modules[ moduleId ];
+			}
+		}]
+	},
+	exports: function ( exports ) {
+		assert.equal( exports, 42 );
+	}
+};

--- a/test/function/does-not-mangle-entry-point/_config.js
+++ b/test/function/does-not-mangle-entry-point/_config.js
@@ -1,5 +1,3 @@
-var path = require( 'path' );
-var fs = require( 'fs' );
 var assert = require( 'assert' );
 
 var modules = {


### PR DESCRIPTION
Normalizing the entry ID before passing it to any plugins is redundant, because if it's a path, it will be normalized in resolveId like any other ID. If it isn't a path, normalizing it before passing it to resolveId may mangle it in a surprising way, such as by replacing backslashes with forward slashes.