### PR TITLE
Export name from

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3898,6 +3898,38 @@
         "resolve": "1.4.0"
       }
     },
+    "rollup-plugin-replace": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-1.1.1.tgz",
+      "integrity": "sha1-OWMV3tBQps5DuVGKiGo/YO+x6jM=",
+      "dev": true,
+      "requires": {
+        "magic-string": "0.15.2",
+        "minimatch": "3.0.4",
+        "rollup-pluginutils": "1.5.2"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.2.tgz",
+          "integrity": "sha1-BoHXOIdBu8Ot2qZQYJkmJMbAnpw=",
+          "dev": true,
+          "requires": {
+            "vlq": "0.2.2"
+          }
+        },
+        "rollup-pluginutils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
+          "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+          "dev": true,
+          "requires": {
+            "estree-walker": "0.2.1",
+            "minimatch": "3.0.4"
+          }
+        }
+      }
+    },
     "rollup-plugin-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-string/-/rollup-plugin-string-2.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3896,38 +3896,6 @@
         "builtin-modules": "1.1.1",
         "is-module": "1.0.0",
         "resolve": "1.4.0"
-      }
-    },
-    "rollup-plugin-replace": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-1.1.1.tgz",
-      "integrity": "sha1-OWMV3tBQps5DuVGKiGo/YO+x6jM=",
-      "dev": true,
-      "requires": {
-        "magic-string": "0.15.2",
-        "minimatch": "3.0.4",
-        "rollup-pluginutils": "1.5.2"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.15.2",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.15.2.tgz",
-          "integrity": "sha1-BoHXOIdBu8Ot2qZQYJkmJMbAnpw=",
-          "dev": true,
-          "requires": {
-            "vlq": "0.2.2"
-          }
-        },
-        "rollup-pluginutils": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
-          "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
-          "dev": true,
-          "requires": {
-            "estree-walker": "0.2.1",
-            "minimatch": "3.0.4"
-          }
-        }
       }
     },
     "rollup-plugin-string": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^1.1.1",
     "rollup-plugin-string": "^2.0.0",
     "rollup-pluginutils": "^2.0.1",
     "rollup-watch": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-replace": "^1.1.0",
     "rollup-plugin-string": "^2.0.0",
     "rollup-pluginutils": "^2.0.1",
     "rollup-watch": "^4.3.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import buble from 'rollup-plugin-buble';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
-import replace from 'rollup-plugin-replace';
+import json from 'rollup-plugin-json';
 
 var pkg = JSON.parse( readFileSync( 'package.json', 'utf-8' ) );
 
@@ -22,6 +22,8 @@ var banner = readFileSync( 'src/banner.js', 'utf-8' )
 export default {
 	entry: 'src/node-entry.js',
 	plugins: [
+		json(),
+
 		buble({
 			include: [ 'src/**', 'node_modules/acorn/**' ],
 			target: {
@@ -31,13 +33,6 @@ export default {
 
 		nodeResolve({
 			jsnext: true
-		}),
-
-		replace({
-			include: 'src/rollup.js',
-			delimiters: [ '<@', '@>' ],
-			sourceMap: true,
-			values: { VERSION: pkg.version }
 		}),
 
 		commonjs()

--- a/src/browser-entry.js
+++ b/src/browser-entry.js
@@ -1,1 +1,2 @@
 export { default as rollup } from './rollup/index.js';
+export { version as VERSION } from '../package.json';

--- a/src/node-entry.js
+++ b/src/node-entry.js
@@ -1,2 +1,3 @@
 export { default as rollup } from './rollup/index.js';
 export { default as watch } from './watch/index.js';
+export { version as VERSION } from '../package.json';

--- a/test/form/samples/reexports-name-from-external/_config.js
+++ b/test/form/samples/reexports-name-from-external/_config.js
@@ -1,0 +1,9 @@
+const assert = require( 'assert' );
+
+module.exports = {
+	description: 're-exports name from external module',
+	options: {
+		external: [ 'external' ],
+		moduleName: 'myBundle'
+	}
+};

--- a/test/form/samples/reexports-name-from-external/_expected/amd.js
+++ b/test/form/samples/reexports-name-from-external/_expected/amd.js
@@ -1,0 +1,9 @@
+define(['exports', 'external'], function (exports, external) { 'use strict';
+
+
+
+	exports.foo = external.foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/reexports-name-from-external/_expected/cjs.js
+++ b/test/form/samples/reexports-name-from-external/_expected/cjs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var external = require('external');
+
+
+
+exports.foo = external.foo;

--- a/test/form/samples/reexports-name-from-external/_expected/es.js
+++ b/test/form/samples/reexports-name-from-external/_expected/es.js
@@ -1,0 +1,1 @@
+export { foo } from 'external';

--- a/test/form/samples/reexports-name-from-external/_expected/iife.js
+++ b/test/form/samples/reexports-name-from-external/_expected/iife.js
@@ -1,0 +1,10 @@
+var myBundle = (function (exports,external) {
+	'use strict';
+
+
+
+	exports.foo = external.foo;
+
+	return exports;
+
+}({},external));

--- a/test/form/samples/reexports-name-from-external/_expected/umd.js
+++ b/test/form/samples/reexports-name-from-external/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('external')) :
+	typeof define === 'function' && define.amd ? define(['exports', 'external'], factory) :
+	(factory((global.myBundle = {}),global.external));
+}(this, (function (exports,external) { 'use strict';
+
+	exports.foo = external.foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/samples/reexports-name-from-external/main.js
+++ b/test/form/samples/reexports-name-from-external/main.js
@@ -1,0 +1,1 @@
+export { foo } from 'external';


### PR DESCRIPTION
`export { foo } from 'bar'` was getting changed to `export { foo }` in `es` output, without the accompanying import that would have made it work.