### PR TITLE
Fix export default regexs

### DIFF
--- a/test/form/samples/export-default-anonymous-declarations/_config.js
+++ b/test/form/samples/export-default-anonymous-declarations/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'export default [Declaration] with spaces and comments'
+};

--- a/test/form/samples/export-default-anonymous-declarations/_expected/amd.js
+++ b/test/form/samples/export-default-anonymous-declarations/_expected/amd.js
@@ -1,0 +1,63 @@
+define(function () { 'use strict';
+
+  function Fn
+
+  //iian iaouns
+  /* aaain ob skubz
+
+
+  */
+
+  () {
+    console.log("Foo");
+  }
+
+  async /* [no LineTerminator here] */ function Async
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  () {
+    console.log("Foo");
+  }
+
+  function
+
+  /* oiasnpiueno */
+  /// iauianpns
+
+  /* aiusni
+  */
+
+  * Generator
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  () {
+    console.log("Foo");
+  }
+
+  class Class
+
+  /* oiasnpiueno */
+  /// iauianpns
+
+  /* aiusni
+  */
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  {
+    constructor() {
+      console.log("Foo");
+    }
+  }
+
+  Fn();
+  Async();
+  Generator();
+  new Class();
+
+});

--- a/test/form/samples/export-default-anonymous-declarations/_expected/cjs.js
+++ b/test/form/samples/export-default-anonymous-declarations/_expected/cjs.js
@@ -1,0 +1,61 @@
+'use strict';
+
+function Fn
+
+//iian iaouns
+/* aaain ob skubz
+
+
+*/
+
+() {
+  console.log("Foo");
+}
+
+async /* [no LineTerminator here] */ function Async
+
+//iian iaouns
+/* aaain ob skubz */
+
+() {
+  console.log("Foo");
+}
+
+function
+
+/* oiasnpiueno */
+/// iauianpns
+
+/* aiusni
+*/
+
+* Generator
+
+//iian iaouns
+/* aaain ob skubz */
+
+() {
+  console.log("Foo");
+}
+
+class Class
+
+/* oiasnpiueno */
+/// iauianpns
+
+/* aiusni
+*/
+
+//iian iaouns
+/* aaain ob skubz */
+
+{
+  constructor() {
+    console.log("Foo");
+  }
+}
+
+Fn();
+Async();
+Generator();
+new Class();

--- a/test/form/samples/export-default-anonymous-declarations/_expected/es.js
+++ b/test/form/samples/export-default-anonymous-declarations/_expected/es.js
@@ -1,0 +1,59 @@
+function Fn
+
+//iian iaouns
+/* aaain ob skubz
+
+
+*/
+
+() {
+  console.log("Foo");
+}
+
+async /* [no LineTerminator here] */ function Async
+
+//iian iaouns
+/* aaain ob skubz */
+
+() {
+  console.log("Foo");
+}
+
+function
+
+/* oiasnpiueno */
+/// iauianpns
+
+/* aiusni
+*/
+
+* Generator
+
+//iian iaouns
+/* aaain ob skubz */
+
+() {
+  console.log("Foo");
+}
+
+class Class
+
+/* oiasnpiueno */
+/// iauianpns
+
+/* aiusni
+*/
+
+//iian iaouns
+/* aaain ob skubz */
+
+{
+  constructor() {
+    console.log("Foo");
+  }
+}
+
+Fn();
+Async();
+Generator();
+new Class();

--- a/test/form/samples/export-default-anonymous-declarations/_expected/iife.js
+++ b/test/form/samples/export-default-anonymous-declarations/_expected/iife.js
@@ -1,0 +1,64 @@
+(function () {
+  'use strict';
+
+  function Fn
+
+  //iian iaouns
+  /* aaain ob skubz
+
+
+  */
+
+  () {
+    console.log("Foo");
+  }
+
+  async /* [no LineTerminator here] */ function Async
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  () {
+    console.log("Foo");
+  }
+
+  function
+
+  /* oiasnpiueno */
+  /// iauianpns
+
+  /* aiusni
+  */
+
+  * Generator
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  () {
+    console.log("Foo");
+  }
+
+  class Class
+
+  /* oiasnpiueno */
+  /// iauianpns
+
+  /* aiusni
+  */
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  {
+    constructor() {
+      console.log("Foo");
+    }
+  }
+
+  Fn();
+  Async();
+  Generator();
+  new Class();
+
+}());

--- a/test/form/samples/export-default-anonymous-declarations/_expected/umd.js
+++ b/test/form/samples/export-default-anonymous-declarations/_expected/umd.js
@@ -1,0 +1,67 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (factory());
+}(this, (function () { 'use strict';
+
+  function Fn
+
+  //iian iaouns
+  /* aaain ob skubz
+
+
+  */
+
+  () {
+    console.log("Foo");
+  }
+
+  async /* [no LineTerminator here] */ function Async
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  () {
+    console.log("Foo");
+  }
+
+  function
+
+  /* oiasnpiueno */
+  /// iauianpns
+
+  /* aiusni
+  */
+
+  * Generator
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  () {
+    console.log("Foo");
+  }
+
+  class Class
+
+  /* oiasnpiueno */
+  /// iauianpns
+
+  /* aiusni
+  */
+
+  //iian iaouns
+  /* aaain ob skubz */
+
+  {
+    constructor() {
+      console.log("Foo");
+    }
+  }
+
+  Fn();
+  Async();
+  Generator();
+  new Class();
+
+})));

--- a/test/form/samples/export-default-anonymous-declarations/async.js
+++ b/test/form/samples/export-default-anonymous-declarations/async.js
@@ -1,0 +1,20 @@
+export
+
+/* comment */
+// aaaa
+
+/* foo */
+
+default // jsjjjsjjjjsjs
+
+/* jsjjddjksj
+*/ // Too many comments lol
+
+async /* [no LineTerminator here] */ function
+
+//iian iaouns
+/* aaain ob skubz */
+
+() {
+  console.log("Foo");
+}

--- a/test/form/samples/export-default-anonymous-declarations/class.js
+++ b/test/form/samples/export-default-anonymous-declarations/class.js
@@ -1,0 +1,27 @@
+export
+
+/* comment */
+// aaaa
+
+/* foo */
+
+default // jsjjjsjjjjsjs
+
+/* jsjjddjksj */ // Too many comments lol
+
+class
+
+/* oiasnpiueno */
+/// iauianpns
+
+/* aiusni
+*/
+
+//iian iaouns
+/* aaain ob skubz */
+
+{
+  constructor() {
+    console.log("Foo");
+  }
+}

--- a/test/form/samples/export-default-anonymous-declarations/fn.js
+++ b/test/form/samples/export-default-anonymous-declarations/fn.js
@@ -1,0 +1,22 @@
+export
+
+/* comment */
+// aaaa
+
+/* foo */
+
+default // jsjjjsjjjjsjs
+
+/* jsjjddjksj */ // Too many comments lol
+
+function
+
+//iian iaouns
+/* aaain ob skubz
+
+
+*/
+
+() {
+  console.log("Foo");
+}

--- a/test/form/samples/export-default-anonymous-declarations/generator.js
+++ b/test/form/samples/export-default-anonymous-declarations/generator.js
@@ -1,0 +1,27 @@
+export
+
+/* comment */
+// aaaa
+
+/* foo */
+
+default // jsjjjsjjjjsjs
+
+/* jsjjddjksj */ // Too many comments lol
+
+function
+
+/* oiasnpiueno */
+/// iauianpns
+
+/* aiusni
+*/
+
+*
+
+//iian iaouns
+/* aaain ob skubz */
+
+() {
+  console.log("Foo");
+}

--- a/test/form/samples/export-default-anonymous-declarations/main.js
+++ b/test/form/samples/export-default-anonymous-declarations/main.js
@@ -1,0 +1,9 @@
+import Fn from "./fn.js"
+import Async from "./async.js";
+import Generator from "./generator.js";
+import Class from "./class.js";
+
+Fn();
+Async();
+Generator();
+new Class();


### PR DESCRIPTION
Fixes #1798

I updated the regular expressions to match comments, async functions and generators.
They are built at runtime to make them more readable; they are built only once so the performance overhead shouldn't be noticeable.

The built regexes are these:
```js
/^(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)*export(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)+default(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)*/
/^(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)*export(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)+default(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)+(?:(?:async(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)+)?function(?:(?:\s|\/\/.*[\n\r]|\/\*[^]*?\*\/)*\*)?|class)/
```