### PR TITLE
Point Readme to up-to-date starter projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rollup is a module bundler for JavaScript which compiles small pieces of code in
 
 ## Quick Start Guide
 
-Install with `npm install --global rollup`. Rollup can be used either through a [command line interface](https://rollupjs.org/#command-line-reference) with an optional configuration file, or else through its [JavaScript API](https://rollupjs.org/#javascript-api). Run `rollup --help` to see the available options and parameters. The [starter project template](https://github.com/rollup/rollup-starter-project) demonstrates common configuration options, and more detailed instructions are available throughout the [user guide](http://rollupjs.org/).
+Install with `npm install --global rollup`. Rollup can be used either through a [command line interface](https://rollupjs.org/#command-line-reference) with an optional configuration file, or else through its [JavaScript API](https://rollupjs.org/#javascript-api). Run `rollup --help` to see the available options and parameters. The starter project templates, [rollup-starter-lib](https://github.com/rollup/rollup-starter-lib) and [rollup-starter-app](https://github.com/rollup/rollup-starter-app), demonstrate common configuration options, and more detailed instructions are available throughout the [user guide](http://rollupjs.org/).
 
 ### Commands
 


### PR DESCRIPTION
The Readme was pointing to an out of date starter project. This PR points it to the two starter projects mentioned at [https://rollupjs.org/#quick-start](https://rollupjs.org/#quick-start)
