### PR TITLE
Fix uninitialized child nodes for conditional expressions

### DIFF
--- a/src/ast/nodes/ConditionalExpression.js
+++ b/src/ast/nodes/ConditionalExpression.js
@@ -40,20 +40,17 @@ export default class ConditionalExpression extends Node {
 	}
 
 	initialiseChildren ( parentScope ) {
+		super.initialiseChildren( parentScope );
 		if ( this.module.bundle.treeshake ) {
 			this.testValue = this.test.getValue();
 
 			if ( this.testValue === UNKNOWN_VALUE ) {
-				super.initialiseChildren( parentScope );
+				return;
 			} else if ( this.testValue ) {
-				this.consequent.initialise( this.scope );
 				this.alternate = null;
 			} else if ( this.alternate ) {
-				this.alternate.initialise( this.scope );
 				this.consequent = null;
 			}
-		} else {
-			super.initialiseChildren( parentScope );
 		}
 	}
 

--- a/test/form/samples/conditional-expression/main.js
+++ b/test/form/samples/conditional-expression/main.js
@@ -20,7 +20,8 @@ var e3 = (true ? () => () => {} : () => () => console.log( 'effect' ))()();
 var f1 = false ? foo() : 2;
 var f2 = (false ? function () {this.x = 1;} : function () {})();
 var f3 = (false ? () => () => console.log( 'effect' ) : () => () => {})()();
-var g = true ? 1 : 2;
+var g1 = true ? 1 : 2;
+var g2 = true || foo() ? 1 : 2;
 
 // known side-effect
 var h1 = true ? foo() : 2;


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

Fixes #1719.

**Problem:** Dead branch nodes of conditional expressions were not initialized. i.e. when condition test is known to be true, test node is not initialized.
**Fix:** Initialize all children of conditional expressions similar to how it's done for if statements.
**Test:** Check unit test, it fails before this fix. 

Another approach would be to remove pruned nodes in logical expressions. E.g. `true || foo()` would be pruned to `true`, `false && foo()` would be pruned to `false`. 