### PR TITLE
Dynamic import parsing support

### DIFF
--- a/test/function/samples/dynamic-import-parse/_config.js
+++ b/test/function/samples/dynamic-import-parse/_config.js
@@ -1,0 +1,13 @@
+var assert = require( 'assert' );
+
+module.exports = {
+	description: 'Allow dynamic import support',
+	options: {
+		acorn: {
+			plugins: { dynamicImport: true }
+		}
+	},
+	runtimeError: function ( error ) {
+		assert.equal( "Unexpected token import", error.message );
+	}
+};

--- a/test/function/samples/dynamic-import-parse/_config.js
+++ b/test/function/samples/dynamic-import-parse/_config.js
@@ -8,6 +8,11 @@ module.exports = {
 		}
 	},
 	runtimeError: function ( error ) {
-		assert.equal( "Unexpected token import", error.message );
+		try {
+			assert.equal( "Unexpected token import", error.message );
+		}
+		catch (err) {
+			assert.equal( "Unexpected reserved word", error.message );
+		}
 	}
 };

--- a/test/function/samples/dynamic-import-parse/foo.js
+++ b/test/function/samples/dynamic-import-parse/foo.js
@@ -1,0 +1,2 @@
+export var x = 42;
+import('./asdf');

--- a/test/function/samples/dynamic-import-parse/main.js
+++ b/test/function/samples/dynamic-import-parse/main.js
@@ -1,0 +1,1 @@
+export { x as y } from './foo';


### PR DESCRIPTION
This is a first step along the road to first-class support in Rollup.

This disables dynamic import support by default, but allows users to include a `acorn: { plugins: { dynamicImport: true } }` option to support parsing and output of dynamic import, completely unmodified.

Tooling around Rollup (exciting project launch pending :P) can then handle the remapping process for now, hopefully extending the way we handle this in Rollup in future.

Let me know if this seems like it can work, would be great to get this baseline first step in.