### PR TITLE
prevent mutation of cached ASTs

### DIFF
--- a/src/ast/clone.js
+++ b/src/ast/clone.js
@@ -1,0 +1,17 @@
+export default function clone ( node ) {
+	if ( !node ) return node;
+	if ( typeof node !== 'object' ) return node;
+
+	if ( Array.isArray( node ) ) {
+		const cloned = new Array( node.length );
+		for ( let i = 0; i < node.length; i += 1 ) cloned[i] = clone( node[i] );
+		return cloned;
+	}
+
+	const cloned = {};
+	for ( const key in node ) {
+		cloned[ key ] = clone( node[ key ] );
+	}
+
+	return cloned;
+}

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -17,24 +17,3 @@ export function assign ( target, ...sources ) {
 
 	return target;
 }
-
-const isArray = Array.isArray;
-
-// used for cloning ASTs. Not for use with cyclical structures!
-export function deepClone ( obj ) {
-	if ( !obj ) return obj;
-	if ( typeof obj !== 'object' ) return obj;
-
-	if ( isArray( obj ) ) {
-		const clone = new Array( obj.length );
-		for ( let i = 0; i < obj.length; i += 1 ) clone[i] = deepClone( obj[i] );
-		return clone;
-	}
-
-	const clone = {};
-	for ( const key in obj ) {
-		clone[ key ] = deepClone( obj[ key ] );
-	}
-
-	return clone;
-}

--- a/test/test.js
+++ b/test/test.js
@@ -684,6 +684,35 @@ describe( 'rollup', function () {
 				assert.deepEqual( asts.foo, acorn.parse( modules.foo, { sourceType: 'module' }) );
 			});
 		});
+
+		it( 'recovers from errors', () => {
+			modules.entry = `import foo from 'foo'; import bar from 'bar'; export default foo + bar;`;
+
+			return rollup.rollup({
+				entry: 'entry',
+				plugins: [ plugin ]
+			}).then( cache => {
+				modules.foo = `var 42 = nope;`;
+
+				return rollup.rollup({
+					entry: 'entry',
+					plugins: [ plugin ],
+					cache
+				}).catch( err => {
+					return cache;
+				});
+			}).then( cache => {
+				modules.foo = `export default 42;`;
+
+				return rollup.rollup({
+					entry: 'entry',
+					plugins: [ plugin ],
+					cache
+				}).then( bundle => {
+					assert.equal( executeBundle( bundle ), 63 );
+				});
+			});
+		});
 	});
 
 	describe( 'hooks', () => {


### PR DESCRIPTION
This fixes the dreaded 'Maximum call stack size exceeded' error that occurs with rollup-watch when a file with an error is subsequently fixed. It does so by preventing mutations of the cached AST, which is reused between incremental builds for files that *don't* have errors.

Fixes #1153, #1010, and https://github.com/rollup/rollup-watch/issues/21.