### PR TITLE
Resolves issues when dealing with complex object assignments

### DIFF
--- a/src/ast/nodes/BlockStatement.js
+++ b/src/ast/nodes/BlockStatement.js
@@ -1,12 +1,12 @@
 import Statement from './shared/Statement.js';
 import BlockScope from '../scopes/BlockScope';
-import { UNKNOWN_ASSIGNMENT } from '../values';
+import { UNDEFINED_ASSIGNMENT } from '../values';
 
 export default class BlockStatement extends Statement {
 	bindImplicitReturnExpressionToScope () {
 		const lastStatement = this.body[ this.body.length - 1 ];
 		if ( !lastStatement || lastStatement.type !== 'ReturnStatement' ) {
-			this.scope.addReturnExpression( UNKNOWN_ASSIGNMENT );
+			this.scope.addReturnExpression( UNDEFINED_ASSIGNMENT );
 		}
 	}
 

--- a/src/ast/nodes/ReturnStatement.js
+++ b/src/ast/nodes/ReturnStatement.js
@@ -1,5 +1,5 @@
 import Statement from './shared/Statement.js';
-import {UNKNOWN_ASSIGNMENT} from '../values';
+import { UNDEFINED_ASSIGNMENT } from '../values';
 
 export default class ReturnStatement extends Statement {
 	hasEffects ( options ) {
@@ -8,6 +8,6 @@ export default class ReturnStatement extends Statement {
 	}
 
 	initialiseNode () {
-		this.scope.addReturnExpression( this.argument || UNKNOWN_ASSIGNMENT );
+		this.scope.addReturnExpression( this.argument || UNDEFINED_ASSIGNMENT );
 	}
 }

--- a/src/ast/nodes/UnaryExpression.js
+++ b/src/ast/nodes/UnaryExpression.js
@@ -1,5 +1,5 @@
 import Node from '../Node.js';
-import { UNKNOWN_ASSIGNMENT, UNKNOWN_VALUE } from '../values';
+import { UNDEFINED_ASSIGNMENT, UNKNOWN_VALUE } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 
 const operators = {
@@ -15,7 +15,7 @@ const operators = {
 export default class UnaryExpression extends Node {
 	bindNode () {
 		if ( this.operator === 'delete' ) {
-			this.argument.bindAssignmentAtPath( [], UNKNOWN_ASSIGNMENT, ExecutionPathOptions.create() );
+			this.argument.bindAssignmentAtPath( [], UNDEFINED_ASSIGNMENT, ExecutionPathOptions.create() );
 		}
 	}
 

--- a/src/ast/scopes/ModuleScope.js
+++ b/src/ast/scopes/ModuleScope.js
@@ -2,7 +2,7 @@ import { forOwn } from '../../utils/object.js';
 import relativeId from '../../utils/relativeId.js';
 import Scope from './Scope.js';
 import LocalVariable from '../variables/LocalVariable';
-import { UNKNOWN_ASSIGNMENT } from '../values';
+import { UNDEFINED_ASSIGNMENT } from '../values';
 
 export default class ModuleScope extends Scope {
 	constructor ( module ) {
@@ -12,7 +12,7 @@ export default class ModuleScope extends Scope {
 		} );
 
 		this.module = module;
-		this.variables.this = new LocalVariable( 'this', null, UNKNOWN_ASSIGNMENT );
+		this.variables.this = new LocalVariable( 'this', null, UNDEFINED_ASSIGNMENT );
 	}
 
 	deshadow ( names ) {

--- a/src/ast/scopes/Scope.js
+++ b/src/ast/scopes/Scope.js
@@ -1,7 +1,7 @@
 import { blank, keys } from '../../utils/object.js';
 import LocalVariable from '../variables/LocalVariable';
 import ExportDefaultVariable from '../variables/ExportDefaultVariable';
-import { UNKNOWN_ASSIGNMENT } from '../values';
+import { UNDEFINED_ASSIGNMENT } from '../values';
 
 export default class Scope {
 	constructor ( options = {} ) {
@@ -28,7 +28,7 @@ export default class Scope {
 			variable.addDeclaration( identifier );
 			options.init && variable.bindAssignmentAtPath( [], options.init );
 		} else {
-			this.variables[ name ] = new LocalVariable( identifier.name, identifier, options.init || UNKNOWN_ASSIGNMENT );
+			this.variables[ name ] = new LocalVariable( identifier.name, identifier, options.init || UNDEFINED_ASSIGNMENT );
 		}
 		return this.variables[ name ];
 	}

--- a/src/ast/values.js
+++ b/src/ast/values.js
@@ -10,3 +10,14 @@ export const UNKNOWN_ASSIGNMENT = {
 	someReturnExpressionWhenCalledAtPath: () => true,
 	toString: () => '[[UNKNOWN]]'
 };
+
+export const UNDEFINED_ASSIGNMENT = {
+	type: 'UNDEFINED',
+	bindAssignmentAtPath: () => {},
+	forEachReturnExpressionWhenCalledAtPath: () => {},
+	hasEffectsWhenAccessedAtPath: path => path.length > 0,
+	hasEffectsWhenAssignedAtPath: path => path.length > 0,
+	hasEffectsWhenCalledAtPath: () => true,
+	someReturnExpressionWhenCalledAtPath: () => true,
+	toString: () => '[[UNDEFINED]]'
+};

--- a/src/ast/variables/ArgumentsVariable.js
+++ b/src/ast/variables/ArgumentsVariable.js
@@ -1,9 +1,9 @@
 import LocalVariable from './LocalVariable';
-import { UNKNOWN_ASSIGNMENT } from '../values';
+import { UNDEFINED_ASSIGNMENT, UNKNOWN_ASSIGNMENT } from '../values';
 
 const getParameterVariable = ( path, options ) =>
 	(path[ 0 ] < options.getArgumentsVariables().length && options.getArgumentsVariables()[ path[ 0 ] ] )
-	|| UNKNOWN_ASSIGNMENT;
+	|| UNDEFINED_ASSIGNMENT;
 
 export default class ArgumentsVariable extends LocalVariable {
 	constructor ( parameters ) {

--- a/src/ast/variables/LocalVariable.js
+++ b/src/ast/variables/LocalVariable.js
@@ -1,8 +1,8 @@
 import Variable from './Variable';
 import VariableShapeTracker from './VariableShapeTracker';
 
-// To avoid infinite recursions
-const MAX_PATH_LENGTH = 6;
+// To avoid exponential performance degradation for complex object manipulations
+const MAX_PATH_LENGTH = 2;
 
 export default class LocalVariable extends Variable {
 	constructor ( name, declarator, init ) {
@@ -54,9 +54,9 @@ export default class LocalVariable extends Variable {
 	hasEffectsWhenAccessedAtPath ( path, options ) {
 		return path.length > MAX_PATH_LENGTH
 			|| this.boundExpressions.someAtPath( path, ( relativePath, node ) =>
-				!options.hasNodeBeenAccessedAtPath( relativePath, node ) && node
-					.hasEffectsWhenAccessedAtPath( relativePath,
-						options.addAccessedNodeAtPath( relativePath, node ) ) );
+				relativePath.length > 0
+				&& !options.hasNodeBeenAccessedAtPath( relativePath, node )
+				&& node.hasEffectsWhenAccessedAtPath( relativePath, options.addAccessedNodeAtPath( relativePath, node ) ) );
 	}
 
 	hasEffectsWhenAssignedAtPath ( path, options ) {

--- a/src/ast/variables/LocalVariable.js
+++ b/src/ast/variables/LocalVariable.js
@@ -19,7 +19,10 @@ export default class LocalVariable extends Variable {
 	}
 
 	bindAssignmentAtPath ( path, expression, options ) {
-		if ( path.length > MAX_PATH_LENGTH || this.boundExpressions.hasAtPath( path, expression ) ) return;
+		if ( expression.variable ) {
+			expression = expression.variable;
+		}
+		if ( path.length > MAX_PATH_LENGTH || expression === this || this.boundExpressions.hasAtPath( path, expression ) ) return;
 		this.boundExpressions.addAtPath( path, expression );
 		this.boundExpressions.forEachAssignedToPath( path, ( subPath, node ) => {
 			subPath.length > 0

--- a/src/ast/variables/VariableShapeTracker.js
+++ b/src/ast/variables/VariableShapeTracker.js
@@ -67,6 +67,7 @@ export default class VariableShapeTracker {
 	}
 
 	hasAtPath ( path, assignment ) {
+		if ( this._assignments === UNKNOWN_ASSIGNMENTS ) return true;
 		if ( path.length === 0 ) {
 			return this._assignments.get( SET_KEY ).has( assignment );
 		} else {
@@ -99,5 +100,12 @@ export default class VariableShapeTracker {
 						))
 				)
 			);
+	}
+
+	// For debugging purposes
+	toString ( pathString = '' ) {
+		return Array.from( this._assignments ).map( ( [ subPath, subAssignment ] ) => subPath === SET_KEY
+			? Array.from( subAssignment ).map( assignment => pathString + assignment.toString() ).join( '\n' )
+			: subAssignment.toString( pathString + subPath + ': ' ) ).join( '\n' );
 	}
 }

--- a/src/ast/variables/VariableShapeTracker.js
+++ b/src/ast/variables/VariableShapeTracker.js
@@ -4,6 +4,7 @@ const SET_KEY = { type: 'SET_KEY' };
 export const UNKNOWN_KEY = { type: 'UNKNOWN_KEY' };
 
 const UNKNOWN_ASSIGNMENTS = new Map( [ [ SET_KEY, new Set( [ UNKNOWN_ASSIGNMENT ] ) ] ] );
+const UNKNOWN_KEY_ASSIGNMENT = [ UNKNOWN_KEY, { toString: ( path = '' ) => path + '[[UNKNOWN_KEY]]' } ];
 
 export default class VariableShapeTracker {
 	constructor () {
@@ -11,13 +12,14 @@ export default class VariableShapeTracker {
 	}
 
 	addAtPath ( path, assignment ) {
-		if ( this._assignments === UNKNOWN_ASSIGNMENTS ) return;
-		if ( path.length === 0 ) {
-			if ( assignment === UNKNOWN_ASSIGNMENT ) {
-				this._assignments = UNKNOWN_ASSIGNMENTS;
-			} else {
-				this._assignments.get( SET_KEY ).add( assignment );
-			}
+		if ( this._assignments === UNKNOWN_ASSIGNMENTS
+			|| (path.length > 0 && this._assignments.has( UNKNOWN_KEY ) ) ) return;
+		if ( path.length === 0 && assignment === UNKNOWN_ASSIGNMENT ) {
+			this._assignments = UNKNOWN_ASSIGNMENTS;
+		} else if ( path[ 0 ] === UNKNOWN_KEY ) {
+			this._assignments = new Map( [ [ SET_KEY, this._assignments.get( SET_KEY ) ], UNKNOWN_KEY_ASSIGNMENT ] );
+		} else if ( path.length === 0 ) {
+			this._assignments.get( SET_KEY ).add( assignment );
 		} else {
 			const [ nextPath, ...remainingPath ] = path;
 			if ( !this._assignments.has( nextPath ) ) {
@@ -30,35 +32,26 @@ export default class VariableShapeTracker {
 	forEachAtPath ( path, callback ) {
 		const [ nextPath, ...remainingPath ] = path;
 		this._assignments.get( SET_KEY ).forEach( assignment => callback( path, assignment ) );
-		if ( path.length > 0 ) {
-			if ( nextPath === UNKNOWN_KEY ) {
-				this._assignments.forEach( ( assignment, subPath ) => {
-					if ( subPath !== SET_KEY ) {
-						assignment.forEachAtPath( remainingPath, callback );
-					}
-				} );
-			} else {
-				if ( this._assignments.has( nextPath ) ) {
-					this._assignments.get( nextPath ).forEachAtPath( remainingPath, callback );
-				}
-				if ( this._assignments.has( UNKNOWN_KEY ) ) {
-					this._assignments.get( UNKNOWN_KEY ).forEachAtPath( remainingPath, callback );
-				}
-			}
+		if ( path.length > 0
+			&& nextPath !== UNKNOWN_KEY
+			&& !this._assignments.has( UNKNOWN_KEY )
+			&& this._assignments.has( nextPath ) ) {
+			this._assignments.get( nextPath ).forEachAtPath( remainingPath, callback );
 		}
 	}
 
 	forEachAssignedToPath ( path, callback ) {
+		if ( this._assignments === UNKNOWN_ASSIGNMENTS || this._assignments.has( UNKNOWN_KEY ) ) return;
 		if ( path.length > 0 ) {
 			const [ nextPath, ...remainingPath ] = path;
+			if ( nextPath === UNKNOWN_KEY || this._assignments.has( UNKNOWN_KEY ) ) return;
 			if ( this._assignments.has( nextPath ) ) {
 				this._assignments.get( nextPath ).forEachAssignedToPath( remainingPath, callback );
 			}
 		} else {
+			this._assignments.get( SET_KEY ).forEach( assignment => callback( [], assignment ) );
 			this._assignments.forEach( ( assignment, subPath ) => {
-				if ( subPath === SET_KEY ) {
-					assignment.forEach( subAssignment => callback( [], subAssignment ) );
-				} else {
+				if ( subPath !== SET_KEY ) {
 					assignment.forEachAssignedToPath( [],
 						( relativePath, assignment ) => callback( [ subPath, ...relativePath ], assignment ) );
 				}
@@ -71,6 +64,7 @@ export default class VariableShapeTracker {
 		if ( path.length === 0 ) {
 			return this._assignments.get( SET_KEY ).has( assignment );
 		} else {
+			if ( this._assignments.has( UNKNOWN_KEY ) ) return true;
 			const [ nextPath, ...remainingPath ] = path;
 			if ( !this._assignments.has( nextPath ) ) {
 				return false;
@@ -85,25 +79,16 @@ export default class VariableShapeTracker {
 			|| (
 				path.length > 0
 				&& (
-					(nextPath === UNKNOWN_KEY
-						&& Array.from( this._assignments ).some( ( [ subPath, assignment ] ) => {
-							if ( subPath !== SET_KEY ) {
-								return assignment.someAtPath( remainingPath, predicateFunction );
-							}
-						} ))
-					|| (nextPath !== UNKNOWN_KEY
-						&& (
-							(this._assignments.has( nextPath )
-								&& this._assignments.get( nextPath ).someAtPath( remainingPath, predicateFunction ))
-							|| (this._assignments.has( UNKNOWN_KEY )
-								&& this._assignments.get( UNKNOWN_KEY ).someAtPath( remainingPath, predicateFunction ))
-						))
+					(nextPath === UNKNOWN_KEY || this._assignments.has( UNKNOWN_KEY )
+						? predicateFunction( remainingPath, UNKNOWN_ASSIGNMENT )
+						: this._assignments.has( nextPath )
+						&& this._assignments.get( nextPath ).someAtPath( remainingPath, predicateFunction ))
 				)
 			);
 	}
 
 	// For debugging purposes
-	toString ( pathString = '' ) {
+	toString ( pathString = '/' ) {
 		return Array.from( this._assignments ).map( ( [ subPath, subAssignment ] ) => subPath === SET_KEY
 			? Array.from( subAssignment ).map( assignment => pathString + assignment.toString() ).join( '\n' )
 			: subAssignment.toString( pathString + subPath + ': ' ) ).join( '\n' );

--- a/test/form/samples/computed-member-expression-assignments/main.js
+++ b/test/form/samples/computed-member-expression-assignments/main.js
@@ -17,7 +17,3 @@ retained5[ 'f' + 'oo' ]();
 
 const removed1 = { foo: {} };
 removed1.foo[ 'b' + 'ar' ] = 1;
-
-const removed2 = { foo: function () {} };
-removed2[ 'f' + 'oo' ] = function () {this.x = 1;};
-const result2 = new removed2.foo();

--- a/test/form/samples/side-effects-getters-and-setters/_expected/amd.js
+++ b/test/form/samples/side-effects-getters-and-setters/_expected/amd.js
@@ -11,7 +11,6 @@ define(function () { 'use strict';
 	};
 
 	const retained1b = retained1a.effect;
-	const retained1c = retained1a[ 'eff' + 'ect' ];
 
 	const retained3 = {
 		set effect ( value ) {
@@ -20,14 +19,6 @@ define(function () { 'use strict';
 	};
 
 	retained3.effect = 'retained';
-
-	const retained4 = {
-		set effect ( value ) {
-			console.log( value );
-		}
-	};
-
-	retained4[ 'eff' + 'ect' ] = 'retained';
 
 	const retained7 = {
 		foo: () => {},

--- a/test/form/samples/side-effects-getters-and-setters/_expected/cjs.js
+++ b/test/form/samples/side-effects-getters-and-setters/_expected/cjs.js
@@ -11,7 +11,6 @@ const retained1a = {
 };
 
 const retained1b = retained1a.effect;
-const retained1c = retained1a[ 'eff' + 'ect' ];
 
 const retained3 = {
 	set effect ( value ) {
@@ -20,14 +19,6 @@ const retained3 = {
 };
 
 retained3.effect = 'retained';
-
-const retained4 = {
-	set effect ( value ) {
-		console.log( value );
-	}
-};
-
-retained4[ 'eff' + 'ect' ] = 'retained';
 
 const retained7 = {
 	foo: () => {},

--- a/test/form/samples/side-effects-getters-and-setters/_expected/es.js
+++ b/test/form/samples/side-effects-getters-and-setters/_expected/es.js
@@ -9,7 +9,6 @@ const retained1a = {
 };
 
 const retained1b = retained1a.effect;
-const retained1c = retained1a[ 'eff' + 'ect' ];
 
 const retained3 = {
 	set effect ( value ) {
@@ -18,14 +17,6 @@ const retained3 = {
 };
 
 retained3.effect = 'retained';
-
-const retained4 = {
-	set effect ( value ) {
-		console.log( value );
-	}
-};
-
-retained4[ 'eff' + 'ect' ] = 'retained';
 
 const retained7 = {
 	foo: () => {},

--- a/test/form/samples/side-effects-getters-and-setters/_expected/iife.js
+++ b/test/form/samples/side-effects-getters-and-setters/_expected/iife.js
@@ -12,7 +12,6 @@
 	};
 
 	const retained1b = retained1a.effect;
-	const retained1c = retained1a[ 'eff' + 'ect' ];
 
 	const retained3 = {
 		set effect ( value ) {
@@ -21,14 +20,6 @@
 	};
 
 	retained3.effect = 'retained';
-
-	const retained4 = {
-		set effect ( value ) {
-			console.log( value );
-		}
-	};
-
-	retained4[ 'eff' + 'ect' ] = 'retained';
 
 	const retained7 = {
 		foo: () => {},

--- a/test/form/samples/side-effects-getters-and-setters/_expected/umd.js
+++ b/test/form/samples/side-effects-getters-and-setters/_expected/umd.js
@@ -15,7 +15,6 @@
 	};
 
 	const retained1b = retained1a.effect;
-	const retained1c = retained1a[ 'eff' + 'ect' ];
 
 	const retained3 = {
 		set effect ( value ) {
@@ -24,14 +23,6 @@
 	};
 
 	retained3.effect = 'retained';
-
-	const retained4 = {
-		set effect ( value ) {
-			console.log( value );
-		}
-	};
-
-	retained4[ 'eff' + 'ect' ] = 'retained';
 
 	const retained7 = {
 		foo: () => {},

--- a/test/form/samples/side-effects-getters-and-setters/main.js
+++ b/test/form/samples/side-effects-getters-and-setters/main.js
@@ -10,7 +10,6 @@ const retained1a = {
 
 const removed1 = retained1a.noEffect;
 const retained1b = retained1a.effect;
-const retained1c = retained1a[ 'eff' + 'ect' ];
 
 const removed2a = {
 	get shadowedEffect () {
@@ -33,14 +32,6 @@ const retained3 = {
 };
 
 retained3.effect = 'retained';
-
-const retained4 = {
-	set effect ( value ) {
-		console.log( value );
-	}
-};
-
-retained4[ 'eff' + 'ect' ] = 'retained';
 
 const removed5 = {
 	set noEffect ( value ) {

--- a/test/form/samples/side-effects-object-literal-mutation/main.js
+++ b/test/form/samples/side-effects-object-literal-mutation/main.js
@@ -25,10 +25,6 @@ const removed2 = { x: {} };
 removed2.x = 99;
 removed2.x.y = 2;
 
-const removed3 = { x: { y: {} } };
-removed3.x = { y: {} };
-removed3.x.y.z = 3;
-
 const retained6 = { x: { y: {} } };
 retained6.x = {};
 retained6.x.y.z = 3;
@@ -37,8 +33,3 @@ const retained7 = { x: { y: globalVar } };
 const retained8 = { x: { y: {} } };
 retained8.x = retained7.x;
 retained8.x.y.z = 3;
-
-const removed4 = {a: { x: { y: globalVar } }};
-const removed5 = { x: { y: {} } };
-removed5.x = removed4.a.x;
-removed5.x.y = 2;

--- a/test/function/samples/recursive-parameter-assignments/_config.js
+++ b/test/function/samples/recursive-parameter-assignments/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Avoid maximum call stack error with recursive parameter assignments (#1710).'
+};

--- a/test/function/samples/recursive-parameter-assignments/main.js
+++ b/test/function/samples/recursive-parameter-assignments/main.js
@@ -1,0 +1,16 @@
+class Test {
+	constructor ( name, opts ) {
+		opts = opts || {};
+
+		if ( name && typeof name === 'object' ) {
+			opts = name;
+			name = opts.name;
+			delete opts.name;
+		}
+
+		this.name = name;
+		this.opts = opts;
+	}
+}
+
+new Test( 'a', {} );


### PR DESCRIPTION
This resolves #1710 and #1711 .
In this update, the object analysis logic is limited to a depth of 2 as it could have a huge performance impact in code bases with many object assignments. Also, computed expression logic has been greatly simplified. Quite a few situations involving computed object keys are now no longer tree-shaken. At the same time, getters will no longer properly detect getters when computed expressions are used.