### PR TITLE
better error logging information

### DIFF
--- a/bin/src/logging.js
+++ b/bin/src/logging.js
@@ -9,16 +9,19 @@ const errorSymbol = process.stderr.isTTY ? `🚨   ` : `Error: `;
 export const stderr = console.error.bind( console ); // eslint-disable-line no-console
 
 function log ( object, symbol ) {
-	const message = (object.plugin ? `(${object.plugin} plugin) ${object.message}` : object.message) || object;
+	let description = object.message || object;
+	if (object.name) description = object.name + ': ' + description;
+	const message = (object.plugin ? `(${object.plugin} plugin) ${description}` : description) || object;;
 
 	stderr( `${symbol}${chalk.bold( message )}` );
 
+  // TODO should this be "object.url || (object.file && object.loc.file) || object.id"?
 	if ( object.url ) {
 		stderr( chalk.cyan( object.url ) );
 	}
 
 	if ( object.loc ) {
-		stderr( `${relativeId( object.loc.file )} (${object.loc.line}:${object.loc.column})` );
+		stderr( `${relativeId( object.loc.file || object.id )} (${object.loc.line}:${object.loc.column})` );
 	} else if ( object.id ) {
 		stderr( relativeId( object.id ) );
 	}

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -1,5 +1,12 @@
 export default function error ( props ) {
-	const err = new Error( props.message );
+	// use the same constructor as props (if it's an error object)
+	// so that err.name is preserved etc
+	// (Object.keys below does not update these values because they
+	// are properties on the prototype chain)
+	// basically if props is a SyntaxError it will not be overriden as a generic Error
+	let constructor = Error;
+	if (props instanceof Error) constructor = props.constructor;
+	const err = new constructor( props.message );
 
 	Object.keys( props ).forEach( key => {
 		err[ key ] = props[ key ];


### PR DESCRIPTION
issue ref: #1433

Improved the error logging a little bit so that you can see where an error is located.

old (rollup v0.43.0)
```
$ rollup -c -f iife -i src/app.js -o bundle.js
🚨   (buble plugin) Unexpected token (1:24)
undefined (1:24)
```

new (needs to be `npm version patch`ed if merged)
```
$ /Users/mollie/temp/rollup/bin/rollup -c -f iife -i src/app.js -o bundle.js
🚨   (buble plugin) SyntaxError: Unexpected token (1:24)
src/subdir/mod.js (1:24)
````