### PR TITLE
Add values to function and arrow function expressions

### DIFF
--- a/src/ast/nodes/ArrowFunctionExpression.js
+++ b/src/ast/nodes/ArrowFunctionExpression.js
@@ -1,5 +1,6 @@
 import Node from '../Node.js';
 import Scope from '../scopes/Scope.js';
+import { FUNCTION } from '../values.js';
 import extractNames from '../utils/extractNames.js';
 
 export default class ArrowFunctionExpression extends Node {
@@ -9,6 +10,10 @@ export default class ArrowFunctionExpression extends Node {
 
 	findScope ( functionScope ) {
 		return this.scope || this.parent.findScope( functionScope );
+	}
+
+	gatherPossibleValues ( values ) {
+		values.add( FUNCTION );
 	}
 
 	hasEffects () {

--- a/src/ast/nodes/FunctionExpression.js
+++ b/src/ast/nodes/FunctionExpression.js
@@ -1,4 +1,5 @@
 import Node from '../Node.js';
+import { FUNCTION } from '../values.js';
 
 export default class FunctionExpression extends Node {
 	activate () {
@@ -8,6 +9,10 @@ export default class FunctionExpression extends Node {
 		const scope = this.body.scope;
 		this.params.forEach( param => param.run( scope ) ); // in case of assignment patterns
 		this.body.run();
+	}
+
+	gatherPossibleValues ( values ) {
+		values.add( FUNCTION );
 	}
 
 	addReference () {

--- a/test/form/side-effect-u/_config.js
+++ b/test/form/side-effect-u/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'setting object properties is not a side effect'
+};

--- a/test/form/side-effect-u/_expected/amd.js
+++ b/test/form/side-effect-u/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	const cube = {};
+
+	console.log( cube );
+
+});

--- a/test/form/side-effect-u/_expected/cjs.js
+++ b/test/form/side-effect-u/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const cube = {};
+
+console.log( cube );

--- a/test/form/side-effect-u/_expected/es.js
+++ b/test/form/side-effect-u/_expected/es.js
@@ -1,0 +1,3 @@
+const cube = {};
+
+console.log( cube );

--- a/test/form/side-effect-u/_expected/iife.js
+++ b/test/form/side-effect-u/_expected/iife.js
@@ -1,0 +1,8 @@
+(function () {
+	'use strict';
+
+	const cube = {};
+
+	console.log( cube );
+
+}());

--- a/test/form/side-effect-u/_expected/umd.js
+++ b/test/form/side-effect-u/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	const cube = {};
+
+	console.log( cube );
+
+})));

--- a/test/form/side-effect-u/main.js
+++ b/test/form/side-effect-u/main.js
@@ -1,0 +1,3 @@
+import { cube } from './maths.js';
+
+console.log( cube );

--- a/test/form/side-effect-u/maths.js
+++ b/test/form/side-effect-u/maths.js
@@ -1,0 +1,4 @@
+export const cube = {};
+export const square = {};
+
+square.a = 'b';

--- a/test/form/side-effect-v/_config.js
+++ b/test/form/side-effect-v/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'setting function properties is not a side effect'
+};

--- a/test/form/side-effect-v/_expected/amd.js
+++ b/test/form/side-effect-v/_expected/amd.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	const cube = {};
+
+	console.log( cube );
+
+});

--- a/test/form/side-effect-v/_expected/cjs.js
+++ b/test/form/side-effect-v/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const cube = {};
+
+console.log( cube );

--- a/test/form/side-effect-v/_expected/es.js
+++ b/test/form/side-effect-v/_expected/es.js
@@ -1,0 +1,3 @@
+const cube = {};
+
+console.log( cube );

--- a/test/form/side-effect-v/_expected/iife.js
+++ b/test/form/side-effect-v/_expected/iife.js
@@ -1,0 +1,8 @@
+(function () {
+	'use strict';
+
+	const cube = {};
+
+	console.log( cube );
+
+}());

--- a/test/form/side-effect-v/_expected/umd.js
+++ b/test/form/side-effect-v/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	const cube = {};
+
+	console.log( cube );
+
+})));

--- a/test/form/side-effect-v/main.js
+++ b/test/form/side-effect-v/main.js
@@ -1,0 +1,3 @@
+import { cube } from './maths.js';
+
+console.log( cube );

--- a/test/form/side-effect-v/maths.js
+++ b/test/form/side-effect-v/maths.js
@@ -1,0 +1,6 @@
+export const cube = {};
+export const square = () => {};
+export const triangle = function () {};
+
+square.b = 'b';
+triangle.c = 'c';


### PR DESCRIPTION
Consider the following React module `lib.js`:

```js
export const Hello = () => { console.log('Hello') }
export const Greeting = () => { console.log('Greetings') }

Greeting.propTypes = {
  name: React.PropTypes.string
};

Greeting.defaultProps = {
  name: 'Mary'
};
```

And a entry that only includes the `Hello` export:

```js
import { Hello } from './lib';
Hello();
```

Currently, the Greeting class will be included in the bundle as well. [Run on rollupjs.org](http://rollupjs.org/?version=0.41.4&shareable=JTdCJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmNqcyUyMiUyQyUyMm1vZHVsZU5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmdsb2JhbHMlMjIlM0ElN0IlN0QlN0QlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyaW1wb3J0JTIwJTdCJTIwSGVsbG8lMjAlN0QlMjBmcm9tJTIwJy4lMkZtYXRocy5qcyclM0IlNUNuSGVsbG8oKSUyMiU3RCUyQyU3QiUyMm5hbWUlMjIlM0ElMjJtYXRocy5qcyUyMiUyQyUyMmNvZGUlMjIlM0ElMjJleHBvcnQlMjBjb25zdCUyMEhlbGxvJTIwJTNEJTIwKCklMjAlM0QlM0UlMjAlN0IlMjBjb25zb2xlLmxvZygnSGVsbG8nKSUyMCU3RCU1Q25leHBvcnQlMjBjb25zdCUyMEdyZWV0aW5nJTIwJTNEJTIwKCklMjAlM0QlM0UlMjAlN0IlMjBjb25zb2xlLmxvZygnR3JlZXRpbmdzJyklMjAlN0QlNUNuJTVDbkdyZWV0aW5nLnByb3BUeXBlcyUyMCUzRCUyMCU3QiU1Q24lMjAlMjBuYW1lJTNBJTIwUmVhY3QuUHJvcFR5cGVzLnN0cmluZyU1Q24lN0QlM0IlNUNuJTVDbkdyZWV0aW5nLmRlZmF1bHRQcm9wcyUyMCUzRCUyMCU3QiU1Q24lMjAlMjBuYW1lJTNBJTIwJ01hcnknJTVDbiU3RCUzQiU1Q24lMjIlN0QlNUQlN0Q=).

This is because the assignment expressions `Greeting.propTypes = {}` and `Greeting.defaultProps = {}` are marked [as having effects](https://github.com/rollup/rollup/blob/master/src/ast/nodes/AssignmentExpression.js#L33) because the [gatherPossibleValues](https://github.com/rollup/rollup/blob/master/src/ast/nodes/shared/isUsedByBundle.js#L33) and subsequently the default [getValue](https://github.com/rollup/rollup/blob/master/src/ast/Node.js#L42) call returns UNKNOWN for the [left side of the assignment](https://github.com/rollup/rollup/blob/master/src/ast/Node.js#L42) when it's a `FunctionExpression` or an `ArrowFunctionExpression`.

This PR adds the correct value to those expressions. The PR includes a "control" test showing how the current behavior works correctly for value = OBJECT, and two new tests showing the new behavior with functions and arrow functions.