### PR TITLE
External function parent and resolved argument

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -70,7 +70,7 @@ export default class Bundle {
 		}
 
 		this.resolveId = first(
-			[ id => this.isExternal( id ) ? false : null ]
+			[ ( id, parentId ) => this.isExternal( id, parentId, false ) ? false : null ]
 				.concat( this.plugins.map( plugin => plugin.resolveId ).filter( Boolean ) )
 				.concat( resolveId )
 		);
@@ -410,7 +410,7 @@ export default class Bundle {
 			return ( resolvedId ? Promise.resolve( resolvedId ) : this.resolveId( source, module.id ) )
 				.then( resolvedId => {
 					const externalId = resolvedId || (isRelative( source ) ? resolve( module.id, '..', source ) : source);
-					let isExternal = this.isExternal( externalId );
+					let isExternal = this.isExternal( externalId, module.id, true );
 
 					if ( !resolvedId && !isExternal ) {
 						if ( isRelative( source ) ) {

--- a/test/function/samples/external-alias-parent/_config.js
+++ b/test/function/samples/external-alias-parent/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 		input: path.join( __dirname, 'first', 'main.js' ),
 		external: function ( id, parentId, isResolved ) {
 			if ( isResolved === false || !parentId )
-				return;
+				return false;
 			if ( parentId.endsWith( 'main.js' ) ) {
 				return id === 'lodash';
 			} else {

--- a/test/function/samples/external-alias-parent/_config.js
+++ b/test/function/samples/external-alias-parent/_config.js
@@ -1,0 +1,36 @@
+var assert = require( 'assert' );
+var path = require( 'path' );
+
+module.exports = {
+	description: 'includes an external module included dynamically by an alias',
+	options: {
+		input: path.join( __dirname, 'first', 'main.js' ),
+		external: function ( id, parentId, isResolved ) {
+			if ( isResolved === false || !parentId )
+				return;
+			if ( parentId.endsWith( 'main.js' ) ) {
+				return id === 'lodash';
+			} else {
+				return id === 'underscore';
+			}
+		},
+
+		// Define a simple alias plugin for underscore
+		plugins: [
+			{
+				resolveId: function ( id, parentId ) {
+					if ( id === 'underscore' && parentId && parentId.endsWith( 'main.js' ) ) {
+						return 'lodash';
+					}
+				}
+			}
+		]
+	},
+
+	context: {
+		require: function ( required ) {
+			assert( required === 'lodash' || required === 'underscore' );
+			return 1;
+		}
+	}
+};

--- a/test/function/samples/external-alias-parent/first/main.js
+++ b/test/function/samples/external-alias-parent/first/main.js
@@ -1,0 +1,10 @@
+import _ from 'underscore';
+import first from './module';
+
+export default function ( inputs ) {
+	if ( !_.isArray( inputs ) ) {
+		return inputs;
+	}
+
+	return first.square( inputs );
+};

--- a/test/function/samples/external-alias-parent/first/module.js
+++ b/test/function/samples/external-alias-parent/first/module.js
@@ -1,0 +1,7 @@
+import _ from 'underscore';
+
+export default function square ( inputs ) {
+	return _.map( inputs, function ( x ) {
+		return x * x;
+	});
+};


### PR DESCRIPTION
Externals as a name space kind of cross various concerns.

This is because the external check is done both pre and post resolve, so that names that exist in both namespaces can conflict between them (eg say `jquery` is an external in resolved space, but some module will have `jquery` resolve to a valid internal name which isn't `jquery`).

It's very much an edge case but I've hit across some scenarios like this already in handling correct external resolution.

To help narrow these cases very specifically this PR adds two new arguments to the external function to make it of the form:

```js
external (name, parent, isResolved)
```

* `parent` is the parent module Id of the module we are check whether it is external.
* `isResolved` is a boolean indicating if the external check is being done pre or post resolve.

Would be really useful to have these.