### PR TITLE
Remove non-expression statements without effects

### DIFF
--- a/src/ast/nodes/ArrowFunctionExpression.js
+++ b/src/ast/nodes/ArrowFunctionExpression.js
@@ -3,8 +3,22 @@ import Scope from '../scopes/Scope.js';
 import extractNames from '../utils/extractNames.js';
 
 export default class ArrowFunctionExpression extends Node {
+	bind ( scope ) {
+		super.bind( this.scope || scope );
+	}
+
+	findScope ( functionScope ) {
+		return this.scope || this.parent.findScope( functionScope );
+	}
+
+	hasEffects () {
+		return false;
+	}
+
 	initialise ( scope ) {
-		if ( this.body.type !== 'BlockStatement' ) {
+		if ( this.body.type === 'BlockStatement' ) {
+			this.body.createScope( scope );
+		} else {
 			this.scope = new Scope({
 				parent: scope,
 				isBlockScope: false,
@@ -18,18 +32,7 @@ export default class ArrowFunctionExpression extends Node {
 			}
 		}
 
+		scope = this.scope || this.body.scope;
 		super.initialise( scope );
-	}
-
-	bind ( scope ) {
-		super.bind( this.scope || scope );
-	}
-
-	findScope ( functionScope ) {
-		return this.scope || this.parent.findScope( functionScope );
-	}
-
-	hasEffects () {
-		return false;
 	}
 }

--- a/src/ast/nodes/AssignmentExpression.js
+++ b/src/ast/nodes/AssignmentExpression.js
@@ -35,11 +35,13 @@ export default class AssignmentExpression extends Node {
 	}
 
 	initialise ( scope ) {
+		this.scope = scope;
+
 		this.module.bundle.dependentExpressions.push( this );
 		super.initialise( scope );
 	}
 
 	isUsedByBundle () {
-		return isUsedByBundle( this.findScope(), this.subject );
+		return isUsedByBundle( this.scope, this.subject );
 	}
 }

--- a/src/ast/nodes/EmptyStatement.js
+++ b/src/ast/nodes/EmptyStatement.js
@@ -1,0 +1,7 @@
+import Statement from './shared/Statement.js';
+
+export default class EmptyStatement extends Statement {
+	render ( code ) {
+		code.remove( this.start, this.end );
+	}
+}

--- a/src/ast/nodes/ExpressionStatement.js
+++ b/src/ast/nodes/ExpressionStatement.js
@@ -1,16 +1,5 @@
-import Node from '../Node.js';
+import Statement from './shared/Statement.js';
 
-export default class ExpressionStatement extends Node {
-	render ( code, es ) {
-		if ( !this.module.bundle.treeshake || this.shouldInclude ) {
-			super.render( code, es );
-		} else {
-			code.remove( this.leadingCommentStart || this.start, this.next || this.end );
-		}
-	}
+export default class ExpressionStatement extends Statement {
 
-	run ( scope ) {
-		this.shouldInclude = true;
-		super.run( scope );
-	}
 }

--- a/src/ast/nodes/ForInStatement.js
+++ b/src/ast/nodes/ForInStatement.js
@@ -1,0 +1,15 @@
+import Node from '../Node.js';
+import { STRING } from '../values.js';
+
+export default class ForInStatement extends Node {
+	initialise ( scope ) {
+		super.initialise( scope );
+
+		// special case
+		if ( this.left.type === 'VariableDeclaration' ) {
+			for ( const proxy of this.left.declarations[0].proxies.values() ) {
+				proxy.possibleValues.add( STRING );
+			}
+		}
+	}
+}

--- a/src/ast/nodes/ForInStatement.js
+++ b/src/ast/nodes/ForInStatement.js
@@ -4,7 +4,8 @@ import { STRING } from '../values.js';
 
 export default class ForInStatement extends Statement {
 	initialise ( scope ) {
-		super.initialise( scope );
-		assignTo( this.left, scope, STRING );
+		this.body.createScope( scope );
+		super.initialise( this.body.scope );
+		assignTo( this.left, this.body.scope, STRING );
 	}
 }

--- a/src/ast/nodes/ForInStatement.js
+++ b/src/ast/nodes/ForInStatement.js
@@ -1,15 +1,10 @@
-import Node from '../Node.js';
+import Statement from './shared/Statement.js';
+import assignTo from './shared/assignTo.js';
 import { STRING } from '../values.js';
 
-export default class ForInStatement extends Node {
+export default class ForInStatement extends Statement {
 	initialise ( scope ) {
 		super.initialise( scope );
-
-		// special case
-		if ( this.left.type === 'VariableDeclaration' ) {
-			for ( const proxy of this.left.declarations[0].proxies.values() ) {
-				proxy.possibleValues.add( STRING );
-			}
-		}
+		assignTo( this.left, scope, STRING );
 	}
 }

--- a/src/ast/nodes/ForOfStatement.js
+++ b/src/ast/nodes/ForOfStatement.js
@@ -1,15 +1,10 @@
-import Node from '../Node.js';
+import Statement from './shared/Statement.js';
+import assignTo from './shared/assignTo.js';
 import { UNKNOWN } from '../values.js';
 
-export default class ForOfStatement extends Node {
+export default class ForOfStatement extends Statement {
 	initialise ( scope ) {
 		super.initialise( scope );
-
-		// special case
-		if ( this.left.type === 'VariableDeclaration' ) {
-			for ( const proxy of this.left.declarations[0].proxies.values() ) {
-				proxy.possibleValues.add( UNKNOWN );
-			}
-		}
+		assignTo( this.left, scope, UNKNOWN );
 	}
 }

--- a/src/ast/nodes/ForOfStatement.js
+++ b/src/ast/nodes/ForOfStatement.js
@@ -4,7 +4,8 @@ import { UNKNOWN } from '../values.js';
 
 export default class ForOfStatement extends Statement {
 	initialise ( scope ) {
-		super.initialise( scope );
-		assignTo( this.left, scope, UNKNOWN );
+		this.body.createScope( scope );
+		super.initialise( this.body.scope );
+		assignTo( this.left, this.body.scope, UNKNOWN );
 	}
 }

--- a/src/ast/nodes/ForOfStatement.js
+++ b/src/ast/nodes/ForOfStatement.js
@@ -1,0 +1,15 @@
+import Node from '../Node.js';
+import { UNKNOWN } from '../values.js';
+
+export default class ForOfStatement extends Node {
+	initialise ( scope ) {
+		super.initialise( scope );
+
+		// special case
+		if ( this.left.type === 'VariableDeclaration' ) {
+			for ( const proxy of this.left.declarations[0].proxies.values() ) {
+				proxy.possibleValues.add( UNKNOWN );
+			}
+		}
+	}
+}

--- a/src/ast/nodes/ForStatement.js
+++ b/src/ast/nodes/ForStatement.js
@@ -1,0 +1,31 @@
+import Statement from './shared/Statement.js';
+
+export default class ForStatement extends Statement {
+	bind () {
+		const scope = this.body.scope;
+
+		this.init.bind( scope );
+		this.test.bind( scope );
+		this.update.bind( scope );
+		this.body.bind( scope );
+	}
+
+	hasEffects () {
+		return super.hasEffects( this.body.scope );
+	}
+
+	initialise ( scope ) {
+		this.body.createScope( scope );
+		scope = this.body.scope;
+
+		// can't use super, because we need to control the order
+		this.init.initialise( scope );
+		this.test.initialise( scope );
+		this.update.initialise( scope );
+		this.body.initialise( scope );
+	}
+
+	run ( scope ) {
+		super.run( scope );
+	}
+}

--- a/src/ast/nodes/FunctionDeclaration.js
+++ b/src/ast/nodes/FunctionDeclaration.js
@@ -36,11 +36,11 @@ export default class FunctionDeclaration extends Node {
 		this.name = this.id.name; // may be overridden by bundle.deconflict
 		scope.addDeclaration( this.name, this, false, false );
 
-		this.body.createScope();
+		this.body.createScope( scope );
 
 		this.id.initialise( scope );
 		this.params.forEach( param => param.initialise( this.body.scope ) );
-		this.body.initialise( scope );
+		this.body.initialise();
 	}
 
 	render ( code, es ) {

--- a/src/ast/nodes/FunctionExpression.js
+++ b/src/ast/nodes/FunctionExpression.js
@@ -11,8 +11,8 @@ export default class FunctionExpression extends Node {
 		return false;
 	}
 
-	initialise () {
-		this.body.createScope(); // TODO we'll also need to do this for For[Of|In]Statement
+	initialise ( scope ) {
+		this.body.createScope( scope );
 
 		if ( this.id ) this.id.initialise( this.body.scope );
 		this.params.forEach( param => param.initialise( this.body.scope ) );

--- a/src/ast/nodes/IfStatement.js
+++ b/src/ast/nodes/IfStatement.js
@@ -1,8 +1,8 @@
-import Node from '../Node.js';
+import Statement from './shared/Statement.js';
 import { UNKNOWN } from '../values.js';
 
 // TODO DRY this out
-export default class IfStatement extends Node {
+export default class IfStatement extends Statement {
 	initialise ( scope ) {
 		this.testValue = this.test.getValue();
 

--- a/src/ast/nodes/ThrowStatement.js
+++ b/src/ast/nodes/ThrowStatement.js
@@ -1,0 +1,7 @@
+import Node from '../Node.js';
+
+export default class ThrowStatement extends Node {
+	hasEffects ( scope ) {
+		return scope.findLexicalBoundary().isModuleScope; // TODO should this just be `true`? probably...
+	}
+}

--- a/src/ast/nodes/index.js
+++ b/src/ast/nodes/index.js
@@ -11,6 +11,8 @@ import ExportAllDeclaration from './ExportAllDeclaration.js';
 import ExportDefaultDeclaration from './ExportDefaultDeclaration.js';
 import ExportNamedDeclaration from './ExportNamedDeclaration.js';
 import ExpressionStatement from './ExpressionStatement.js';
+import ForInStatement from './ForInStatement.js';
+import ForOfStatement from './ForOfStatement.js';
 import FunctionDeclaration from './FunctionDeclaration.js';
 import FunctionExpression from './FunctionExpression.js';
 import Identifier from './Identifier.js';
@@ -43,6 +45,8 @@ export default {
 	ExportDefaultDeclaration,
 	ExportNamedDeclaration,
 	ExpressionStatement,
+	ForInStatement,
+	ForOfStatement,
 	FunctionDeclaration,
 	FunctionExpression,
 	Identifier,

--- a/src/ast/nodes/index.js
+++ b/src/ast/nodes/index.js
@@ -26,6 +26,7 @@ import ParenthesizedExpression from './ParenthesizedExpression.js';
 import ReturnStatement from './ReturnStatement.js';
 import TemplateLiteral from './TemplateLiteral.js';
 import ThisExpression from './ThisExpression.js';
+import ThrowStatement from './ThrowStatement.js';
 import UnaryExpression from './UnaryExpression.js';
 import UpdateExpression from './UpdateExpression.js';
 import VariableDeclarator from './VariableDeclarator.js';
@@ -60,6 +61,7 @@ export default {
 	ReturnStatement,
 	TemplateLiteral,
 	ThisExpression,
+	ThrowStatement,
 	UnaryExpression,
 	UpdateExpression,
 	VariableDeclarator,

--- a/src/ast/nodes/index.js
+++ b/src/ast/nodes/index.js
@@ -7,10 +7,12 @@ import CallExpression from './CallExpression.js';
 import ClassDeclaration from './ClassDeclaration.js';
 import ClassExpression from './ClassExpression.js';
 import ConditionalExpression from './ConditionalExpression.js';
+import EmptyStatement from './EmptyStatement.js';
 import ExportAllDeclaration from './ExportAllDeclaration.js';
 import ExportDefaultDeclaration from './ExportDefaultDeclaration.js';
 import ExportNamedDeclaration from './ExportNamedDeclaration.js';
 import ExpressionStatement from './ExpressionStatement.js';
+import ForStatement from './ForStatement.js';
 import ForInStatement from './ForInStatement.js';
 import ForOfStatement from './ForOfStatement.js';
 import FunctionDeclaration from './FunctionDeclaration.js';
@@ -24,6 +26,7 @@ import NewExpression from './NewExpression.js';
 import ObjectExpression from './ObjectExpression.js';
 import ParenthesizedExpression from './ParenthesizedExpression.js';
 import ReturnStatement from './ReturnStatement.js';
+import Statement from './shared/Statement.js';
 import TemplateLiteral from './TemplateLiteral.js';
 import ThisExpression from './ThisExpression.js';
 import ThrowStatement from './ThrowStatement.js';
@@ -42,10 +45,13 @@ export default {
 	ClassDeclaration,
 	ClassExpression,
 	ConditionalExpression,
+	DoWhileStatement: Statement,
+	EmptyStatement,
 	ExportAllDeclaration,
 	ExportDefaultDeclaration,
 	ExportNamedDeclaration,
 	ExpressionStatement,
+	ForStatement,
 	ForInStatement,
 	ForOfStatement,
 	FunctionDeclaration,
@@ -59,11 +65,14 @@ export default {
 	ObjectExpression,
 	ParenthesizedExpression,
 	ReturnStatement,
+	SwitchStatement: Statement,
 	TemplateLiteral,
 	ThisExpression,
 	ThrowStatement,
+	TryStatement: Statement,
 	UnaryExpression,
 	UpdateExpression,
 	VariableDeclarator,
-	VariableDeclaration
+	VariableDeclaration,
+	WhileStatement: Statement
 };

--- a/src/ast/nodes/shared/Statement.js
+++ b/src/ast/nodes/shared/Statement.js
@@ -1,0 +1,16 @@
+import Node from '../../Node.js';
+
+export default class Statement extends Node {
+	render ( code, es ) {
+		if ( !this.module.bundle.treeshake || this.shouldInclude ) {
+			super.render( code, es );
+		} else {
+			code.remove( this.leadingCommentStart || this.start, this.next || this.end );
+		}
+	}
+
+	run ( scope ) {
+		this.shouldInclude = true;
+		super.run( scope );
+	}
+}

--- a/src/ast/nodes/shared/assignTo.js
+++ b/src/ast/nodes/shared/assignTo.js
@@ -1,0 +1,29 @@
+import extractNames from '../../utils/extractNames.js';
+
+export default function assignToForLoopLeft ( node, scope, value ) {
+	if ( node.type === 'VariableDeclaration' ) {
+		for ( const proxy of node.declarations[0].proxies.values() ) {
+			proxy.possibleValues.add( value );
+		}
+	}
+
+	else {
+		while ( node.type === 'ParenthesizedExpression' ) node = node.expression;
+
+		if ( node.type === 'MemberExpression' ) {
+			// apparently this is legal JavaScript? Though I don't know what
+			// kind of monster would write `for ( foo.bar of thing ) {...}`
+
+			// for now, do nothing, as I'm not sure anything needs to happen...
+		}
+
+		else {
+			for ( const name of extractNames( node ) ) {
+				const declaration = scope.findDeclaration( name );
+				if ( declaration.possibleValues ) {
+					declaration.possibleValues.add( value );
+				}
+			}
+		}
+	}
+}

--- a/test/form/effect-in-for-of-loop-in-functions/_config.js
+++ b/test/form/effect-in-for-of-loop-in-functions/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'includes effects in for-of loop (#870)'
+}

--- a/test/form/effect-in-for-of-loop-in-functions/_expected/amd.js
+++ b/test/form/effect-in-for-of-loop-in-functions/_expected/amd.js
@@ -2,14 +2,22 @@ define(function () { 'use strict';
 
 	const items = [{}, {}, {}];
 
-	for ( const a of items.children ) {
-		a.foo = 'a';
+	function a () {
+		for ( const item of items.children ) {
+			item.foo = 'a';
+		}
 	}
 
-	let c;
-	for ( c of items.children ) {
-		c.bar = 'c';
+	a();
+
+	function c () {
+		let item;
+		for ( item of items.children ) {
+			item.bar = 'c';
+		}
 	}
+
+	c();
 
 	assert.deepEqual( items, [
 		{ foo: 'a', bar: 'c' },

--- a/test/form/effect-in-for-of-loop-in-functions/_expected/cjs.js
+++ b/test/form/effect-in-for-of-loop-in-functions/_expected/cjs.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const items = [{}, {}, {}];
+
+function a () {
+	for ( const item of items.children ) {
+		item.foo = 'a';
+	}
+}
+
+a();
+
+function c () {
+	let item;
+	for ( item of items.children ) {
+		item.bar = 'c';
+	}
+}
+
+c();
+
+assert.deepEqual( items, [
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' }
+]);

--- a/test/form/effect-in-for-of-loop-in-functions/_expected/es.js
+++ b/test/form/effect-in-for-of-loop-in-functions/_expected/es.js
@@ -1,0 +1,24 @@
+const items = [{}, {}, {}];
+
+function a () {
+	for ( const item of items.children ) {
+		item.foo = 'a';
+	}
+}
+
+a();
+
+function c () {
+	let item;
+	for ( item of items.children ) {
+		item.bar = 'c';
+	}
+}
+
+c();
+
+assert.deepEqual( items, [
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' }
+]);

--- a/test/form/effect-in-for-of-loop-in-functions/_expected/iife.js
+++ b/test/form/effect-in-for-of-loop-in-functions/_expected/iife.js
@@ -3,14 +3,22 @@
 
 	const items = [{}, {}, {}];
 
-	for ( const a of items.children ) {
-		a.foo = 'a';
+	function a () {
+		for ( const item of items.children ) {
+			item.foo = 'a';
+		}
 	}
 
-	let c;
-	for ( c of items.children ) {
-		c.bar = 'c';
+	a();
+
+	function c () {
+		let item;
+		for ( item of items.children ) {
+			item.bar = 'c';
+		}
 	}
+
+	c();
 
 	assert.deepEqual( items, [
 		{ foo: 'a', bar: 'c' },

--- a/test/form/effect-in-for-of-loop-in-functions/_expected/umd.js
+++ b/test/form/effect-in-for-of-loop-in-functions/_expected/umd.js
@@ -6,14 +6,22 @@
 
 	const items = [{}, {}, {}];
 
-	for ( const a of items.children ) {
-		a.foo = 'a';
+	function a () {
+		for ( const item of items.children ) {
+			item.foo = 'a';
+		}
 	}
 
-	let c;
-	for ( c of items.children ) {
-		c.bar = 'c';
+	a();
+
+	function c () {
+		let item;
+		for ( item of items.children ) {
+			item.bar = 'c';
+		}
 	}
+
+	c();
 
 	assert.deepEqual( items, [
 		{ foo: 'a', bar: 'c' },

--- a/test/form/effect-in-for-of-loop-in-functions/main.js
+++ b/test/form/effect-in-for-of-loop-in-functions/main.js
@@ -1,0 +1,41 @@
+const items = [{}, {}, {}];
+
+function a () {
+	for ( const item of items.children ) {
+		item.foo = 'a';
+	}
+}
+
+a();
+
+function b () {
+	for ( const item of items.children ) {
+		// do nothing
+	}
+}
+
+b();
+
+function c () {
+	let item;
+	for ( item of items.children ) {
+		item.bar = 'c';
+	}
+}
+
+c();
+
+function d () {
+	let item;
+	for ( item of items.children ) {
+		// do nothing
+	}
+}
+
+d();
+
+assert.deepEqual( items, [
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' }
+]);

--- a/test/form/effect-in-for-of-loop/_config.js
+++ b/test/form/effect-in-for-of-loop/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'includes effects in for-of loop (#870)'
+}

--- a/test/form/effect-in-for-of-loop/_expected/amd.js
+++ b/test/form/effect-in-for-of-loop/_expected/amd.js
@@ -1,0 +1,19 @@
+define(function () { 'use strict';
+
+	const items = [{}, {}, {}];
+
+	function x () {
+		for ( const item of items.children ) {
+			item.foo = 'bar';
+		}
+	}
+
+	x();
+
+	assert.deepEqual( items, [
+		{ foo: 'bar' },
+		{ foo: 'bar' },
+		{ foo: 'bar' }
+	]);
+
+});

--- a/test/form/effect-in-for-of-loop/_expected/cjs.js
+++ b/test/form/effect-in-for-of-loop/_expected/cjs.js
@@ -2,16 +2,17 @@
 
 const items = [{}, {}, {}];
 
-function x () {
-	for ( const item of items.children ) {
-		item.foo = 'bar';
-	}
+for ( const a of items.children ) {
+	a.foo = 'a';
 }
 
-x();
+let c;
+for ( c of items.children ) {
+	c.bar = 'c';
+}
 
 assert.deepEqual( items, [
-	{ foo: 'bar' },
-	{ foo: 'bar' },
-	{ foo: 'bar' }
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' }
 ]);

--- a/test/form/effect-in-for-of-loop/_expected/cjs.js
+++ b/test/form/effect-in-for-of-loop/_expected/cjs.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const items = [{}, {}, {}];
+
+function x () {
+	for ( const item of items.children ) {
+		item.foo = 'bar';
+	}
+}
+
+x();
+
+assert.deepEqual( items, [
+	{ foo: 'bar' },
+	{ foo: 'bar' },
+	{ foo: 'bar' }
+]);

--- a/test/form/effect-in-for-of-loop/_expected/es.js
+++ b/test/form/effect-in-for-of-loop/_expected/es.js
@@ -1,0 +1,15 @@
+const items = [{}, {}, {}];
+
+function x () {
+	for ( const item of items.children ) {
+		item.foo = 'bar';
+	}
+}
+
+x();
+
+assert.deepEqual( items, [
+	{ foo: 'bar' },
+	{ foo: 'bar' },
+	{ foo: 'bar' }
+]);

--- a/test/form/effect-in-for-of-loop/_expected/es.js
+++ b/test/form/effect-in-for-of-loop/_expected/es.js
@@ -1,15 +1,16 @@
 const items = [{}, {}, {}];
 
-function x () {
-	for ( const item of items.children ) {
-		item.foo = 'bar';
-	}
+for ( const a of items.children ) {
+	a.foo = 'a';
 }
 
-x();
+let c;
+for ( c of items.children ) {
+	c.bar = 'c';
+}
 
 assert.deepEqual( items, [
-	{ foo: 'bar' },
-	{ foo: 'bar' },
-	{ foo: 'bar' }
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' }
 ]);

--- a/test/form/effect-in-for-of-loop/_expected/iife.js
+++ b/test/form/effect-in-for-of-loop/_expected/iife.js
@@ -1,0 +1,20 @@
+(function () {
+	'use strict';
+
+	const items = [{}, {}, {}];
+
+	function x () {
+		for ( const item of items.children ) {
+			item.foo = 'bar';
+		}
+	}
+
+	x();
+
+	assert.deepEqual( items, [
+		{ foo: 'bar' },
+		{ foo: 'bar' },
+		{ foo: 'bar' }
+	]);
+
+}());

--- a/test/form/effect-in-for-of-loop/_expected/umd.js
+++ b/test/form/effect-in-for-of-loop/_expected/umd.js
@@ -1,0 +1,23 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	const items = [{}, {}, {}];
+
+	function x () {
+		for ( const item of items.children ) {
+			item.foo = 'bar';
+		}
+	}
+
+	x();
+
+	assert.deepEqual( items, [
+		{ foo: 'bar' },
+		{ foo: 'bar' },
+		{ foo: 'bar' }
+	]);
+
+})));

--- a/test/form/effect-in-for-of-loop/main.js
+++ b/test/form/effect-in-for-of-loop/main.js
@@ -1,0 +1,23 @@
+const items = [{}, {}, {}];
+
+function x () {
+	for ( const item of items.children ) {
+		item.foo = 'bar';
+	}
+}
+
+x();
+
+function y () {
+	for ( const item of items.children ) {
+		// do nothing
+	}
+}
+
+y();
+
+assert.deepEqual( items, [
+	{ foo: 'bar' },
+	{ foo: 'bar' },
+	{ foo: 'bar' }
+]);

--- a/test/form/effect-in-for-of-loop/main.js
+++ b/test/form/effect-in-for-of-loop/main.js
@@ -1,23 +1,25 @@
 const items = [{}, {}, {}];
 
-function x () {
-	for ( const item of items.children ) {
-		item.foo = 'bar';
-	}
+for ( const a of items.children ) {
+	a.foo = 'a';
 }
 
-x();
-
-function y () {
-	for ( const item of items.children ) {
-		// do nothing
-	}
+for ( const b of items.children ) {
+	// do nothing
 }
 
-y();
+let c;
+for ( c of items.children ) {
+	c.bar = 'c';
+}
+
+let d;
+for ( d of items.children ) {
+	// do nothing
+}
 
 assert.deepEqual( items, [
-	{ foo: 'bar' },
-	{ foo: 'bar' },
-	{ foo: 'bar' }
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' },
+	{ foo: 'a', bar: 'c' }
 ]);

--- a/test/form/empty-block-statement/_config.js
+++ b/test/form/empty-block-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty block statement'
+};

--- a/test/form/empty-block-statement/_expected/amd.js
+++ b/test/form/empty-block-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-block-statement/_expected/cjs.js
+++ b/test/form/empty-block-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-block-statement/_expected/es.js
+++ b/test/form/empty-block-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-block-statement/_expected/iife.js
+++ b/test/form/empty-block-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-block-statement/_expected/umd.js
+++ b/test/form/empty-block-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-block-statement/main.js
+++ b/test/form/empty-block-statement/main.js
@@ -1,0 +1,5 @@
+console.log( 1 );
+{
+	// empty
+}
+console.log( 2 );

--- a/test/form/empty-do-while-statement/_config.js
+++ b/test/form/empty-do-while-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty do-while statement'
+};

--- a/test/form/empty-do-while-statement/_expected/amd.js
+++ b/test/form/empty-do-while-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-do-while-statement/_expected/cjs.js
+++ b/test/form/empty-do-while-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-do-while-statement/_expected/es.js
+++ b/test/form/empty-do-while-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-do-while-statement/_expected/iife.js
+++ b/test/form/empty-do-while-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-do-while-statement/_expected/umd.js
+++ b/test/form/empty-do-while-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-do-while-statement/main.js
+++ b/test/form/empty-do-while-statement/main.js
@@ -1,0 +1,6 @@
+console.log( 1 );
+var condition = true;
+do {
+	condition = false;
+} while ( condition );
+console.log( 2 );

--- a/test/form/empty-for-in-statement/_config.js
+++ b/test/form/empty-for-in-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty for-in statement'
+};

--- a/test/form/empty-for-in-statement/_expected/amd.js
+++ b/test/form/empty-for-in-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-for-in-statement/_expected/cjs.js
+++ b/test/form/empty-for-in-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-for-in-statement/_expected/es.js
+++ b/test/form/empty-for-in-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-for-in-statement/_expected/iife.js
+++ b/test/form/empty-for-in-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-for-in-statement/_expected/umd.js
+++ b/test/form/empty-for-in-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-for-in-statement/main.js
+++ b/test/form/empty-for-in-statement/main.js
@@ -1,0 +1,5 @@
+console.log( 1 );
+for ( const i in whatever ) {
+	// do nothing
+}
+console.log( 2 );

--- a/test/form/empty-for-of-statement/_config.js
+++ b/test/form/empty-for-of-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty for-of statement'
+};

--- a/test/form/empty-for-of-statement/_expected/amd.js
+++ b/test/form/empty-for-of-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-for-of-statement/_expected/cjs.js
+++ b/test/form/empty-for-of-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-for-of-statement/_expected/es.js
+++ b/test/form/empty-for-of-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-for-of-statement/_expected/iife.js
+++ b/test/form/empty-for-of-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-for-of-statement/_expected/umd.js
+++ b/test/form/empty-for-of-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-for-of-statement/main.js
+++ b/test/form/empty-for-of-statement/main.js
@@ -1,0 +1,5 @@
+console.log( 1 );
+for ( const i of whatever ) {
+	// do nothing
+}
+console.log( 2 );

--- a/test/form/empty-for-statement/_config.js
+++ b/test/form/empty-for-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty for statement'
+};

--- a/test/form/empty-for-statement/_expected/amd.js
+++ b/test/form/empty-for-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-for-statement/_expected/cjs.js
+++ b/test/form/empty-for-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-for-statement/_expected/es.js
+++ b/test/form/empty-for-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-for-statement/_expected/iife.js
+++ b/test/form/empty-for-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-for-statement/_expected/umd.js
+++ b/test/form/empty-for-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-for-statement/main.js
+++ b/test/form/empty-for-statement/main.js
@@ -1,0 +1,5 @@
+console.log( 1 );
+for ( let i = 0; i < 10; i += 1 ) {
+	// do nothing
+}
+console.log( 2 );

--- a/test/form/empty-if-statement/_config.js
+++ b/test/form/empty-if-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty if statement'
+};

--- a/test/form/empty-if-statement/_expected/amd.js
+++ b/test/form/empty-if-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-if-statement/_expected/cjs.js
+++ b/test/form/empty-if-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-if-statement/_expected/es.js
+++ b/test/form/empty-if-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-if-statement/_expected/iife.js
+++ b/test/form/empty-if-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-if-statement/_expected/umd.js
+++ b/test/form/empty-if-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-if-statement/main.js
+++ b/test/form/empty-if-statement/main.js
@@ -1,0 +1,5 @@
+console.log( 1 );
+if ( nothing ) {
+	// empty
+}
+console.log( 2 );

--- a/test/form/empty-statement/_config.js
+++ b/test/form/empty-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty statement'
+};

--- a/test/form/empty-statement/_expected/amd.js
+++ b/test/form/empty-statement/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+
+	console.log( 2 );
+
+});

--- a/test/form/empty-statement/_expected/cjs.js
+++ b/test/form/empty-statement/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+console.log( 1 );
+
+console.log( 2 );

--- a/test/form/empty-statement/_expected/es.js
+++ b/test/form/empty-statement/_expected/es.js
@@ -1,0 +1,3 @@
+console.log( 1 );
+
+console.log( 2 );

--- a/test/form/empty-statement/_expected/iife.js
+++ b/test/form/empty-statement/_expected/iife.js
@@ -1,0 +1,8 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+
+	console.log( 2 );
+
+}());

--- a/test/form/empty-statement/_expected/umd.js
+++ b/test/form/empty-statement/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+
+	console.log( 2 );
+
+})));

--- a/test/form/empty-statement/main.js
+++ b/test/form/empty-statement/main.js
@@ -1,0 +1,4 @@
+;
+console.log( 1 );;
+;
+console.log( 2 );;

--- a/test/form/empty-switch-statement/_config.js
+++ b/test/form/empty-switch-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty switch statement'
+};

--- a/test/form/empty-switch-statement/_expected/amd.js
+++ b/test/form/empty-switch-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-switch-statement/_expected/cjs.js
+++ b/test/form/empty-switch-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-switch-statement/_expected/es.js
+++ b/test/form/empty-switch-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-switch-statement/_expected/iife.js
+++ b/test/form/empty-switch-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-switch-statement/_expected/umd.js
+++ b/test/form/empty-switch-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-switch-statement/main.js
+++ b/test/form/empty-switch-statement/main.js
@@ -1,0 +1,11 @@
+console.log( 1 );
+var result;
+switch ( whatever ) {
+	case foo:
+		result = 'foo';
+		break;
+
+	default:
+		result = 'default';
+}
+console.log( 2 );

--- a/test/form/empty-try-catch-statement/_config.js
+++ b/test/form/empty-try-catch-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty try-catch-finally statement'
+};

--- a/test/form/empty-try-catch-statement/_expected/amd.js
+++ b/test/form/empty-try-catch-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-try-catch-statement/_expected/cjs.js
+++ b/test/form/empty-try-catch-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-try-catch-statement/_expected/es.js
+++ b/test/form/empty-try-catch-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-try-catch-statement/_expected/iife.js
+++ b/test/form/empty-try-catch-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-try-catch-statement/_expected/umd.js
+++ b/test/form/empty-try-catch-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-try-catch-statement/main.js
+++ b/test/form/empty-try-catch-statement/main.js
@@ -1,0 +1,9 @@
+console.log( 1 );
+try {
+	// do nothing
+} catch ( err ) {
+	// do nothing
+} finally {
+	// do nothing
+}
+console.log( 2 );

--- a/test/form/empty-while-statement/_config.js
+++ b/test/form/empty-while-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes an empty while statement'
+};

--- a/test/form/empty-while-statement/_expected/amd.js
+++ b/test/form/empty-while-statement/_expected/amd.js
@@ -1,0 +1,6 @@
+define(function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+});

--- a/test/form/empty-while-statement/_expected/cjs.js
+++ b/test/form/empty-while-statement/_expected/cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-while-statement/_expected/es.js
+++ b/test/form/empty-while-statement/_expected/es.js
@@ -1,0 +1,2 @@
+console.log( 1 );
+console.log( 2 );

--- a/test/form/empty-while-statement/_expected/iife.js
+++ b/test/form/empty-while-statement/_expected/iife.js
@@ -1,0 +1,7 @@
+(function () {
+	'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+}());

--- a/test/form/empty-while-statement/_expected/umd.js
+++ b/test/form/empty-while-statement/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	console.log( 1 );
+	console.log( 2 );
+
+})));

--- a/test/form/empty-while-statement/main.js
+++ b/test/form/empty-while-statement/main.js
@@ -1,0 +1,6 @@
+console.log( 1 );
+var condition = true;
+while ( condition ) {
+	condition = false;
+}
+console.log( 2 );

--- a/test/form/erroneous-nested-member-expression/_expected/amd.js
+++ b/test/form/erroneous-nested-member-expression/_expected/amd.js
@@ -6,7 +6,7 @@ define(function () { 'use strict';
 				console.log('har?');
 			}
 		};
-	};
+	}
 
 	yar.har();
 

--- a/test/form/erroneous-nested-member-expression/_expected/cjs.js
+++ b/test/form/erroneous-nested-member-expression/_expected/cjs.js
@@ -6,6 +6,6 @@ function yar() {
 			console.log('har?');
 		}
 	};
-};
+}
 
 yar.har();

--- a/test/form/erroneous-nested-member-expression/_expected/es.js
+++ b/test/form/erroneous-nested-member-expression/_expected/es.js
@@ -4,6 +4,6 @@ function yar() {
 			console.log('har?');
 		}
 	};
-};
+}
 
 yar.har();

--- a/test/form/erroneous-nested-member-expression/_expected/iife.js
+++ b/test/form/erroneous-nested-member-expression/_expected/iife.js
@@ -7,7 +7,7 @@
 				console.log('har?');
 			}
 		};
-	};
+	}
 
 	yar.har();
 

--- a/test/form/erroneous-nested-member-expression/_expected/umd.js
+++ b/test/form/erroneous-nested-member-expression/_expected/umd.js
@@ -10,7 +10,7 @@
 				console.log('har?');
 			}
 		};
-	};
+	}
 
 	yar.har();
 

--- a/test/form/spacing-after-function-with-semicolon/_expected/amd.js
+++ b/test/form/spacing-after-function-with-semicolon/_expected/amd.js
@@ -1,6 +1,6 @@
 define(function () { 'use strict';
 
-	function x () { return 'x' };
+	function x () { return 'x' }
 
 	assert.equal( x(), 'x' );
 

--- a/test/form/spacing-after-function-with-semicolon/_expected/cjs.js
+++ b/test/form/spacing-after-function-with-semicolon/_expected/cjs.js
@@ -1,5 +1,5 @@
 'use strict';
 
-function x () { return 'x' };
+function x () { return 'x' }
 
 assert.equal( x(), 'x' );

--- a/test/form/spacing-after-function-with-semicolon/_expected/es.js
+++ b/test/form/spacing-after-function-with-semicolon/_expected/es.js
@@ -1,3 +1,3 @@
-function x () { return 'x' };
+function x () { return 'x' }
 
 assert.equal( x(), 'x' );

--- a/test/form/spacing-after-function-with-semicolon/_expected/iife.js
+++ b/test/form/spacing-after-function-with-semicolon/_expected/iife.js
@@ -1,7 +1,7 @@
 (function () {
 	'use strict';
 
-	function x () { return 'x' };
+	function x () { return 'x' }
 
 	assert.equal( x(), 'x' );
 

--- a/test/form/spacing-after-function-with-semicolon/_expected/umd.js
+++ b/test/form/spacing-after-function-with-semicolon/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory());
 }(this, (function () { 'use strict';
 
-	function x () { return 'x' };
+	function x () { return 'x' }
 
 	assert.equal( x(), 'x' );
 


### PR DESCRIPTION
A few things that got overlooked until #917 – in many cases we can discard `IfStatement` and `WhileStatement` nodes etc if they don't have any effects outside the bundle. Think I might have fixed some scoping issues while I was at it