### PR TITLE
options.amd

### DIFF
--- a/src/finalisers/amd.js
+++ b/src/finalisers/amd.js
@@ -14,12 +14,14 @@ export default function amd ( bundle, magicString, { exportMode, indentString, i
 		deps.unshift( `'exports'` );
 	}
 
+	const amdOptions = options.amd || {};
+
 	const params =
-		( options.moduleId ? `'${options.moduleId}', ` : `` ) +
+		( amdOptions.id ? `'${amdOptions.id}', ` : `` ) +
 		( deps.length ? `[${deps.join( ', ' )}], ` : `` );
 
 	const useStrict = options.useStrict !== false ? ` 'use strict';` : ``;
-	const define = options.defineReplacement || 'define';
+	const define = amdOptions.define || 'define';
 	const wrapperStart = `${define}(${params}function (${args.join( ', ' )}) {${useStrict}\n\n`;
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;

--- a/src/finalisers/amd.js
+++ b/src/finalisers/amd.js
@@ -19,7 +19,8 @@ export default function amd ( bundle, magicString, { exportMode, indentString, i
 		( deps.length ? `[${deps.join( ', ' )}], ` : `` );
 
 	const useStrict = options.useStrict !== false ? ` 'use strict';` : ``;
-	const wrapperStart = `define(${params}function (${args.join( ', ' )}) {${useStrict}\n\n`;
+	const define = options.defineReplacement || 'define';
+	const wrapperStart = `${define}(${params}function (${args.join( ', ' )}) {${useStrict}\n\n`;
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
 	const interopBlock = getInteropBlock( bundle, options );

--- a/src/finalisers/umd.js
+++ b/src/finalisers/umd.js
@@ -54,9 +54,13 @@ export default function umd ( bundle, magicString, { exportMode, indentString, i
 		args.unshift( 'exports' );
 	}
 
+	const amdOptions = options.amd || {};
+
 	const amdParams =
-		( options.moduleId ? `'${options.moduleId}', ` : `` ) +
+		( amdOptions.id ? `'${amdOptions.id}', ` : `` ) +
 		( amdDeps.length ? `[${amdDeps.join( ', ' )}], ` : `` );
+
+	const define = amdOptions.define || 'define';
 
 	const cjsExport = exportMode === 'default' ? `module.exports = ` : ``;
 	const defaultExport = exportMode === 'default' ? `${setupNamespace(options.moduleName)} = ` : '';
@@ -74,7 +78,7 @@ export default function umd ( bundle, magicString, { exportMode, indentString, i
 	const wrapperIntro =
 		`(function (global, factory) {
 			typeof exports === 'object' && typeof module !== 'undefined' ? ${cjsExport}factory(${cjsDeps.join( ', ' )}) :
-			typeof define === 'function' && define.amd ? define(${amdParams}factory) :
+			typeof ${define} === 'function' && ${define}.amd ? ${define}(${amdParams}factory) :
 			${globalExport};
 		}(this, (function (${args}) {${useStrict}
 

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -61,7 +61,7 @@ function checkOptions ( options ) {
 		if ( options.onwarn ) {
 			options.onwarn( msg );
 		} else {
-			console.warn( msg );
+			console.warn( msg ); // eslint-disable-line no-console
 		}
 	}
 

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -12,10 +12,10 @@ export const VERSION = '<@VERSION@>';
 
 const ALLOWED_KEYS = [
 	'acorn',
+	'amd',
 	'banner',
 	'cache',
 	'context',
-	'defineReplacement',
 	'dest',
 	'entry',
 	'exports',
@@ -28,7 +28,6 @@ const ALLOWED_KEYS = [
 	'intro',
 	'legacy',
 	'moduleContext',
-	'moduleId',
 	'moduleName',
 	'noConflict',
 	'onwarn',
@@ -50,6 +49,20 @@ function checkOptions ( options ) {
 
 	if ( options.transform || options.load || options.resolveId || options.resolveExternal ) {
 		return new Error( 'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://github.com/rollup/rollup/wiki/Plugins for details' );
+	}
+
+	if ( options.moduleId ) {
+		if ( options.amd ) throw new Error( 'Cannot have both options.amd and options.moduleId' );
+
+		options.amd = { id: options.moduleId };
+		delete options.moduleId;
+
+		const msg = `options.moduleId is deprecated in favour of options.amd = { id: moduleId }`;
+		if ( options.onwarn ) {
+			options.onwarn( msg );
+		} else {
+			console.warn( msg );
+		}
 	}
 
 	const err = validateKeys( keys(options), ALLOWED_KEYS );

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -15,6 +15,7 @@ const ALLOWED_KEYS = [
 	'banner',
 	'cache',
 	'context',
+	'defineReplacement',
 	'dest',
 	'entry',
 	'exports',

--- a/test/form/define-replacement/_config.js
+++ b/test/form/define-replacement/_config.js
@@ -1,0 +1,9 @@
+var path = require('path');
+
+module.exports = {
+	solo: true,
+	description: 'defineReplacement',
+	options: {
+		defineReplacement: 'enifed'
+	}
+};

--- a/test/form/define-replacement/_config.js
+++ b/test/form/define-replacement/_config.js
@@ -1,9 +1,8 @@
 var path = require('path');
 
 module.exports = {
-	solo: true,
-	description: 'defineReplacement',
+	description: 'amd.define',
 	options: {
-		defineReplacement: 'enifed'
+		amd: { define: 'enifed' }
 	}
 };

--- a/test/form/define-replacement/_expected/amd.js
+++ b/test/form/define-replacement/_expected/amd.js
@@ -1,0 +1,10 @@
+enifed(function () { 'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+});

--- a/test/form/define-replacement/_expected/cjs.js
+++ b/test/form/define-replacement/_expected/cjs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var a = () => {
+    console.log('props');
+};
+
+a();
+a();

--- a/test/form/define-replacement/_expected/es.js
+++ b/test/form/define-replacement/_expected/es.js
@@ -1,0 +1,6 @@
+var a = () => {
+    console.log('props');
+};
+
+a();
+a();

--- a/test/form/define-replacement/_expected/iife.js
+++ b/test/form/define-replacement/_expected/iife.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+}());

--- a/test/form/define-replacement/_expected/umd.js
+++ b/test/form/define-replacement/_expected/umd.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
-    typeof define === 'function' && define.amd ? define(factory) :
+    typeof enifed === 'function' && enifed.amd ? enifed(factory) :
     (factory());
 }(this, (function () { 'use strict';
 

--- a/test/form/define-replacement/_expected/umd.js
+++ b/test/form/define-replacement/_expected/umd.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    (factory());
+}(this, (function () { 'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+})));

--- a/test/form/define-replacement/a.js
+++ b/test/form/define-replacement/a.js
@@ -1,0 +1,3 @@
+export var a = () => {
+    console.log('props');
+};

--- a/test/form/define-replacement/main.js
+++ b/test/form/define-replacement/main.js
@@ -1,0 +1,4 @@
+import { a } from "./a.js";
+import { a as b } from "./a.js";
+a();
+b();

--- a/test/test.js
+++ b/test/test.js
@@ -132,7 +132,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( () => {
 				throw new Error( 'Missing expected error' );
 			}, err => {
-				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
+				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, amd, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
 			});
 		});
 


### PR DESCRIPTION
Alternative to #1363. I think it probably makes sense to group `moduleId` and `defineReplacement` under a single `amd` option, since it feels a bit neater and is possibly a bit more 'discoverable'.

Also, this ought to apply to UMD output as well as AMD.

@stefanpenner thoughts?