### PR TITLE
Support ES.Next object rest spread in config files like rollup.config.js

### DIFF
--- a/bin/src/run/loadConfigFile.js
+++ b/bin/src/run/loadConfigFile.js
@@ -1,3 +1,4 @@
+import buble from 'rollup-plugin-buble'
 import path from 'path';
 import chalk from 'chalk';
 import * as rollup from 'rollup';
@@ -13,7 +14,10 @@ export default function loadConfigFile (configFile, silent) {
 		external: id => {
 			return (id[0] !== '.' && !path.isAbsolute(id)) || id.slice(-5,id.length) === '.json';
 		},
-		onwarn: warnings.add
+		onwarn: warnings.add,
+		plugins: [
+			buble({objectAssign: 'Object.assign'}),
+		],
 	})
 		.then( bundle => {
 			if ( !silent && warnings.count > 0 ) {


### PR DESCRIPTION
fixes #1758

test preparation:
```bash
# checkout rollup
npm run build
cat <<EOF >test.js
const a = {b: 1}
const c = {...a}
EOF
```

test execution:
```./bin/rollup --config ./test.js```

<pre>
if it works:
           [!] Config file must export an options object, or an array of options objects
           https://github.com/rollup/rollup/wiki/Command-Line-Interface#using-a-config-file

if it fails:
           [!] Error: Unexpected token
           test.js (2:11)
           1: const a = {b: 1}
           2: const c = {...a}
                         ^
</pre>