### PR TITLE
support async functions

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -16,7 +16,7 @@ import ModuleScope from './ast/scopes/ModuleScope.js';
 function tryParse ( code, comments, acornOptions, id ) {
 	try {
 		return parse( code, assign({
-			ecmaVersion: 7,
+			ecmaVersion: 8,
 			sourceType: 'module',
 			onComment: ( block, text, start, end ) => comments.push({ block, text, start, end }),
 			preserveParens: false

--- a/test/form/async-function-unused/_config.js
+++ b/test/form/async-function-unused/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'treeshakes async functions (#492)'
+};

--- a/test/form/async-function-unused/_expected/amd.js
+++ b/test/form/async-function-unused/_expected/amd.js
@@ -1,0 +1,9 @@
+define(function () { 'use strict';
+
+	async function foo () {
+		return 'foo';
+	}
+
+	foo().then( value => console.log( value ) );
+
+});

--- a/test/form/async-function-unused/_expected/cjs.js
+++ b/test/form/async-function-unused/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+async function foo () {
+	return 'foo';
+}
+
+foo().then( value => console.log( value ) );

--- a/test/form/async-function-unused/_expected/es.js
+++ b/test/form/async-function-unused/_expected/es.js
@@ -1,0 +1,5 @@
+async function foo () {
+	return 'foo';
+}
+
+foo().then( value => console.log( value ) );

--- a/test/form/async-function-unused/_expected/iife.js
+++ b/test/form/async-function-unused/_expected/iife.js
@@ -1,0 +1,10 @@
+(function () {
+	'use strict';
+
+	async function foo () {
+		return 'foo';
+	}
+
+	foo().then( value => console.log( value ) );
+
+}());

--- a/test/form/async-function-unused/_expected/umd.js
+++ b/test/form/async-function-unused/_expected/umd.js
@@ -1,0 +1,13 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	async function foo () {
+		return 'foo';
+	}
+
+	foo().then( value => console.log( value ) );
+
+})));

--- a/test/form/async-function-unused/main.js
+++ b/test/form/async-function-unused/main.js
@@ -1,0 +1,3 @@
+import { foo } from './utils.js';
+
+foo().then( value => console.log( value ) );

--- a/test/form/async-function-unused/utils.js
+++ b/test/form/async-function-unused/utils.js
@@ -1,0 +1,7 @@
+export async function foo () {
+	return 'foo';
+}
+
+export async function bar () {
+	return 'bar';
+}


### PR DESCRIPTION
Ref #492. This won't fix the issue (which is that Babel transpiles async functions to something hard to treeshake), but it provides an alternative – treeshaking the async function in Rollup *then* running Babel on the bundle, rather than on individual modules.

(In many cases you'd need a hybrid approach – transpiling with Babel beforehand so that Rollup can parse the module but *not* using any plugins that transpile async functions, then running the async transformation afterwards.)