### PR TITLE
Let process.stdin actually trigger it’s end event

### DIFF
--- a/bin/src/run/watch.js
+++ b/bin/src/run/watch.js
@@ -96,6 +96,7 @@ export default function watch(configFile, configs, command, silent) {
 	// only listen to stdin if it is a pipe
 	if (!process.stdin.isTTY) {
 		process.stdin.on('end', close); // in case we ever support stdin!
+		process.stdin.resume()
 	}
 
 	function close() {


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
As per https://github.com/rollup/rollup-watch/pull/57

Without the added line the previous listener will never be triggered.
