### PR TITLE
Correctly deshadow star imports when conflicting

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -208,6 +208,15 @@ export default class Bundle {
 
 				declaration.name = getSafeName( declaration.name );
 			});
+			// special case - for `import * as Foo`, we need to make sure that Foo
+			// gets its own variable because it will eventually be rendered as
+			// `var Foo = Object.freeze(...)`
+			forOwn( module.imports, ( importee, importeeName ) => {
+				if ( importee.name === '*' ) {
+					delete module.imports[ importeeName ];
+					module.imports[ getSafeName(importeeName) ] = importee;
+				}
+			});
 		});
 
 		this.scope.deshadow( toDeshadow );

--- a/test/form/namespace-optimization-b/_expected/amd.js
+++ b/test/form/namespace-optimization-b/_expected/amd.js
@@ -1,12 +1,12 @@
 define(function () { 'use strict';
 
-	function foo () {
+	function foo$1 () {
 		console.log( 'foo' );
 	}
 
 	function a () {
-		foo();
-		foo();
+		foo$1();
+		foo$1();
 
 		var a;
 		if ( a.b ) {

--- a/test/form/namespace-optimization-b/_expected/cjs.js
+++ b/test/form/namespace-optimization-b/_expected/cjs.js
@@ -1,12 +1,12 @@
 'use strict';
 
-function foo () {
+function foo$1 () {
 	console.log( 'foo' );
 }
 
 function a () {
-	foo();
-	foo();
+	foo$1();
+	foo$1();
 
 	var a;
 	if ( a.b ) {

--- a/test/form/namespace-optimization-b/_expected/es.js
+++ b/test/form/namespace-optimization-b/_expected/es.js
@@ -1,10 +1,10 @@
-function foo () {
+function foo$1 () {
 	console.log( 'foo' );
 }
 
 function a () {
-	foo();
-	foo();
+	foo$1();
+	foo$1();
 
 	var a;
 	if ( a.b ) {

--- a/test/form/namespace-optimization-b/_expected/iife.js
+++ b/test/form/namespace-optimization-b/_expected/iife.js
@@ -1,13 +1,13 @@
 (function () {
 	'use strict';
 
-	function foo () {
+	function foo$1 () {
 		console.log( 'foo' );
 	}
 
 	function a () {
-		foo();
-		foo();
+		foo$1();
+		foo$1();
 
 		var a;
 		if ( a.b ) {

--- a/test/form/namespace-optimization-b/_expected/umd.js
+++ b/test/form/namespace-optimization-b/_expected/umd.js
@@ -4,13 +4,13 @@
 	(factory());
 }(this, (function () { 'use strict';
 
-	function foo () {
+	function foo$1 () {
 		console.log( 'foo' );
 	}
 
 	function a () {
-		foo();
-		foo();
+		foo$1();
+		foo$1();
 
 		var a;
 		if ( a.b ) {

--- a/test/function/namespacing-collisions-2/Material.js
+++ b/test/function/namespacing-collisions-2/Material.js
@@ -1,0 +1,3 @@
+export function Material() {
+  return 'Material';
+}

--- a/test/function/namespacing-collisions-2/MaterialAgain.js
+++ b/test/function/namespacing-collisions-2/MaterialAgain.js
@@ -1,0 +1,3 @@
+export function MaterialAgain() {
+  return 'MaterialAgain';
+}

--- a/test/function/namespacing-collisions-2/Something.js
+++ b/test/function/namespacing-collisions-2/Something.js
@@ -1,0 +1,6 @@
+import * as Material from './Material';
+
+export function Something() {
+	console.log(Material);
+	return 'Something';
+}

--- a/test/function/namespacing-collisions-2/SomethingAgain.js
+++ b/test/function/namespacing-collisions-2/SomethingAgain.js
@@ -1,0 +1,6 @@
+import * as Material from './MaterialAgain';
+
+export function SomethingAgain() {
+  console.log(Material);
+	return 'SomethingAgain';
+}

--- a/test/function/namespacing-collisions-2/_config.js
+++ b/test/function/namespacing-collisions-2/_config.js
@@ -1,0 +1,8 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'correctly namespaces when using * exports, take two (#910)',
+	exports: function ( exports ) {
+		assert.deepEqual( exports, ['Material', 'MaterialAgain', 'Something', 'SomethingAgain'] );
+	}
+};

--- a/test/function/namespacing-collisions-2/main.js
+++ b/test/function/namespacing-collisions-2/main.js
@@ -1,0 +1,7 @@
+import { Something } from './Something';
+import { SomethingAgain } from './SomethingAgain';
+import { Material } from './Material';
+import { MaterialAgain } from './MaterialAgain';
+
+var result = [Material(), MaterialAgain(), Something(), SomethingAgain()]
+export default result;

--- a/test/function/namespacing-collisions/Material.js
+++ b/test/function/namespacing-collisions/Material.js
@@ -1,0 +1,3 @@
+export function Material() {
+  return 'Material';
+}

--- a/test/function/namespacing-collisions/Something.js
+++ b/test/function/namespacing-collisions/Something.js
@@ -1,0 +1,6 @@
+import * as Material from './Material';
+
+export function Something() {
+	console.log(Material);
+	return 'Something';
+}

--- a/test/function/namespacing-collisions/_config.js
+++ b/test/function/namespacing-collisions/_config.js
@@ -1,0 +1,8 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'correctly namespaces when using * exports (#910)',
+	exports: function ( exports ) {
+		assert.deepEqual( exports, [ 'Material', 'Something' ] );
+	}
+};

--- a/test/function/namespacing-collisions/main.js
+++ b/test/function/namespacing-collisions/main.js
@@ -1,0 +1,5 @@
+import { Something } from './Something';
+import { Material } from './Material';
+
+var result = [Material(), Something()]
+export default result;


### PR DESCRIPTION
As @Benjamin-Dobell pointed out in https://github.com/rollup/rollup/issues/910#issuecomment-246220533, there's another case where deshadowing was not working correctly.

If you do `import * as Foo` in one place, and then `import { Foo }` in another, then those two `Foo` declarations aren't checked for namespace collisions. In fact, the problem is with the `import * as Foo`, because `Foo` doesn't get added to the list of usages and therefore isn't checked when doing `getSafeName()`.

I fixed that issue; the two new added tests fail before the fix but succeed after. (In fact they throw an error if you try to execute them.)  Unfortunately there's an aesthetic regression in this PR in that it can too-aggressively deshadow, as shown by the fact that I had to change one of the `form` tests to use `foo$1()` instead of `foo()` even though the `$1` isn't necessary.

However, since this PR fixes the functionality at the expense of making the output a little less pretty, I'm still offering it up. Please let me know if there's a good way to fix the `form` regression; I couldn't find one.