### PR TITLE
apply kzc patch to prevent escape codes and emojis appearing in non-TTY stderr

### DIFF
--- a/bin/src/handleError.js
+++ b/bin/src/handleError.js
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 function stderr ( msg ) {
 	console.error( msg ); // eslint-disable-line no-console

--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -1,13 +1,16 @@
 import { realpathSync } from 'fs';
 import * as rollup from 'rollup';
 import relative from 'require-relative';
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 import handleError from './handleError';
 import relativeId from '../../src/utils/relativeId.js';
 import SOURCEMAPPING_URL from './sourceMappingUrl.js';
 
 import { install as installSourcemapSupport } from 'source-map-support';
 installSourcemapSupport();
+
+if ( !process.stderr.isTTY ) chalk.enabled = false;
+const warnSymbol = process.stderr.isTTY ? `⚠️   ` : `Warning: `;
 
 // stderr to stderr to keep `rollup main.js > bundle.js` from breaking
 const stderr = console.error.bind( console ); // eslint-disable-line no-console
@@ -154,7 +157,7 @@ function execute ( options, command ) {
 			if ( seen.has( str ) ) return;
 			seen.add( str );
 
-			stderr( `⚠️   ${chalk.bold( warning.message )}` );
+			stderr( `${warnSymbol}${chalk.bold( warning.message )}` );
 
 			if ( warning.url ) {
 				stderr( chalk.cyan( warning.url ) );

--- a/rollup.config.cli.js
+++ b/rollup.config.cli.js
@@ -14,10 +14,7 @@ export default {
 		json(),
 		buble(),
 		commonjs({
-			include: 'node_modules/**',
-			namedExports: {
-				chalk: [ 'yellow', 'red', 'cyan', 'grey', 'dim', 'bold' ]
-			}
+			include: 'node_modules/**'
 		}),
 		nodeResolve({
 			main: true


### PR DESCRIPTION
fixes #1201 