### PR TITLE
allow unknown binary operators

### DIFF
--- a/src/ast/nodes/BinaryExpression.js
+++ b/src/ast/nodes/BinaryExpression.js
@@ -33,6 +33,8 @@ export default class BinaryExpression extends Node {
 		const rightValue = this.right.getValue();
 		if ( rightValue === UNKNOWN ) return UNKNOWN;
 
+		if (!operators[ this.operator ]) return UNKNOWN;
+
 		return operators[ this.operator ]( leftValue, rightValue );
 	}
 }

--- a/test/function/allows-unknown-binary-operators/_config.js
+++ b/test/function/allows-unknown-binary-operators/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'allows unknown binary operators'
+};

--- a/test/function/allows-unknown-binary-operators/main.js
+++ b/test/function/allows-unknown-binary-operators/main.js
@@ -1,0 +1,3 @@
+export default {
+  minInt24x: - (2 ** 23)
+};


### PR DESCRIPTION
 - fix issue #1416
 - the issue exposes rollup's assumption that it knows
   about all binary operators which is untrue for future
   ES versions.  The fix is to return UNKNOWN when
   the operator is not in the hardcoded hash.
 - the test must have the subtraction symbol before the
   exponent operator in order for the
   <Binary Operator>.getValue code to run

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
