### PR TITLE
resolve index.js if file is a path

### DIFF
--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -1,4 +1,4 @@
-import { isFile, readdirSync, readFileSync } from './fs.js';
+import { isFile, isDir, readdirSync, readFileSync } from './fs.js';
 import { basename, dirname, isAbsolute, resolve } from './path.js';
 import { blank } from './object.js';
 
@@ -7,6 +7,7 @@ export function load ( id ) {
 }
 
 function addJsExtensionIfNecessary ( file ) {
+	if (isDir(file) && !isFile(`${file}.js`)) return `${file}/index.js`;
 	try {
 		const name = basename( file );
 		const files = readdirSync( dirname( file ) );

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -20,6 +20,15 @@ export function isFile ( file ) {
 	}
 }
 
+export function isDir ( file ) {
+	try {
+		const stats = fs.statSync(file);
+		return stats.isDirectory();
+	} catch ( err ) {
+		return false;
+	}
+}
+
 export function writeFile ( dest, data ) {
 	return new Promise( ( fulfil, reject ) => {
 		mkdirpath( dest );

--- a/test/function/non-extension-folder/_config.js
+++ b/test/function/non-extension-folder/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'add index.js to module paths when path is directory'
+};

--- a/test/function/non-extension-folder/foobar/index.js
+++ b/test/function/non-extension-folder/foobar/index.js
@@ -1,0 +1,1 @@
+export default 'fubar';

--- a/test/function/non-extension-folder/foobaz.js
+++ b/test/function/non-extension-folder/foobaz.js
@@ -1,0 +1,1 @@
+export default 'fubaz';

--- a/test/function/non-extension-folder/foobaz/index.js
+++ b/test/function/non-extension-folder/foobaz/index.js
@@ -1,0 +1,1 @@
+export default 'fubar';

--- a/test/function/non-extension-folder/main.js
+++ b/test/function/non-extension-folder/main.js
@@ -1,0 +1,4 @@
+import fooBar from './foobar';
+import fooBaz from './foobaz';
+assert.equal( fooBar, 'fubar' );
+assert.equal(fooBaz, 'fubaz');


### PR DESCRIPTION
resolve index.js when the import file is a directory 
```javascript
// main.js
import store from './store'
```
```
+-- app/
+-- main.js
+-- store/
|   +-- index.js  
```
will load ./store/index.js

```
+-- app/
+-- main.js
+-- store.js
+-- store/
|   +-- index.js  
```
will load ./store.js


