### PR TITLE
fixes #1278

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -314,7 +314,9 @@ export default class Bundle {
 
 				return this.fetchAllDependencies( module ).then( () => {
 					keys( module.exports ).forEach( name => {
-						module.exportsAll[name] = module.id;
+						if ( name !== 'default' ) {
+							module.exportsAll[name] = module.id;
+						}
 					});
 					module.exportAllSources.forEach( source => {
 						const id = module.resolvedIds[ source ];


### PR DESCRIPTION
 - only add named exports to module.exportsAll

\* I didn't add any tests to this since it's only a warning and is really  just an extension of [the fix](https://github.com/rollup/rollup/pull/1038) for #1028

If you would prefer me to write a test and re-send the PR, I will certainly do that.