### PR TITLE
Make sure Task.run returns a Promise

### DIFF
--- a/src/watch/index.js
+++ b/src/watch/index.js
@@ -160,7 +160,7 @@ class Task {
 	}
 
 	run() {
-		if (!this.dirty) return;
+		if (!this.dirty) return Promise.resolve();
 		this.dirty = false;
 
 		const options = Object.assign(this.inputOptions, {


### PR DESCRIPTION
Earlier in the file, there's a call `mapSequence(this.tasks, task => task.run())`, which was crashing for me (when calling `watch` directly, not going through the command-line tool) because of the short-circuit return in `run` returning undefined. I don't really know what I'm doing here, since I only briefly looked at the code, but returning an empty promise seems like it should address this, and indeed it stops my use from crashing.