### PR TITLE
include all ancestors of expression with effects, up to function boundary

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -141,7 +141,9 @@ export default class Bundle {
 						let i = this.dependentExpressions.length;
 						while ( i-- ) {
 							const expression = this.dependentExpressions[i];
-							const statement = expression.findParent( /ExpressionStatement/ );
+
+							let statement = expression;
+							while ( statement.parent && !/Function/.test( statement.parent.type ) ) statement = statement.parent;
 
 							if ( !statement || statement.ran ) {
 								this.dependentExpressions.splice( i, 1 );

--- a/src/ast/nodes/UpdateExpression.js
+++ b/src/ast/nodes/UpdateExpression.js
@@ -28,11 +28,13 @@ export default class UpdateExpression extends Node {
 	}
 
 	initialise ( scope ) {
+		this.scope = scope;
+
 		this.module.bundle.dependentExpressions.push( this );
 		super.initialise( scope );
 	}
 
 	isUsedByBundle () {
-		return isUsedByBundle( this.findScope(), this.subject );
+		return isUsedByBundle( this.scope, this.subject );
 	}
 }

--- a/test/function/if-statement-with-assignment/_config.js
+++ b/test/function/if-statement-with-assignment/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'update assignments to names are preserved (#930)'
+};

--- a/test/function/if-statement-with-assignment/main.js
+++ b/test/function/if-statement-with-assignment/main.js
@@ -1,0 +1,4 @@
+var result = 0;
+if ( Math.random() <= 1 ) result += 1;
+
+assert.equal( result, 1 );

--- a/test/function/if-statement-with-assignment/main.js
+++ b/test/function/if-statement-with-assignment/main.js
@@ -1,4 +1,6 @@
 var result = 0;
-if ( Math.random() <= 1 ) result += 1;
+if ( Math.random() <= 1 ) {
+	if ( Math.random() <= 1 ) result += 1;
+}
 
 assert.equal( result, 1 );

--- a/test/function/if-statement-with-update/_config.js
+++ b/test/function/if-statement-with-update/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'updates to names are preserved (#930)'
+};

--- a/test/function/if-statement-with-update/main.js
+++ b/test/function/if-statement-with-update/main.js
@@ -1,0 +1,4 @@
+var result = 0;
+if ( Math.random() <= 1 ) ++result;
+
+assert.equal( result, 1 );

--- a/test/function/if-statement-with-update/main.js
+++ b/test/function/if-statement-with-update/main.js
@@ -1,4 +1,6 @@
 var result = 0;
-if ( Math.random() <= 1 ) ++result;
+if ( Math.random() <= 1 ) {
+	if ( Math.random() <= 1 ) ++result;
+}
 
 assert.equal( result, 1 );


### PR DESCRIPTION
Fixes #930. In cases where a statement is included for its effects, and those effects aren't known to be relevant until late in the process, but it lives inside a statement (such as an if statement) that doesn't *independently* have any effects, the child statement would be marked for inclusion but the parent wouldn't – meaning the whole lot got stripped out.

This fixes that by including all ancestors of an expression with effects, up to the closest function boundary.

