### PR TITLE
Print timestamps on "END" events.

### DIFF
--- a/bin/src/run/watch.js
+++ b/bin/src/run/watch.js
@@ -3,6 +3,7 @@ import * as rollup from 'rollup';
 import chalk from 'chalk';
 import ms from 'pretty-ms';
 import onExit from 'signal-exit';
+import dateTime from 'date-time';
 import mergeOptions from './mergeOptions.js';
 import batchWarnings from './batchWarnings.js';
 import alternateScreen from './alternateScreen.js';
@@ -77,8 +78,7 @@ export default function watch(configFile, configs, command, silent) {
 
 				case 'END':
 					if ( !silent && isTTY ) {
-						stderr( `\nfinished at ${new Date()}` );
-						stderr( `\nwaiting for changes...` );
+						stderr( `\n[${dateTime()}] waiting for changes...` );
 					}
 			}
 		});

--- a/bin/src/run/watch.js
+++ b/bin/src/run/watch.js
@@ -76,7 +76,10 @@ export default function watch(configFile, configs, command, silent) {
 					break;
 
 				case 'END':
-					if ( !silent && isTTY ) stderr( `\nwaiting for changes...` );
+					if ( !silent && isTTY ) {
+						stderr( `\nfinished at ${new Date()}` );
+						stderr( `\nwaiting for changes...` );
+					}
 			}
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chalk": "^2.1.0",
     "codecov.io": "^0.1.6",
     "console-group": "^0.3.1",
+    "date-time": "^2.1.0",
     "eslint": "^4.4.1",
     "eslint-plugin-import": "^2.2.0",
     "is-reference": "^1.0.0",


### PR DESCRIPTION
Previously, it was not clear when work had been completed.  This sets clearer expectations for someone monitoring the watcher output as to when they can expect their code to have updated.
