### PR TITLE
Correctly deshadow re-assigned module functions

### DIFF
--- a/src/ast/scopes/ModuleScope.js
+++ b/src/ast/scopes/ModuleScope.js
@@ -19,14 +19,15 @@ export default class ModuleScope extends Scope {
 		forOwn( this.module.imports, specifier => {
 			if ( specifier.module.isExternal ) return;
 
-			if ( specifier.name === '*' ) {
-				specifier.module.getExports().forEach( name => {
-					names.set( name, true );
-				});
-			} else {
+			specifier.module.getExports().forEach( name => {
+				names.set(name);
+			});
+			if ( specifier.name !== '*' ) {
 				const declaration = specifier.module.traceExport( specifier.name );
 				const name = declaration.getName( true );
-				if ( name !== specifier.name ) names.set( declaration.getName( true ) );
+				if ( name !== specifier.name ) {
+					names.set(declaration.getName( true ));
+				}
 			}
 		});
 

--- a/test/function/namespacing-in-sub-functions/_config.js
+++ b/test/function/namespacing-in-sub-functions/_config.js
@@ -1,0 +1,8 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'correctly namespaces sub-functions (#910)',
+	exports: function ( exports ) {
+		assert.equal( exports, 'foobar' );
+	}
+};

--- a/test/function/namespacing-in-sub-functions/main.js
+++ b/test/function/namespacing-in-sub-functions/main.js
@@ -1,0 +1,11 @@
+import { problematicFunc as otherFunc } from './problematicFunc';
+function innerFunc() {
+	function problematicFunc () {
+		return otherFunc();
+	}
+	return problematicFunc();
+}
+
+var res = innerFunc();
+
+export default res;

--- a/test/function/namespacing-in-sub-functions/problematicFunc.js
+++ b/test/function/namespacing-in-sub-functions/problematicFunc.js
@@ -1,0 +1,5 @@
+function problematicFunc() {
+	return 'foobar';
+}
+
+export { problematicFunc };


### PR DESCRIPTION
This fixes #910. I've added a failing test that succeeds once the fix is in place. I also tested this PR on PouchDB, and it fixes https://github.com/pouchdb/pouchdb/pull/5673#issuecomment-246186805 .

Apparently what was happening here was that functions re-assigned upon import were not causing proper deshadowing in other variables inside of subfunctions. So in the test, this:

```js
// problematicFunc.js
function problematicFunc() {
  return 'foobar';
}
export { problematicFunc };
```

```js
// main.js
import { problematicFunc as otherFunc } from './problematicFunc';
function innerFunc() {
  function problematicFunc () {
    return otherFunc();
  }
  return problematicFunc();
}
var res = innerFunc();
export default res;
```

Would get (incorrectly) compiled to:

```js
function problematicFunc() {
  return 'foobar';
}
function innerFunc() {
  function problematicFunc () {
    return problematicFunc();
  }
  return problematicFunc();
}
var res = innerFunc();
export default res;
```

In the example above, this would cause `problematicFunc()` to spin indefinitely.

After this fix, the compiled code becomes:

```js
function problematicFunc() {
  return 'foobar';
}
function innerFunc() {
  function problematicFunc$$1 () {
    return problematicFunc();
  }
  return problematicFunc$$1();
}
var res = innerFunc();
export default res;
```