### PR TITLE
`pureExternalImports` -> `pureExternalModules` in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Allow config files to import JSON ([#1426](https://github.com/rollup/rollup/issues/1426))
 * Allow undefined imports in interop block ([#1341](https://github.com/rollup/rollup/issues/1341))
 * Add `process.env.ROLLUP_WATCH = 'true'` in watch mode ([#1429](https://github.com/rollup/rollup/issues/1429))
-* Add `pureExternalImports` option ([#1352](https://github.com/rollup/rollup/issues/1352))
+* Add `pureExternalModules` option ([#1352](https://github.com/rollup/rollup/issues/1352))
 * Allow plugins to specify `options.entry` ([#1270](https://github.com/rollup/rollup/issues/1270))
 * Update dependencies
 


### PR DESCRIPTION
Looks like the option is actually named `pureExternalModules`

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
