### PR TITLE
deconflict classes

### DIFF
--- a/src/ast/nodes/ClassDeclaration.js
+++ b/src/ast/nodes/ClassDeclaration.js
@@ -18,7 +18,7 @@ export default class ClassDeclaration extends Node {
 	}
 
 	getName () {
-		return this.id.name;
+		return this.name;
 	}
 
 	hasEffects () {
@@ -26,7 +26,9 @@ export default class ClassDeclaration extends Node {
 	}
 
 	initialise ( scope ) {
-		scope.addDeclaration( this.id.name, this, false, false );
+		this.name = this.id.name;
+
+		scope.addDeclaration( this.name, this, false, false );
 		super.initialise( scope );
 	}
 

--- a/test/function/deconflicts-classes/_config.js
+++ b/test/function/deconflicts-classes/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	solo: true,
+	description: 'deconflicts top-level classes'
+};

--- a/test/function/deconflicts-classes/a.js
+++ b/test/function/deconflicts-classes/a.js
@@ -1,0 +1,2 @@
+var Foo = function Foo () {};
+export { Foo };

--- a/test/function/deconflicts-classes/b.js
+++ b/test/function/deconflicts-classes/b.js
@@ -1,0 +1,2 @@
+class Foo {};
+export { Foo };

--- a/test/function/deconflicts-classes/main.js
+++ b/test/function/deconflicts-classes/main.js
@@ -1,0 +1,4 @@
+import { Foo as A } from './a.js';
+import { Foo as B } from './b.js';
+
+assert.notEqual( A, B );


### PR DESCRIPTION
Bug in 0.35 – deconflicted class IDs weren't being rendered. (Funnily enough, didn't see this until I tried to use Rollup 0.35 to roll up Rollup.)