### PR TITLE
Hack to fix external modules with --watch, as seen in issue #982

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -267,7 +267,7 @@ export default class Bundle {
 				return transform( source, id, this.plugins );
 			})
 			.then( source => {
-				const { code, originalCode, originalSourceMap, ast, sourceMapChain, resolvedIds } = source;
+				const { code, originalCode, originalSourceMap, ast, sourceMapChain } = source;
 
 				const module = new Module({
 					id,
@@ -276,7 +276,6 @@ export default class Bundle {
 					originalSourceMap,
 					ast,
 					sourceMapChain,
-					resolvedIds,
 					bundle: this
 				});
 


### PR DESCRIPTION
When running rollup `--watch`, the module cache triggers a bug when compiling in the second run.

In the first run, `fetchAllDependencies` calls `this.resolveId(..)` that yields `false` for externals. However, it subsequently saves the actual `externalId` in the `resolvedIds` cache.

The second run, this `externalId` is now returned instead of `false` and the `Treating xx as external dependency` path is not hit.

The hack just doesn't copy `resolvedIds` from the module cache letting rollup re-evaluate them on subsequent compiles. I have no idea what the proper fix should be. Should externals be saved on `resolvedIds`?
