### PR TITLE
warn about using node built-ins in browser bundle (#1051)

### DIFF
--- a/src/finalisers/amd.js
+++ b/src/finalisers/amd.js
@@ -2,8 +2,10 @@ import { getName, quotePath } from '../utils/map-helpers.js';
 import getInteropBlock from './shared/getInteropBlock.js';
 import getExportBlock from './shared/getExportBlock.js';
 import esModuleExport from './shared/esModuleExport.js';
+import warnOnBuiltins from './shared/warnOnBuiltins.js';
 
 export default function amd ( bundle, magicString, { exportMode, indentString, intro, outro }, options ) {
+	warnOnBuiltins( bundle );
 	const deps = bundle.externalModules.map( quotePath );
 	const args = bundle.externalModules.map( getName );
 

--- a/src/finalisers/iife.js
+++ b/src/finalisers/iife.js
@@ -4,6 +4,7 @@ import getInteropBlock from './shared/getInteropBlock.js';
 import getExportBlock from './shared/getExportBlock.js';
 import getGlobalNameMaker from './shared/getGlobalNameMaker.js';
 import propertyStringFor from './shared/propertyStringFor';
+import warnOnBuiltins from './shared/warnOnBuiltins.js';
 
 // thisProp('foo.bar-baz.qux') === "this.foo['bar-baz'].qux"
 const thisProp = propertyStringFor('this');
@@ -29,8 +30,9 @@ export default function iife ( bundle, magicString, { exportMode, indentString, 
 	const name = options.moduleName;
 	const isNamespaced = name && ~name.indexOf( '.' );
 
-	const dependencies = bundle.externalModules.map( globalNameMaker );
+	warnOnBuiltins( bundle );
 
+	const dependencies = bundle.externalModules.map( globalNameMaker );
 	const args = bundle.externalModules.map( getName );
 
 	if ( exportMode !== 'none' && !name ) {

--- a/src/finalisers/shared/warnOnBuiltins.js
+++ b/src/finalisers/shared/warnOnBuiltins.js
@@ -1,0 +1,39 @@
+const builtins = {
+	process: true,
+	events: true,
+	stream: true,
+	util: true,
+	path: true,
+	buffer: true,
+	querystring: true,
+	url: true,
+	string_decoder: true,
+	punycode: true,
+	http: true,
+	https: true,
+	os: true,
+	assert: true,
+	constants: true,
+	timers: true,
+	console: true,
+	vm: true,
+	zlib: true,
+	tty: true,
+	domain: true
+};
+
+// Creating a browser bundle that depends on Node.js built-in modules ('util'). You might need to include https://www.npmjs.com/package/rollup-plugin-node-builtins
+
+export default function warnOnBuiltins ( bundle ) {
+	const externalBuiltins = bundle.externalModules
+		.filter( mod => mod.id in builtins )
+		.map( mod => mod.id );
+
+	if ( !externalBuiltins.length ) return;
+
+	const detail = externalBuiltins.length === 1 ?
+		`module ('${externalBuiltins[0]}')` :
+		`modules (${externalBuiltins.slice( 0, -1 ).map( name => `'${name}'` ).join( ', ' )} and '${externalBuiltins.pop()}')`;
+
+	bundle.onwarn( `Creating a browser bundle that depends on Node.js built-in ${detail}. You might need to include https://www.npmjs.com/package/rollup-plugin-node-builtins` );
+}

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -5,6 +5,7 @@ import getExportBlock from './shared/getExportBlock.js';
 import getGlobalNameMaker from './shared/getGlobalNameMaker.js';
 import esModuleExport from './shared/esModuleExport.js';
 import propertyStringFor from './shared/propertyStringFor.js';
+import warnOnBuiltins from './shared/warnOnBuiltins.js';
 
 // globalProp('foo.bar-baz') === "global.foo['bar-baz']"
 const globalProp = propertyStringFor('global');
@@ -29,6 +30,8 @@ export default function umd ( bundle, magicString, { exportMode, indentString, i
 	if ( exportMode !== 'none' && !options.moduleName ) {
 		throw new Error( 'You must supply options.moduleName for UMD bundles' );
 	}
+
+	warnOnBuiltins( bundle );
 
 	const globalNameMaker = getGlobalNameMaker( options.globals || blank(), bundle.onwarn );
 


### PR DESCRIPTION
More #1051. This warns if the bundle has external dependencies on Node.js builtins, but only if the bundle is a browser bundle (AMD, UMD or IIFE) since the assumption otherwise is that you're either running the bundle in Node or running it through another tool like Webpack.