### PR TITLE
add test for rxjs wierdness

### DIFF
--- a/test/function/rxjs/Observable.js
+++ b/test/function/rxjs/Observable.js
@@ -1,0 +1,6 @@
+export var Observable = (function() {
+  function Observable() {}
+  return Observable
+}())
+
+export default {Observable}

--- a/test/function/rxjs/_config.js
+++ b/test/function/rxjs/_config.js
@@ -1,0 +1,4 @@
+
+module.exports = {
+  solo: true
+};

--- a/test/function/rxjs/add.js
+++ b/test/function/rxjs/add.js
@@ -1,0 +1,7 @@
+// import * as Observable_1 from './Observable'
+// import * as scan_1 from './scan'
+
+import Observable_1 from  './Observable';
+import scan_1 from './scan';
+
+Observable_1.Observable.prototype.scan = scan_1.scan

--- a/test/function/rxjs/main.js
+++ b/test/function/rxjs/main.js
@@ -1,0 +1,3 @@
+import { Observable } from './Observable';
+import './add';
+assert(Observable.prototype.scan)

--- a/test/function/rxjs/scan.js
+++ b/test/function/rxjs/scan.js
@@ -1,0 +1,2 @@
+export function scan() {}
+export default {scan}


### PR DESCRIPTION
I was able to recreate rollup/rollup-plugin-commonjs#196 without using the plugin, basically the side effect causing code in `add.js` is being tree shaken out if it imports it's dependencies as default exports, if you comment out the 2 imports and uncomment the import * lines it now passes which is, strange behavior