### PR TITLE
prevent leaky state, always clone magic-string

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -448,7 +448,7 @@ export default class Module {
 	}
 
 	render ( es ) {
-		const magicString = this.magicString;
+		const magicString = this.magicString.clone();
 
 		this.statements.forEach( statement => {
 			if ( !statement.isIncluded ) {

--- a/test/test.js
+++ b/test/test.js
@@ -290,10 +290,12 @@ describe( 'rollup', function () {
 				}
 			}, config.options );
 
-			( config.skip ? describe.skip : config.solo ? describe.only : describe)( dir, () => {
+			( config.skip ? describe.skip : config.solo ? describe.only : describe )( dir, () => {
+				const promise = rollup.rollup( options );
+
 				PROFILES.forEach( profile => {
 					it( 'generates ' + profile.format, () => {
-						return rollup.rollup( options ).then( bundle => {
+						return promise.then( bundle => {
 							const options = extend( {}, config.options, {
 								dest: FORM + '/' + dir + '/_actual/' + profile.format + '.js',
 								format: profile.format


### PR DESCRIPTION
It looks like https://github.com/rollup/rollup/commit/ebd5ead5e6f9b40960f73d03027c9ef2ad1e4c4d has caused some bugs related to leaky state, e.g. https://github.com/rollup/rollup/issues/875 (have verified that this PR fixes the issue). @TrySound I think we should revert that change until we're confident we can prevent unnecessary cloning without causing those bugs – this PR changes the tests so that the bundle is shared between targets, which will make that easier