### PR TITLE
Fix regressions when handling assignments and expression statements with side effects

### DIFF
--- a/src/ast/Node.js
+++ b/src/ast/Node.js
@@ -33,6 +33,10 @@ export default class Node {
 		return this.included || this.someChild( child => child.hasEffects( options ) );
 	}
 
+	hasEffectsAsExpressionStatement () {
+		return true;
+	}
+
 	hasEffectsWhenAssigned () {
 		return false;
 	}

--- a/src/ast/nodes/AssignmentExpression.js
+++ b/src/ast/nodes/AssignmentExpression.js
@@ -12,6 +12,10 @@ export default class AssignmentExpression extends Node {
 		return super.hasEffects( options ) || this.left.hasEffectsWhenAssigned( options );
 	}
 
+	hasEffectsAsExpressionStatement ( options ) {
+		return this.hasEffects( options );
+	}
+
 	hasEffectsWhenMutated () {
 		return true;
 	}

--- a/src/ast/nodes/AwaitExpression.js
+++ b/src/ast/nodes/AwaitExpression.js
@@ -5,4 +5,8 @@ export default class AwaitExpression extends Node {
 		return super.hasEffects( options )
 			|| !options.inNestedFunctionCall;
 	}
+
+	hasEffectsAsExpressionStatement ( options ) {
+		return this.hasEffects( options );
+	}
 }

--- a/src/ast/nodes/CallExpression.js
+++ b/src/ast/nodes/CallExpression.js
@@ -31,6 +31,10 @@ export default class CallExpression extends Node {
 			|| callHasEffects( this.scope, this.callee, false );
 	}
 
+	hasEffectsAsExpressionStatement ( options ) {
+		return this.hasEffects( options );
+	}
+
 	hasEffectsWhenMutated () {
 		return true;
 	}

--- a/src/ast/nodes/ExpressionStatement.js
+++ b/src/ast/nodes/ExpressionStatement.js
@@ -1,6 +1,10 @@
 import Statement from './shared/Statement.js';
 
 export default class ExpressionStatement extends Statement {
+	hasEffects ( options ) {
+		return super.hasEffects( options ) || this.expression.hasEffectsAsExpressionStatement(options);
+	}
+
 	render ( code, es ) {
 		super.render( code, es );
 		if ( this.included ) this.insertSemicolon( code );

--- a/src/ast/nodes/Identifier.js
+++ b/src/ast/nodes/Identifier.js
@@ -47,6 +47,7 @@ export default class Identifier extends Node {
 			this.declaration.isGlobal ||
 			this.declaration.isExternal ||
 			this.declaration.isNamespace ||
+			!this.declaration.assignedExpressions ||
 			Array.from( this.declaration.assignedExpressions ).some( node => node.hasEffectsWhenMutated( options ) ));
 	}
 

--- a/src/ast/nodes/UnaryExpression.js
+++ b/src/ast/nodes/UnaryExpression.js
@@ -32,6 +32,10 @@ export default class UnaryExpression extends Node {
 			));
 	}
 
+	hasEffectsAsExpressionStatement ( options ) {
+		return this.hasEffects( options );
+	}
+
 	initialiseNode () {
 		this.value = this.getValue();
 	}

--- a/src/ast/nodes/UpdateExpression.js
+++ b/src/ast/nodes/UpdateExpression.js
@@ -14,4 +14,8 @@ export default class UpdateExpression extends Node {
 	hasEffects ( options ) {
 		return this.included || this.argument.hasEffectsWhenAssigned( options );
 	}
+
+	hasEffectsAsExpressionStatement ( options ) {
+		return this.hasEffects( options );
+	}
 }

--- a/test/form/samples/side-effects-expressions-as-statements/_config.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'in order to keep certain getter calls, do not remove some expression statements'
+};

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/amd.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/amd.js
@@ -1,0 +1,10 @@
+define(function () { 'use strict';
+
+	// Access getters with side-effects to e.g. force DOM repaints
+	globalVar.getter;
+	globalVar && globalVar.member && globalVar.member.getter;
+
+	// Call pure constructors for side-effects for e.g. feature detection
+	new Function('');
+
+});

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/amd.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/amd.js
@@ -1,5 +1,8 @@
 define(function () { 'use strict';
 
+	// Use strict has an effect
+	'use strict';
+
 	// Access getters with side-effects to e.g. force DOM repaints
 	globalVar.getter;
 	globalVar && globalVar.member && globalVar.member.getter;

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/cjs.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/cjs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// Access getters with side-effects to e.g. force DOM repaints
+globalVar.getter;
+globalVar && globalVar.member && globalVar.member.getter;
+
+// Call pure constructors for side-effects for e.g. feature detection
+new Function('');

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/cjs.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/cjs.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Use strict has an effect
+'use strict';
+
 // Access getters with side-effects to e.g. force DOM repaints
 globalVar.getter;
 globalVar && globalVar.member && globalVar.member.getter;

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/es.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/es.js
@@ -1,0 +1,6 @@
+// Access getters with side-effects to e.g. force DOM repaints
+globalVar.getter;
+globalVar && globalVar.member && globalVar.member.getter;
+
+// Call pure constructors for side-effects for e.g. feature detection
+new Function('');

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/es.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/es.js
@@ -1,3 +1,6 @@
+// Use strict has an effect
+'use strict';
+
 // Access getters with side-effects to e.g. force DOM repaints
 globalVar.getter;
 globalVar && globalVar.member && globalVar.member.getter;

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/iife.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/iife.js
@@ -1,6 +1,9 @@
 (function () {
 	'use strict';
 
+	// Use strict has an effect
+	'use strict';
+
 	// Access getters with side-effects to e.g. force DOM repaints
 	globalVar.getter;
 	globalVar && globalVar.member && globalVar.member.getter;

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/iife.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/iife.js
@@ -1,0 +1,11 @@
+(function () {
+	'use strict';
+
+	// Access getters with side-effects to e.g. force DOM repaints
+	globalVar.getter;
+	globalVar && globalVar.member && globalVar.member.getter;
+
+	// Call pure constructors for side-effects for e.g. feature detection
+	new Function('');
+
+}());

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/umd.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/umd.js
@@ -4,6 +4,9 @@
 	(factory());
 }(this, (function () { 'use strict';
 
+	// Use strict has an effect
+	'use strict';
+
 	// Access getters with side-effects to e.g. force DOM repaints
 	globalVar.getter;
 	globalVar && globalVar.member && globalVar.member.getter;

--- a/test/form/samples/side-effects-expressions-as-statements/_expected/umd.js
+++ b/test/form/samples/side-effects-expressions-as-statements/_expected/umd.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	// Access getters with side-effects to e.g. force DOM repaints
+	globalVar.getter;
+	globalVar && globalVar.member && globalVar.member.getter;
+
+	// Call pure constructors for side-effects for e.g. feature detection
+	new Function('');
+
+})));

--- a/test/form/samples/side-effects-expressions-as-statements/main.js
+++ b/test/form/samples/side-effects-expressions-as-statements/main.js
@@ -1,0 +1,6 @@
+// Access getters with side-effects to e.g. force DOM repaints
+globalVar.getter;
+globalVar && globalVar.member && globalVar.member.getter;
+
+// Call pure constructors for side-effects for e.g. feature detection
+new Function('');

--- a/test/form/samples/side-effects-expressions-as-statements/main.js
+++ b/test/form/samples/side-effects-expressions-as-statements/main.js
@@ -1,3 +1,6 @@
+// Use strict has an effect
+'use strict';
+
 // Access getters with side-effects to e.g. force DOM repaints
 globalVar.getter;
 globalVar && globalVar.member && globalVar.member.getter;


### PR DESCRIPTION
This will resolve #1589 and #1592.

For #1589: In Identifier.js, I assumed that all declarations have assignedExpressions, which is certainly not true for SyntheticNamespaceDeclarations. To be cautious, for now we assume that those always have effects when mutated.

For #1592: It seems that people are calling getters for side-effects and this is something that rollup is not (and was never) prepared for yet. The better solution, as suggested by @kzc , is probably to start adding flags for certain more aggressive aspects of tree-shaking such as assuming that all getters are pure. Until then with this PR, rollup will keep all expression statements that are not usually called as statements because we assume that they are called for side-effects. That seems to cover the cases listed in #1592 and also keep things like 'use strict'.