### PR TITLE
Fix sequence expressions

### DIFF
--- a/src/ast/nodes/SequenceExpression.js
+++ b/src/ast/nodes/SequenceExpression.js
@@ -41,7 +41,7 @@ export default class SequenceExpression extends Node {
 			} else {
 				let previousEnd = this.start;
 				for ( const expression of included ) {
-					expression.render();
+					expression.render( code, es );
 					code.remove( previousEnd, expression.start );
 					code.appendLeft( expression.end, ', ' );
 					previousEnd = expression.end;

--- a/src/ast/nodes/SequenceExpression.js
+++ b/src/ast/nodes/SequenceExpression.js
@@ -32,16 +32,16 @@ export default class SequenceExpression extends Node {
 
 		else {
 			const last = this.expressions[ this.expressions.length - 1 ];
-			const included = this.expressions.slice( 0, this.expressions.length - 1 ).filter( expression => expression.included );
+			last.render( code, es );
 
+			const included = this.expressions.slice( 0, this.expressions.length - 1 ).filter( expression => expression.included );
 			if ( included.length === 0 ) {
 				code.remove( this.start, last.start );
 				code.remove( last.end, this.end );
-			}
-
-			else {
+			} else {
 				let previousEnd = this.start;
 				for ( const expression of included ) {
+					expression.render();
 					code.remove( previousEnd, expression.start );
 					code.appendLeft( expression.end, ', ' );
 					previousEnd = expression.end;

--- a/test/form/samples/sequence-expression/_expected/amd.js
+++ b/test/form/samples/sequence-expression/_expected/amd.js
@@ -3,17 +3,18 @@ define(function () { 'use strict';
     function foo$1 () {
         console.log( 'foo' );
     }
-	// should remove expressions without side-effect, multiple effects
-	var a = (foo(), foo(), 2);
-	// without white-space, effect at the end
-	var b = (foo());
 
-	// should only keep final expression
-	var d = (2);
-	console.log(d);
+    // should remove expressions without side-effect, multiple effects
+    var a = (foo(), foo(), 2);
+    // without white-space, effect at the end
+    var b = (foo());
 
-	// should infer value
-	// should keep f import
-	var e = (foo$1());
+    // should only keep final expression
+    var d = (2);
+    console.log(d);
+
+    // should infer value
+    // should keep f import
+    var e = (foo$1());
 
 });

--- a/test/form/samples/sequence-expression/_expected/amd.js
+++ b/test/form/samples/sequence-expression/_expected/amd.js
@@ -1,5 +1,8 @@
 define(function () { 'use strict';
 
+    function foo$1 () {
+        console.log( 'foo' );
+    }
 	// should remove expressions without side-effect, multiple effects
 	var a = (foo(), foo(), 2);
 	// without white-space, effect at the end
@@ -10,5 +13,7 @@ define(function () { 'use strict';
 	console.log(d);
 
 	// should infer value
+	// should keep f import
+	var e = (foo$1());
 
 });

--- a/test/form/samples/sequence-expression/_expected/amd.js
+++ b/test/form/samples/sequence-expression/_expected/amd.js
@@ -17,4 +17,7 @@ define(function () { 'use strict';
     // should keep f import
     var e = (foo$1());
 
+    // should properly render complex sub-expressions
+    var g = ((() => {console.log(foo$1());})(), 1);
+
 });

--- a/test/form/samples/sequence-expression/_expected/cjs.js
+++ b/test/form/samples/sequence-expression/_expected/cjs.js
@@ -16,3 +16,6 @@ console.log(d);
 // should infer value
 // should keep f import
 var e = (foo$1());
+
+// should properly render complex sub-expressions
+var g = ((() => {console.log(foo$1());})(), 1);

--- a/test/form/samples/sequence-expression/_expected/cjs.js
+++ b/test/form/samples/sequence-expression/_expected/cjs.js
@@ -1,5 +1,8 @@
 'use strict';
 
+function foo$1 () {
+    console.log( 'foo' );
+}
 // should remove expressions without side-effect, multiple effects
 var a = (foo(), foo(), 2);
 // without white-space, effect at the end
@@ -10,3 +13,5 @@ var d = (2);
 console.log(d);
 
 // should infer value
+// should keep f import
+var e = (foo$1());

--- a/test/form/samples/sequence-expression/_expected/cjs.js
+++ b/test/form/samples/sequence-expression/_expected/cjs.js
@@ -3,6 +3,7 @@
 function foo$1 () {
     console.log( 'foo' );
 }
+
 // should remove expressions without side-effect, multiple effects
 var a = (foo(), foo(), 2);
 // without white-space, effect at the end

--- a/test/form/samples/sequence-expression/_expected/es.js
+++ b/test/form/samples/sequence-expression/_expected/es.js
@@ -14,3 +14,6 @@ console.log(d);
 // should infer value
 // should keep f import
 var e = (foo$1());
+
+// should properly render complex sub-expressions
+var g = ((() => {console.log(foo$1());})(), 1);

--- a/test/form/samples/sequence-expression/_expected/es.js
+++ b/test/form/samples/sequence-expression/_expected/es.js
@@ -1,3 +1,6 @@
+function foo$1 () {
+    console.log( 'foo' );
+}
 // should remove expressions without side-effect, multiple effects
 var a = (foo(), foo(), 2);
 // without white-space, effect at the end
@@ -8,3 +11,5 @@ var d = (2);
 console.log(d);
 
 // should infer value
+// should keep f import
+var e = (foo$1());

--- a/test/form/samples/sequence-expression/_expected/es.js
+++ b/test/form/samples/sequence-expression/_expected/es.js
@@ -1,6 +1,7 @@
 function foo$1 () {
     console.log( 'foo' );
 }
+
 // should remove expressions without side-effect, multiple effects
 var a = (foo(), foo(), 2);
 // without white-space, effect at the end

--- a/test/form/samples/sequence-expression/_expected/iife.js
+++ b/test/form/samples/sequence-expression/_expected/iife.js
@@ -1,6 +1,9 @@
 (function () {
 	'use strict';
 
+    function foo$1 () {
+        console.log( 'foo' );
+    }
 	// should remove expressions without side-effect, multiple effects
 	var a = (foo(), foo(), 2);
 	// without white-space, effect at the end
@@ -11,5 +14,7 @@
 	console.log(d);
 
 	// should infer value
+	// should keep f import
+	var e = (foo$1());
 
 }());

--- a/test/form/samples/sequence-expression/_expected/iife.js
+++ b/test/form/samples/sequence-expression/_expected/iife.js
@@ -18,4 +18,7 @@
     // should keep f import
     var e = (foo$1());
 
+    // should properly render complex sub-expressions
+    var g = ((() => {console.log(foo$1());})(), 1);
+
 }());

--- a/test/form/samples/sequence-expression/_expected/iife.js
+++ b/test/form/samples/sequence-expression/_expected/iife.js
@@ -1,20 +1,21 @@
 (function () {
-	'use strict';
+    'use strict';
 
     function foo$1 () {
         console.log( 'foo' );
     }
-	// should remove expressions without side-effect, multiple effects
-	var a = (foo(), foo(), 2);
-	// without white-space, effect at the end
-	var b = (foo());
 
-	// should only keep final expression
-	var d = (2);
-	console.log(d);
+    // should remove expressions without side-effect, multiple effects
+    var a = (foo(), foo(), 2);
+    // without white-space, effect at the end
+    var b = (foo());
 
-	// should infer value
-	// should keep f import
-	var e = (foo$1());
+    // should only keep final expression
+    var d = (2);
+    console.log(d);
+
+    // should infer value
+    // should keep f import
+    var e = (foo$1());
 
 }());

--- a/test/form/samples/sequence-expression/_expected/umd.js
+++ b/test/form/samples/sequence-expression/_expected/umd.js
@@ -21,4 +21,7 @@
     // should keep f import
     var e = (foo$1());
 
+    // should properly render complex sub-expressions
+    var g = ((() => {console.log(foo$1());})(), 1);
+
 })));

--- a/test/form/samples/sequence-expression/_expected/umd.js
+++ b/test/form/samples/sequence-expression/_expected/umd.js
@@ -4,6 +4,9 @@
 	(factory());
 }(this, (function () { 'use strict';
 
+    function foo$1 () {
+        console.log( 'foo' );
+    }
 	// should remove expressions without side-effect, multiple effects
 	var a = (foo(), foo(), 2);
 	// without white-space, effect at the end
@@ -14,5 +17,7 @@
 	console.log(d);
 
 	// should infer value
+	// should keep f import
+	var e = (foo$1());
 
 })));

--- a/test/form/samples/sequence-expression/_expected/umd.js
+++ b/test/form/samples/sequence-expression/_expected/umd.js
@@ -1,23 +1,24 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
-	typeof define === 'function' && define.amd ? define(factory) :
-	(factory());
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    (factory());
 }(this, (function () { 'use strict';
 
     function foo$1 () {
         console.log( 'foo' );
     }
-	// should remove expressions without side-effect, multiple effects
-	var a = (foo(), foo(), 2);
-	// without white-space, effect at the end
-	var b = (foo());
 
-	// should only keep final expression
-	var d = (2);
-	console.log(d);
+    // should remove expressions without side-effect, multiple effects
+    var a = (foo(), foo(), 2);
+    // without white-space, effect at the end
+    var b = (foo());
 
-	// should infer value
-	// should keep f import
-	var e = (foo$1());
+    // should only keep final expression
+    var d = (2);
+    console.log(d);
+
+    // should infer value
+    // should keep f import
+    var e = (foo$1());
 
 })));

--- a/test/form/samples/sequence-expression/foo.js
+++ b/test/form/samples/sequence-expression/foo.js
@@ -1,0 +1,3 @@
+export function foo () {
+    console.log( 'foo' );
+}

--- a/test/form/samples/sequence-expression/main.js
+++ b/test/form/samples/sequence-expression/main.js
@@ -18,3 +18,6 @@ if ((1, 2) !== 2) {
 
 // should keep f import
 var e = (0, f.foo());
+
+// should properly render complex sub-expressions
+var g = ((() => {})(), (() => {console.log(f.foo())})(), 1);

--- a/test/form/samples/sequence-expression/main.js
+++ b/test/form/samples/sequence-expression/main.js
@@ -1,3 +1,4 @@
+import * as f from './foo';
 // should remove expressions without side-effect, multiple effects
 var a = (0, foo(), 1, foo(), 2);
 // without white-space, effect at the end
@@ -15,3 +16,5 @@ if ((1, 2) !== 2) {
 	console.log( 'effect' );
 }
 
+// should keep f import
+var e = (0, f.foo());


### PR DESCRIPTION
With the recent changes to sequence (i.e. comma) expression handling, variables in sequence expressions were no longer renamed as the new render logic did not call `.render()` on its included children. This PR fixes it. Thanks for everyone who provided input, broken tests, reproductions and who knows what! You are great 👍

This PR is based on and closes #1716.