### PR TITLE
Extract options validation into a method

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -39,20 +39,24 @@ const ALLOWED_KEYS = [
 	'useStrict'
 ];
 
-export function rollup ( options ) {
+function checkOptions ( options ) {
 	if ( !options || !options.entry ) {
-		return Promise.reject( new Error( 'You must supply options.entry to rollup' ) );
+		return new Error( 'You must supply options.entry to rollup' );
 	}
 
 	if ( options.transform || options.load || options.resolveId || options.resolveExternal ) {
-		return Promise.reject( new Error( 'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://github.com/rollup/rollup/wiki/Plugins for details' ) );
+		return new Error( 'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://github.com/rollup/rollup/wiki/Plugins for details' );
 	}
 
-	const error = validateKeys( options, ALLOWED_KEYS );
+	const error = validateKeys( keys(options), ALLOWED_KEYS );
+	if ( error ) return error;
 
-	if ( error ) {
-		return Promise.reject( error );
-	}
+	return null;
+}
+
+export function rollup ( options ) {
+	const error = checkOptions ( options );
+	if ( error ) return Promise.reject( error );
 
 	const bundle = new Bundle( options );
 

--- a/src/utils/validateKeys.js
+++ b/src/utils/validateKeys.js
@@ -1,8 +1,4 @@
-import { keys } from './object.js';
-
-export default function validateKeys ( object, allowedKeys ) {
-	const actualKeys = keys( object );
-
+export default function validateKeys ( actualKeys, allowedKeys ) {
 	let i = actualKeys.length;
 
 	while ( i-- ) {


### PR DESCRIPTION
Hi @Rich-Harris @TrySound ,
in this PR I extracted options validation into a function according to single responsibility principle. 

There is `checkOptions` function now, which returns an error if options are incorrect, otherwise `null`. Function `rollup` is responsible to return promise, so it wraps error from `checkOptions` into rejection.

Also in this PR I removed dependency on `key` both from `validateKeys` function and module.

If something wrong please tell me, I ready to fix it according your recommendations.