### PR TITLE
Fix regression when using pureExternalModules flag

### DIFF
--- a/src/ast/variables/ExternalVariable.js
+++ b/src/ast/variables/ExternalVariable.js
@@ -29,7 +29,7 @@ export default class ExternalVariable extends Variable {
 		return es ? this.safeName : `${this.module.name}.${this.name}`;
 	}
 
-	includeDeclaration () {
+	includeVariable () {
 		if ( this.included ) {
 			return false;
 		}

--- a/test/function/samples/keep-used-imports-from-pure-external-modules/_config.js
+++ b/test/function/samples/keep-used-imports-from-pure-external-modules/_config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	description: 'imports from pure external modules that are used should not be omitted',
+	options: {
+		external: [ 'warning' ],
+		pureExternalModules: [ 'warning' ]
+	},
+	context: {
+		require: id => {
+			if ( id === 'warning' ) return arg => console.log( arg );
+			throw new Error( 'Unexpected import', id );
+		}
+	}
+};

--- a/test/function/samples/keep-used-imports-from-pure-external-modules/main.js
+++ b/test/function/samples/keep-used-imports-from-pure-external-modules/main.js
@@ -1,0 +1,3 @@
+import warning from 'warning';
+
+warning('hi');


### PR DESCRIPTION
Due to a failed refactoring, imports of external modules were never included for modules listed in `pureExternalModules`. This fixes that (and adds a test 😜)