### PR TITLE
Throw warnings from plugins

### DIFF
--- a/src/Module.js
+++ b/src/Module.js
@@ -14,6 +14,7 @@ import extractNames from './ast/utils/extractNames.js';
 import enhance from './ast/enhance.js';
 import clone from './ast/clone.js';
 import ModuleScope from './ast/scopes/ModuleScope.js';
+import Warning from './Warning.js';
 
 function tryParse ( module, acornOptions ) {
 	try {
@@ -452,6 +453,6 @@ export default class Module {
 		}
 
 		warning.id = this.id;
-		this.bundle.warn( warning );
+		Warning.print( warning );
 	}
 }

--- a/src/Warning.js
+++ b/src/Warning.js
@@ -1,0 +1,33 @@
+import relativeId from './utils/relativeId.js';
+
+export default class Warning {
+	static createFrom(object) {
+		if (object instanceof Warning)
+			return object;
+		else
+			return Object.assign(new Warning(), object);
+	}
+
+	constructor() {
+	}
+
+	toString () {
+		let str = '';
+
+		if (this.plugin) str += `(${this.plugin} plugin) `;
+		if (this.loc) str += `${relativeId(this.loc.file)} (${this.loc.line}:${this.loc.column}) `;
+		str += this.message;
+
+		return str;
+	}
+
+	static print(warning) {
+		warning = Warning.createFrom(warning);
+		
+		const str = warning.toString();
+		if (Warning.onwarn)
+			Warning.onwarn(warning);
+		else 
+			console.warn(str); //eslint-disable-line no-console
+	}
+}

--- a/src/finalisers/shared/getGlobalNameMaker.js
+++ b/src/finalisers/shared/getGlobalNameMaker.js
@@ -1,3 +1,5 @@
+import Warning from '../../Warning.js';
+
 export default function getGlobalNameMaker ( globals, bundle, fallback = null ) {
 	const fn = typeof globals === 'function' ? globals : id => globals[ id ];
 
@@ -6,7 +8,7 @@ export default function getGlobalNameMaker ( globals, bundle, fallback = null ) 
 		if ( name ) return name;
 
 		if ( Object.keys( module.declarations ).length > 0 ) {
-			bundle.warn({
+			Warning.print({
 				code: 'MISSING_GLOBAL_NAME',
 				source: module.id,
 				guess: module.name,

--- a/src/finalisers/shared/warnOnBuiltins.js
+++ b/src/finalisers/shared/warnOnBuiltins.js
@@ -1,3 +1,5 @@
+import Warning from '../../Warning.js';
+
 const builtins = {
 	process: true,
 	events: true,
@@ -35,7 +37,7 @@ export default function warnOnBuiltins ( bundle ) {
 		`module ('${externalBuiltins[0]}')` :
 		`modules (${externalBuiltins.slice( 0, -1 ).map( name => `'${name}'` ).join( ', ' )} and '${externalBuiltins.slice( -1 )}')`;
 
-	bundle.warn({
+	Warning.print({
 		code: 'MISSING_NODE_BUILTINS',
 		modules: externalBuiltins,
 		message: `Creating a browser bundle that depends on Node.js built-in ${detail}. You might need to include https://www.npmjs.com/package/rollup-plugin-node-builtins`

--- a/src/node-entry.js
+++ b/src/node-entry.js
@@ -1,3 +1,4 @@
 export { default as rollup } from './rollup/index.js';
 export { default as watch } from './watch/index.js';
 export { version as VERSION } from '../package.json';
+export { default as Warning } from './Warning.js';

--- a/src/rollup/index.js
+++ b/src/rollup/index.js
@@ -7,6 +7,7 @@ import validateKeys from '../utils/validateKeys.js';
 import error from '../utils/error.js';
 import { SOURCEMAPPING_URL } from '../utils/sourceMappingURL.js';
 import Bundle from '../Bundle.js';
+import Warning from '../Warning.js';
 
 export const VERSION = '<@VERSION@>';
 
@@ -54,23 +55,20 @@ function checkAmd ( options ) {
 		options.amd = { id: options.moduleId };
 		delete options.moduleId;
 
-		const message = `options.moduleId is deprecated in favour of options.amd = { id: moduleId }`;
-		if ( options.onwarn ) {
-			options.onwarn({ message });
-		} else {
-			console.warn( message ); // eslint-disable-line no-console
-		}
+		Warning.print({ 
+			message: `options.moduleId is deprecated in favour of options.amd = { id: moduleId }`
+		 });
 	}
 }
 
-function checkInputOptions ( options, warn ) {
+function checkInputOptions ( options ) {
 	if ( options.transform || options.load || options.resolveId || options.resolveExternal ) {
 		throw new Error( 'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://github.com/rollup/rollup/wiki/Plugins for details' );
 	}
 
 	if ( options.entry && !options.input ) {
 		options.input = options.entry;
-		warn({
+		Warning.print({
 			message: `options.entry is deprecated, use options.input`
 		});
 	}
@@ -87,7 +85,7 @@ const deprecated = {
 	useStrict: 'strict'
 };
 
-function checkOutputOptions ( options, warn ) {
+function checkOutputOptions ( options ) {
 	if ( options.format === 'es6' ) {
 		error({
 			message: 'The `es6` output format is deprecated – use `es` instead',
@@ -108,7 +106,7 @@ function checkOutputOptions ( options, warn ) {
 		options.amd = { id: options.moduleId };
 		delete options.moduleId;
 
-		warn({
+		Warning.print({
 			message: `options.moduleId is deprecated in favour of options.amd = { id: moduleId }`
 		});
 	}
@@ -124,7 +122,7 @@ function checkOutputOptions ( options, warn ) {
 
 	if ( deprecations.length ) {
 		const message = `The following options have been renamed — please update your config: ${deprecations.map(option => `${option.old} -> ${option.new}`).join(', ')}`;
-		warn({
+		Warning.print({
 			code: 'DEPRECATED_OPTIONS',
 			message,
 			deprecations
@@ -144,9 +142,9 @@ export default function rollup ( options ) {
 			throw new Error( 'You must supply an options object to rollup' );
 		}
 
-		const warn = options.onwarn || (warning => console.warn( warning.message )); // eslint-disable-line no-console
+		Warning.onwarn = options.onwarn;
 
-		checkInputOptions( options, warn );
+		checkInputOptions( options );
 		const bundle = new Bundle( options );
 
 		timeStart( '--BUILD--' );
@@ -158,7 +156,7 @@ export default function rollup ( options ) {
 				if ( !options ) {
 					throw new Error( 'You must supply an options object' );
 				}
-				checkOutputOptions( options, warn );
+				checkOutputOptions( options );
 				checkAmd( options );
 
 				timeStart( '--GENERATE--' );

--- a/src/utils/collapseSourcemaps.js
+++ b/src/utils/collapseSourcemaps.js
@@ -1,6 +1,7 @@
 import { encode } from 'sourcemap-codec';
 import error from './error.js';
 import { basename, dirname, relative, resolve } from './path.js';
+import Warning from '../Warning.js';
 
 class Source {
 	constructor ( filename, content ) {
@@ -133,7 +134,7 @@ export default function collapseSourcemaps ( bundle, file, map, modules, bundleS
 
 		sourcemapChain.forEach( map => {
 			if ( map.missing ) {
-				bundle.warn({
+				Warning.print({
 					code: 'SOURCEMAP_BROKEN',
 					plugin: map.plugin,
 					message: `Sourcemap is likely to be incorrect: a plugin${map.plugin ? ` ('${map.plugin}')` : ``} was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -1,6 +1,5 @@
 import { lstatSync, readdirSync, readFileSync, realpathSync } from './fs.js'; // eslint-disable-line
 import { basename, dirname, isAbsolute, resolve } from './path.js';
-import { blank } from './object.js';
 import error from './error.js';
 
 export function load ( id ) {

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -47,15 +47,3 @@ export function resolveId ( importee, importer ) {
 	return addJsExtensionIfNecessary(
 		resolve( importer ? dirname( importer ) : resolve(), importee ) );
 }
-
-
-export function makeOnwarn () {
-	const warned = blank();
-
-	return warning => {
-		const str = warning.toString();
-		if ( str in warned ) return;
-		console.error( str ); //eslint-disable-line no-console
-		warned[ str ] = true;
-	};
-}

--- a/src/utils/getExportMode.js
+++ b/src/utils/getExportMode.js
@@ -1,5 +1,6 @@
 import { keys } from './object.js';
 import error from './error.js';
+import Warning from '../Warning.js';
 
 function badExports ( option, keys ) {
 	error({
@@ -28,7 +29,7 @@ export default function getExportMode ( bundle, {exports: exportMode, name, form
 			exportMode = 'default';
 		} else {
 			if ( bundle.entryModule.exports.default && format !== 'es') {
-				bundle.warn({
+				Warning.print({
 					code: 'MIXED_EXPORTS',
 					message: `Using named and default exports together. Consumers of your bundle will have to use ${name || 'bundle'}['default'] to access the default export, which may not be what you want. Use \`exports: 'named'\` to disable this warning`,
 					url: `https://github.com/rollup/rollup/wiki/JavaScript-API#exports`

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -2,6 +2,7 @@ import { decode } from 'sourcemap-codec';
 import { locate } from 'locate-character';
 import error from './error.js';
 import getCodeFrame from './getCodeFrame.js';
+import Warning from '../Warning.js';
 
 export default function transform ( bundle, source, id, plugins ) {
 	const sourcemapChain = [];
@@ -54,7 +55,7 @@ export default function transform ( bundle, source, id, plugins ) {
 			const context = {
 				warn: ( warning, pos ) => {
 					warning = augment( warning, pos, 'PLUGIN_WARNING' );
-					bundle.warn( warning );
+					Warning.print( warning );
 				},
 
 				error ( err, pos ) {

--- a/src/watch/index.js
+++ b/src/watch/index.js
@@ -6,6 +6,7 @@ import ensureArray from '../utils/ensureArray.js';
 import { mapSequence } from '../utils/promise.js';
 import { addTask, deleteTask } from './fileWatchers.js';
 import chokidar from './chokidar.js';
+import Warning from '../Warning.js';
 
 const DELAY = 100;
 
@@ -90,7 +91,7 @@ class Task {
 			treeshake: config.treeshake,
 			plugins: config.plugins,
 			external: config.external,
-			onwarn: config.onwarn || (warning => console.warn(warning.message)), // eslint-disable-line no-console
+			onwarn: config.onwarn,
 			acorn: config.acorn,
 			context: config.context,
 			moduleContext: config.moduleContext
@@ -176,7 +177,7 @@ class Task {
 		});
 
 		if (this.deprecations) {
-			this.inputOptions.onwarn({
+			Warning.print({
 				code: 'DEPRECATED_OPTIONS',
 				deprecations: this.deprecations
 			});


### PR DESCRIPTION
Fix #1501 

Documentation must be updated with :
Plugin can throw warning with 
```
import { Warning } from 'rollup'

Warning.print({
     code: MY_PLUGIN_WARNING,
     message: 'This plugin throw a warning'
});
```

