### PR TITLE
Fix issue when using labels inside functions

### DIFF
--- a/src/ast/ExecutionPathOptions.js
+++ b/src/ast/ExecutionPathOptions.js
@@ -36,6 +36,16 @@ export default class ExecutionPathOptions {
 	}
 
 	/**
+	 * Returns a new ExecutionPathOptions instance with the given option removed.
+	 * Does not mutate the current instance. Also works in sub-classes.
+	 * @param {string} option - The name of an option
+	 * @returns {*} Its value
+	 */
+	remove ( option ) {
+		return new this.constructor( this._optionValues.remove( option ) );
+	}
+
+	/**
 	 * Returns a new ExecutionPathOptions instance with the given option set to a new value.
 	 * Does not mutate the current instance. Also works in sub-classes.
 	 * @param {string} option - The name of an option
@@ -245,7 +255,7 @@ export default class ExecutionPathOptions {
 	 * @return {ExecutionPathOptions}
 	 */
 	setIgnoreNoLabels () {
-		return this.set( OPTION_IGNORED_LABELS, null );
+		return this.remove( OPTION_IGNORED_LABELS );
 	}
 
 	/**

--- a/test/function/samples/handle-labels-inside-functions/_config.js
+++ b/test/function/samples/handle-labels-inside-functions/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'do not fail when using labels inside functions (#1706)'
+};

--- a/test/function/samples/handle-labels-inside-functions/main.js
+++ b/test/function/samples/handle-labels-inside-functions/main.js
@@ -1,0 +1,12 @@
+function loopWithLabel () {
+	label2: {
+		while ( true ) {
+			if ( Math.random() < 0.5 ) {
+				break label2;
+			}
+			console.log( 'loop' );
+		}
+	}
+}
+
+loopWithLabel();


### PR DESCRIPTION
Previously, using labels inside functions would trigger a "keypath" error due to some option cleared in the wrong way. This resolves #1706.