### PR TITLE
Default re-export fix for #1794

### DIFF
--- a/src/finalisers/es.js
+++ b/src/finalisers/es.js
@@ -78,7 +78,6 @@ export default function es ( bundle, magicString, { getPath, intro, outro } ) {
 		});
 
 	module.getReexports()
-		.filter( notDefault )
 		.forEach( name => {
 			const declaration = module.traceExport( name );
 
@@ -100,7 +99,7 @@ export default function es ( bundle, magicString, { getPath, intro, outro } ) {
 
 	const exportBlock = [];
 	if ( exportInternalSpecifiers.length ) exportBlock.push( `export { ${exportInternalSpecifiers.join(', ')} };` );
-	if ( module.exports.default || module.reexports.default ) exportBlock.push( `export default ${module.traceExport( 'default' ).getName( true )};` );
+	if ( module.exports.default ) exportBlock.push( `export default ${module.traceExport( 'default' ).getName( true )};` );
 	if ( exportAllDeclarations.length ) exportBlock.push( exportAllDeclarations.join( '\n' ) );
 	if ( exportExternalSpecifiers.size ) {
 		exportExternalSpecifiers.forEach( ( specifiers, id ) => {

--- a/src/finalisers/es.js
+++ b/src/finalisers/es.js
@@ -87,7 +87,8 @@ export default function es ( bundle, magicString, { getPath, intro, outro } ) {
 					exportAllDeclarations.push( `export * from '${name.slice( 1 )}';` );
 				} else {
 					if ( !exportExternalSpecifiers.has( declaration.module.id ) ) exportExternalSpecifiers.set( declaration.module.id, [] );
-					exportExternalSpecifiers.get( declaration.module.id ).push( name );
+					const rendered = declaration.getName( true );
+					exportExternalSpecifiers.get( declaration.module.id ).push( rendered === name ? name : `${rendered} as ${name}` );
 				}
 
 				return;

--- a/test/form/samples/export-default-2/_expected/es.js
+++ b/test/form/samples/export-default-2/_expected/es.js
@@ -1,3 +1,3 @@
 var bar = 1;
 
-export default bar;
+export { bar as default };

--- a/test/form/samples/re-export-default-external/_config.js
+++ b/test/form/samples/re-export-default-external/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 're-exports a default import',
+	options: {
+		name: 'reexportsDefaultExternal',
+		format: 'es',
+		external: ['external'],
+	},
+};

--- a/test/form/samples/re-export-default-external/_expected/amd.js
+++ b/test/form/samples/re-export-default-external/_expected/amd.js
@@ -1,0 +1,7 @@
+define(['external'], function (external) { 'use strict';
+
+
+
+	return external.objAlias;
+
+});

--- a/test/form/samples/re-export-default-external/_expected/cjs.js
+++ b/test/form/samples/re-export-default-external/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var external = require('external');
+
+
+
+module.exports = external.objAlias;

--- a/test/form/samples/re-export-default-external/_expected/es.js
+++ b/test/form/samples/re-export-default-external/_expected/es.js
@@ -1,1 +1,1 @@
-export { default } from 'external';
+export { objAlias as default } from 'external';

--- a/test/form/samples/re-export-default-external/_expected/es.js
+++ b/test/form/samples/re-export-default-external/_expected/es.js
@@ -1,0 +1,1 @@
+export { default } from 'external';

--- a/test/form/samples/re-export-default-external/_expected/iife.js
+++ b/test/form/samples/re-export-default-external/_expected/iife.js
@@ -1,0 +1,8 @@
+var reexportsDefaultExternal = (function (external) {
+	'use strict';
+
+
+
+	return external.objAlias;
+
+}(external));

--- a/test/form/samples/re-export-default-external/_expected/umd.js
+++ b/test/form/samples/re-export-default-external/_expected/umd.js
@@ -1,0 +1,9 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('external')) :
+	typeof define === 'function' && define.amd ? define(['external'], factory) :
+	(global.reexportsDefaultExternal = factory(global.external));
+}(this, (function (external) { 'use strict';
+
+	return external.objAlias;
+
+})));

--- a/test/form/samples/re-export-default-external/first.js
+++ b/test/form/samples/re-export-default-external/first.js
@@ -1,0 +1,1 @@
+export { objAlias as default } from 'external';

--- a/test/form/samples/re-export-default-external/main.js
+++ b/test/form/samples/re-export-default-external/main.js
@@ -1,0 +1,1 @@
+export { default } from './first.js';


### PR DESCRIPTION
This is a bug fix for https://github.com/rollup/rollup/issues/1794 (which includes replication).

`default` can be re-exported just like any other export, so this removes the special casing handling that doesn't respect these scenarios.

The only case default export doesn't work through is `export {default} from 'x'` where x contains `export * from 'y'` and y contains `export default 'y'`. The `default` export can't travel through these export * boundaries, but otherwise just acts like any other named export.