### PR TITLE
Removes `new Foo(...)` when Foo is a pure function

### DIFF
--- a/src/ast/nodes/CallExpression.js
+++ b/src/ast/nodes/CallExpression.js
@@ -27,7 +27,7 @@ export default class CallExpression extends Node {
 	}
 
 	hasEffects ( scope ) {
-		return callHasEffects( scope, this.callee );
+		return callHasEffects( scope, this.callee, false );
 	}
 
 	initialise ( scope ) {

--- a/src/ast/nodes/NewExpression.js
+++ b/src/ast/nodes/NewExpression.js
@@ -3,6 +3,6 @@ import callHasEffects from './shared/callHasEffects.js';
 
 export default class NewExpression extends Node {
 	hasEffects ( scope ) {
-		return callHasEffects( scope, this.callee );
+		return callHasEffects( scope, this.callee, true );
 	}
 }

--- a/test/form/side-effect-es5-classes/_config.js
+++ b/test/form/side-effect-es5-classes/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'omits ES5 classes which are pure (e.g. they only assign to `this`)'
+};

--- a/test/form/side-effect-es5-classes/_expected/amd.js
+++ b/test/form/side-effect-es5-classes/_expected/amd.js
@@ -1,0 +1,34 @@
+define(function () { 'use strict';
+
+	function Bar ( x ) {
+		console.log( 'side effect' );
+		this.value = x;
+	}
+
+	function Baz ( x ) {
+		this[ console.log( 'side effect' ) ] = x;
+	}
+
+	function Qux ( x ) {
+		this.value = console.log( 'side effect' );
+	}
+
+	function Corge ( x ) {
+		this.value = x;
+	}
+
+	var Arrow = ( x ) => {
+		undefined.value = x;
+	};
+
+	console.log( 'before' );
+
+	var bar = new Bar(5);
+	var baz = new Baz(5);
+	var qux = new Qux(5);
+	var corge = Corge(5);
+	var arrow = new Arrow(5);
+
+	console.log( 'after' );
+
+});

--- a/test/form/side-effect-es5-classes/_expected/cjs.js
+++ b/test/form/side-effect-es5-classes/_expected/cjs.js
@@ -1,0 +1,32 @@
+'use strict';
+
+function Bar ( x ) {
+	console.log( 'side effect' );
+	this.value = x;
+}
+
+function Baz ( x ) {
+	this[ console.log( 'side effect' ) ] = x;
+}
+
+function Qux ( x ) {
+	this.value = console.log( 'side effect' );
+}
+
+function Corge ( x ) {
+	this.value = x;
+}
+
+var Arrow = ( x ) => {
+	undefined.value = x;
+};
+
+console.log( 'before' );
+
+var bar = new Bar(5);
+var baz = new Baz(5);
+var qux = new Qux(5);
+var corge = Corge(5);
+var arrow = new Arrow(5);
+
+console.log( 'after' );

--- a/test/form/side-effect-es5-classes/_expected/es.js
+++ b/test/form/side-effect-es5-classes/_expected/es.js
@@ -1,0 +1,30 @@
+function Bar ( x ) {
+	console.log( 'side effect' );
+	this.value = x;
+}
+
+function Baz ( x ) {
+	this[ console.log( 'side effect' ) ] = x;
+}
+
+function Qux ( x ) {
+	this.value = console.log( 'side effect' );
+}
+
+function Corge ( x ) {
+	this.value = x;
+}
+
+var Arrow = ( x ) => {
+	undefined.value = x;
+};
+
+console.log( 'before' );
+
+var bar = new Bar(5);
+var baz = new Baz(5);
+var qux = new Qux(5);
+var corge = Corge(5);
+var arrow = new Arrow(5);
+
+console.log( 'after' );

--- a/test/form/side-effect-es5-classes/_expected/iife.js
+++ b/test/form/side-effect-es5-classes/_expected/iife.js
@@ -1,0 +1,35 @@
+(function () {
+	'use strict';
+
+	function Bar ( x ) {
+		console.log( 'side effect' );
+		this.value = x;
+	}
+
+	function Baz ( x ) {
+		this[ console.log( 'side effect' ) ] = x;
+	}
+
+	function Qux ( x ) {
+		this.value = console.log( 'side effect' );
+	}
+
+	function Corge ( x ) {
+		this.value = x;
+	}
+
+	var Arrow = ( x ) => {
+		undefined.value = x;
+	};
+
+	console.log( 'before' );
+
+	var bar = new Bar(5);
+	var baz = new Baz(5);
+	var qux = new Qux(5);
+	var corge = Corge(5);
+	var arrow = new Arrow(5);
+
+	console.log( 'after' );
+
+}());

--- a/test/form/side-effect-es5-classes/_expected/umd.js
+++ b/test/form/side-effect-es5-classes/_expected/umd.js
@@ -1,0 +1,38 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	function Bar ( x ) {
+		console.log( 'side effect' );
+		this.value = x;
+	}
+
+	function Baz ( x ) {
+		this[ console.log( 'side effect' ) ] = x;
+	}
+
+	function Qux ( x ) {
+		this.value = console.log( 'side effect' );
+	}
+
+	function Corge ( x ) {
+		this.value = x;
+	}
+
+	var Arrow = ( x ) => {
+		undefined.value = x;
+	};
+
+	console.log( 'before' );
+
+	var bar = new Bar(5);
+	var baz = new Baz(5);
+	var qux = new Qux(5);
+	var corge = Corge(5);
+	var arrow = new Arrow(5);
+
+	console.log( 'after' );
+
+})));

--- a/test/form/side-effect-es5-classes/arrow.js
+++ b/test/form/side-effect-es5-classes/arrow.js
@@ -1,0 +1,3 @@
+export var Arrow = ( x ) => {
+	this.value = x;
+};

--- a/test/form/side-effect-es5-classes/bar.js
+++ b/test/form/side-effect-es5-classes/bar.js
@@ -1,0 +1,4 @@
+export function Bar ( x ) {
+	console.log( 'side effect' );
+	this.value = x;
+}

--- a/test/form/side-effect-es5-classes/baz.js
+++ b/test/form/side-effect-es5-classes/baz.js
@@ -1,0 +1,3 @@
+export function Baz ( x ) {
+	this[ console.log( 'side effect' ) ] = x;
+}

--- a/test/form/side-effect-es5-classes/corge.js
+++ b/test/form/side-effect-es5-classes/corge.js
@@ -1,0 +1,3 @@
+export function Corge ( x ) {
+	this.value = x;
+}

--- a/test/form/side-effect-es5-classes/foo.js
+++ b/test/form/side-effect-es5-classes/foo.js
@@ -1,0 +1,4 @@
+export function Foo ( x ) {
+	this.value = x;
+	this["string property"] = 20;
+}

--- a/test/form/side-effect-es5-classes/main.js
+++ b/test/form/side-effect-es5-classes/main.js
@@ -1,0 +1,17 @@
+import { Foo } from './foo';
+import { Bar } from './bar';
+import { Baz } from './baz';
+import { Qux } from './qux';
+import { Corge } from './corge';
+import { Arrow } from './arrow';
+
+console.log( 'before' );
+
+var foo = new Foo(5);
+var bar = new Bar(5);
+var baz = new Baz(5);
+var qux = new Qux(5);
+var corge = Corge(5);
+var arrow = new Arrow(5);
+
+console.log( 'after' );

--- a/test/form/side-effect-es5-classes/qux.js
+++ b/test/form/side-effect-es5-classes/qux.js
@@ -1,0 +1,3 @@
+export function Qux ( x ) {
+	this.value = console.log( 'side effect' );
+}

--- a/test/form/unmodified-default-exports/_expected/amd.js
+++ b/test/form/unmodified-default-exports/_expected/amd.js
@@ -1,6 +1,7 @@
 define(function () { 'use strict';
 
 	var Foo = function () {
+		console.log( 'side effect' );
 		this.isFoo = true;
 	};
 

--- a/test/form/unmodified-default-exports/_expected/cjs.js
+++ b/test/form/unmodified-default-exports/_expected/cjs.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Foo = function () {
+	console.log( 'side effect' );
 	this.isFoo = true;
 };
 

--- a/test/form/unmodified-default-exports/_expected/es.js
+++ b/test/form/unmodified-default-exports/_expected/es.js
@@ -1,4 +1,5 @@
 var Foo = function () {
+	console.log( 'side effect' );
 	this.isFoo = true;
 };
 

--- a/test/form/unmodified-default-exports/_expected/iife.js
+++ b/test/form/unmodified-default-exports/_expected/iife.js
@@ -2,6 +2,7 @@
 	'use strict';
 
 	var Foo = function () {
+		console.log( 'side effect' );
 		this.isFoo = true;
 	};
 

--- a/test/form/unmodified-default-exports/_expected/umd.js
+++ b/test/form/unmodified-default-exports/_expected/umd.js
@@ -5,6 +5,7 @@
 }(this, (function () { 'use strict';
 
 	var Foo = function () {
+		console.log( 'side effect' );
 		this.isFoo = true;
 	};
 

--- a/test/form/unmodified-default-exports/foo.js
+++ b/test/form/unmodified-default-exports/foo.js
@@ -1,4 +1,5 @@
 var Foo = function () {
+	console.log( 'side effect' );
 	this.isFoo = true;
 };
 

--- a/test/function/es5-class-called-without-new/_config.js
+++ b/test/function/es5-class-called-without-new/_config.js
@@ -1,0 +1,2 @@
+module.exports = {
+};

--- a/test/function/es5-class-called-without-new/foo.js
+++ b/test/function/es5-class-called-without-new/foo.js
@@ -1,0 +1,7 @@
+export function Foo ( x ) {
+	this.value = x;
+}
+
+export function Bar ( x ) {
+	this.value = x;
+}

--- a/test/function/es5-class-called-without-new/main.js
+++ b/test/function/es5-class-called-without-new/main.js
@@ -1,0 +1,7 @@
+import { Foo, Bar } from './foo';
+
+assert.equal( new Foo(5).value, 5 );
+
+assert.throws( function () {
+	Bar(5);
+}, /^TypeError: Cannot set property 'value' of undefined$/ );


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

This PR adds in the following optimization (which fixes https://github.com/rollup/rollup/issues/179#issuecomment-250903867):

When using `new Foo(...)` and the `Foo` function is "pure", then the `new Foo(...)` is removed.

A function is pure if it meets all of the following conditions:
- It is called with `new Foo(...)`
- The only side effects it contains are of the form `this.foo = bar` or `this[foo] = bar` (the expressions `foo` and `bar` can be anything, but they may not contain side effects)
- It does not have any other side effects
- It is an ES5 function (e.g. not an arrow function)

This detection is currently very limited: it requires the assignment to occur at the top level of the function, and it does not support nested assignment (e.g. `this.foo.bar = qux`)

The detection can be improved later, this just covers the common case.

It only treats the `Foo` function as pure if it is called as `new Foo(...)`. The reason is because `Foo(...)` will cause a runtime error (because it tries to assign to `undefined`), therefore removing the `Foo(...)` would change the behavior of the program.

All of the tests pass, but I had to change the `form/unmodified-default-exports` test, because this optimization (correctly) removed the `Foo` function in that test.
