### PR TITLE
Do not open alternate buffer during piped --watch

### DIFF
--- a/bin/src/run/alternateScreen.js
+++ b/bin/src/run/alternateScreen.js
@@ -1,0 +1,33 @@
+import ansiEscape from 'ansi-escapes';
+import { stderr } from '../logging.js';
+
+const SHOW_ALTERNATE_SCREEN = '\u001B[?1049h';
+const HIDE_ALTERNATE_SCREEN = '\u001B[?1049l';
+
+export default function alternateScreen ( enabled ) {
+	if (!enabled) {
+		let needAnnounce = true;
+		return {
+			open() {},
+			close() {},
+			reset( heading ) {
+				if ( needAnnounce ) {
+					stderr( heading );
+					needAnnounce = false;
+				}
+			}
+		};
+	}
+
+	return {
+		open() {
+			process.stderr.write(SHOW_ALTERNATE_SCREEN);
+		},
+		close() {
+			process.stderr.write(HIDE_ALTERNATE_SCREEN);
+		},
+		reset( heading ) {
+			stderr( `${ansiEscape.eraseScreen}${ansiEscape.cursorTo(0, 0)}${heading}` );
+		}
+	};
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "rollup-pluginutils": "^2.0.1",
     "rollup-watch": "^4.3.1",
     "sander": "^0.6.0",
+    "signal-exit": "^3.0.2",
     "source-map": "^0.5.6",
     "source-map-support": "^0.4.15",
     "sourcemap-codec": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/rollup/rollup",
   "devDependencies": {
     "acorn": "^5.1.1",
+    "ansi-escapes": "^2.0.0",
     "buble": "^0.15.1",
     "chalk": "^2.1.0",
     "codecov.io": "^0.1.6",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -92,6 +92,7 @@ export default [
 			'module',
 			'events',
 			'rollup',
+			'assert',
 			'os'
 		],
 		output: {


### PR DESCRIPTION
Recently, the output of `rollup --watch` was modified to reset the buffer when changes caused a rebuild. Works brilliantly when invoked in an active terminal, e.g. `rollup -cw`.

However, this really doesn't play nicely with processes that pipe the output from a child process (such as [`lerna exec`](https://github.com/lerna/lerna#exec)), which is effectively a _non_-interactive terminal. Clearing the screen repeatedly causes a bunch of thrashing, as well as unwanted removal of other process logging.

### Tests?!

I was unable to locate examples of testing both CLI _and_ watching, so I did a bunch of local testing with npm-linked rollup in several lerna repos where I was using rollup. Here's an example repo I whipped up that demonstrates the problem and solution:

https://github.com/evocateur/lerna-rollup-example