### PR TITLE
update uglify-js to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {
@@ -53,12 +53,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true
     },
     "amdefine": {
@@ -267,12 +261,6 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
-    "camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-      "dev": true
-    },
     "camelcase-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
@@ -291,12 +279,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
       "integrity": "sha1-gWfBq4OX+1u5X5bSjlqBxQ8kesQ=",
-      "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true
     },
     "chalk": {
@@ -322,20 +304,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
       "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
-      }
     },
     "clone": {
       "version": "1.0.2",
@@ -1299,12 +1267,6 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1461,12 +1423,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loud-rejection": {
@@ -1974,12 +1930,6 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
-    },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
@@ -2332,17 +2282,10 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.27",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
-      "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.19.tgz",
+      "integrity": "sha512-/MRnHKKJemMVs4iKmiUZY8S0knDRFOJI9Ein/rdn0w9hrK8ELdj+6bjWmHeBjSDPGUWxi/4960A+GAWZbzHvDA==",
       "dev": true
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
     },
     "urlgrey": {
       "version": "0.4.0",
@@ -2386,12 +2329,6 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true
-    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -2414,12 +2351,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "sander": "^0.6.0",
     "source-map": "^0.5.6",
     "sourcemap-codec": "^1.3.0",
-    "uglify-js": "^2.6.2"
+    "uglify-js": "^3.0.19"
   },
   "dependencies": {
     "source-map-support": "^0.4.0"

--- a/test/sourcemaps/names-transformed/_config.js
+++ b/test/sourcemaps/names-transformed/_config.js
@@ -25,8 +25,9 @@ module.exports = {
 				},
 				transformBundle: function ( code ) {
 					return uglify.minify( code, {
-						fromString: true,
-						outSourceMap: 'x'
+						sourceMap: {
+						    filename: 'x'
+						}
 					});
 				}
 			}

--- a/test/sourcemaps/transform-bundle/_config.js
+++ b/test/sourcemaps/transform-bundle/_config.js
@@ -10,8 +10,9 @@ module.exports = {
 			{
 				transformBundle: function ( code ) {
 					var options = {
-						fromString: true,
-						outSourceMap: 'x' // trigger sourcemap generation
+						sourceMap: {
+						    filename: 'x' // trigger sourcemap generation
+						}
 					};
 
 					return uglify.minify( code, options );


### PR DESCRIPTION
This PR updates Uglify-JS from v2 to v3, while also adjusting the code to conform the new API.
Uglify-JS is only used for internal testing, namely in two `_config.js` files.
All tests work after updating; `npm run lint` runs with success.