### PR TITLE
Correctly handle variables introduced in switch scopes

### DIFF
--- a/src/ast/nodes/SwitchStatement.js
+++ b/src/ast/nodes/SwitchStatement.js
@@ -1,0 +1,14 @@
+import Scope from '../scopes/Scope.js';
+import Statement from './shared/Statement.js';
+
+export default class SwitchStatement extends Statement {
+	initialise ( scope ) {
+		this.scope = new Scope( {
+			parent: scope,
+			isBlockScope: true,
+			isLexicalBoundary: false
+		} );
+
+		super.initialise( this.scope );
+	}
+}

--- a/src/ast/nodes/index.js
+++ b/src/ast/nodes/index.js
@@ -28,6 +28,7 @@ import NewExpression from './NewExpression.js';
 import ObjectExpression from './ObjectExpression.js';
 import ReturnStatement from './ReturnStatement.js';
 import Statement from './shared/Statement.js';
+import SwitchStatement from './SwitchStatement.js';
 import TemplateLiteral from './TemplateLiteral.js';
 import ThisExpression from './ThisExpression.js';
 import ThrowStatement from './ThrowStatement.js';
@@ -67,7 +68,7 @@ export default {
 	NewExpression,
 	ObjectExpression,
 	ReturnStatement,
-	SwitchStatement: Statement,
+	SwitchStatement,
 	TemplateLiteral,
 	ThisExpression,
 	ThrowStatement,

--- a/test/form/switch-scopes/_config.js
+++ b/test/form/switch-scopes/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'correctly handles switch scopes',
+  options: {
+    moduleName: 'myBundle'
+  }
+};

--- a/test/form/switch-scopes/_expected/amd.js
+++ b/test/form/switch-scopes/_expected/amd.js
@@ -1,0 +1,13 @@
+define(function () { 'use strict';
+
+	const x = globalFunction;
+	switch ( anotherGlobal ) {
+		case 2:
+			x();
+	}
+
+	switch ( globalFunction() ) {
+		case 4:
+	}
+
+});

--- a/test/form/switch-scopes/_expected/cjs.js
+++ b/test/form/switch-scopes/_expected/cjs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const x = globalFunction;
+switch ( anotherGlobal ) {
+	case 2:
+		x();
+}
+
+switch ( globalFunction() ) {
+	case 4:
+}

--- a/test/form/switch-scopes/_expected/es.js
+++ b/test/form/switch-scopes/_expected/es.js
@@ -1,0 +1,9 @@
+const x = globalFunction;
+switch ( anotherGlobal ) {
+	case 2:
+		x();
+}
+
+switch ( globalFunction() ) {
+	case 4:
+}

--- a/test/form/switch-scopes/_expected/iife.js
+++ b/test/form/switch-scopes/_expected/iife.js
@@ -1,0 +1,14 @@
+(function () {
+	'use strict';
+
+	const x = globalFunction;
+	switch ( anotherGlobal ) {
+		case 2:
+			x();
+	}
+
+	switch ( globalFunction() ) {
+		case 4:
+	}
+
+}());

--- a/test/form/switch-scopes/_expected/umd.js
+++ b/test/form/switch-scopes/_expected/umd.js
@@ -1,0 +1,17 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	const x = globalFunction;
+	switch ( anotherGlobal ) {
+		case 2:
+			x();
+	}
+
+	switch ( globalFunction() ) {
+		case 4:
+	}
+
+})));

--- a/test/form/switch-scopes/main.js
+++ b/test/form/switch-scopes/main.js
@@ -1,0 +1,23 @@
+const x = globalFunction;
+function y () {}
+
+switch ( anotherGlobal ) {
+	case 1:
+		const x = function () {};
+		x();
+}
+
+switch ( anotherGlobal ) {
+	case 2:
+		x();
+}
+
+switch ( anotherGlobal ) {
+	case 3:
+		const y = globalFunction;
+}
+y();
+
+switch ( globalFunction() ) {
+	case 4:
+}


### PR DESCRIPTION
In Javascript, switch statements introduce a local scope which means that variables can be re-declared inside of them. This pull request implements this behaviour and includes several test cases. To illustrate:

**Test cases:**
```javascript
const x = globalFunction;
function y () {}

switch ( anotherGlobal ) {
  case 1:
    const x = function () {};
    x();
}

switch ( anotherGlobal ) {
  case 2:
    x();
}

switch ( anotherGlobal ) {
  case 3:
    const y = globalFunction;
}
y();

switch ( globalFunction() ) {
  case 4:
}
```

**Previous output:**
```javascript
const x = globalFunction;
switch ( anotherGlobal ) { // Could have been removed as there are no side-effects
  case 1:
    const x = function () {};
    x();
}

switch ( anotherGlobal ) {
  case 2:
    x();
}

y(); // This is REALLY bad!

switch ( globalFunction() ) {
  case 4:
}
```

**Output after this pull request:**
```javascript
const x = globalFunction;
switch ( anotherGlobal ) {
  case 2:
    x();
}

switch ( globalFunction() ) {
  case 4:
}
```

As a little background about me, I have recently completed an ESLint plugin that will flag code that is not tree-shaken by rollup due to side-effects:
[eslint-plugin-tree-shaking](https://www.npmjs.com/package/eslint-plugin-tree-shaking)

Writing this plugin--which basically implements a side-effect detection algorithm similar to yours--gave me some insights as to how your algorithm might be improved in the future. This pull request is the one that was easiest to implement, others would require greater refactorings.

If you are open for these kinds of contributions, I would be very interested in discussing my ideas and possibly making more pull requests.