### PR TITLE
Add case for sequence this context (broken test)

### DIFF
--- a/test/form/samples/sequence-expression/_expected/amd.js
+++ b/test/form/samples/sequence-expression/_expected/amd.js
@@ -20,4 +20,6 @@ define(function () { 'use strict';
     // should properly render complex sub-expressions
     var g = ((() => {console.log(foo$1());})(), 1);
 
+    // should maintain this context
+    var h = (0, f.foo)();
 });

--- a/test/form/samples/sequence-expression/_expected/cjs.js
+++ b/test/form/samples/sequence-expression/_expected/cjs.js
@@ -19,3 +19,6 @@ var e = (foo$1());
 
 // should properly render complex sub-expressions
 var g = ((() => {console.log(foo$1());})(), 1);
+
+// should maintain this context
+var h = (0, f.foo)();

--- a/test/form/samples/sequence-expression/_expected/es.js
+++ b/test/form/samples/sequence-expression/_expected/es.js
@@ -17,3 +17,6 @@ var e = (foo$1());
 
 // should properly render complex sub-expressions
 var g = ((() => {console.log(foo$1());})(), 1);
+
+// should maintain this context
+var h = (0, f.foo)();

--- a/test/form/samples/sequence-expression/_expected/iife.js
+++ b/test/form/samples/sequence-expression/_expected/iife.js
@@ -21,4 +21,7 @@
     // should properly render complex sub-expressions
     var g = ((() => {console.log(foo$1());})(), 1);
 
+    // should maintain this context
+    var h = (0, f.foo)();
+
 }());

--- a/test/form/samples/sequence-expression/_expected/umd.js
+++ b/test/form/samples/sequence-expression/_expected/umd.js
@@ -24,4 +24,7 @@
     // should properly render complex sub-expressions
     var g = ((() => {console.log(foo$1());})(), 1);
 
+    // should maintain this context
+    var h = (0, f.foo)();
+
 })));

--- a/test/form/samples/sequence-expression/main.js
+++ b/test/form/samples/sequence-expression/main.js
@@ -21,3 +21,6 @@ var e = (0, f.foo());
 
 // should properly render complex sub-expressions
 var g = ((() => {})(), (() => {console.log(f.foo())})(), 1);
+
+// should maintain this context
+var h = (0, f.foo)();


### PR DESCRIPTION
When calling a sequence as a function, the `this` context is maintained. The pattern (especially used by Babel for module functions) is:

```js
var a = (0, module.f)()  // basically f.call(this)
```

Currently in 0.51.3, this becomes:

```js
var a = (module.f)()  // basically f.call(module)
```

When the sequence is called as a function, the first items should not be discarded.