### PR TITLE
[WIP] account for side-effects in call expression arguments, and functions passed to functions

### DIFF
--- a/src/ast/nodes/CallExpression.js
+++ b/src/ast/nodes/CallExpression.js
@@ -31,7 +31,15 @@ export default class CallExpression extends Node {
 	}
 
 	hasEffects ( scope ) {
-		return callHasEffects( scope, this.callee, false );
+		if ( callHasEffects( scope, this.callee, false ) ) return true;
+
+		for ( let i = 0; i < this.arguments.length; i += 1 ) {
+			const arg = this.arguments[i];
+			if ( arg.hasEffects( scope ) ) return true;
+
+			// if a function is passed to a function, assume it is called
+			if ( callHasEffects( scope, arg, false ) ) return true;
+		}
 	}
 
 	initialise ( scope ) {

--- a/src/ast/nodes/NewExpression.js
+++ b/src/ast/nodes/NewExpression.js
@@ -3,6 +3,14 @@ import callHasEffects from './shared/callHasEffects.js';
 
 export default class NewExpression extends Node {
 	hasEffects ( scope ) {
-		return callHasEffects( scope, this.callee, true );
+		if ( callHasEffects( scope, this.callee, true ) ) return true;
+
+		for ( let i = 0; i < this.arguments.length; i += 1 ) {
+			const arg = this.arguments[i];
+			if ( arg.hasEffects( scope ) ) return true;
+
+			// if a function is passed to a function, assume it is called
+			if ( callHasEffects( scope, arg, false ) ) return true;
+		}
 	}
 }

--- a/src/ast/nodes/ReturnStatement.js
+++ b/src/ast/nodes/ReturnStatement.js
@@ -1,7 +1,0 @@
-import Node from '../Node.js';
-
-export default class ReturnStatement extends Node {
-	// hasEffects () {
-	// 	return true;
-	// }
-}

--- a/src/ast/nodes/index.js
+++ b/src/ast/nodes/index.js
@@ -25,7 +25,6 @@ import LogicalExpression from './LogicalExpression.js';
 import MemberExpression from './MemberExpression.js';
 import NewExpression from './NewExpression.js';
 import ObjectExpression from './ObjectExpression.js';
-import ReturnStatement from './ReturnStatement.js';
 import Statement from './shared/Statement.js';
 import TemplateLiteral from './TemplateLiteral.js';
 import ThisExpression from './ThisExpression.js';
@@ -64,7 +63,6 @@ export default {
 	MemberExpression,
 	NewExpression,
 	ObjectExpression,
-	ReturnStatement,
 	SwitchStatement: Statement,
 	TemplateLiteral,
 	ThisExpression,

--- a/test/form/side-effect-t/_config.js
+++ b/test/form/side-effect-t/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'preserves side-effects inside promises (#786)',
+	options: {
+		moduleName: 'myBundle'
+	}
+};

--- a/test/form/side-effect-t/_expected/amd.js
+++ b/test/form/side-effect-t/_expected/amd.js
@@ -1,0 +1,32 @@
+define(['exports'], function (exports) { 'use strict';
+
+	function x () {
+		return new Promise( ( resolve, reject ) => {
+			console.log( 'this is a side-effect' );
+			resolve();
+		});
+	}
+
+	x();
+
+	function promiseCallback ( resolve, reject ) {
+		console.log( 'this is a side-effect' );
+		resolve();
+	}
+
+	function y () {
+		return new Promise( promiseCallback );
+	}
+
+	y();
+
+	function z ( x ) {
+		// this function has no side-effects, so should be excluded...
+	}
+
+	exports.a = 1;
+	z( exports.a += 1 ); // ...unless the call expression statement has its own side-effects
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/side-effect-t/_expected/cjs.js
+++ b/test/form/side-effect-t/_expected/cjs.js
@@ -1,0 +1,30 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function x () {
+	return new Promise( ( resolve, reject ) => {
+		console.log( 'this is a side-effect' );
+		resolve();
+	});
+}
+
+x();
+
+function promiseCallback ( resolve, reject ) {
+	console.log( 'this is a side-effect' );
+	resolve();
+}
+
+function y () {
+	return new Promise( promiseCallback );
+}
+
+y();
+
+function z ( x ) {
+	// this function has no side-effects, so should be excluded...
+}
+
+exports.a = 1;
+z( exports.a += 1 ); // ...unless the call expression statement has its own side-effects

--- a/test/form/side-effect-t/_expected/es.js
+++ b/test/form/side-effect-t/_expected/es.js
@@ -1,0 +1,28 @@
+function x () {
+	return new Promise( ( resolve, reject ) => {
+		console.log( 'this is a side-effect' );
+		resolve();
+	});
+}
+
+x();
+
+function promiseCallback ( resolve, reject ) {
+	console.log( 'this is a side-effect' );
+	resolve();
+}
+
+function y () {
+	return new Promise( promiseCallback );
+}
+
+y();
+
+function z ( x ) {
+	// this function has no side-effects, so should be excluded...
+}
+
+let a = 1;
+z( a += 1 ); // ...unless the call expression statement has its own side-effects
+
+export { a };

--- a/test/form/side-effect-t/_expected/iife.js
+++ b/test/form/side-effect-t/_expected/iife.js
@@ -1,0 +1,31 @@
+(function (exports) {
+	'use strict';
+
+	function x () {
+		return new Promise( ( resolve, reject ) => {
+			console.log( 'this is a side-effect' );
+			resolve();
+		});
+	}
+
+	x();
+
+	function promiseCallback ( resolve, reject ) {
+		console.log( 'this is a side-effect' );
+		resolve();
+	}
+
+	function y () {
+		return new Promise( promiseCallback );
+	}
+
+	y();
+
+	function z ( x ) {
+		// this function has no side-effects, so should be excluded...
+	}
+
+	exports.a = 1;
+	z( exports.a += 1 ); // ...unless the call expression statement has its own side-effects
+
+}((this.myBundle = this.myBundle || {})));

--- a/test/form/side-effect-t/_expected/umd.js
+++ b/test/form/side-effect-t/_expected/umd.js
@@ -1,0 +1,36 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.myBundle = global.myBundle || {})));
+}(this, (function (exports) { 'use strict';
+
+	function x () {
+		return new Promise( ( resolve, reject ) => {
+			console.log( 'this is a side-effect' );
+			resolve();
+		});
+	}
+
+	x();
+
+	function promiseCallback ( resolve, reject ) {
+		console.log( 'this is a side-effect' );
+		resolve();
+	}
+
+	function y () {
+		return new Promise( promiseCallback );
+	}
+
+	y();
+
+	function z ( x ) {
+		// this function has no side-effects, so should be excluded...
+	}
+
+	exports.a = 1;
+	z( exports.a += 1 ); // ...unless the call expression statement has its own side-effects
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/side-effect-t/main.js
+++ b/test/form/side-effect-t/main.js
@@ -1,0 +1,28 @@
+function x () {
+	return new Promise( ( resolve, reject ) => {
+		console.log( 'this is a side-effect' );
+		resolve();
+	});
+}
+
+x();
+
+function promiseCallback ( resolve, reject ) {
+	console.log( 'this is a side-effect' );
+	resolve();
+}
+
+function y () {
+	return new Promise( promiseCallback );
+}
+
+y();
+
+function z ( x ) {
+	// this function has no side-effects, so should be excluded...
+}
+
+let a = 1;
+z( a += 1 ); // ...unless the call expression statement has its own side-effects
+
+export { a };


### PR DESCRIPTION
Ref #786. This addresses an important oversight – side-effects in call expression arguments...

```js
function foo ( x ) {
  // this function has no side-effects, so should be excluded...
}

let a = 1;
foo( a += 1 ); // ...unless the call expression statement has its own side-effects
```

...or in functions passed to functions...

```js
function x () {
  return new Promise( ( resolve, reject ) => {
    console.log( 'this is a side-effect' );
    resolve();
  });
}

x();
```

...get erroneously removed.

Unfortunately, as it stands the solution results in a lot of false positives – want to see if it's possible to eliminate at least some of them before merging this.