### PR TITLE
Add module id when warning about top level this

### DIFF
--- a/src/ast/nodes/ThisExpression.js
+++ b/src/ast/nodes/ThisExpression.js
@@ -7,7 +7,7 @@ export default class ThisExpression extends Node {
 		if ( lexicalBoundary.isModuleScope ) {
 			this.alias = this.module.bundle.context;
 			if ( this.alias === 'undefined' ) {
-				this.module.bundle.onwarn( 'The `this` keyword is equivalent to `undefined` at the top level of an ES module, and has been rewritten' );
+				this.module.bundle.onwarn( `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten (in ${this.module.id})` );
 			}
 		}
 	}

--- a/src/ast/nodes/ThisExpression.js
+++ b/src/ast/nodes/ThisExpression.js
@@ -1,4 +1,5 @@
 import Node from '../Node.js';
+import getLocation from '../../utils/getLocation.js';
 
 export default class ThisExpression extends Node {
 	initialise ( scope ) {
@@ -7,7 +8,9 @@ export default class ThisExpression extends Node {
 		if ( lexicalBoundary.isModuleScope ) {
 			this.alias = this.module.bundle.context;
 			if ( this.alias === 'undefined' ) {
-				this.module.bundle.onwarn( `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten (in ${this.module.id})` );
+				const location = getLocation(this.module.code, this.module.ast.end);
+				const detail = `${this.module.id}, line: ${location.line}, column: ${location.column}`;
+				this.module.bundle.onwarn( `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten (in ${detail})`);
 			}
 		}
 	}

--- a/test/function/warn-on-top-level-this/_config.js
+++ b/test/function/warn-on-top-level-this/_config.js
@@ -3,9 +3,10 @@ const assert = require( 'assert' );
 module.exports = {
 	description: 'warns on top-level this (#770)',
 	warnings: warnings => {
-		assert.deepEqual( warnings, [
-			'The `this` keyword is equivalent to `undefined` at the top level of an ES module, and has been rewritten'
-		]);
+		const message = `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`;
+		assert.equal(warnings.length, 1);
+		assert.equal(warnings[0].indexOf(message), 0);
+		assert(warnings[0].match(/\(in.*warn-on-top-level-this.*\)/));
 	},
 	runtimeError: err => {
 		assert.equal( err.message, `Cannot set property 'foo' of undefined` );

--- a/test/function/warn-on-top-level-this/_config.js
+++ b/test/function/warn-on-top-level-this/_config.js
@@ -7,6 +7,7 @@ module.exports = {
 		assert.equal(warnings.length, 1);
 		assert.equal(warnings[0].indexOf(message), 0);
 		assert(warnings[0].match(/\(in.*warn-on-top-level-this.*\)/));
+		assert(warnings[0].match(/line: 4, column: 0/));
 	},
 	runtimeError: err => {
 		assert.equal( err.message, `Cannot set property 'foo' of undefined` );

--- a/test/function/warn-on-top-level-this/main.js
+++ b/test/function/warn-on-top-level-this/main.js
@@ -1,1 +1,3 @@
+const someVariableJustToCheckOnCorrectLineNumber = true; // eslint-disable-line
+
 this.foo = 'bar';


### PR DESCRIPTION
When during a bundling I get a cryptic message stating `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`, it's not very helpful to find actual problematic module especially since it can occur anywhere inside node_modules.

Adding module ID to the message should help locate and possibly remove the problem.