### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rollup is a module bundler for JavaScript which compiles small pieces of code in
 
 ## Quick Start Guide
 
-Install with `npm install --global rollup`. Rollup can be used either through a [command line interface](https://github.com/rollup/rollup/wiki/Command-Line-Interface) with an optional configuration file, or else through its [JavaScript API](https://github.com/rollup/rollup/wiki/JavaScript-API). Run `rollup --help` to see the available options and parameters. The [starter project template](https://github.com/rollup/rollup-starter-project) demonstrates common configuration options, and more detailed instructions are available throughout the [user guide](http://rollupjs.org/guide/).
+Install with `npm install --global rollup`. Rollup can be used either through a [command line interface](https://github.com/rollup/rollup/wiki/Command-Line-Interface) with an optional configuration file, or else through its [JavaScript API](https://github.com/rollup/rollup/wiki/JavaScript-API). Run `rollup --help` to see the available options and parameters. The [starter project template](https://github.com/rollup/rollup-starter-project) demonstrates common configuration options, and more detailed instructions are available throughout the [user guide](http://rollupjs.org/).
 
 ### Commands
 


### PR DESCRIPTION
It looks like `rollupjs.org/guide/` doesn't exist anymore, fixed this link to point at `rollupjs.org` root.
