### PR TITLE
Do not output getter defs when in legacy mode

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -79,7 +79,7 @@ export class SyntheticNamespaceDeclaration {
 		const members = keys( this.originals ).map( name => {
 			const original = this.originals[ name ];
 
-			if ( original.isReassigned ) {
+			if ( original.isReassigned && !legacy ) {
 				return `${indentString}get ${name} () { return ${original.getName( es )}; }`;
 			}
 

--- a/test/form/legacy-getter/_config.js
+++ b/test/form/legacy-getter/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'Does not output getters when in legacy',
+	options: {
+		legacy: true,
+		moduleName: 'foo'
+	}
+};

--- a/test/form/legacy-getter/_expected/amd.js
+++ b/test/form/legacy-getter/_expected/amd.js
@@ -1,0 +1,25 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var browserSpecificThing;
+
+	if ('ActiveXObject' in window) {
+		browserSpecificThing = "InternetExplorerThing";
+	} else {
+		browserSpecificThing = "DecentBrowserThing";
+	}
+
+	function foo() {}
+
+
+	var browserStuff = (Object.freeze || Object)({
+		browserSpecificThing: browserSpecificThing,
+		foo: foo
+	});
+
+	console.log(browserSpecificThing);
+
+	exports.B = browserStuff;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/legacy-getter/_expected/cjs.js
+++ b/test/form/legacy-getter/_expected/cjs.js
@@ -1,0 +1,23 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var browserSpecificThing;
+
+if ('ActiveXObject' in window) {
+	browserSpecificThing = "InternetExplorerThing";
+} else {
+	browserSpecificThing = "DecentBrowserThing";
+}
+
+function foo() {}
+
+
+var browserStuff = (Object.freeze || Object)({
+	browserSpecificThing: browserSpecificThing,
+	foo: foo
+});
+
+console.log(browserSpecificThing);
+
+exports.B = browserStuff;

--- a/test/form/legacy-getter/_expected/es.js
+++ b/test/form/legacy-getter/_expected/es.js
@@ -1,0 +1,19 @@
+var browserSpecificThing;
+
+if ('ActiveXObject' in window) {
+	browserSpecificThing = "InternetExplorerThing";
+} else {
+	browserSpecificThing = "DecentBrowserThing";
+}
+
+function foo() {}
+
+
+var browserStuff = (Object.freeze || Object)({
+	browserSpecificThing: browserSpecificThing,
+	foo: foo
+});
+
+console.log(browserSpecificThing);
+
+export { browserStuff as B };

--- a/test/form/legacy-getter/_expected/iife.js
+++ b/test/form/legacy-getter/_expected/iife.js
@@ -1,0 +1,24 @@
+(function (exports) {
+	'use strict';
+
+	var browserSpecificThing;
+
+	if ('ActiveXObject' in window) {
+		browserSpecificThing = "InternetExplorerThing";
+	} else {
+		browserSpecificThing = "DecentBrowserThing";
+	}
+
+	function foo() {}
+
+
+	var browserStuff = (Object.freeze || Object)({
+		browserSpecificThing: browserSpecificThing,
+		foo: foo
+	});
+
+	console.log(browserSpecificThing);
+
+	exports.B = browserStuff;
+
+}((this.foo = this.foo || {})));

--- a/test/form/legacy-getter/_expected/umd.js
+++ b/test/form/legacy-getter/_expected/umd.js
@@ -1,0 +1,29 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.foo = global.foo || {})));
+}(this, (function (exports) { 'use strict';
+
+	var browserSpecificThing;
+
+	if ('ActiveXObject' in window) {
+		browserSpecificThing = "InternetExplorerThing";
+	} else {
+		browserSpecificThing = "DecentBrowserThing";
+	}
+
+	function foo() {}
+
+
+	var browserStuff = (Object.freeze || Object)({
+		browserSpecificThing: browserSpecificThing,
+		foo: foo
+	});
+
+	console.log(browserSpecificThing);
+
+	exports.B = browserStuff;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/legacy-getter/browserStuff.js
+++ b/test/form/legacy-getter/browserStuff.js
@@ -1,0 +1,9 @@
+export var browserSpecificThing;
+
+if ('ActiveXObject' in window) {
+	browserSpecificThing = "InternetExplorerThing";
+} else {
+	browserSpecificThing = "DecentBrowserThing";
+}
+
+export function foo() {}

--- a/test/form/legacy-getter/main.js
+++ b/test/form/legacy-getter/main.js
@@ -1,0 +1,4 @@
+import * as B from './browserStuff';
+export {B};
+
+console.log(B.browserSpecificThing);


### PR DESCRIPTION
This prevents rollup from outputting object getters for reassigned exports (which will trigger a syntax error when `Object.freeze()` is skipped).

Related to #1068, based on comments from https://github.com/futurist/rollup-plugin-es3/issues/3 , ~~will try to add~~ added a test for this.
