### PR TITLE
better error for missing export (#1033)

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -6,6 +6,7 @@ import { basename, extname } from './utils/path.js';
 import getLocation from './utils/getLocation.js';
 import makeLegalIdentifier from './utils/makeLegalIdentifier.js';
 import SOURCEMAPPING_URL from './utils/sourceMappingURL.js';
+import relativeId from './utils/relativeId.js';
 import { SyntheticNamespaceDeclaration } from './Declaration.js';
 import extractNames from './ast/utils/extractNames.js';
 import enhance from './ast/enhance.js';
@@ -357,7 +358,7 @@ export default class Module {
 
 			const declaration = otherModule.traceExport( importDeclaration.name );
 
-			if ( !declaration ) throw new Error( `Module ${otherModule.id} does not export ${importDeclaration.name} (imported by ${this.id})` );
+			if ( !declaration ) throw new Error( `'${importDeclaration.name}' is not exported by ${relativeId( otherModule.id )} (imported by ${relativeId( this.id )}). For help fixing this error see https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module` );
 			return declaration;
 		}
 

--- a/src/utils/relativeId.js
+++ b/src/utils/relativeId.js
@@ -1,0 +1,4 @@
+export default function relativeId ( id ) {
+	if ( typeof process === 'undefined' ) return id;
+	return id.replace( process.cwd(), '' ).replace( /^[\/\\]/, '' );
+}

--- a/test/function/import-of-unexported-fails/_config.js
+++ b/test/function/import-of-unexported-fails/_config.js
@@ -3,6 +3,6 @@ var assert = require( 'assert' );
 module.exports = {
 	description: 'marking an imported, but unexported, identifier should throw',
 	error: function ( err ) {
-		assert.ok( /Module .+empty\.js does not export default \(imported by .+main\.js\)/.test( err.message ) );
+		assert.equal( err.message, `'default' is not exported by empty.js (imported by main.js). For help fixing this error see https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module` );
 	}
 };

--- a/test/test.js
+++ b/test/test.js
@@ -186,6 +186,8 @@ describe( 'rollup', function () {
 
 			const config = loadConfig( FUNCTION + '/' + dir + '/_config.js' );
 			( config.skip ? it.skip : config.solo ? it.only : it )( dir, () => {
+				process.chdir( FUNCTION + '/' + dir );
+
 				const warnings = [];
 				const captureWarning = msg => warnings.push( msg );
 


### PR DESCRIPTION
Addresses #1033 – changes the error message from

> Module /path/to/my/project/src/foo.js does not export bar (imported by /path/to/my/project/src/baz.js)

to

> 'bar' is not exported by src/foo.js (imported by src/baz.js). For help fixing this error see https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module

