### PR TITLE
add options.defineReplacement

### DIFF
--- a/src/finalisers/amd.js
+++ b/src/finalisers/amd.js
@@ -19,7 +19,8 @@ export default function amd ( bundle, magicString, { exportMode, indentString, i
 		( deps.length ? `[${deps.join( ', ' )}], ` : `` );
 
 	const useStrict = options.useStrict !== false ? ` 'use strict';` : ``;
-	const wrapperStart = `define(${params}function (${args.join( ', ' )}) {${useStrict}\n\n`;
+	const define = options.defineReplacement || 'define';
+	const wrapperStart = `${define}(${params}function (${args.join( ', ' )}) {${useStrict}\n\n`;
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
 	const interopBlock = getInteropBlock( bundle, options );

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -15,6 +15,7 @@ const ALLOWED_KEYS = [
 	'banner',
 	'cache',
 	'context',
+	'defineReplacement',
 	'dest',
 	'entry',
 	'exports',

--- a/test/form/define-replacement/_config.js
+++ b/test/form/define-replacement/_config.js
@@ -1,0 +1,9 @@
+var path = require('path');
+
+module.exports = {
+	solo: true,
+	description: 'defineReplacement',
+	options: {
+		defineReplacement: 'enifed'
+	}
+};

--- a/test/form/define-replacement/_expected/amd.js
+++ b/test/form/define-replacement/_expected/amd.js
@@ -1,0 +1,10 @@
+enifed(function () { 'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+});

--- a/test/form/define-replacement/_expected/cjs.js
+++ b/test/form/define-replacement/_expected/cjs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var a = () => {
+    console.log('props');
+};
+
+a();
+a();

--- a/test/form/define-replacement/_expected/es.js
+++ b/test/form/define-replacement/_expected/es.js
@@ -1,0 +1,6 @@
+var a = () => {
+    console.log('props');
+};
+
+a();
+a();

--- a/test/form/define-replacement/_expected/iife.js
+++ b/test/form/define-replacement/_expected/iife.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+}());

--- a/test/form/define-replacement/_expected/umd.js
+++ b/test/form/define-replacement/_expected/umd.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    (factory());
+}(this, (function () { 'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+})));

--- a/test/form/define-replacement/a.js
+++ b/test/form/define-replacement/a.js
@@ -1,0 +1,3 @@
+export var a = () => {
+    console.log('props');
+};

--- a/test/form/define-replacement/main.js
+++ b/test/form/define-replacement/main.js
@@ -1,0 +1,4 @@
+import { a } from "./a.js";
+import { a as b } from "./a.js";
+a();
+b();


### PR DESCRIPTION
In some scenarios it is useful to rename the amd/umd `define` to something else, one such scenario is to provide a non-conflicting build.