### PR TITLE
mergeOptions inputOptions includes config.watch option.

### DIFF
--- a/bin/src/run/mergeOptions.js
+++ b/bin/src/run/mergeOptions.js
@@ -17,7 +17,8 @@ export default function mergeOptions ( config, command ) {
 		context: config.context,
 		moduleContext: config.moduleContext,
 		plugins: config.plugins,
-		onwarn: config.onwarn
+		onwarn: config.onwarn,
+		watch: config.watch
 	};
 
 	// legacy, to ensure e.g. commonjs plugin still works


### PR DESCRIPTION
Fixes https://github.com/rollup/rollup/issues/1596

The following option now applies.
`
watch: {
  chokidar: {
    usePolling: true
  }
}
`
