### PR TITLE
Remove sourceMappingURL only in comments

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -15,7 +15,6 @@ import { mapSequence } from './utils/promise.js';
 import transform from './utils/transform.js';
 import transformBundle from './utils/transformBundle.js';
 import collapseSourcemaps from './utils/collapseSourcemaps.js';
-import SOURCEMAPPING_URL from './utils/sourceMappingURL.js';
 import callIfFunction from './utils/callIfFunction.js';
 import { dirname, isRelative, isAbsolute, normalize, relative, resolve } from './utils/path.js';
 import BundleScope from './ast/scopes/BundleScope.js';
@@ -428,8 +427,7 @@ export default class Bundle {
 		let map = null;
 		const bundleSourcemapChain = [];
 
-		code = transformBundle( code, this.plugins, bundleSourcemapChain, options )
-			.replace( new RegExp( `^\\/\\/#\\s+${SOURCEMAPPING_URL}=.+\\n?`, 'gm' ), '' );
+		code = transformBundle( code, this.plugins, bundleSourcemapChain, options );
 
 		if ( options.sourceMap ) {
 			timeStart( 'sourceMap' );

--- a/src/Module.js
+++ b/src/Module.js
@@ -5,7 +5,7 @@ import { assign, blank, deepClone, keys } from './utils/object.js';
 import { basename, extname } from './utils/path.js';
 import getLocation from './utils/getLocation.js';
 import makeLegalIdentifier from './utils/makeLegalIdentifier.js';
-import SOURCEMAPPING_URL from './utils/sourceMappingURL.js';
+import { SOURCEMAPPING_URL_RE } from './utils/sourceMappingURL.js';
 import error from './utils/error.js';
 import relativeId from './utils/relativeId.js';
 import { SyntheticNamespaceDeclaration } from './Declaration.js';
@@ -72,11 +72,14 @@ export default class Module {
 		});
 
 		// remove existing sourceMappingURL comments
-		const pattern = new RegExp( `^\\/\\/#\\s+${SOURCEMAPPING_URL}=.+\\n?`, 'gm' );
-		let match;
-		while ( match = pattern.exec( code ) ) {
-			this.magicString.remove( match.index, match.index + match[0].length );
-		}
+		this.comments = this.comments.filter(comment => {
+			//only one line comment can contain source maps
+			const isSourceMapComment = !comment.block && SOURCEMAPPING_URL_RE.test(comment.text);
+			if (isSourceMapComment) {
+				this.magicString.remove(comment.start, comment.end );
+			}
+			return !isSourceMapComment;
+		});
 
 		this.declarations = blank();
 		this.type = 'Module'; // TODO only necessary so that Scope knows this should be treated as a function scope... messy

--- a/src/utils/sourceMappingURL.js
+++ b/src/utils/sourceMappingURL.js
@@ -4,3 +4,5 @@ let SOURCEMAPPING_URL = 'sourceMa';
 SOURCEMAPPING_URL += 'ppingURL';
 
 export default SOURCEMAPPING_URL;
+
+export const SOURCEMAPPING_URL_RE = new RegExp( `^#\\s+${SOURCEMAPPING_URL}=.+\\n?` );

--- a/test/form/removes-existing-sourcemap-comments/_expected/amd.js
+++ b/test/form/removes-existing-sourcemap-comments/_expected/amd.js
@@ -4,6 +4,9 @@ define(function () { 'use strict';
 		return 42;
 	};
 
-	console.log( foo() );
+	// we should not trim this string
+	var str = '//# sourceMappingURL=main.js.map';
+
+	console.log( foo(str) );
 
 });

--- a/test/form/removes-existing-sourcemap-comments/_expected/cjs.js
+++ b/test/form/removes-existing-sourcemap-comments/_expected/cjs.js
@@ -4,4 +4,7 @@ var foo = function () {
 	return 42;
 };
 
-console.log( foo() );
+// we should not trim this string
+var str = '//# sourceMappingURL=main.js.map';
+
+console.log( foo(str) );

--- a/test/form/removes-existing-sourcemap-comments/_expected/es.js
+++ b/test/form/removes-existing-sourcemap-comments/_expected/es.js
@@ -2,4 +2,7 @@ var foo = function () {
 	return 42;
 };
 
-console.log( foo() );
+// we should not trim this string
+var str = '//# sourceMappingURL=main.js.map';
+
+console.log( foo(str) );

--- a/test/form/removes-existing-sourcemap-comments/_expected/iife.js
+++ b/test/form/removes-existing-sourcemap-comments/_expected/iife.js
@@ -5,6 +5,9 @@
 		return 42;
 	};
 
-	console.log( foo() );
+	// we should not trim this string
+	var str = '//# sourceMappingURL=main.js.map';
+
+	console.log( foo(str) );
 
 }());

--- a/test/form/removes-existing-sourcemap-comments/_expected/umd.js
+++ b/test/form/removes-existing-sourcemap-comments/_expected/umd.js
@@ -8,6 +8,9 @@
 		return 42;
 	};
 
-	console.log( foo() );
+	// we should not trim this string
+	var str = '//# sourceMappingURL=main.js.map';
+
+	console.log( foo(str) );
 
 })));

--- a/test/form/removes-existing-sourcemap-comments/main.js
+++ b/test/form/removes-existing-sourcemap-comments/main.js
@@ -1,5 +1,8 @@
 import foo from './foo';
 
-console.log( foo() );
+// we should not trim this string
+var str = '//# sourceMappingURL=main.js.map';
+
+console.log( foo(str) );
 
 //# sourceMappingURL=main.js.map


### PR DESCRIPTION
I have problem that current code removes `//# sourceMappingURL=....` even from string (because of regexp search). I noticed in code there are 2 places where remove happen - in Module and Bundle classes.

With Module idea is very clear - we iterate by comments only and clean sourcemaps. But with Bundle i did not get original idea why it is need, and it is also breaking my usecase (i am inserting SM with plugin.intro string matching this regexp - point there it is a string not comment). Also there is no test for this part of code. 

Could you please point me how should i better rework this part? or i can remove it at all? (we can reparse end bundle to remove comments, but i do not see why plugin could not do anything they want).

Also it looks it is more correct to remove comment body but rest //. For example we had `//# sourceMappingURL=...` and rest only `//`. Is it right?

Thanks.
