### PR TITLE
Error occurs when using webpack loader query string as import in rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rollup",
+  "name": "@twc/rollup",
   "version": "0.45.0",
   "description": "Next-generation ES6 module bundler",
   "main": "dist/rollup.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@twc/rollup",
+  "name": "rollup",
   "version": "0.45.0",
   "description": "Next-generation ES6 module bundler",
   "main": "dist/rollup.js",

--- a/src/finalisers/shared/getInteropBlock.js
+++ b/src/finalisers/shared/getInteropBlock.js
@@ -11,7 +11,7 @@ export default function getInteropBlock ( bundle, options ) {
 				return `${bundle.varOrConst} ${module.name}__default = 'default' in ${module.name} ? ${module.name}['default'] : ${module.name};`;
 			}
 
-			return `${module.name} = ${module.name} && 'default' in ${module.name} ? ${module.name}['default'] : ${module.name};`;
+			return `${module.name} = ${module.name} && ${module.name}.hasOwnProperty('default') ? ${module.name}['default'] : ${module.name};`;
 		})
 		.filter( Boolean )
 		.join( '\n' );

--- a/test/form/export-default-import/_expected/amd.js
+++ b/test/form/export-default-import/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['exports', 'x'], function (exports, x) { 'use strict';
 
-	x = x && 'default' in x ? x['default'] : x;
+	x = x && x.hasOwnProperty('default') ? x['default'] : x;
 
 
 

--- a/test/form/export-default-import/_expected/iife.js
+++ b/test/form/export-default-import/_expected/iife.js
@@ -1,7 +1,7 @@
 var myBundle = (function (exports,x) {
 	'use strict';
 
-	x = x && 'default' in x ? x['default'] : x;
+	x = x && x.hasOwnProperty('default') ? x['default'] : x;
 
 
 

--- a/test/form/export-default-import/_expected/umd.js
+++ b/test/form/export-default-import/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory((global.myBundle = {}),global.x));
 }(this, (function (exports,x) { 'use strict';
 
-	x = x && 'default' in x ? x['default'] : x;
+	x = x && x.hasOwnProperty('default') ? x['default'] : x;
 
 
 

--- a/test/form/external-imports-custom-names/_expected/amd.js
+++ b/test/form/external-imports-custom-names/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['jquery'], function ($) { 'use strict';
 
-	$ = $ && 'default' in $ ? $['default'] : $;
+	$ = $ && $.hasOwnProperty('default') ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/external-imports-custom-names/_expected/iife.js
+++ b/test/form/external-imports-custom-names/_expected/iife.js
@@ -1,7 +1,7 @@
 (function ($) {
 	'use strict';
 
-	$ = $ && 'default' in $ ? $['default'] : $;
+	$ = $ && $.hasOwnProperty('default') ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/external-imports-custom-names/_expected/umd.js
+++ b/test/form/external-imports-custom-names/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.jQuery));
 }(this, (function ($) { 'use strict';
 
-	$ = $ && 'default' in $ ? $['default'] : $;
+	$ = $ && $.hasOwnProperty('default') ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/external-imports/_expected/amd.js
+++ b/test/form/external-imports/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['factory', 'baz', 'shipping-port', 'alphabet'], function (factory, baz, containers, alphabet) { 'use strict';
 
-	factory = factory && 'default' in factory ? factory['default'] : factory;
+	factory = factory && factory.hasOwnProperty('default') ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/external-imports/_expected/iife.js
+++ b/test/form/external-imports/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (factory,baz,containers,alphabet) {
 	'use strict';
 
-	factory = factory && 'default' in factory ? factory['default'] : factory;
+	factory = factory && factory.hasOwnProperty('default') ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/external-imports/_expected/umd.js
+++ b/test/form/external-imports/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.factory,global.baz,global.containers,global.alphabet));
 }(this, (function (factory,baz,containers,alphabet) { 'use strict';
 
-	factory = factory && 'default' in factory ? factory['default'] : factory;
+	factory = factory && factory.hasOwnProperty('default') ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/paths-function/_expected/amd.js
+++ b/test/form/paths-function/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['https://unpkg.com/foo'], function (foo) { 'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-function/_expected/iife.js
+++ b/test/form/paths-function/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-function/_expected/umd.js
+++ b/test/form/paths-function/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-relative/_expected/amd.js
+++ b/test/form/paths-relative/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['../foo'], function (foo) { 'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-relative/_expected/iife.js
+++ b/test/form/paths-relative/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths-relative/_expected/umd.js
+++ b/test/form/paths-relative/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths/_expected/amd.js
+++ b/test/form/paths/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['https://unpkg.com/foo'], function (foo) { 'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths/_expected/iife.js
+++ b/test/form/paths/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/paths/_expected/umd.js
+++ b/test/form/paths/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = foo && 'default' in foo ? foo['default'] : foo;
+	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/relative-external-with-global/_expected/amd.js
+++ b/test/form/relative-external-with-global/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['./lib/throttle.js'], function (throttle) { 'use strict';
 
-	throttle = throttle && 'default' in throttle ? throttle['default'] : throttle;
+	throttle = throttle && throttle.hasOwnProperty('default') ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );

--- a/test/form/relative-external-with-global/_expected/iife.js
+++ b/test/form/relative-external-with-global/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (throttle) {
 	'use strict';
 
-	throttle = throttle && 'default' in throttle ? throttle['default'] : throttle;
+	throttle = throttle && throttle.hasOwnProperty('default') ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );

--- a/test/form/relative-external-with-global/_expected/umd.js
+++ b/test/form/relative-external-with-global/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.Lib.throttle));
 }(this, (function (throttle) { 'use strict';
 
-	throttle = throttle && 'default' in throttle ? throttle['default'] : throttle;
+	throttle = throttle && throttle.hasOwnProperty('default') ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );


### PR DESCRIPTION
Addresses #1486 

Fixes the issue with TypeError that occurs when using `'default' in string`
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
