### PR TITLE
Quote names in module definition if legacy option is set

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -82,6 +82,9 @@ export class SyntheticNamespaceDeclaration {
 			if ( original.isReassigned ) {
 				return `${indentString}get ${name} () { return ${original.getName( es )}; }`;
 			}
+			if (legacy) {
+				name = `'${name}'`;
+			}
 
 			return `${indentString}${name}: ${original.getName( es )}`;
 		});

--- a/test/form/legacy/_expected/amd.js
+++ b/test/form/legacy/_expected/amd.js
@@ -4,7 +4,7 @@ define(function () { 'use strict';
 
 
 	var namespace = (Object.freeze || Object)({
-		foo: foo
+		'foo': foo
 	});
 
 	const x = 'foo';

--- a/test/form/legacy/_expected/cjs.js
+++ b/test/form/legacy/_expected/cjs.js
@@ -4,7 +4,7 @@ const foo = 42;
 
 
 var namespace = (Object.freeze || Object)({
-	foo: foo
+	'foo': foo
 });
 
 const x = 'foo';

--- a/test/form/legacy/_expected/es.js
+++ b/test/form/legacy/_expected/es.js
@@ -2,7 +2,7 @@ const foo = 42;
 
 
 var namespace = (Object.freeze || Object)({
-	foo: foo
+	'foo': foo
 });
 
 const x = 'foo';

--- a/test/form/legacy/_expected/iife.js
+++ b/test/form/legacy/_expected/iife.js
@@ -5,7 +5,7 @@
 
 
 	var namespace = (Object.freeze || Object)({
-		foo: foo
+		'foo': foo
 	});
 
 	const x = 'foo';

--- a/test/form/legacy/_expected/umd.js
+++ b/test/form/legacy/_expected/umd.js
@@ -8,7 +8,7 @@
 
 
 	var namespace = (Object.freeze || Object)({
-		foo: foo
+		'foo': foo
 	});
 
 	const x = 'foo';


### PR DESCRIPTION
In addition to pull request #989.

This adds single quotes around property names inside module definition, if `legacy` option is set, to prevent reserved words to appear in object keys.

Example output:

``` javascript
var foo = (Object.freeze || Object)({
    'default': bar
});
```
