### PR TITLE
Prune unused pure external imports

### DIFF
--- a/src/Declaration.js
+++ b/src/Declaration.js
@@ -105,6 +105,7 @@ export class ExternalDeclaration {
 	}
 
 	activate () {
+		this.module.used = true;
 		this.activated = true;
 	}
 

--- a/src/ExternalModule.js
+++ b/src/ExternalModule.js
@@ -13,6 +13,7 @@ export default class ExternalModule {
 		this.mostCommonSuggestion = 0;
 
 		this.isExternal = true;
+		this.used = false;
 		this.declarations = blank();
 
 		this.exportsNames = false;

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -35,6 +35,7 @@ const ALLOWED_KEYS = [
 	'paths',
 	'plugins',
 	'preferConst',
+	'pureExternalModules',
 	'sourceMap',
 	'sourceMapFile',
 	'targets',

--- a/test/form/prune-pure-unused-import/_config.js
+++ b/test/form/prune-pure-unused-import/_config.js
@@ -1,0 +1,8 @@
+const assert = require( 'assert' );
+
+module.exports = {
+  options: {
+    pureExternalModules: true
+  },
+	description: 'prunes pure unused external imports ([#1352])'
+};

--- a/test/form/prune-pure-unused-import/_expected/amd.js
+++ b/test/form/prune-pure-unused-import/_expected/amd.js
@@ -1,0 +1,5 @@
+define(function () { 'use strict';
+
+
+
+});

--- a/test/form/prune-pure-unused-import/_expected/cjs.js
+++ b/test/form/prune-pure-unused-import/_expected/cjs.js
@@ -1,0 +1,2 @@
+'use strict';
+

--- a/test/form/prune-pure-unused-import/_expected/iife.js
+++ b/test/form/prune-pure-unused-import/_expected/iife.js
@@ -1,0 +1,6 @@
+(function () {
+	'use strict';
+
+
+
+}());

--- a/test/form/prune-pure-unused-import/_expected/umd.js
+++ b/test/form/prune-pure-unused-import/_expected/umd.js
@@ -1,0 +1,9 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+
+
+})));

--- a/test/form/prune-pure-unused-import/main.js
+++ b/test/form/prune-pure-unused-import/main.js
@@ -1,0 +1,5 @@
+import { unused } from 'external';
+
+function alsoUnused () {
+	unused();
+}

--- a/test/test.js
+++ b/test/test.js
@@ -132,7 +132,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( () => {
 				throw new Error( 'Missing expected error' );
 			}, err => {
-				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
+				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleId, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, pureExternalModules, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
 			});
 		});
 


### PR DESCRIPTION
Resolves https://github.com/rollup/rollup/issues/1352

I didn't get a chance to fully get familiarized with the codebase so not sure if this is the best way to implement it, but this seems to work. I'll definitely need to add a few more tests, but figured I'd throw this up in the meantime.

I've made this feature  configurable based on the config I described in  https://github.com/rollup/rollup/issues/1352, reproduce below:

```js
{
  // The default option. Assume all external modules have side effects and don't remove unused imports
  pureExternalImports: false, 

  // Assume all external modules don't have side effects and remove unused imports
  pureExternalImports: true, 

  // Assume all external modules but 'foo' and 'bar' have imports with side effects
  pureExternalImports: {
     pure: ['foo', 'bar'] 
  },

  // Assume all external modules but 'foo' and 'bar' have pure imports
  pureExternalImports: {
     impure: ['foo', 'bar'] 
  },
}
```