### PR TITLE
ADD: fallback for Object.freeze

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -86,7 +86,7 @@ export class SyntheticNamespaceDeclaration {
 			return `${indentString}${name}: ${original.getName( es )}`;
 		});
 
-		return `${this.module.bundle.varOrConst} ${this.getName( es )} = Object.freeze({\n${members.join( ',\n' )}\n});\n\n`;
+		return `${this.module.bundle.varOrConst} ${this.getName( es )} = (Object.freeze || Object)({\n${members.join( ',\n' )}\n});\n\n`;
 	}
 }
 

--- a/test/form/prefer-const/_expected/amd.js
+++ b/test/form/prefer-const/_expected/amd.js
@@ -4,7 +4,7 @@ define(['external', 'other', 'another'], function (external, other, another) { '
 	const b = 2;
 
 
-	const namespace = Object.freeze({
+	const namespace = (Object.freeze || Object)({
 		a: a,
 		b: b
 	});

--- a/test/form/prefer-const/_expected/cjs.js
+++ b/test/form/prefer-const/_expected/cjs.js
@@ -8,7 +8,7 @@ const a = 1;
 const b = 2;
 
 
-const namespace = Object.freeze({
+const namespace = (Object.freeze || Object)({
 	a: a,
 	b: b
 });

--- a/test/form/prefer-const/_expected/es.js
+++ b/test/form/prefer-const/_expected/es.js
@@ -6,7 +6,7 @@ const a = 1;
 const b = 2;
 
 
-const namespace = Object.freeze({
+const namespace = (Object.freeze || Object)({
 	a: a,
 	b: b
 });

--- a/test/form/prefer-const/_expected/iife.js
+++ b/test/form/prefer-const/_expected/iife.js
@@ -5,7 +5,7 @@ const myBundle = (function (external,other,another) {
 	const b = 2;
 
 
-	const namespace = Object.freeze({
+	const namespace = (Object.freeze || Object)({
 		a: a,
 		b: b
 	});

--- a/test/form/prefer-const/_expected/umd.js
+++ b/test/form/prefer-const/_expected/umd.js
@@ -8,7 +8,7 @@
 	const b = 2;
 
 
-	const namespace = Object.freeze({
+	const namespace = (Object.freeze || Object)({
 		a: a,
 		b: b
 	});


### PR DESCRIPTION
gracefully fallback for `Object.freeze` to make it more compatible in browser that don't support it.

