### PR TITLE
add a watch option

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -39,7 +39,8 @@ const ALLOWED_KEYS = [
 	'sourceMapFile',
 	'targets',
 	'treeshake',
-	'useStrict'
+	'useStrict',
+	'watch'
 ];
 
 function checkOptions ( options ) {

--- a/test/function/watch-option/_config.js
+++ b/test/function/watch-option/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'expects watch option',
+	options: {
+		watch: {}
+	}
+};

--- a/test/function/watch-option/main.js
+++ b/test/function/watch-option/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);

--- a/test/test.js
+++ b/test/test.js
@@ -132,7 +132,7 @@ describe( 'rollup', function () {
 			return rollup.rollup({ entry: 'x', plUgins: [] }).then( () => {
 				throw new Error( 'Missing expected error' );
 			}, err => {
-				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, amd, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict' );
+				assert.equal( err.message, 'Unexpected key \'plUgins\' found, expected one of: acorn, amd, banner, cache, context, dest, entry, exports, external, footer, format, globals, indent, interop, intro, legacy, moduleContext, moduleName, noConflict, onwarn, outro, paths, plugins, preferConst, sourceMap, sourceMapFile, targets, treeshake, useStrict, watch' );
 			});
 		});
 


### PR DESCRIPTION
This adds `watch` to the list of expected options. We need this so that we can pass through options to `rollup-watch`, such as `useChokidar` (without which we can't even test whether chokidar is working — it currently isn't, which will be fixed soon), and potentially other things we might add in future