### PR TITLE
README: recommending to specify `pkg.module`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Unfortunately, **traditional modules – CommonJS and AMD – result in code mo
 
 ## Can I distribute my package as an ES6 module?
 
-If your `package.json` has a `jsnext:main` field, ES6-aware tools like Rollup can import the ES6 version of the package instead of the legacy CommonJS or UMD version. You'll be writing your code in a more future-proof way, and helping to bring an end to the [dark days of JavaScript package management](https://medium.com/@trek/last-week-i-had-a-small-meltdown-on-twitter-about-npms-future-plans-around-front-end-packaging-b424dd8d367a). [Learn more here.](https://github.com/rollup/rollup/wiki/jsnext:main)
+If your `package.json` has a `module` field, ES6-aware tools like Rollup can import the ES6 version of the package instead of the legacy CommonJS or UMD version. You'll be writing your code in a more future-proof way, and helping to bring an end to the [dark days of JavaScript package management](https://medium.com/@trek/last-week-i-had-a-small-meltdown-on-twitter-about-npms-future-plans-around-front-end-packaging-b424dd8d367a). [Learn more here.](https://github.com/rollup/rollup/wiki/pkg.module)
 
 See [rollup-starter-project](https://github.com/rollup/rollup-starter-project) for inspiration on how to get started.
 


### PR DESCRIPTION
The current propsal suggests pkg.module as a key: https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md
I'm sure that pkg.module should be the recommendation but I'm not sure if `jsnext:main` should be removed from README.
But it seems reasonable to discourage using `jsnext:main`.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
