### PR TITLE
merge command & config's output options

### DIFF
--- a/bin/src/run/mergeOptions.js
+++ b/bin/src/run/mergeOptions.js
@@ -73,14 +73,21 @@ export default function mergeOptions ( config, command ) {
 		paths: getOption('paths')
 	};
 
-	const outputOptions = (
-		(command.output || config.output) ?
+	let mergedOutputOptions;
+	if (Array.isArray(config.output)) {
+		mergedOutputOptions = config.output.map((output) => Object.assign({}, output, command.output));
+	} else if (config.output && command.output) {
+		mergedOutputOptions = [Object.assign({}, config.output, command.output)];
+	} else {
+		mergedOutputOptions = (command.output || config.output) ?
 			ensureArray(command.output || config.output) :
 			[{
 				file: command.output ? command.output.file : null,
 				format: command.output ? command.output.format : null
-			}]
-	).map(output => {
+			}];
+	}
+
+	const outputOptions = mergedOutputOptions.map(output => {
 		return Object.assign({}, baseOutputOptions, output);
 	});
 


### PR DESCRIPTION
Fix #1573 , #1600 

Both command line and config file can set `output` option, they should be merged but instead of used separately.