### PR TITLE
add: interop option

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 [these people](https://github.com/rollup/rollup/graphs/contributors)
+Copyright (c) 2016 [these people](https://github.com/rollup/rollup/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/finalisers/amd.js
+++ b/src/finalisers/amd.js
@@ -20,7 +20,7 @@ export default function amd ( bundle, magicString, { exportMode, indentString, i
 	const wrapperStart = `define(${params}function (${args.join( ', ' )}) {${useStrict}\n\n`;
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
-	const interopBlock = getInteropBlock( bundle );
+	const interopBlock = getInteropBlock( bundle, options );
 	if ( interopBlock ) magicString.prepend( interopBlock + '\n\n' );
 
 	if ( intro ) magicString.prepend( intro );

--- a/src/finalisers/iife.js
+++ b/src/finalisers/iife.js
@@ -49,7 +49,7 @@ export default function iife ( bundle, magicString, { exportMode, indentString, 
 	}
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
-	const interopBlock = getInteropBlock( bundle );
+	const interopBlock = getInteropBlock( bundle, options );
 	if ( interopBlock ) magicString.prepend( interopBlock + '\n\n' );
 
 	if ( intro ) magicString.prepend( intro );

--- a/src/finalisers/shared/getInteropBlock.js
+++ b/src/finalisers/shared/getInteropBlock.js
@@ -1,7 +1,7 @@
-export default function getInteropBlock ( bundle ) {
+export default function getInteropBlock ( bundle, options ) {
 	return bundle.externalModules
 		.map( module => {
-			if ( !module.declarations.default ) return null;
+			if ( !module.declarations.default || options.interop === false ) return null;
 
 			if ( module.exportsNamespace ) {
 				return `${bundle.varOrConst} ${module.name}__default = ${module.name}['default'];`;

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -66,7 +66,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString, i
 		`.replace( /^\t\t/gm, '' ).replace( /^\t/gm, magicString.getIndentString() );
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
-	const interopBlock = getInteropBlock( bundle );
+	const interopBlock = getInteropBlock( bundle, options );
 	if ( interopBlock ) magicString.prepend( interopBlock + '\n\n' );
 
 	if ( intro ) magicString.prepend( intro );

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -22,6 +22,7 @@ const ALLOWED_KEYS = [
 	'format',
 	'globals',
 	'indent',
+	'interop',
 	'intro',
 	'moduleId',
 	'moduleName',

--- a/test/form/interop-false/_config.js
+++ b/test/form/interop-false/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'getInterop with interop: false',
+	options: {
+		moduleName: 'foo',
+		interop: false
+	}
+};

--- a/test/form/interop-false/_expected/amd.js
+++ b/test/form/interop-false/_expected/amd.js
@@ -1,0 +1,8 @@
+define(['core/view'], function (View) { 'use strict';
+
+	/*eslint import/no-unresolved: 0*/
+	var main = View.extend({});
+
+	return main;
+
+});

--- a/test/form/interop-false/_expected/cjs.js
+++ b/test/form/interop-false/_expected/cjs.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var View = _interopDefault(require('core/view'));
+
+/*eslint import/no-unresolved: 0*/
+var main = View.extend({});
+
+module.exports = main;

--- a/test/form/interop-false/_expected/es.js
+++ b/test/form/interop-false/_expected/es.js
@@ -1,0 +1,6 @@
+import View from 'core/view';
+
+/*eslint import/no-unresolved: 0*/
+var main = View.extend({});
+
+export default main;

--- a/test/form/interop-false/_expected/iife.js
+++ b/test/form/interop-false/_expected/iife.js
@@ -1,0 +1,9 @@
+var foo = (function (View) {
+	'use strict';
+
+	/*eslint import/no-unresolved: 0*/
+	var main = View.extend({});
+
+	return main;
+
+}(View));

--- a/test/form/interop-false/_expected/umd.js
+++ b/test/form/interop-false/_expected/umd.js
@@ -1,0 +1,12 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('core/view')) :
+	typeof define === 'function' && define.amd ? define(['core/view'], factory) :
+	(global.foo = factory(global.View));
+}(this, (function (View) { 'use strict';
+
+	/*eslint import/no-unresolved: 0*/
+	var main = View.extend({});
+
+	return main;
+
+})));

--- a/test/form/interop-false/main.js
+++ b/test/form/interop-false/main.js
@@ -1,0 +1,3 @@
+/*eslint import/no-unresolved: 0*/
+import View from 'core/view';
+export default View.extend({});

--- a/test/test.js
+++ b/test/test.js
@@ -90,7 +90,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( () => {
 				throw new Error( 'Missing expected error' );
 			}, err => {
-				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, intro, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
+				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
 			});
 		});
 


### PR DESCRIPTION
Hey,

https://github.com/rollup/rollup/issues/939

I've added the interop option, so that there's a possibility to disable it if necessary. I have three small concerns:

1) I needed to add a `/*eslint import/no-unresolved: 0*/` comment to the `interop-false/main.js` file to mark the dependency as unresolved, but that doesn't seems to be pretty and causes the comment to be in the result files, is there anything we can do to remove it in this case?

2) the interop works a little bit differently in the `src/finalisers/cjs.js` file and the implementation is split into few lines, do you have any suggestions for this part? It would be great if you could provide me with some background on this one.

3) should I add it to the docs? What's the best place?

Best,
Emil