### PR TITLE
Support for async transformBundle

### DIFF
--- a/bin/src/runRollup.js
+++ b/bin/src/runRollup.js
@@ -73,10 +73,11 @@ export default function runRollup ( command ) {
 			onwarn: handleWarning
 		})
 			.then( bundle => {
-				const { code } = bundle.generate({
+				return bundle.generate({
 					format: 'cjs'
 				});
-
+			})
+			.then( ({ code }) => {
 				if ( command.watch ) process.env.ROLLUP_WATCH = 'true';
 
 				// temporarily override require
@@ -270,13 +271,13 @@ function bundle ( options ) {
 				});
 			}
 
-			let { code, map } = bundle.generate( options );
+			return bundle.generate(options).then( ({ code, map }) => {
+				if ( options.sourceMap === 'inline' ) {
+					code += `\n//# ${SOURCEMAPPING_URL}=${map.toUrl()}\n`;
+				}
 
-			if ( options.sourceMap === 'inline' ) {
-				code += `\n//# ${SOURCEMAPPING_URL}=${map.toUrl()}\n`;
-			}
-
-			process.stdout.write( code );
+				process.stdout.write( code );
+			});
 		})
 		.catch( handleError );
 }

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -437,119 +437,121 @@ export default class Bundle {
 	}
 
 	render ( options = {} ) {
-		if ( options.format === 'es6' ) {
-			this.warn({
-				code: 'DEPRECATED_ES6',
-				message: 'The es6 format is deprecated – use `es` instead'
-			});
+		return Promise.resolve().then( () => {
+			if ( options.format === 'es6' ) {
+				this.warn({
+					code: 'DEPRECATED_ES6',
+					message: 'The es6 format is deprecated – use `es` instead'
+				});
 
-			options.format = 'es';
-		}
-
-		// Determine export mode - 'default', 'named', 'none'
-		const exportMode = getExportMode( this, options );
-
-		let magicString = new MagicStringBundle({ separator: '\n\n' });
-		const usedModules = [];
-
-		timeStart( 'render modules' );
-
-		this.orderedModules.forEach( module => {
-			const source = module.render( options.format === 'es', this.legacy );
-
-			if ( source.toString().length ) {
-				magicString.addSource( source );
-				usedModules.push( module );
+				options.format = 'es';
 			}
-		});
 
-		if ( !magicString.toString().trim() && this.entryModule.getExports().length === 0 ) {
-			this.warn({
-				code: 'EMPTY_BUNDLE',
-				message: 'Generated an empty bundle'
-			});
-		}
+			// Determine export mode - 'default', 'named', 'none'
+			const exportMode = getExportMode( this, options );
 
-		timeEnd( 'render modules' );
+			let magicString = new MagicStringBundle({ separator: '\n\n' });
+			const usedModules = [];
 
-		let intro = [ options.intro ]
-			.concat(
-				this.plugins.map( plugin => plugin.intro && plugin.intro() )
-			)
-			.filter( Boolean )
-			.join( '\n\n' );
+			timeStart( 'render modules' );
 
-		if ( intro ) intro += '\n\n';
+			this.orderedModules.forEach( module => {
+				const source = module.render( options.format === 'es', this.legacy );
 
-		let outro = [ options.outro ]
-			.concat(
-				this.plugins.map( plugin => plugin.outro && plugin.outro() )
-			)
-			.filter( Boolean )
-			.join( '\n\n' );
-
-		if ( outro ) outro = `\n\n${outro}`;
-
-		const indentString = getIndentString( magicString, options );
-
-		const finalise = finalisers[ options.format ];
-		if ( !finalise ) {
-			error({
-				code: 'INVALID_OPTION',
-				message: `You must specify an output type - valid options are ${keys( finalisers ).join( ', ' )}`
-			});
-		}
-
-		timeStart( 'render format' );
-
-		magicString = finalise( this, magicString.trim(), { exportMode, indentString, intro, outro }, options );
-
-		timeEnd( 'render format' );
-
-		const banner = [ options.banner ]
-			.concat( this.plugins.map( plugin => plugin.banner ) )
-			.map( callIfFunction )
-			.filter( Boolean )
-			.join( '\n' );
-
-		const footer = [ options.footer ]
-			.concat( this.plugins.map( plugin => plugin.footer ) )
-			.map( callIfFunction )
-			.filter( Boolean )
-			.join( '\n' );
-
-		if ( banner ) magicString.prepend( banner + '\n' );
-		if ( footer ) magicString.append( '\n' + footer );
-
-		let code = magicString.toString();
-		let map = null;
-		const bundleSourcemapChain = [];
-
-		code = transformBundle( code, this.plugins, bundleSourcemapChain, options );
-
-		if ( options.sourceMap ) {
-			timeStart( 'sourceMap' );
-
-			let file = options.sourceMapFile || options.dest;
-			if ( file ) file = resolve( typeof process !== 'undefined' ? process.cwd() : '', file );
-
-			if ( this.hasLoaders || find( this.plugins, plugin => plugin.transform || plugin.transformBundle ) ) {
-				map = magicString.generateMap({});
-				if ( typeof map.mappings === 'string' ) {
-					map.mappings = decode( map.mappings );
+				if ( source.toString().length ) {
+					magicString.addSource( source );
+					usedModules.push( module );
 				}
-				map = collapseSourcemaps( this, file, map, usedModules, bundleSourcemapChain );
-			} else {
-				map = magicString.generateMap({ file, includeContent: true });
+			});
+
+			if ( !magicString.toString().trim() && this.entryModule.getExports().length === 0 ) {
+				this.warn({
+					code: 'EMPTY_BUNDLE',
+					message: 'Generated an empty bundle'
+				});
 			}
 
-			map.sources = map.sources.map( normalize );
+			timeEnd( 'render modules' );
 
-			timeEnd( 'sourceMap' );
-		}
+			let intro = [ options.intro ]
+				.concat(
+					this.plugins.map( plugin => plugin.intro && plugin.intro() )
+				)
+				.filter( Boolean )
+				.join( '\n\n' );
 
-		if ( code[ code.length - 1 ] !== '\n' ) code += '\n';
-		return { code, map };
+			if ( intro ) intro += '\n\n';
+
+			let outro = [ options.outro ]
+				.concat(
+					this.plugins.map( plugin => plugin.outro && plugin.outro() )
+				)
+				.filter( Boolean )
+				.join( '\n\n' );
+
+			if ( outro ) outro = `\n\n${outro}`;
+
+			const indentString = getIndentString( magicString, options );
+
+			const finalise = finalisers[ options.format ];
+			if ( !finalise ) {
+				error({
+					code: 'INVALID_OPTION',
+					message: `You must specify an output type - valid options are ${keys( finalisers ).join( ', ' )}`
+				});
+			}
+
+			timeStart( 'render format' );
+
+			magicString = finalise( this, magicString.trim(), { exportMode, indentString, intro, outro }, options );
+
+			timeEnd( 'render format' );
+
+			const banner = [ options.banner ]
+				.concat( this.plugins.map( plugin => plugin.banner ) )
+				.map( callIfFunction )
+				.filter( Boolean )
+				.join( '\n' );
+
+			const footer = [ options.footer ]
+				.concat( this.plugins.map( plugin => plugin.footer ) )
+				.map( callIfFunction )
+				.filter( Boolean )
+				.join( '\n' );
+
+			if ( banner ) magicString.prepend( banner + '\n' );
+			if ( footer ) magicString.append( '\n' + footer );
+
+			const prevCode = magicString.toString();
+			let map = null;
+			const bundleSourcemapChain = [];
+
+			return transformBundle( prevCode, this.plugins, bundleSourcemapChain, options ).then( code => {
+				if ( options.sourceMap ) {
+					timeStart( 'sourceMap' );
+
+					let file = options.sourceMapFile || options.dest;
+					if ( file ) file = resolve( typeof process !== 'undefined' ? process.cwd() : '', file );
+
+					if ( this.hasLoaders || find( this.plugins, plugin => plugin.transform || plugin.transformBundle ) ) {
+						map = magicString.generateMap({});
+						if ( typeof map.mappings === 'string' ) {
+							map.mappings = decode( map.mappings );
+						}
+						map = collapseSourcemaps( this, file, map, usedModules, bundleSourcemapChain );
+					} else {
+						map = magicString.generateMap({ file, includeContent: true });
+					}
+
+					map.sources = map.sources.map( normalize );
+
+					timeEnd( 'sourceMap' );
+				}
+
+				if ( code[ code.length - 1 ] !== '\n' ) code += '\n';
+				return { code, map };
+			});
+		});
 	}
 
 	sort () {

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -94,7 +94,7 @@ export function rollup ( options ) {
 
 				timeStart( '--GENERATE--' );
 
-				return Promise.resolve().then(() => {
+				return Promise.resolve().then( () => {
 					return bundle.render( options );
 				}).then( rendered => {
 					timeEnd( '--GENERATE--' );

--- a/src/rollup.js
+++ b/src/rollup.js
@@ -94,21 +94,23 @@ export function rollup ( options ) {
 
 				timeStart( '--GENERATE--' );
 
-				const rendered = bundle.render( options );
+				return Promise.resolve().then(() => {
+					return bundle.render( options );
+				}).then( rendered => {
+					timeEnd( '--GENERATE--' );
 
-				timeEnd( '--GENERATE--' );
+					bundle.plugins.forEach( plugin => {
+						if ( plugin.ongenerate ) {
+							plugin.ongenerate( assign({
+								bundle: result
+							}, options ), rendered);
+						}
+					});
 
-				bundle.plugins.forEach( plugin => {
-					if ( plugin.ongenerate ) {
-						plugin.ongenerate( assign({
-							bundle: result
-						}, options ), rendered);
-					}
+					flushTime();
+
+					return rendered;
 				});
-
-				flushTime();
-
-				return rendered;
 			}
 
 			const result = {
@@ -126,30 +128,31 @@ export function rollup ( options ) {
 					}
 
 					const dest = options.dest;
-					const output = generate( options );
-					let { code, map } = output;
+					return generate( options ).then( output => {
+						let { code, map } = output;
 
-					const promises = [];
+						const promises = [];
 
-					if ( options.sourceMap ) {
-						let url;
+						if ( options.sourceMap ) {
+							let url;
 
-						if ( options.sourceMap === 'inline' ) {
-							url = map.toUrl();
-						} else {
-							url = `${basename( dest )}.map`;
-							promises.push( writeFile( dest + '.map', map.toString() ) );
+							if ( options.sourceMap === 'inline' ) {
+								url = map.toUrl();
+							} else {
+								url = `${basename( dest )}.map`;
+								promises.push( writeFile( dest + '.map', map.toString() ) );
+							}
+
+							code += `//# ${SOURCEMAPPING_URL}=${url}\n`;
 						}
 
-						code += `//# ${SOURCEMAPPING_URL}=${url}\n`;
-					}
-
-					promises.push( writeFile( dest, code ) );
-					return Promise.all( promises ).then( () => {
-						return mapSequence( bundle.plugins.filter( plugin => plugin.onwrite ), plugin => {
-							return Promise.resolve( plugin.onwrite( assign({
-								bundle: result
-							}, options ), output));
+						promises.push( writeFile( dest, code ) );
+						return Promise.all( promises ).then( () => {
+							return mapSequence( bundle.plugins.filter( plugin => plugin.onwrite ), plugin => {
+								return Promise.resolve( plugin.onwrite( assign({
+									bundle: result
+								}, options ), output));
+							});
 						});
 					});
 				}

--- a/src/utils/transformBundle.js
+++ b/src/utils/transformBundle.js
@@ -2,37 +2,38 @@ import { decode } from 'sourcemap-codec';
 import error from './error.js';
 
 export default function transformBundle ( code, plugins, sourceMapChain, options ) {
-	return plugins.reduce( ( code, plugin ) => {
-		if ( !plugin.transformBundle ) return code;
+	return plugins.reduce( ( promise, plugin ) => {
+		if ( !plugin.transformBundle ) return promise;
 
-		let result;
+		return promise.then( code => {
+			return Promise.resolve().then( () => {
+				return plugin.transformBundle( code, { format : options.format } );
+			}).then( result => {
+				if ( result == null ) return code;
 
-		try {
-			result = plugin.transformBundle( code, { format : options.format } );
-		} catch ( err ) {
-			error({
-				code: 'BAD_BUNDLE_TRANSFORMER',
-				message: `Error transforming bundle${plugin.name ? ` with '${plugin.name}' plugin` : ''}: ${err.message}`,
-				plugin: plugin.name
+				if ( typeof result === 'string' ) {
+					result = {
+						code: result,
+						map: null
+					};
+				}
+
+				const map = typeof result.map === 'string' ? JSON.parse( result.map ) : result.map;
+				if ( map && typeof map.mappings === 'string' ) {
+					map.mappings = decode( map.mappings );
+				}
+
+				sourceMapChain.push( map );
+
+				return result.code;
+			}).catch( err => {
+				error({
+					code: 'BAD_BUNDLE_TRANSFORMER',
+					message: `Error transforming bundle${plugin.name ? ` with '${plugin.name}' plugin` : ''}: ${err.message}`,
+					plugin: plugin.name
+				});
 			});
-		}
+		});
 
-		if ( result == null ) return code;
-
-		if ( typeof result === 'string' ) {
-			result = {
-				code: result,
-				map: null
-			};
-		}
-
-		const map = typeof result.map === 'string' ? JSON.parse( result.map ) : result.map;
-		if ( map && typeof map.mappings === 'string' ) {
-			map.mappings = decode( map.mappings );
-		}
-
-		sourceMapChain.push( map );
-
-		return result.code;
-	}, code );
+	}, Promise.resolve( code ) );
 }

--- a/test/function/bundle-transformer-async/_config.js
+++ b/test/function/bundle-transformer-async/_config.js
@@ -1,0 +1,22 @@
+module.exports = {
+	description: 'bundle transformers can be asynchronous',
+	options: {
+		plugins: [
+			{
+				transformBundle: function ( code ) {
+					return Promise.resolve( code.replace( 'x', 1 ) );
+				}
+			},
+			{
+				transformBundle: function ( code ) {
+					return code.replace( '1', 2 );
+				}
+			},
+			{
+				transformBundle: function ( code ) {
+					return Promise.resolve( code.replace( '2', 3 ) );
+				}
+			}
+		]
+	}
+};

--- a/test/function/bundle-transformer-async/main.js
+++ b/test/function/bundle-transformer-async/main.js
@@ -1,0 +1,1 @@
+assert.equal( x, 3 );

--- a/test/test.js
+++ b/test/test.js
@@ -897,7 +897,7 @@ describe( 'rollup', function () {
 					format: 'iife',
 					moduleName: 'myBundle'
 				}))
-				.then(() => {
+				.then( () => {
 					const relevantWarnings = warnings.filter( warning => warning.code === 'MISSING_NODE_BUILTINS' );
 					assert.equal( relevantWarnings.length, 1 );
 					assert.equal( relevantWarnings[0].message, `Creating a browser bundle that depends on Node.js built-in module ('util'). You might need to include https://www.npmjs.com/package/rollup-plugin-node-builtins` );


### PR DESCRIPTION
Attempt at solving the https://github.com/rollup/rollup/issues/1474 issue.

A real-life scenario where this could be useful is if you need to build the same code (same entry) with different parameters and minify the resulting bundles with Google Closure Compiler.

Because Google Closure Compiler is a java program, it needs to be started via a `spawn` call. At the moment, rollup only allows for synchronous `transformBundle` methods with means that we need to use the sync version of `spawn`: `spawnSync`.

This change essentially wraps the `transformBundle` calls into promises, and propagate the behaviour all the way up to the `generate` function. As a result, this means changing the signature of `generate` to return a promise, making this feature a **breaking change**.

I guess the code could be written to be backward compatible but that would mean:

- promise duck-typing the return value of `transformBundle()`.
- making the code more complex with extra branches.
- confusing the user with two possible return types.