### PR TITLE
deepClone causes 'RangeError: Maximum call stack size exceeded' error…

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -39,7 +39,8 @@ export default class Module {
 		timeStart( 'ast' );
 
 		this.ast = ast || tryParse( code, this.comments, bundle.acornOptions, id ); // TODO what happens to comments if AST is provided?
-		this.astClone = deepClone( this.ast );
+		// this.astClone = deepClone( this.ast );
+		this.astClone = this.ast
 
 		timeEnd( 'ast' );
 


### PR DESCRIPTION
I think the issue may be with deepClone, rollup v.0.34.13 seems to be the latest version that should work, after that the deepClone commit was added that seems to cause RangeError: Maximum call stack exceeded errors.

I think this commit (between v0.34.13 and v0.35.0) is the reason for the errors: https://github.com/rollup/rollup/commit/83ccb9725374e0fde9d07043959c397b15d26c67

test case: https://github.com/talmobi/wrollup_issue_2

more discussion of the issue: https://github.com/rollup/rollup-watch/issues/7#issuecomment-251746728

and: https://github.com/rollup/rollup/issues/1010

suggested temporary fix (or use rollup v 0.34.13): https://github.com/talmobi/rollup/commit/3eceff612fe96ddb2b99be5d6e8e12cc9bc1b9e9
