### PR TITLE
reduce instead forEach to update options 

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -31,11 +31,10 @@ export default class Bundle {
 
 		this.plugins = ensureArray( options.plugins );
 
-		this.plugins.forEach( plugin => {
-			if ( plugin.options ) {
-				options = plugin.options( options ) || options;
-			}
-		});
+		options = this.plugins.reduce( ( acc, plugin ) => {
+			if ( plugin.options ) return plugin.options( acc ) || acc;
+			return acc;
+		}, options);
 
 		this.entry = options.entry;
 		this.entryId = null;


### PR DESCRIPTION
Hi,

I explored the repo and I found serial `options` updates  by plugins in `Bundle` constructor. I suppose this case is more suitable for `reduce`, not for `forEach`. With `reduce` `options` will be rewritten once.

I think this code looks more declarative and shows that meaning of this block is more about `options` update and less about `plugins` iteration. As side effect there is performance micro-optimisation.

/cc @Rich-Harris @TrySound @Victorystick 