### PR TITLE
Guard against 2 parallel rollups trying to make the same dir

### DIFF
--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -9,7 +9,13 @@ function mkdirpath ( path ) {
 		fs.readdirSync( dir );
 	} catch ( err ) {
 		mkdirpath( dir );
-		fs.mkdirSync( dir );
+		try {
+			fs.mkdirSync( dir );
+		} catch (err2) {
+			if (err2.code !== 'EEXIST') {
+				throw err2;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This introduces an additional guard for a situation where 2 instances of rollup being run in parallel try to create the same directory and thus failing, because 1 succeeds and the other one throws.

While I could restructure my scripts I do not see any potential harm in guarding against this and at the moment this causes failing builds from time to time on CI server.

To illustrate better why its even the case, please take look at the configuration in `package.json`:
```json
  "scripts": {
    "build:umd:min": "cross-env BABEL_ENV=es NODE_ENV=production rollup -c -i src/index.js -o dist/module.min.js",
    "build:umd": "cross-env BABEL_ENV=es NODE_ENV=development rollup -c -i src/index.js -o dist/module.js",
    "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib",
    "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
    "build": "run-p build:**"
  }
```
So while wanting to keep both umd builds (minified and unminified) in the same directory (`dist`) and running all 4 builds in parallel (thanks to [`npm-run-all package`](https://github.com/mysticatea/npm-run-all)) it sometimes case the mentioned issue.