### PR TITLE
Allow undefined import in interop

### DIFF
--- a/src/finalisers/shared/getInteropBlock.js
+++ b/src/finalisers/shared/getInteropBlock.js
@@ -11,7 +11,7 @@ export default function getInteropBlock ( bundle, options ) {
 				return `${bundle.varOrConst} ${module.name}__default = 'default' in ${module.name} ? ${module.name}['default'] : ${module.name};`;
 			}
 
-			return `${module.name} = 'default' in ${module.name} ? ${module.name}['default'] : ${module.name};`;
+			return `${module.name} = ${module.name} && 'default' in ${module.name} ? ${module.name}['default'] : ${module.name};`;
 		})
 		.filter( Boolean )
 		.join( '\n' );

--- a/test/form/export-default-import/_expected/amd.js
+++ b/test/form/export-default-import/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['exports', 'x'], function (exports, x) { 'use strict';
 
-	x = 'default' in x ? x['default'] : x;
+	x = x && 'default' in x ? x['default'] : x;
 
 
 

--- a/test/form/export-default-import/_expected/iife.js
+++ b/test/form/export-default-import/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (exports,x) {
 	'use strict';
 
-	x = 'default' in x ? x['default'] : x;
+	x = x && 'default' in x ? x['default'] : x;
 
 
 

--- a/test/form/export-default-import/_expected/umd.js
+++ b/test/form/export-default-import/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory((global.myBundle = global.myBundle || {}),global.x));
 }(this, (function (exports,x) { 'use strict';
 
-	x = 'default' in x ? x['default'] : x;
+	x = x && 'default' in x ? x['default'] : x;
 
 
 

--- a/test/form/external-imports-custom-names/_expected/amd.js
+++ b/test/form/external-imports-custom-names/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['jquery'], function ($) { 'use strict';
 
-	$ = 'default' in $ ? $['default'] : $;
+	$ = $ && 'default' in $ ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/external-imports-custom-names/_expected/iife.js
+++ b/test/form/external-imports-custom-names/_expected/iife.js
@@ -1,7 +1,7 @@
 (function ($) {
 	'use strict';
 
-	$ = 'default' in $ ? $['default'] : $;
+	$ = $ && 'default' in $ ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/external-imports-custom-names/_expected/umd.js
+++ b/test/form/external-imports-custom-names/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.jQuery));
 }(this, (function ($) { 'use strict';
 
-	$ = 'default' in $ ? $['default'] : $;
+	$ = $ && 'default' in $ ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/external-imports/_expected/amd.js
+++ b/test/form/external-imports/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['factory', 'baz', 'shipping-port', 'alphabet'], function (factory, baz, containers, alphabet) { 'use strict';
 
-	factory = 'default' in factory ? factory['default'] : factory;
+	factory = factory && 'default' in factory ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/external-imports/_expected/iife.js
+++ b/test/form/external-imports/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (factory,baz,containers,alphabet) {
 	'use strict';
 
-	factory = 'default' in factory ? factory['default'] : factory;
+	factory = factory && 'default' in factory ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/external-imports/_expected/umd.js
+++ b/test/form/external-imports/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.factory,global.baz,global.containers,global.alphabet));
 }(this, (function (factory,baz,containers,alphabet) { 'use strict';
 
-	factory = 'default' in factory ? factory['default'] : factory;
+	factory = factory && 'default' in factory ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/paths-function/_expected/amd.js
+++ b/test/form/paths-function/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['https://unpkg.com/foo'], function (foo) { 'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-function/_expected/iife.js
+++ b/test/form/paths-function/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-function/_expected/umd.js
+++ b/test/form/paths-function/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-relative/_expected/amd.js
+++ b/test/form/paths-relative/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['../foo'], function (foo) { 'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-relative/_expected/iife.js
+++ b/test/form/paths-relative/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-relative/_expected/umd.js
+++ b/test/form/paths-relative/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths/_expected/amd.js
+++ b/test/form/paths/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['https://unpkg.com/foo'], function (foo) { 'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths/_expected/iife.js
+++ b/test/form/paths/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths/_expected/umd.js
+++ b/test/form/paths/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = 'default' in foo ? foo['default'] : foo;
+	foo = foo && 'default' in foo ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/relative-external-with-global/_expected/amd.js
+++ b/test/form/relative-external-with-global/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['./lib/throttle.js'], function (throttle) { 'use strict';
 
-	throttle = 'default' in throttle ? throttle['default'] : throttle;
+	throttle = throttle && 'default' in throttle ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );

--- a/test/form/relative-external-with-global/_expected/iife.js
+++ b/test/form/relative-external-with-global/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (throttle) {
 	'use strict';
 
-	throttle = 'default' in throttle ? throttle['default'] : throttle;
+	throttle = throttle && 'default' in throttle ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );

--- a/test/form/relative-external-with-global/_expected/umd.js
+++ b/test/form/relative-external-with-global/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.Lib.throttle));
 }(this, (function (throttle) { 'use strict';
 
-	throttle = 'default' in throttle ? throttle['default'] : throttle;
+	throttle = throttle && 'default' in throttle ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );


### PR DESCRIPTION
Resolves https://github.com/rollup/rollup/issues/1341

Most interopts I've seen, babel, webpack, and rollup's [cjs interop](https://github.com/rollup/rollup/blob/master/src/finalisers/cjs.js#L42) check for the existence of the imported value prior to checking for `default`.

I tried to read the ecma specs but they're pretty confusing.  Is this expected to throw an error?

```js
import foo from 'file-does-not-exist';

// or would it just be undefined?
foo === undefined;
```

Even _if_ it would throw an error in ES2015 modules, if I know my target is UMD anyways, why not allow it to import without an error?
