### PR TITLE
warn if exporting an IIFE that looks like a function declaration, and wrap in parens if necessary

### DIFF
--- a/test/function/warn-on-ambiguous-function-export/_config.js
+++ b/test/function/warn-on-ambiguous-function-export/_config.js
@@ -1,0 +1,10 @@
+const assert = require( 'assert' );
+
+module.exports = {
+	description: 'uses original name of default export function (#1011)',
+	warnings: warnings => {
+		assert.deepEqual( warnings, [
+			'foo.js (1:15) Ambiguous default export (is a call expression, but looks like a function declaration). See https://github.com/rollup/rollup/wiki/Troubleshooting#ambiguous-default-export'
+		]);
+	}
+};

--- a/test/function/warn-on-ambiguous-function-export/foo.js
+++ b/test/function/warn-on-ambiguous-function-export/foo.js
@@ -1,0 +1,6 @@
+export default function foo ( a, b ) {
+	assert.equal( a, b );
+	return 3;
+}
+
+( 1 + 1, 2 );

--- a/test/function/warn-on-ambiguous-function-export/main.js
+++ b/test/function/warn-on-ambiguous-function-export/main.js
@@ -1,0 +1,2 @@
+import x from './foo.js';
+assert.equal( x, 3 );

--- a/test/function/wraps-ambiguous-default-export/_config.js
+++ b/test/function/wraps-ambiguous-default-export/_config.js
@@ -1,0 +1,10 @@
+const assert = require( 'assert' );
+
+module.exports = {
+	description: 'wraps a function expression callee in parens to avoid it being parsed as function declaration (#1011)',
+	warnings: warnings => {
+		assert.deepEqual( warnings, [
+			'foo.js (1:15) Ambiguous default export (is a call expression, but looks like a function declaration). See https://github.com/rollup/rollup/wiki/Troubleshooting#ambiguous-default-export'
+		]);
+	}
+};

--- a/test/function/wraps-ambiguous-default-export/_config.js
+++ b/test/function/wraps-ambiguous-default-export/_config.js
@@ -1,10 +1,3 @@
-const assert = require( 'assert' );
-
 module.exports = {
-	description: 'wraps a function expression callee in parens to avoid it being parsed as function declaration (#1011)',
-	warnings: warnings => {
-		assert.deepEqual( warnings, [
-			'foo.js (1:15) Ambiguous default export (is a call expression, but looks like a function declaration). See https://github.com/rollup/rollup/wiki/Troubleshooting#ambiguous-default-export'
-		]);
-	}
+	description: 'wraps a function expression callee in parens to avoid it being parsed as function declaration (#1011)'
 };

--- a/test/function/wraps-ambiguous-default-export/foo.js
+++ b/test/function/wraps-ambiguous-default-export/foo.js
@@ -1,6 +1,4 @@
 export default function foo ( x ) {
 	assert.equal( x, 42 );
 	global.ran = true;
-}
-
-( 42 );
+}( 42 );

--- a/test/function/wraps-ambiguous-default-export/foo.js
+++ b/test/function/wraps-ambiguous-default-export/foo.js
@@ -1,0 +1,6 @@
+export default function foo ( x ) {
+	assert.equal( x, 42 );
+	global.ran = true;
+}
+
+( 42 );

--- a/test/function/wraps-ambiguous-default-export/main.js
+++ b/test/function/wraps-ambiguous-default-export/main.js
@@ -1,0 +1,2 @@
+import './foo.js';
+assert.ok( global.ran );


### PR DESCRIPTION
Fixes two things related to #1011.

Firstly, in a situation like this...

```js
export default function foo () {}

(function iife () {
  // code goes here
}())
```

...it will print a warning that you're exporting a call expression when you probably thought you were exporting the `foo` declaration.

Secondly, [this valid (if unusual) JavaScript](http://rollupjs.org/?version=0.38.1&shareable=JTdCJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmNqcyUyMiUyQyUyMm1vZHVsZU5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmdsb2JhbHMlMjIlM0ElN0IlN0QlN0QlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyaW1wb3J0JTIwJy4lMkZmb28uanMnJTNCJTIyJTdEJTJDJTdCJTIybmFtZSUyMiUzQSUyMmZvby5qcyUyMiUyQyUyMmNvZGUlMjIlM0ElMjJleHBvcnQlMjBkZWZhdWx0JTIwZnVuY3Rpb24lMjBmb28lMjAoJTIweCUyMCklMjAlN0IlNUNuJTVDdGFzc2VydC5lcXVhbCglMjB4JTJDJTIwNDIlMjApJTNCJTVDbiU3RCglMjA0MiUyMCklM0IlNUNuJTIyJTdEJTVEJTdE)...

```js
// main.js
import './foo.js';

// foo.js
export default function foo ( x ) {
	assert.equal( x, 42 );
}( 42 );
```

...gets changed into something different (the IIFE becomes a function declaration and a separate expression statement) by the removal of the `export default`:

```js
function foo ( x ) {
	assert.equal( x, 42 );
}( 42 );
```

Rollup will now wrap the function expression in parentheses, preserving the correct meaning:

```js
(function foo ( x ) {
	assert.equal( x, 42 );
})( 42 );
```