### PR TITLE
Reinstate support for Node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - "0.12"
   - "4"
   - "6"
 env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ init:
 environment:
   matrix:
     # node.js
+    - nodejs_version: 0.12
     - nodejs_version: 4
     - nodejs_version: 6
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default {
 		buble({
 			include: [ 'src/**', 'node_modules/acorn/**' ],
 			target: {
-				node: 4
+				node: '0.12'
 			}
 		}),
 

--- a/test/function/deconflicts-classes/_config.js
+++ b/test/function/deconflicts-classes/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	description: 'deconflicts top-level classes'
+	description: 'deconflicts top-level classes',
+	buble: true
 };

--- a/test/function/identifiers-in-template-literals/_config.js
+++ b/test/function/identifiers-in-template-literals/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	description: 'identifiers in template literals are rendered correctly'
+	description: 'identifiers in template literals are rendered correctly',
+	buble: true
 };

--- a/test/function/rename-conditional-expression-children/_config.js
+++ b/test/function/rename-conditional-expression-children/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	description: 'correctly renders children of ConditionalExpressions'
+	description: 'correctly renders children of ConditionalExpressions',
+	buble: true
 };


### PR DESCRIPTION
Emoji reactions please... Turns out this wasn't at all hard to do, and has minimal impact on the build. So I'm 👍 if it makes life easier for Ember folks.

Ember is dropping support for 0.12 on Jan 1 2017, so we could probably do likewise then.