### PR TITLE
Descriptive error message for invalid format type.

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -506,7 +506,7 @@ export default class Bundle {
 			if ( !finalise ) {
 				error({
 					code: 'INVALID_OPTION',
-					message: `You must specify an output type - valid options are ${keys( finalisers ).join( ', ' )}`
+					message: `Unknown or missing format: ${options.format} - valid options are ${keys( finalisers ).join( ', ' )}`
 				});
 			}
 


### PR DESCRIPTION
I just spent 30 minutes because I misspelled a clj (cljs). This error message would make easier to figure out what option is wrong and what is current vs expected value.

Maybe this message can be a bit better but I do not know wider context that well. 