### PR TITLE
feat: let --environment be specified multiple times

### DIFF
--- a/bin/src/run/index.js
+++ b/bin/src/run/index.js
@@ -28,14 +28,18 @@ export default function runRollup ( command ) {
 	}
 
 	if ( command.environment ) {
-		command.environment.split( ',' ).forEach( pair => {
-			const index = pair.indexOf( ':' );
-			if ( ~index ) {
-				process.env[ pair.slice( 0, index ) ] = pair.slice( index + 1 );
-			} else {
-				process.env[ pair ] = true;
-			}
-		});
+		const environment = Array.isArray(command.environment) ? command.environment : [ command.environment ];
+
+		environment.forEach( arg => {
+			arg.split( ',' ).forEach( pair => {
+				const [ key, value ] = pair.split( ':' );
+				if ( value ) {
+					process.env[ key ] = value;
+				} else {
+					process.env[ key ] = true;
+				}
+			});
+		})
 	}
 
 	let configFile = command.config === true ? 'rollup.config.js' : command.config;

--- a/test/cli/samples/config-env-multiple/_config.js
+++ b/test/cli/samples/config-env-multiple/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'passes environment variables to config file via multiple --environment values',
+	command: 'rollup --config --environment PRODUCTION,FOO:bar --environment SECOND,KEY:value --environment FOO:foo',
+	execute: true
+};

--- a/test/cli/samples/config-env-multiple/main.js
+++ b/test/cli/samples/config-env-multiple/main.js
@@ -1,0 +1,4 @@
+assert.equal( '__ENVIRONMENT__', 'production' );
+assert.equal( '__FOO__', 'foo' );
+assert.equal('__SECOND__', 'true');
+assert.equal('__KEY__', "value");

--- a/test/cli/samples/config-env-multiple/rollup.config.js
+++ b/test/cli/samples/config-env-multiple/rollup.config.js
@@ -1,0 +1,16 @@
+var replace = require( 'rollup-plugin-replace' );
+
+module.exports = {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+	plugins: [
+		replace( {
+			__ENVIRONMENT__: process.env.PRODUCTION ? 'production' : 'development',
+			__FOO__: process.env.FOO,
+			__SECOND__: process.env.SECOND,
+			__KEY__: process.env.KEY
+		} )
+	]
+};


### PR DESCRIPTION
Fixes #1764 

Later instances of `--environment` that contain already-defined keys will simply overwrite the previous value, which is what I expect. The test covers this behavior, if that isn't wanted I can change it but it'll complicate the code.

`npm run lint` shows me 18k errors, I don't think that's right? I did use array destructuring so if that isn't kosher in the codebase I'm happy to rewrite it in the longer-form version.
