### PR TITLE
Fix closure memory leak in Bundle constructor

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -70,10 +70,11 @@ export default class Bundle {
 		this.hasLoaders = loaders.length !== 0;
 		this.load = first( loaders.concat( load ) );
 
-		this.getPath = typeof options.paths === 'function' ?
-			( id => options.paths( id ) || this.getPathRelativeToEntryDirname( id ) ) :
-			options.paths ?
-				( id => options.paths.hasOwnProperty( id ) ? options.paths[ id ] : this.getPathRelativeToEntryDirname( id ) ) :
+		const optionsPaths = options.paths;
+		this.getPath = typeof optionsPaths === 'function' ?
+			( id => optionsPaths( id ) || this.getPathRelativeToEntryDirname( id ) ) :
+			optionsPaths ?
+				( id => optionsPaths.hasOwnProperty( id ) ? optionsPaths[ id ] : this.getPathRelativeToEntryDirname( id ) ) :
 				id => this.getPathRelativeToEntryDirname( id );
 
 		this.scope = new BundleScope();
@@ -88,12 +89,13 @@ export default class Bundle {
 
 		this.context = String( options.context );
 
-		if ( typeof options.moduleContext === 'function' ) {
-			this.getModuleContext = id => options.moduleContext( id ) || this.context;
-		} else if ( typeof options.moduleContext === 'object' ) {
+		const optionsModuleContext = options.moduleContext;
+		if ( typeof optionsModuleContext === 'function' ) {
+			this.getModuleContext = id => optionsModuleContext( id ) || this.context;
+		} else if ( typeof optionsModuleContext === 'object' ) {
 			const moduleContext = new Map();
-			Object.keys( options.moduleContext ).forEach( key => {
-				moduleContext.set( resolve( key ), options.moduleContext[ key ] );
+			Object.keys( optionsModuleContext ).forEach( key => {
+				moduleContext.set( resolve( key ), optionsModuleContext[ key ] );
 			});
 			this.getModuleContext = id => moduleContext.get( id ) || this.context;
 		} else {


### PR DESCRIPTION
Should fix https://github.com/rollup/rollup/issues/883

"options" argument is captured by closures in Bundle constructor, so passing "cache" leads to chain of bundles in memory. 

Similar bug is described here: https://blog.meteor.com/an-interesting-kind-of-javascript-memory-leak-8b47d2e7f156

I've created gist with test script, but don't known how to properly integrate it here.
https://gist.github.com/dmitrage/fff3d30280688356194c137323ea4e02
