### PR TITLE
Run same options transform on generate for bundle

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -44,15 +44,7 @@ const ALLOWED_KEYS = [
 	'watch'
 ];
 
-function checkOptions ( options ) {
-	if ( !options ) {
-		throw new Error( 'You must supply an options object to rollup' );
-	}
-
-	if ( options.transform || options.load || options.resolveId || options.resolveExternal ) {
-		throw new Error( 'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://github.com/rollup/rollup/wiki/Plugins for details' );
-	}
-
+function checkAmd ( options ) {
 	if ( options.moduleId ) {
 		if ( options.amd ) throw new Error( 'Cannot have both options.amd and options.moduleId' );
 
@@ -66,6 +58,18 @@ function checkOptions ( options ) {
 			console.warn( msg ); // eslint-disable-line no-console
 		}
 	}
+}
+
+function checkOptions ( options ) {
+	if ( !options ) {
+		throw new Error( 'You must supply an options object to rollup' );
+	}
+
+	if ( options.transform || options.load || options.resolveId || options.resolveExternal ) {
+		throw new Error( 'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://github.com/rollup/rollup/wiki/Plugins for details' );
+	}
+
+	checkAmd (options);
 
 	const err = validateKeys( keys(options), ALLOWED_KEYS );
 	if ( err ) throw err;
@@ -91,6 +95,8 @@ export function rollup ( options ) {
 
 					options.format = 'es';
 				}
+
+				checkAmd( options );
 
 				timeStart( '--GENERATE--' );
 


### PR DESCRIPTION
Some recent changes introduced in `0.43.0` breaks the amd named module generation.

The checkOptions function is applied only on the main entry point (rollup), but not in the generate() function.

Basically when passing this options:
```js
// Passing a set of options
rollup({ entry, plugins, ..otherOptions }).then(() => {
    ... 
   // Passing another set of options
    bundle.generate({ format: 'amd', moduleId: 'something' });
    ...
```
The output does respect the `moduleId` option, nor does it error out.

This change addresses this inconsistency, and it will give the same warning.

We tried to add a tests but the tests makes the assumption that both entry points rollup and bundle will receive the same options object, which is not necessarily imposed in the API.

//cc @pmdartus who coPR this.