### PR TITLE
allow imports to resolve against certain extensions

### DIFF
--- a/bin/src/help.md
+++ b/bin/src/help.md
@@ -13,6 +13,7 @@ Basic options:
 -i, --input              Input (alternative to <entry file>)
 -o, --output <output>    Output (if absent, prints to stdout)
 -f, --format [es]       Type of output (amd, cjs, es, iife, umd)
+-ext, --extensions       Allowed file extensions
 -e, --external           Comma-separate list of module IDs to exclude
 -g, --globals            Comma-separate list of `module ID:Global` pairs
                             Any module IDs defined here are added to external

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -97,6 +97,8 @@ export default class Bundle {
 		this.legacy = options.legacy;
 		this.acornOptions = options.acorn || {};
 
+		this.extensions = ensureArray(options.extensions || '.js');
+
 		this.dependentExpressions = [];
 	}
 
@@ -104,7 +106,7 @@ export default class Bundle {
 		// Phase 1 – discovery. We load the entry module and find which
 		// modules it imports, and import those, until we have all
 		// of the entry module's dependencies
-		return this.resolveId( this.entry, undefined )
+		return this.resolveId( this.entry, undefined, this.extensions )
 			.then( id => {
 				if ( id == null ) throw new Error( `Could not resolve entry (${this.entry})` );
 				this.entryId = id;
@@ -307,7 +309,7 @@ export default class Bundle {
 	fetchAllDependencies ( module ) {
 		return mapSequence( module.sources, source => {
 			const resolvedId = module.resolvedIds[ source ];
-			return ( resolvedId ? Promise.resolve( resolvedId ) : this.resolveId( source, module.id ) )
+			return ( resolvedId ? Promise.resolve( resolvedId ) : this.resolveId( source, module.id, this.extensions ) )
 				.then( resolvedId => {
 					const externalId = resolvedId || (
 						isRelative( source ) ? resolve( module.id, '..', source ) : source

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -17,6 +17,7 @@ const ALLOWED_KEYS = [
 	'dest',
 	'entry',
 	'exports',
+	'extensions',
 	'external',
 	'footer',
 	'format',

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -6,13 +6,22 @@ export function load ( id ) {
 	return readFileSync( id, 'utf-8' );
 }
 
-function addJsExtensionIfNecessary ( file ) {
+function addJsExtensionIfNecessary ( file, extensions = ['.js'] ) {
 	try {
 		const name = basename( file );
 		const files = readdirSync( dirname( file ) );
 
 		if ( ~files.indexOf( name ) && isFile( file ) ) return file;
-		if ( ~files.indexOf( `${name}.js` ) && isFile( `${file}.js` ) ) return `${file}.js`;
+
+		if (extensions) {
+			const extensionsLength = extensions.length;
+			for (let index = 0; index < extensionsLength; index += 1) {
+				const ext = extensions[index];
+				if ( ~files.indexOf( `${name}${ext}` ) && isFile( `${file}${ext}` ) ) {
+					return `${file}${ext}`;
+				}
+			}
+		}
 	} catch ( err ) {
 		// noop
 	}
@@ -20,19 +29,19 @@ function addJsExtensionIfNecessary ( file ) {
 	return null;
 }
 
-export function resolveId ( importee, importer ) {
+export function resolveId ( importee, importer, extensions ) {
 	if ( typeof process === 'undefined' ) throw new Error( `It looks like you're using Rollup in a non-Node.js environment. This means you must supply a plugin with custom resolveId and load functions. See https://github.com/rollup/rollup/wiki/Plugins for more information` );
 
 	// absolute paths are left untouched
-	if ( isAbsolute( importee ) ) return addJsExtensionIfNecessary( resolve( importee ) );
+	if ( isAbsolute( importee ) ) return addJsExtensionIfNecessary( resolve( importee ), extensions );
 
 	// if this is the entry point, resolve against cwd
-	if ( importer === undefined ) return addJsExtensionIfNecessary( resolve( process.cwd(), importee ) );
+	if ( importer === undefined ) return addJsExtensionIfNecessary( resolve( process.cwd(), importee ), extensions );
 
 	// external modules are skipped at this stage
 	if ( importee[0] !== '.' ) return null;
 
-	return addJsExtensionIfNecessary( resolve( dirname( importer ), importee ) );
+	return addJsExtensionIfNecessary( resolve( dirname( importer ), importee ), extensions );
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -90,7 +90,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( () => {
 				throw new Error( 'Missing expected error' );
 			}, err => {
-				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
+				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, context, dest, entry, exports, extensions, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
 			});
 		});
 


### PR DESCRIPTION
See #1052 for more information.

For more robust support, what about passing `{ extensions: this.extensions }` instead of passing this.extensions directly? LMK...
