### PR TITLE
prevent false positives for sourcemapping url comments with newlines

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -429,7 +429,7 @@ export default class Bundle {
 		const bundleSourcemapChain = [];
 
 		code = transformBundle( code, this.plugins, bundleSourcemapChain, options )
-			.replace( new RegExp( `^\\/\\/#\\s+${SOURCEMAPPING_URL}=.+\\n?`, 'gm' ), '' );
+			.replace( new RegExp( `^\\/\\/# +${SOURCEMAPPING_URL}=.+\\n?`, 'gm' ), '' );
 
 		if ( options.sourceMap ) {
 			timeStart( 'sourceMap' );

--- a/src/Module.js
+++ b/src/Module.js
@@ -72,7 +72,7 @@ export default class Module {
 		});
 
 		// remove existing sourceMappingURL comments
-		const pattern = new RegExp( `^\\/\\/#\\s+${SOURCEMAPPING_URL}=.+\\n?`, 'gm' );
+		const pattern = new RegExp( `^\\/\\/# +${SOURCEMAPPING_URL}=.+\\n?`, 'gm' );
 		let match;
 		while ( match = pattern.exec( code ) ) {
 			this.magicString.remove( match.index, match.index + match[0].length );

--- a/test/function/sourcemapping-url-multiline/_config.js
+++ b/test/function/sourcemapping-url-multiline/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not mistakenly recognise sourceMappingURL comment with newline'
+};

--- a/test/function/sourcemapping-url-multiline/main.js
+++ b/test/function/sourcemapping-url-multiline/main.js
@@ -1,0 +1,6 @@
+var sourceMappingURL;
+
+//#
+sourceMappingURL='something';
+
+assert.equal( sourceMappingURL, 'something' );


### PR DESCRIPTION
Fixes https://github.com/rollup/rollup/issues/988#issuecomment-251017219