### PR TITLE
Set data cache to null when file doesn't exist

### DIFF
--- a/src/watch/fileWatchers.js
+++ b/src/watch/fileWatchers.js
@@ -52,6 +52,7 @@ export default class FileWatcher {
 			if (err.code === 'ENOENT') {
 				// can't watch files that don't exist (e.g. injected
 				// by plugins somehow)
+				data = null;
 				this.fileExists = false;
 				return;
 			} else {


### PR DESCRIPTION
So that it will trigger a rebuild without having to change the entry file next time.

Fixes #1619
