### PR TITLE
fix class removed when `treeshake: false`

### DIFF
--- a/src/ast/nodes/ClassDeclaration.js
+++ b/src/ast/nodes/ClassDeclaration.js
@@ -36,7 +36,7 @@ export default class ClassDeclaration extends Node {
 	}
 
 	render ( code, es ) {
-		if ( this.activated ) {
+		if ( !this.module.bundle.treeshake || this.activated ) {
 			super.render( code, es );
 		} else {
 			code.remove( this.leadingCommentStart || this.start, this.next || this.end );


### PR DESCRIPTION
main.js
```js
import { Foo } from './foo'
console.log(Foo.name)
```

foo.js
```js
export class Foo {
}
```


output
```js
console.log(Foo.name)
```


This bug comes from 173cfc0d

