### PR TITLE
Fix "process.hrtime() only accepts an Array tuple." error.

### DIFF
--- a/src/utils/flushTime.js
+++ b/src/utils/flushTime.js
@@ -1,7 +1,8 @@
 const DEBUG = false;
 const map = new Map;
 
-let time, toMilliseconds;
+let time;
+let toMilliseconds;
 
 if ( typeof process === 'undefined' ) {
 	time = function time ( previous ) {
@@ -11,7 +12,7 @@ if ( typeof process === 'undefined' ) {
 
 	toMilliseconds = function toMilliseconds ( time ) {
 		return time;
-	}
+	};
 } else {
 	time = function time ( previous ) {
 		return previous === undefined ? process.hrtime() : process.hrtime( previous );
@@ -19,7 +20,7 @@ if ( typeof process === 'undefined' ) {
 
 	toMilliseconds = function toMilliseconds ( time ) {
 		return time[0] * 1e3 + time[1] / 1e6;
-	}
+	};
 }
 
 export function timeStart ( label ) {

--- a/src/utils/flushTime.js
+++ b/src/utils/flushTime.js
@@ -1,25 +1,25 @@
 const DEBUG = false;
 const map = new Map;
 
-let time;
-let toMilliseconds;
+let timeStartHelper;
+let timeEndHelper;
 
 if ( typeof process === 'undefined' ) {
-	time = function time ( previous ) {
-		const now = window.performance.now();
-		return previous ? previous - now : now;
+	timeStartHelper = function timeStartHelper () {
+		return window.performance.now();
 	};
 
-	toMilliseconds = function toMilliseconds ( time ) {
-		return time;
+	timeEndHelper = function timeEndHelper ( previous ) {
+		return window.performance.now() - previous;
 	};
 } else {
-	time = function time ( previous ) {
-		return previous === undefined ? process.hrtime() : process.hrtime( previous );
+	timeStartHelper = function timeStartHelper () {
+		return process.hrtime();
 	};
 
-	toMilliseconds = function toMilliseconds ( time ) {
-		return time[0] * 1e3 + time[1] / 1e6;
+	timeEndHelper = function timeEndHelper ( previous ) {
+		const hrtime = process.hrtime( previous );
+		return hrtime[0] * 1e3 + hrtime[1] / 1e6;
 	};
 }
 
@@ -29,13 +29,13 @@ export function timeStart ( label ) {
 			time: 0
 		});
 	}
-	map.get( label ).start = time();
+	map.get( label ).start = timeStartHelper();
 }
 
 export function timeEnd ( label ) {
 	if ( map.has( label ) ) {
 		const item = map.get( label );
-		item.time += toMilliseconds( time( item.start ) );
+		item.time += timeEndHelper( item.start );
 	}
 }
 

--- a/src/utils/flushTime.js
+++ b/src/utils/flushTime.js
@@ -10,8 +10,8 @@ if ( typeof process === 'undefined' ) {
 	};
 } else {
 	time = function time ( previous ) {
-		const hrtime = process.hrtime( previous );
 		if ( previous ) {
+			const hrtime = process.hrtime( previous );
 			return hrtime[0] * 1e3 + hrtime[1] / 1e6;
 		}
 	};

--- a/src/utils/flushTime.js
+++ b/src/utils/flushTime.js
@@ -1,20 +1,25 @@
 const DEBUG = false;
 const map = new Map;
 
-let time;
+let time, toMilliseconds;
 
 if ( typeof process === 'undefined' ) {
 	time = function time ( previous ) {
 		const now = window.performance.now();
 		return previous ? previous - now : now;
 	};
+
+	toMilliseconds = function toMilliseconds ( time ) {
+		return time;
+	}
 } else {
 	time = function time ( previous ) {
-		if ( previous ) {
-			const hrtime = process.hrtime( previous );
-			return hrtime[0] * 1e3 + hrtime[1] / 1e6;
-		}
+		return previous === undefined ? process.hrtime() : process.hrtime( previous );
 	};
+
+	toMilliseconds = function toMilliseconds ( time ) {
+		return time[0] * 1e3 + time[1] / 1e6;
+	}
 }
 
 export function timeStart ( label ) {
@@ -29,7 +34,7 @@ export function timeStart ( label ) {
 export function timeEnd ( label ) {
 	if ( map.has( label ) ) {
 		const item = map.get( label );
-		item.time += time( item.start );
+		item.time += toMilliseconds( time( item.start ) );
 	}
 }
 


### PR DESCRIPTION
I was upgrading the version of Rollup used by gulp-rollup when suddenly almost all of my tests started failing on Travis with the error `process.hrtime() only accepts an Array tuple.`.

Turns out Rollup had been updated again while I was working, introducing this error. Tracking that down was fun. So here's a fix&mdash;enjoy.