### PR TITLE
Fix typo: outpot -> output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@
 ## 0.46.3
 
 * init for/for-of loop section head with correct scopes ([#1538](https://github.com/rollup/rollup/issues/1538), [#1539](https://github.com/rollup/rollup/issues/1539))
-* Fix namespace imports and re-exports in `es` outpot ([#1511](https://github.com/rollup/rollup/issues/1511))
+* Fix namespace imports and re-exports in `es` output ([#1511](https://github.com/rollup/rollup/issues/1511))
 * Deshadow indirectly imported namespaces ([#1488](https://github.com/rollup/rollup/issues/1488), [#1505](https://github.com/rollup/rollup/issues/1505))
 
 ## 0.46.2


### PR DESCRIPTION
Minor text correction in the CHANGELOG.