### PR TITLE
accomodate incorrect ExportDefaultDeclaration.start produced by rollup-plugin-json

### DIFF
--- a/src/ast/nodes/ExportDefaultDeclaration.js
+++ b/src/ast/nodes/ExportDefaultDeclaration.js
@@ -53,7 +53,7 @@ export default class ExportDefaultDeclaration extends Node {
 		let declaration_start;
 		if ( this.declaration ) {
 			const statementStr = code.original.slice( this.start, this.end );
-			declaration_start = this.start + statementStr.match(/^export\s+default\s*/)[0].length;
+			declaration_start = this.start + statementStr.match(/^\s*export\s+default\s+/)[0].length;
 		}
 
 		if ( this.shouldInclude || this.declaration.activated ) {


### PR DESCRIPTION
Likely workaround for #1146 (incorrect `ExportDefaultDeclaration.start` generated by `rollup-plugin-json`)