### PR TITLE
[fix] remove Object.define for legacy; pass into cli; test legacy

### DIFF
--- a/bin/src/index.js
+++ b/bin/src/index.js
@@ -16,6 +16,7 @@ const command = minimist( process.argv.slice( 2 ), {
 		g: 'globals',
 		h: 'help',
 		i: 'input',
+		l: 'legacy',
 		m: 'sourcemap',
 		n: 'name',
 		o: 'output',

--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -105,6 +105,7 @@ const equivalents = {
 	indent: 'indent',
 	input: 'entry',
 	intro: 'intro',
+	legacy: 'legacy',
 	name: 'moduleName',
 	output: 'dest',
 	outro: 'outro',

--- a/src/finalisers/amd.js
+++ b/src/finalisers/amd.js
@@ -27,7 +27,7 @@ export default function amd ( bundle, magicString, { exportMode, indentString, i
 
 	const exportBlock = getExportBlock( bundle.entryModule, exportMode );
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
-	if ( exportMode === 'named' ) magicString.append( `\n\n${esModuleExport}` );
+	if ( exportMode === 'named' && options.legacy !== true ) magicString.append( `\n\n${esModuleExport}` );
 	if ( options.outro ) magicString.append( `\n${options.outro}` );
 
 	return magicString

--- a/src/finalisers/cjs.js
+++ b/src/finalisers/cjs.js
@@ -3,7 +3,7 @@ import esModuleExport from './shared/esModuleExport.js';
 
 export default function cjs ( bundle, magicString, { exportMode, intro }, options ) {
 	intro = ( options.useStrict === false ? intro : `'use strict';\n\n${intro}` ) +
-	        ( exportMode === 'named' ? `${esModuleExport}\n\n` : '' );
+	        ( exportMode === 'named' && options.legacy !== true ? `${esModuleExport}\n\n` : '' );
 
 	let needsInterop = false;
 

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -73,7 +73,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString, i
 
 	const exportBlock = getExportBlock( bundle.entryModule, exportMode );
 	if ( exportBlock ) magicString.append( '\n\n' + exportBlock );
-	if ( exportMode === 'named' ) magicString.append( `\n\n${esModuleExport}` );
+	if ( exportMode === 'named' && options.legacy !== true ) magicString.append( `\n\n${esModuleExport}` );
 	if ( options.outro ) magicString.append( `\n${options.outro}` );
 
 	return magicString

--- a/test/form/legacy/_config.js
+++ b/test/form/legacy/_config.js
@@ -1,6 +1,7 @@
 module.exports = {
-	description: 'supports environments without Object.freeze',
+	description: 'supports environments without Object.freeze, Object.defined',
 	options: {
+    moduleName: 'myBundle',
 		legacy: true
 	}
 };

--- a/test/form/legacy/_expected/amd.js
+++ b/test/form/legacy/_expected/amd.js
@@ -1,13 +1,20 @@
-define(function () { 'use strict';
+define(['exports'], function (exports) { 'use strict';
 
-	const foo = 42;
+	const foo = 1;
+	const bar = 2;
 
 
 	var namespace = (Object.freeze || Object)({
-		foo: foo
+		foo: foo,
+		bar: bar
 	});
 
-	const x = 'foo';
-	assert.equal( namespace[x], 42 );
+	console.log( Object.keys( namespace ) );
+
+	const a = 1;
+	const b = 2;
+
+	exports.a = a;
+	exports.b = b;
 
 });

--- a/test/form/legacy/_expected/cjs.js
+++ b/test/form/legacy/_expected/cjs.js
@@ -1,11 +1,18 @@
 'use strict';
 
-const foo = 42;
+const foo = 1;
+const bar = 2;
 
 
 var namespace = (Object.freeze || Object)({
-	foo: foo
+	foo: foo,
+	bar: bar
 });
 
-const x = 'foo';
-assert.equal( namespace[x], 42 );
+console.log( Object.keys( namespace ) );
+
+const a = 1;
+const b = 2;
+
+exports.a = a;
+exports.b = b;

--- a/test/form/legacy/_expected/es.js
+++ b/test/form/legacy/_expected/es.js
@@ -1,9 +1,15 @@
-const foo = 42;
+const foo = 1;
+const bar = 2;
 
 
 var namespace = (Object.freeze || Object)({
-	foo: foo
+	foo: foo,
+	bar: bar
 });
 
-const x = 'foo';
-assert.equal( namespace[x], 42 );
+console.log( Object.keys( namespace ) );
+
+const a = 1;
+const b = 2;
+
+export { a, b };

--- a/test/form/legacy/_expected/iife.js
+++ b/test/form/legacy/_expected/iife.js
@@ -1,14 +1,21 @@
-(function () {
+(function (exports) {
 	'use strict';
 
-	const foo = 42;
+	const foo = 1;
+	const bar = 2;
 
 
 	var namespace = (Object.freeze || Object)({
-		foo: foo
+		foo: foo,
+		bar: bar
 	});
 
-	const x = 'foo';
-	assert.equal( namespace[x], 42 );
+	console.log( Object.keys( namespace ) );
 
-}());
+	const a = 1;
+	const b = 2;
+
+	exports.a = a;
+	exports.b = b;
+
+}((this.myBundle = this.myBundle || {})));

--- a/test/form/legacy/_expected/umd.js
+++ b/test/form/legacy/_expected/umd.js
@@ -1,17 +1,24 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
-	typeof define === 'function' && define.amd ? define(factory) :
-	(factory());
-}(this, (function () { 'use strict';
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.myBundle = global.myBundle || {})));
+}(this, (function (exports) { 'use strict';
 
-	const foo = 42;
+	const foo = 1;
+	const bar = 2;
 
 
 	var namespace = (Object.freeze || Object)({
-		foo: foo
+		foo: foo,
+		bar: bar
 	});
 
-	const x = 'foo';
-	assert.equal( namespace[x], 42 );
+	console.log( Object.keys( namespace ) );
+
+	const a = 1;
+	const b = 2;
+
+	exports.a = a;
+	exports.b = b;
 
 })));

--- a/test/form/legacy/main.js
+++ b/test/form/legacy/main.js
@@ -1,4 +1,6 @@
 import * as namespace from './namespace.js';
 
-const x = 'foo';
-assert.equal( namespace[x], 42 );
+console.log( Object.keys( namespace ) );
+
+export const a = 1;
+export const b = 2;

--- a/test/form/legacy/namespace.js
+++ b/test/form/legacy/namespace.js
@@ -1,1 +1,2 @@
-export const foo = 42;
+export const foo = 1;
+export const bar = 2;


### PR DESCRIPTION
This PR does below things for `option.legacy=true`
1. Remove `Object.define` esModule line
2. Also pass the `legacy` option to CLI
3. Test for the new code, fix previously legacy test use case.
