### PR TITLE
[WIP] Optimize dynamic access of namespace imports with literal keys

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -200,8 +200,8 @@ export class SyntheticNamespaceDeclaration {
 		// the reference by pointing directly to `bar`
 		if ( reference.parts.length ) {
 			const ref = reference.parts.shift();
-			reference.name = ref.name;
-			reference.end = ref.end;
+			reference.name = ref.type === 'Literal' ? ref.value : ref.name;
+			reference.end = reference.node.end;
 
 			const original = this.originals[ reference.name ];
 

--- a/src/ast/flatten.js
+++ b/src/ast/flatten.js
@@ -1,7 +1,11 @@
 export default function flatten ( node ) {
 	const parts = [];
 	while ( node.type === 'MemberExpression' ) {
-		if ( node.computed ) return null;
+		if ( node.computed ) {
+			if ( node.property.type !== 'Literal' || typeof node.property.value !== 'string' ) {
+				return null;
+			}
+		}
 		parts.unshift( node.property.name );
 
 		node = node.object;

--- a/src/ast/isReference.js
+++ b/src/ast/isReference.js
@@ -1,6 +1,11 @@
 export default function isReference ( node, parent ) {
 	if ( node.type === 'MemberExpression' ) {
-		return !node.computed && isReference( node.object, node );
+		if ( node.computed ) {
+			if ( node.property.type !== 'Literal' || typeof node.property.value !== 'string' ) {
+				return false
+			}
+		}
+		return isReference( node.object, node );
 	}
 
 	if ( node.type === 'Identifier' ) {

--- a/test/form/namespace-optimization-computed-string/_config.js
+++ b/test/form/namespace-optimization-computed-string/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'it does dynamic lookup optimization of internal namespaces for string-literal keys'
+};

--- a/test/form/namespace-optimization-computed-string/_expected/amd.js
+++ b/test/form/namespace-optimization-computed-string/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	function a () {}
+
+	a();
+
+});

--- a/test/form/namespace-optimization-computed-string/_expected/cjs.js
+++ b/test/form/namespace-optimization-computed-string/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function a () {}
+
+a();

--- a/test/form/namespace-optimization-computed-string/_expected/es.js
+++ b/test/form/namespace-optimization-computed-string/_expected/es.js
@@ -1,0 +1,3 @@
+function a () {}
+
+a();

--- a/test/form/namespace-optimization-computed-string/_expected/iife.js
+++ b/test/form/namespace-optimization-computed-string/_expected/iife.js
@@ -1,0 +1,8 @@
+(function () {
+	'use strict';
+
+	function a () {}
+
+	a();
+
+}());

--- a/test/form/namespace-optimization-computed-string/_expected/umd.js
+++ b/test/form/namespace-optimization-computed-string/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, function () { 'use strict';
+
+	function a () {}
+
+	a();
+
+}));

--- a/test/form/namespace-optimization-computed-string/bar.js
+++ b/test/form/namespace-optimization-computed-string/bar.js
@@ -1,0 +1,3 @@
+import * as quux from './quux.js';
+
+export { quux };

--- a/test/form/namespace-optimization-computed-string/foo.js
+++ b/test/form/namespace-optimization-computed-string/foo.js
@@ -1,0 +1,3 @@
+import * as bar from './bar.js';
+
+export { bar };

--- a/test/form/namespace-optimization-computed-string/main.js
+++ b/test/form/namespace-optimization-computed-string/main.js
@@ -1,0 +1,3 @@
+import * as foo from './foo.js';
+
+foo['bar']['quux']['a']();

--- a/test/form/namespace-optimization-computed-string/quux.js
+++ b/test/form/namespace-optimization-computed-string/quux.js
@@ -1,0 +1,1 @@
+export function a () {}


### PR DESCRIPTION
This doesn’t fully work yet since it causes the erroneous-nested-member-expression test to regress. Any thoughts how to make these play nice together?

This would fix https://github.com/rollup/rollup-plugin-babel/issues/65.
