### PR TITLE
fix incorrect namespace conflict warning

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -325,10 +325,11 @@ export default class Bundle {
 							if ( name in module.exportsAll ) {
 								this.warn({
 									code: 'NAMESPACE_CONFLICT',
-									message: `Conflicting namespaces: ${relativeId( module.id )} re-exports '${name}' from both ${relativeId( module.exportsAll[ name ] )} (will be ignored) and ${relativeId( exportAllModule.exportsAll[ name ] )}`
+									message: `Conflicting namespaces: ${relativeId( module.id )} re-exports '${name}' from both ${relativeId( module.exportsAll[ name ] )} and ${relativeId( exportAllModule.exportsAll[ name ] )} (will be ignored)`
 								});
+							} else {
+							  module.exportsAll[ name ] = exportAllModule.exportsAll[ name ];
 							}
-							module.exportsAll[ name ] = exportAllModule.exportsAll[ name ];
 						});
 					});
 					return module;

--- a/test/function/warn-on-namespace-conflict/_config.js
+++ b/test/function/warn-on-namespace-conflict/_config.js
@@ -3,7 +3,7 @@ module.exports = {
 	warnings: [
 		{
 			code: 'NAMESPACE_CONFLICT',
-			message: `Conflicting namespaces: main.js re-exports 'foo' from both foo.js (will be ignored) and deep.js`
+			message: `Conflicting namespaces: main.js re-exports 'foo' from both foo.js and deep.js (will be ignored)`
 		}
 	]
 };


### PR DESCRIPTION
 - only set module.exportsAll when no conflict is found
 - fix warning in test
