### PR TITLE
When collecting imported names to deshadow the current ModuleScope, use

### DIFF
--- a/src/ast/scopes/ModuleScope.js
+++ b/src/ast/scopes/ModuleScope.js
@@ -21,7 +21,7 @@ export default class ModuleScope extends Scope {
 			if ( specifier.module.isExternal ) return;
 
 			specifier.module.getExports().forEach( name => {
-				names.add( name );
+				names.add( specifier.module.traceExport(name).name );
 			});
 
 			if ( specifier.name !== '*' ) {

--- a/test/function/already-deshadowed-import/_config.js
+++ b/test/function/already-deshadowed-import/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handle already module import names correctly if they are have already been deshadowed'
+};

--- a/test/function/already-deshadowed-import/alice.js
+++ b/test/function/already-deshadowed-import/alice.js
@@ -1,0 +1,5 @@
+import * as Bob from "./bob";
+export function foo() {
+  return "alice";
+}
+

--- a/test/function/already-deshadowed-import/bob.js
+++ b/test/function/already-deshadowed-import/bob.js
@@ -1,0 +1,4 @@
+import * as Alice from "./alice";
+export function foo() {
+  return "bob";
+}

--- a/test/function/already-deshadowed-import/main.js
+++ b/test/function/already-deshadowed-import/main.js
@@ -1,0 +1,18 @@
+import * as Bob from "./bob";
+import * as Alice from "./alice";
+
+function g() {
+  var foo = Bob.foo();
+  return foo;
+}
+
+function f() {
+  var foo = Alice.foo();
+  return foo;
+}
+
+assert.equal(f(), "alice");
+assert.equal(g(), "bob");
+
+
+


### PR DESCRIPTION
previously deshadowed names if available

Fixes issue in https://github.com/rollup/rollup/issues/1384


<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
