### PR TITLE
Tweaked install/publish related scripts - enabled installing as dep d…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ env:
   global:
     - BUILD_TIMEOUT=10000
 install: npm install
+before_install:
+  - if [[ $TRAVIS_NODE_VERSION -lt 7 ]]; then npm install --global npm@4; fi
 # script: npm run ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
+  - IF %nodejs_version% LSS 7 npm -g install npm@4
   - npm install
 
 build: off

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "pretest": "npm run build",
-    "test": "mocha",
+    "test": "npm run test:only",
+    "test:only": "mocha",
     "test:leak": "node --expose-gc test/leak/index.js",
     "test:quick": "rollup -c && mocha",
     "pretest-coverage": "npm run build",
@@ -19,7 +20,8 @@
     "ci": "npm run test-coverage && codecov < coverage/coverage-remapped.lcov",
     "build": "git rev-parse HEAD > .commithash && rollup -c && chmod a+x bin/rollup",
     "watch": "rollup -cw",
-    "prepublish": "npm run lint && npm test && npm run test:leak",
+    "prepublishOnly": "npm run lint && npm run test:only && npm run test:leak",
+    "prepare": "npm run build",
     "lint": "eslint src browser test/test.js test/*/index.js test/utils test/**/_config.js"
   },
   "repository": "rollup/rollup",


### PR DESCRIPTION
…irectly from git

Fixed issue mentioned in https://github.com/rollup/rollup-plugin-babel/issues/100#issuecomment-334992527

This enabled installing rollup directly from github, convenient for testing PRs etc in other projects.

cc @lukastaegert 