### PR TITLE
optimize namespace["foo"]

### DIFF
--- a/test/form/namespace-optimization-computed-string/_config.js
+++ b/test/form/namespace-optimization-computed-string/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'it does dynamic lookup optimization of internal namespaces for string-literal keys'
+};

--- a/test/form/namespace-optimization-computed-string/_expected/amd.js
+++ b/test/form/namespace-optimization-computed-string/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	function a () {}
+
+	a();
+
+});

--- a/test/form/namespace-optimization-computed-string/_expected/cjs.js
+++ b/test/form/namespace-optimization-computed-string/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function a () {}
+
+a();

--- a/test/form/namespace-optimization-computed-string/_expected/es.js
+++ b/test/form/namespace-optimization-computed-string/_expected/es.js
@@ -1,0 +1,3 @@
+function a () {}
+
+a();

--- a/test/form/namespace-optimization-computed-string/_expected/iife.js
+++ b/test/form/namespace-optimization-computed-string/_expected/iife.js
@@ -1,0 +1,8 @@
+(function () {
+	'use strict';
+
+	function a () {}
+
+	a();
+
+}());

--- a/test/form/namespace-optimization-computed-string/_expected/umd.js
+++ b/test/form/namespace-optimization-computed-string/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	function a () {}
+
+	a();
+
+})));

--- a/test/form/namespace-optimization-computed-string/bar.js
+++ b/test/form/namespace-optimization-computed-string/bar.js
@@ -1,0 +1,3 @@
+import * as quux from './quux.js';
+
+export { quux };

--- a/test/form/namespace-optimization-computed-string/foo.js
+++ b/test/form/namespace-optimization-computed-string/foo.js
@@ -1,0 +1,3 @@
+import * as bar from './bar.js';
+
+export { bar };

--- a/test/form/namespace-optimization-computed-string/main.js
+++ b/test/form/namespace-optimization-computed-string/main.js
@@ -1,0 +1,3 @@
+import * as foo from './foo.js';
+
+foo['bar']['quux']['a']();

--- a/test/form/namespace-optimization-computed-string/quux.js
+++ b/test/form/namespace-optimization-computed-string/quux.js
@@ -1,0 +1,1 @@
+export function a () {}


### PR DESCRIPTION
This is #841 revisited (since that PR was against an ancient version of the codebase and would be hopeless to try and merge). It means that `namespace['foo']` and `namespace.foo` are treated the same way for the purposes of tree-shaking.