### PR TITLE
Support cycles in deepClone

### DIFF
--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -20,20 +20,24 @@ export function assign ( target, ...sources ) {
 
 const isArray = Array.isArray;
 
-// used for cloning ASTs. Not for use with cyclical structures!
-export function deepClone ( obj ) {
+// used for cloning ASTs.
+export function deepClone ( obj, identityMap = new Map() ) {
 	if ( !obj ) return obj;
 	if ( typeof obj !== 'object' ) return obj;
+	const existing = identityMap.get(obj);
+	if ( existing != null ) return existing;
 
 	if ( isArray( obj ) ) {
 		const clone = new Array( obj.length );
-		for ( let i = 0; i < obj.length; i += 1 ) clone[i] = deepClone( obj[i] );
+		identityMap.set( obj, clone );
+		for ( let i = 0; i < obj.length; i += 1 ) clone[i] = deepClone( obj[i], identityMap );
 		return clone;
 	}
 
 	const clone = {};
+	identityMap.set( obj, clone );
 	for ( const key in obj ) {
-		clone[ key ] = deepClone( obj[ key ] );
+		clone[ key ] = deepClone( obj[ key ], identityMap );
 	}
 
 	return clone;


### PR DESCRIPTION
Besides adding support for cycles (introduced by tsc through the [Node.parent](https://github.com/Microsoft/TypeScript/blob/08eafd3a28a33842511f96e83582317ce74ec6ef/lib/typescriptServices.d.ts#L423) property), this code helps reuse other node instances that are present in multiple locations (e.g. [Identifier](https://github.com/Microsoft/TypeScript/blob/08eafd3a28a33842511f96e83582317ce74ec6ef/lib/typescriptServices.d.ts#L433) nodes, empty `[]` array, etc).

Note: ES6 [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) uses same-value semantics for keys (ie. its an IdentityHashMap in Java terms)
