### PR TITLE
Fix 977

### DIFF
--- a/src/ast/nodes/CallExpression.js
+++ b/src/ast/nodes/CallExpression.js
@@ -30,11 +30,24 @@ export default class CallExpression extends Node {
 	}
 
 	initialise ( scope ) {
-		this.module.bundle.dependentExpressions.push( this );
+		if ( isProgramLevel( this ) ) {
+			this.module.bundle.dependentExpressions.push( this );
+		}
 		super.initialise( scope );
 	}
 
 	isUsedByBundle () {
 		return this.hasEffects( this.findScope() );
 	}
+}
+
+function isProgramLevel ( node ) {
+	do {
+		if ( node.type === 'Program' ) {
+			return true;
+		}
+		node = node.parent;
+	} while ( node && !/Function/.test( node.type ) );
+
+	return false;
 }

--- a/test/form/unused-called-import/_config.js
+++ b/test/form/unused-called-import/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not include called-in-unused-code import'
+};

--- a/test/form/unused-called-import/_expected/amd.js
+++ b/test/form/unused-called-import/_expected/amd.js
@@ -1,6 +1,6 @@
 define(function () { 'use strict';
 
-	var foo = function() { return 'foo'; }
+	var foo = function() { return 'foo'; };
 
 	assert.equal( foo(), 'foo' );
 

--- a/test/form/unused-called-import/_expected/amd.js
+++ b/test/form/unused-called-import/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var foo = function() { return 'foo'; }
+
+	assert.equal( foo(), 'foo' );
+
+});

--- a/test/form/unused-called-import/_expected/cjs.js
+++ b/test/form/unused-called-import/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var foo = function() { return 'foo'; }
+
+assert.equal( foo(), 'foo' );

--- a/test/form/unused-called-import/_expected/cjs.js
+++ b/test/form/unused-called-import/_expected/cjs.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var foo = function() { return 'foo'; }
+var foo = function() { return 'foo'; };
 
 assert.equal( foo(), 'foo' );

--- a/test/form/unused-called-import/_expected/es.js
+++ b/test/form/unused-called-import/_expected/es.js
@@ -1,3 +1,3 @@
-var foo = function() { return 'foo'; }
+var foo = function() { return 'foo'; };
 
 assert.equal( foo(), 'foo' );

--- a/test/form/unused-called-import/_expected/es.js
+++ b/test/form/unused-called-import/_expected/es.js
@@ -1,0 +1,3 @@
+var foo = function() { return 'foo'; }
+
+assert.equal( foo(), 'foo' );

--- a/test/form/unused-called-import/_expected/iife.js
+++ b/test/form/unused-called-import/_expected/iife.js
@@ -1,7 +1,7 @@
 (function () {
 	'use strict';
 
-	var foo = function() { return 'foo'; }
+	var foo = function() { return 'foo'; };
 
 	assert.equal( foo(), 'foo' );
 

--- a/test/form/unused-called-import/_expected/iife.js
+++ b/test/form/unused-called-import/_expected/iife.js
@@ -1,0 +1,8 @@
+(function () {
+	'use strict';
+
+	var foo = function() { return 'foo'; }
+
+	assert.equal( foo(), 'foo' );
+
+}());

--- a/test/form/unused-called-import/_expected/umd.js
+++ b/test/form/unused-called-import/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory());
 }(this, (function () { 'use strict';
 
-	var foo = function() { return 'foo'; }
+	var foo = function() { return 'foo'; };
 
 	assert.equal( foo(), 'foo' );
 

--- a/test/form/unused-called-import/_expected/umd.js
+++ b/test/form/unused-called-import/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	var foo = function() { return 'foo'; }
+
+	assert.equal( foo(), 'foo' );
+
+})));

--- a/test/form/unused-called-import/dead.js
+++ b/test/form/unused-called-import/dead.js
@@ -1,0 +1,1 @@
+export default function() { return 'dead'; }

--- a/test/form/unused-called-import/foo.js
+++ b/test/form/unused-called-import/foo.js
@@ -1,0 +1,5 @@
+import dead from './dead';
+
+export default function() { return 'foo'; }
+
+export function foodead() { return 'foo' + dead(); }

--- a/test/form/unused-called-import/main.js
+++ b/test/form/unused-called-import/main.js
@@ -1,0 +1,2 @@
+import foo from './foo';
+assert.equal( foo(), 'foo' );

--- a/test/form/unused-called-with-side-effects/_config.js
+++ b/test/form/unused-called-with-side-effects/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not include called-in-unused-code import'
+};

--- a/test/form/unused-called-with-side-effects/_expected/amd.js
+++ b/test/form/unused-called-with-side-effects/_expected/amd.js
@@ -1,0 +1,9 @@
+define(function () { 'use strict';
+
+  function foo() {
+    return 'foo'
+  }
+
+  assert.equal( foo(), 'foo' );
+
+});

--- a/test/form/unused-called-with-side-effects/_expected/cjs.js
+++ b/test/form/unused-called-with-side-effects/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function foo() {
+  return 'foo'
+}
+
+assert.equal( foo(), 'foo' );

--- a/test/form/unused-called-with-side-effects/_expected/es.js
+++ b/test/form/unused-called-with-side-effects/_expected/es.js
@@ -1,0 +1,5 @@
+function foo() {
+  return 'foo'
+}
+
+assert.equal( foo(), 'foo' );

--- a/test/form/unused-called-with-side-effects/_expected/iife.js
+++ b/test/form/unused-called-with-side-effects/_expected/iife.js
@@ -1,0 +1,10 @@
+(function () {
+  'use strict';
+
+  function foo() {
+    return 'foo'
+  }
+
+  assert.equal( foo(), 'foo' );
+
+}());

--- a/test/form/unused-called-with-side-effects/_expected/umd.js
+++ b/test/form/unused-called-with-side-effects/_expected/umd.js
@@ -1,0 +1,13 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (factory());
+}(this, (function () { 'use strict';
+
+  function foo() {
+    return 'foo'
+  }
+
+  assert.equal( foo(), 'foo' );
+
+})));

--- a/test/form/unused-called-with-side-effects/main.js
+++ b/test/form/unused-called-with-side-effects/main.js
@@ -1,0 +1,13 @@
+function foo() {
+  return 'foo'
+}
+
+function bar() {
+  dead();
+}
+
+function dead() {
+  console.log('dead');
+}
+
+assert.equal( foo(), 'foo' );


### PR DESCRIPTION
Improves tree-shaking by only considering program-level call expressions as a Bundle's dependent expressions. /cc @mbostock

Fixes #977