### PR TITLE
Assume we always have all of the new effects unless specified otherwise

### DIFF
--- a/src/ast/Node.js
+++ b/src/ast/Node.js
@@ -38,11 +38,11 @@ export default class Node {
 	}
 
 	hasEffectsWhenAssigned () {
-		return false;
+		return true;
 	}
 
 	hasEffectsWhenMutated () {
-		return false;
+		return true;
 	}
 
 	includeDeclaration () {

--- a/src/ast/nodes/AssignmentExpression.js
+++ b/src/ast/nodes/AssignmentExpression.js
@@ -15,8 +15,4 @@ export default class AssignmentExpression extends Node {
 	hasEffectsAsExpressionStatement ( options ) {
 		return this.hasEffects( options );
 	}
-
-	hasEffectsWhenMutated () {
-		return true;
-	}
 }

--- a/src/ast/nodes/AssignmentPattern.js
+++ b/src/ast/nodes/AssignmentPattern.js
@@ -1,0 +1,7 @@
+import Node from '../Node.js';
+
+export default class AssignmentPattern extends Node {
+	hasEffectsWhenAssigned ( options ) {
+		return this.left.hasEffectsWhenAssigned( options );
+	}
+}

--- a/src/ast/nodes/BinaryExpression.js
+++ b/src/ast/nodes/BinaryExpression.js
@@ -38,8 +38,4 @@ export default class BinaryExpression extends Node {
 
 		return operators[ this.operator ]( leftValue, rightValue );
 	}
-
-	hasEffectsWhenMutated () {
-		return true;
-	}
 }

--- a/src/ast/nodes/CallExpression.js
+++ b/src/ast/nodes/CallExpression.js
@@ -34,8 +34,4 @@ export default class CallExpression extends Node {
 	hasEffectsAsExpressionStatement ( options ) {
 		return this.hasEffects( options );
 	}
-
-	hasEffectsWhenMutated () {
-		return true;
-	}
 }

--- a/src/ast/nodes/ConditionalExpression.js
+++ b/src/ast/nodes/ConditionalExpression.js
@@ -37,10 +37,6 @@ export default class ConditionalExpression extends Node {
 		return testValue ? this.consequent.getValue() : this.alternate.getValue();
 	}
 
-	hasEffectsWhenMutated () {
-		return true;
-	}
-
 	render ( code, es ) {
 		if ( !this.module.bundle.treeshake ) {
 			super.render( code, es );

--- a/src/ast/nodes/Identifier.js
+++ b/src/ast/nodes/Identifier.js
@@ -36,6 +36,10 @@ export default class Identifier extends Node {
 		}
 	}
 
+	hasEffectsAsExpressionStatement ( options ) {
+		return this.hasEffects( options ) || this.declaration.isGlobal;
+	}
+
 	hasEffectsWhenAssigned () {
 		return this.declaration && this.declaration.included;
 	}

--- a/src/ast/nodes/Literal.js
+++ b/src/ast/nodes/Literal.js
@@ -9,6 +9,10 @@ export default class Literal extends Node {
 		values.add( this );
 	}
 
+	hasEffectsWhenMutated () {
+		return false;
+	}
+
 	render ( code ) {
 		if ( typeof this.value === 'string' ) {
 			code.indentExclusionRanges.push( [ this.start + 1, this.end - 1 ] );

--- a/src/ast/nodes/LogicalExpression.js
+++ b/src/ast/nodes/LogicalExpression.js
@@ -16,4 +16,15 @@ export default class LogicalExpression extends Node {
 
 		return operators[ this.operator ]( leftValue, rightValue );
 	}
+
+	hasEffectsWhenMutated ( options ) {
+		const leftValue = this.left.getValue();
+		if ( leftValue === UNKNOWN_VALUE ) {
+			return this.left.hasEffectsWhenMutated( options ) || this.right.hasEffectsWhenMutated( options );
+		}
+		if ((leftValue && this.operator === '||') || (!leftValue && this.operator === '&&')) {
+			return this.left.hasEffectsWhenMutated( options );
+		}
+		return this.right.hasEffectsWhenMutated( options );
+	}
 }

--- a/src/ast/nodes/MemberExpression.js
+++ b/src/ast/nodes/MemberExpression.js
@@ -83,10 +83,6 @@ export default class MemberExpression extends Node {
 		return this.object.hasEffectsWhenMutated( options );
 	}
 
-	hasEffectsWhenMutated () {
-		return true;
-	}
-
 	includeInBundle () {
 		let addedNewNodes = super.includeInBundle();
 		if ( this.declaration && !this.declaration.included ) {

--- a/src/ast/nodes/ObjectExpression.js
+++ b/src/ast/nodes/ObjectExpression.js
@@ -1,0 +1,7 @@
+import Node from '../Node.js';
+
+export default class ObjectExpression extends Node {
+	hasEffectsWhenMutated () {
+		return false;
+	}
+}

--- a/src/ast/nodes/ThisExpression.js
+++ b/src/ast/nodes/ThisExpression.js
@@ -1,10 +1,6 @@
 import Node from '../Node.js';
 
 export default class ThisExpression extends Node {
-	hasEffectsWhenMutated () {
-		return true;
-	}
-
 	initialiseNode () {
 		const lexicalBoundary = this.scope.findLexicalBoundary();
 

--- a/src/ast/nodes/UnknownNode.js
+++ b/src/ast/nodes/UnknownNode.js
@@ -4,12 +4,4 @@ export default class UnknownNode extends Node {
 	hasEffects () {
 		return true;
 	}
-
-	hasEffectsWhenAssigned () {
-		return true;
-	}
-
-	hasEffectsWhenMutated () {
-		return true;
-	}
 }

--- a/src/ast/nodes/index.js
+++ b/src/ast/nodes/index.js
@@ -1,6 +1,7 @@
 import ArrayPattern from './ArrayPattern.js';
 import ArrowFunctionExpression from './ArrowFunctionExpression.js';
 import AssignmentExpression from './AssignmentExpression.js';
+import AssignmentPattern from './AssignmentPattern.js';
 import AwaitExpression from './AwaitExpression.js';
 import BinaryExpression from './BinaryExpression.js';
 import BlockStatement from './BlockStatement.js';
@@ -28,6 +29,7 @@ import Literal from './Literal.js';
 import LogicalExpression from './LogicalExpression.js';
 import MemberExpression from './MemberExpression.js';
 import NewExpression from './NewExpression.js';
+import ObjectExpression from './ObjectExpression.js';
 import ObjectPattern from './ObjectPattern.js';
 import Property from './Property.js';
 import RestElement from './RestElement.js';
@@ -52,7 +54,7 @@ export default {
 	ArrayPattern,
 	ArrowFunctionExpression,
 	AssignmentExpression,
-	AssignmentPattern: Node,
+	AssignmentPattern,
 	AwaitExpression,
 	BinaryExpression,
 	BlockStatement,
@@ -80,7 +82,7 @@ export default {
 	LogicalExpression,
 	MemberExpression,
 	NewExpression,
-	ObjectExpression: Node,
+	ObjectExpression,
 	ObjectPattern,
 	Property,
 	RestElement,

--- a/src/ast/nodes/shared/pureFunctions.js
+++ b/src/ast/nodes/shared/pureFunctions.js
@@ -26,7 +26,7 @@ simdTypes.forEach( t => {
 	'ArrayBuffer', 'ArrayBuffer.isView',
 	'DataView',
 	'JSON.parse', 'JSON.stringify',
-	'Promise', 'Promise.all', 'Promise.race', 'Promise.reject', 'Promise.resolve',
+	'Promise.all', 'Promise.race', 'Promise.resolve',
 	'Intl.Collator', 'Intl.Collator.supportedLocalesOf', 'Intl.DateTimeFormat', 'Intl.DateTimeFormat.supportedLocalesOf', 'Intl.NumberFormat', 'Intl.NumberFormat.supportedLocalesOf'
 
 	// TODO properties of e.g. window...

--- a/test/form/samples/assignment-to-array-buffer-view/_config.js
+++ b/test/form/samples/assignment-to-array-buffer-view/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'assignment to views of buffers should be kept',
+	options: { name: 'bundle' }
+};

--- a/test/form/samples/assignment-to-array-buffer-view/_expected/amd.js
+++ b/test/form/samples/assignment-to-array-buffer-view/_expected/amd.js
@@ -1,0 +1,14 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var buffer = new ArrayBuffer( 8 );
+
+	var view8 = new Int8Array( buffer );
+	var view16 = new Int16Array( buffer );
+
+	view16[ 0 ] = 3;
+
+	exports.view8 = view8;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/assignment-to-array-buffer-view/_expected/cjs.js
+++ b/test/form/samples/assignment-to-array-buffer-view/_expected/cjs.js
@@ -1,0 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var buffer = new ArrayBuffer( 8 );
+
+var view8 = new Int8Array( buffer );
+var view16 = new Int16Array( buffer );
+
+view16[ 0 ] = 3;
+
+exports.view8 = view8;

--- a/test/form/samples/assignment-to-array-buffer-view/_expected/es.js
+++ b/test/form/samples/assignment-to-array-buffer-view/_expected/es.js
@@ -1,0 +1,8 @@
+var buffer = new ArrayBuffer( 8 );
+
+var view8 = new Int8Array( buffer );
+var view16 = new Int16Array( buffer );
+
+view16[ 0 ] = 3;
+
+export { view8 };

--- a/test/form/samples/assignment-to-array-buffer-view/_expected/iife.js
+++ b/test/form/samples/assignment-to-array-buffer-view/_expected/iife.js
@@ -1,0 +1,15 @@
+var bundle = (function (exports) {
+	'use strict';
+
+	var buffer = new ArrayBuffer( 8 );
+
+	var view8 = new Int8Array( buffer );
+	var view16 = new Int16Array( buffer );
+
+	view16[ 0 ] = 3;
+
+	exports.view8 = view8;
+
+	return exports;
+
+}({}));

--- a/test/form/samples/assignment-to-array-buffer-view/_expected/umd.js
+++ b/test/form/samples/assignment-to-array-buffer-view/_expected/umd.js
@@ -1,0 +1,18 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.bundle = {})));
+}(this, (function (exports) { 'use strict';
+
+	var buffer = new ArrayBuffer( 8 );
+
+	var view8 = new Int8Array( buffer );
+	var view16 = new Int16Array( buffer );
+
+	view16[ 0 ] = 3;
+
+	exports.view8 = view8;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/samples/assignment-to-array-buffer-view/main.js
+++ b/test/form/samples/assignment-to-array-buffer-view/main.js
@@ -1,0 +1,8 @@
+var buffer = new ArrayBuffer( 8 );
+
+var view8 = new Int8Array( buffer );
+var view16 = new Int16Array( buffer );
+
+view16[ 0 ] = 3;
+
+export { view8 };

--- a/test/form/samples/mutate-logical-expression/_config.js
+++ b/test/form/samples/mutate-logical-expression/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'properly handle the results of mutating logical expressions',
+	options: { name: 'bundle' }
+};

--- a/test/form/samples/mutate-logical-expression/_expected/amd.js
+++ b/test/form/samples/mutate-logical-expression/_expected/amd.js
@@ -1,0 +1,26 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var aExp = {};
+	var logicalAExp = aExp || true;
+	logicalAExp.bar = 1;
+
+	var bExp = {};
+	var cExp = {};
+	var logicalCExp = false || cExp;
+	logicalCExp.bar = 1;
+
+	var dExp = {};
+	var logicalDExp = true && dExp;
+	logicalDExp.bar = 1;
+
+	var eExp = {};
+
+	exports.aExp = aExp;
+	exports.bExp = bExp;
+	exports.cExp = cExp;
+	exports.dExp = dExp;
+	exports.eExp = eExp;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/mutate-logical-expression/_expected/cjs.js
+++ b/test/form/samples/mutate-logical-expression/_expected/cjs.js
@@ -1,0 +1,24 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var aExp = {};
+var logicalAExp = aExp || true;
+logicalAExp.bar = 1;
+
+var bExp = {};
+var cExp = {};
+var logicalCExp = false || cExp;
+logicalCExp.bar = 1;
+
+var dExp = {};
+var logicalDExp = true && dExp;
+logicalDExp.bar = 1;
+
+var eExp = {};
+
+exports.aExp = aExp;
+exports.bExp = bExp;
+exports.cExp = cExp;
+exports.dExp = dExp;
+exports.eExp = eExp;

--- a/test/form/samples/mutate-logical-expression/_expected/es.js
+++ b/test/form/samples/mutate-logical-expression/_expected/es.js
@@ -1,0 +1,16 @@
+var aExp = {};
+var logicalAExp = aExp || true;
+logicalAExp.bar = 1;
+
+var bExp = {};
+var cExp = {};
+var logicalCExp = false || cExp;
+logicalCExp.bar = 1;
+
+var dExp = {};
+var logicalDExp = true && dExp;
+logicalDExp.bar = 1;
+
+var eExp = {};
+
+export { aExp, bExp, cExp, dExp, eExp };

--- a/test/form/samples/mutate-logical-expression/_expected/iife.js
+++ b/test/form/samples/mutate-logical-expression/_expected/iife.js
@@ -1,0 +1,27 @@
+var bundle = (function (exports) {
+	'use strict';
+
+	var aExp = {};
+	var logicalAExp = aExp || true;
+	logicalAExp.bar = 1;
+
+	var bExp = {};
+	var cExp = {};
+	var logicalCExp = false || cExp;
+	logicalCExp.bar = 1;
+
+	var dExp = {};
+	var logicalDExp = true && dExp;
+	logicalDExp.bar = 1;
+
+	var eExp = {};
+
+	exports.aExp = aExp;
+	exports.bExp = bExp;
+	exports.cExp = cExp;
+	exports.dExp = dExp;
+	exports.eExp = eExp;
+
+	return exports;
+
+}({}));

--- a/test/form/samples/mutate-logical-expression/_expected/umd.js
+++ b/test/form/samples/mutate-logical-expression/_expected/umd.js
@@ -1,0 +1,30 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.bundle = {})));
+}(this, (function (exports) { 'use strict';
+
+	var aExp = {};
+	var logicalAExp = aExp || true;
+	logicalAExp.bar = 1;
+
+	var bExp = {};
+	var cExp = {};
+	var logicalCExp = false || cExp;
+	logicalCExp.bar = 1;
+
+	var dExp = {};
+	var logicalDExp = true && dExp;
+	logicalDExp.bar = 1;
+
+	var eExp = {};
+
+	exports.aExp = aExp;
+	exports.bExp = bExp;
+	exports.cExp = cExp;
+	exports.dExp = dExp;
+	exports.eExp = eExp;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/samples/mutate-logical-expression/main.js
+++ b/test/form/samples/mutate-logical-expression/main.js
@@ -1,0 +1,49 @@
+var a = {};
+var logicalA = a || true;
+logicalA.bar = 1;
+
+var aExp = {};
+var logicalAExp = aExp || true;
+logicalAExp.bar = 1;
+
+export {aExp}
+
+var b = {};
+var logicalB = true || b;
+logicalB.bar = 1;
+
+var bExp = {};
+var logicalBExp = true || bExp;
+logicalBExp.bar = 1;
+
+export {bExp}
+
+var c = {};
+var logicalC = false || c;
+logicalC.bar = 1;
+
+var cExp = {};
+var logicalCExp = false || cExp;
+logicalCExp.bar = 1;
+
+export {cExp}
+
+var d = {};
+var logicalD = true && d;
+logicalD.bar = 1;
+
+var dExp = {};
+var logicalDExp = true && dExp;
+logicalDExp.bar = 1;
+
+export {dExp}
+
+var e = {};
+var logicalE = false && e;
+logicalE.bar = 1;
+
+var eExp = {};
+var logicalEExp = false && eExp;
+logicalEExp.bar = 1;
+
+export {eExp}

--- a/test/form/samples/promises/_config.js
+++ b/test/form/samples/promises/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'do not remove promise creations',
+	options: { name: 'bundle' }
+};

--- a/test/form/samples/promises/_expected/amd.js
+++ b/test/form/samples/promises/_expected/amd.js
@@ -1,0 +1,23 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const p1 = new Promise( () => {
+		console.log( 'fire & forget' );
+	} );
+
+	const p2 = new Promise( () => {
+		console.info( 'forget me as well' );
+	} );
+
+	const p3 = new Promise( () => {
+		console.info( 'and me too' );
+	} );
+
+	const p5 = Promise.reject('should be kept for uncaught rejections');
+
+	const allExported = Promise.all([p2, p3]);
+
+	exports.allExported = allExported;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/promises/_expected/cjs.js
+++ b/test/form/samples/promises/_expected/cjs.js
@@ -1,0 +1,21 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const p1 = new Promise( () => {
+	console.log( 'fire & forget' );
+} );
+
+const p2 = new Promise( () => {
+	console.info( 'forget me as well' );
+} );
+
+const p3 = new Promise( () => {
+	console.info( 'and me too' );
+} );
+
+const p5 = Promise.reject('should be kept for uncaught rejections');
+
+const allExported = Promise.all([p2, p3]);
+
+exports.allExported = allExported;

--- a/test/form/samples/promises/_expected/es.js
+++ b/test/form/samples/promises/_expected/es.js
@@ -1,0 +1,17 @@
+const p1 = new Promise( () => {
+	console.log( 'fire & forget' );
+} );
+
+const p2 = new Promise( () => {
+	console.info( 'forget me as well' );
+} );
+
+const p3 = new Promise( () => {
+	console.info( 'and me too' );
+} );
+
+const p5 = Promise.reject('should be kept for uncaught rejections');
+
+const allExported = Promise.all([p2, p3]);
+
+export { allExported };

--- a/test/form/samples/promises/_expected/iife.js
+++ b/test/form/samples/promises/_expected/iife.js
@@ -1,0 +1,24 @@
+var bundle = (function (exports) {
+	'use strict';
+
+	const p1 = new Promise( () => {
+		console.log( 'fire & forget' );
+	} );
+
+	const p2 = new Promise( () => {
+		console.info( 'forget me as well' );
+	} );
+
+	const p3 = new Promise( () => {
+		console.info( 'and me too' );
+	} );
+
+	const p5 = Promise.reject('should be kept for uncaught rejections');
+
+	const allExported = Promise.all([p2, p3]);
+
+	exports.allExported = allExported;
+
+	return exports;
+
+}({}));

--- a/test/form/samples/promises/_expected/umd.js
+++ b/test/form/samples/promises/_expected/umd.js
@@ -1,0 +1,27 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.bundle = {})));
+}(this, (function (exports) { 'use strict';
+
+	const p1 = new Promise( () => {
+		console.log( 'fire & forget' );
+	} );
+
+	const p2 = new Promise( () => {
+		console.info( 'forget me as well' );
+	} );
+
+	const p3 = new Promise( () => {
+		console.info( 'and me too' );
+	} );
+
+	const p5 = Promise.reject('should be kept for uncaught rejections');
+
+	const allExported = Promise.all([p2, p3]);
+
+	exports.allExported = allExported;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/samples/promises/main.js
+++ b/test/form/samples/promises/main.js
@@ -1,0 +1,18 @@
+const p1 = new Promise( () => {
+	console.log( 'fire & forget' );
+} );
+
+const p2 = new Promise( () => {
+	console.info( 'forget me as well' );
+} );
+
+const p3 = new Promise( () => {
+	console.info( 'and me too' );
+} );
+
+const p4 = Promise.resolve('no side effect');
+const p5 = Promise.reject('should be kept for uncaught rejections');
+
+const all = Promise.all([p2, p3]);
+export const allExported = Promise.all([p2, p3]);
+const race = Promise.race([p2, p3]);

--- a/test/form/samples/side-effects-expressions-as-statements/main.js
+++ b/test/form/samples/side-effects-expressions-as-statements/main.js
@@ -7,3 +7,6 @@ globalVar && globalVar.member && globalVar.member.getter;
 
 // Call pure constructors for side-effects for e.g. feature detection
 new Function('');
+
+var localVarsAreRemoved;
+localVarsAreRemoved;


### PR DESCRIPTION
This will resolve #1599, #1601 and #1603.

This is a very important patch as it will also prevent further bugs like the two mentioned above by setting `.hasEffectsWhenAssigned()` and  `.hasEffectsWhenMutated()` to true for all nodes unless they explicitly specify it otherwise. Also, I made `Promise()` impure until we have a better solution. For safety reasons, I also made `Promise.reject()` impure since it can cause uncaught Promise rejections. Not sure if we will ever be able to fix this properly.

# New tests
## assignment-to-array-buffer-view
Here the mutation of the buffer via the second view was dropped. For now, this is solved by assuming that mutating the result of a NewExpression (or CallExpression for that matter) always has an effect. This will probably prevent tree-shaking in quite a few cases but is certainly necessary for now. The situation may improve at least for non-global functions once we have function return value assignment tracking in place (will take some time, though).

<Details>
<Summary>Output of v0.49.2</Summary>

```javascript
var buffer = new ArrayBuffer( 8 );

var view8 = new Int8Array( buffer );

export { view8 };
```
</Details>
<Details>
<Summary>New output</Summary>

```javascript
var buffer = new ArrayBuffer( 8 );

var view8 = new Int8Array( buffer );
var view16 = new Int16Array( buffer );

view16[ 0 ] = 3;

export { view8 };
```
</Details>

## mutate-logical-expression
This was completely broken. However, instead of doing the same as for CallExpressions, I decided to implement the proper logic for LogicalExpressions. This means that if the LogicalExpression can be partially evaluated, mutating it has only an effect if mutating the result of the expression has an effect. In the future we might implement similar behaviour for ConditionalExpressions, but I decided to stick with the problem at hand for now.

<Details>
<Summary>Output of v0.49.2</Summary>

```javascript
var aExp = {};
var bExp = {};
var cExp = {};
var dExp = {};
var eExp = {};

export { aExp, bExp, cExp, dExp, eExp };
```
</Details>
<Details>
<Summary>New output</Summary>

```javascript
var aExp = {};
var logicalAExp = aExp || true;
logicalAExp.bar = 1;

var bExp = {};
var cExp = {};
var logicalCExp = false || cExp;
logicalCExp.bar = 1;

var dExp = {};
var logicalDExp = true && dExp;
logicalDExp.bar = 1;

var eExp = {};

export { aExp, bExp, cExp, dExp, eExp };
```
</Details>

## promises
By making `Promise` impure, we no longer suppress side-effects of a Promise callback. This will for now also include Promises that do not have side-effects, but I am quite sure there will be a solution for this in the future.

<Details>
<Summary>Output of v0.49.2</Summary>

```javascript
const p2 = new Promise( () => {
	console.info( 'forget me as well' );
} );

const p3 = new Promise( () => {
	console.info( 'and me too' );
} );

const allExported = Promise.all([p2, p3]);

export { allExported };
```
</Details>
<Details>
<Summary>New output</Summary>

```javascript
const p1 = new Promise( () => {
	console.log( 'fire & forget' );
} );

const p2 = new Promise( () => {
	console.info( 'forget me as well' );
} );

const p3 = new Promise( () => {
	console.info( 'and me too' );
} );

const p5 = Promise.reject('should be kept for uncaught rejections');

const allExported = Promise.all([p2, p3]);

export { allExported };
```
</Details>