### PR TITLE
Faster indexing for key validation

### DIFF
--- a/src/utils/arrayToMap.js
+++ b/src/utils/arrayToMap.js
@@ -1,0 +1,6 @@
+export function arrayToMap (list) {
+	return list.reduce((accum, el) => {
+		accum[el] = el;
+		return accum;
+	}, {});
+}

--- a/src/utils/validateKeys.js
+++ b/src/utils/validateKeys.js
@@ -1,14 +1,16 @@
 import { keys } from './object.js';
+import { arrayToMap } from './arrayToMap';
 
 export default function validateKeys ( object, allowedKeys ) {
 	const actualKeys = keys( object );
 
+	const keysMap = arrayToMap( allowedKeys );
 	let i = actualKeys.length;
 
 	while ( i-- ) {
 		const key = actualKeys[i];
 
-		if ( allowedKeys.indexOf( key ) === -1 ) {
+		if ( !keysMap[key] ) {
 			return new Error(
 				`Unexpected key '${ key }' found, expected one of: ${ allowedKeys.join( ', ' ) }`
 			);


### PR DESCRIPTION
Old solution run `indexOf` for each key which is O(n^keys length). Instead iterate only once - create `Map` object and then index element with O(1). Could be proved by bench.