### PR TITLE
more informative warning for implicit external dependencies

### DIFF
--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -60,7 +60,8 @@ export default function runRollup ( command ) {
 		rollup.rollup({
 			entry: config,
 			onwarn: message => {
-				if ( /Treating .+ as external dependency/.test( message ) ) return;
+				// TODO use warning codes instead of this hackery
+				if ( /treating it as an external dependency/.test( message ) ) return;
 				stderr( message );
 			}
 		}).then( bundle => {

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -16,6 +16,7 @@ import transform from './utils/transform.js';
 import transformBundle from './utils/transformBundle.js';
 import collapseSourcemaps from './utils/collapseSourcemaps.js';
 import callIfFunction from './utils/callIfFunction.js';
+import relativeId from './utils/relativeId.js';
 import { dirname, isRelative, isAbsolute, normalize, relative, resolve } from './utils/path.js';
 import BundleScope from './ast/scopes/BundleScope.js';
 
@@ -332,7 +333,7 @@ export default class Bundle {
 					if ( !resolvedId && !isExternal ) {
 						if ( isRelative( source ) ) throw new Error( `Could not resolve '${source}' from ${module.id}` );
 
-						this.onwarn( `Treating '${source}' as external dependency` );
+						this.onwarn( `'${source}' is imported by ${relativeId( module.id )}, but could not be resolved – treating it as an external dependency. For help see https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency` );
 						isExternal = true;
 					}
 

--- a/src/utils/relativeId.js
+++ b/src/utils/relativeId.js
@@ -1,4 +1,6 @@
+import { isAbsolute, relative } from './path.js';
+
 export default function relativeId ( id ) {
-	if ( typeof process === 'undefined' ) return id;
-	return id.replace( process.cwd(), '' ).replace( /^[\/\\]/, '' );
+	if ( typeof process === 'undefined' || !isAbsolute( id ) ) return id;
+	return relative( process.cwd(), id );
 }

--- a/test/function/custom-path-resolver-async/_config.js
+++ b/test/function/custom-path-resolver-async/_config.js
@@ -23,7 +23,7 @@ module.exports = {
 	},
 	warnings: function ( warnings ) {
 		assert.deepEqual( warnings, [
-			"Treating 'path' as external dependency"
+			`'path' is imported by main.js, but could not be resolved – treating it as an external dependency. For help see https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`
 		]);
 	},
 	exports: function ( exports ) {

--- a/test/function/custom-path-resolver-sync/_config.js
+++ b/test/function/custom-path-resolver-sync/_config.js
@@ -15,7 +15,7 @@ module.exports = {
 	},
 	warnings: function ( warnings ) {
 		assert.deepEqual( warnings, [
-			"Treating 'path' as external dependency"
+			`'path' is imported by main.js, but could not be resolved – treating it as an external dependency. For help see https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`
 		]);
 	},
 	exports: function ( exports ) {

--- a/test/function/does-not-hang-on-missing-module/_config.js
+++ b/test/function/does-not-hang-on-missing-module/_config.js
@@ -2,10 +2,10 @@ var assert = require( 'assert' );
 
 module.exports = {
 	description: 'does not hang on missing module (#53)',
-	options: {
-		onwarn: function ( msg ) {
-			assert.equal( "Treating 'unlessYouCreatedThisFileForSomeReason' as external dependency", msg );
-		}
+	warnings: warnings => {
+		assert.deepEqual( warnings, [
+			`'unlessYouCreatedThisFileForSomeReason' is imported by main.js, but could not be resolved – treating it as an external dependency. For help see https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`
+		]);
 	},
 	runtimeError: function ( error ) {
 		assert.equal( "Cannot find module 'unlessYouCreatedThisFileForSomeReason'", error.message );

--- a/test/function/unused-import/_config.js
+++ b/test/function/unused-import/_config.js
@@ -4,7 +4,7 @@ module.exports = {
 	description: 'warns on unused imports ([#595])',
 	warnings: warnings => {
 		assert.deepEqual( warnings, [
-			`Treating 'external' as external dependency`,
+			`'external' is imported by main.js, but could not be resolved – treating it as an external dependency. For help see https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`,
 			`'unused', 'notused' and 'neverused' are imported from external module 'external' but never used`,
 			`Generated an empty bundle`
 		]);


### PR DESCRIPTION
This started out as a response to https://github.com/rollup/rollup/issues/1051#issuecomment-267878171 but I decided it makes more sense to just have a better warning than 'Treating xxx as external dependency'. It now tells you the importing module, and points you to [this wiki section](https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency).