### PR TITLE
Refactoring - WIP [do not merge]

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -1,275 +1,27 @@
 import { timeStart, timeEnd } from './utils/flushTime.js';
 import { decode } from 'sourcemap-codec';
 import { Bundle as MagicStringBundle } from 'magic-string';
-import first from './utils/first.js';
 import { find } from './utils/array.js';
 import { blank, forOwn, keys } from './utils/object.js';
-import Module from './Module.js';
-import ExternalModule from './ExternalModule.js';
 import finalisers from './finalisers/index.js';
-import ensureArray from './utils/ensureArray.js';
-import { load, makeOnwarn, resolveId } from './utils/defaults.js';
 import getExportMode from './utils/getExportMode.js';
 import getIndentString from './utils/getIndentString.js';
-import { mapSequence, runSequence } from './utils/promise.js';
-import transform from './utils/transform.js';
+import { runSequence } from './utils/promise.js';
 import transformBundle from './utils/transformBundle.js';
 import collapseSourcemaps from './utils/collapseSourcemaps.js';
 import callIfFunction from './utils/callIfFunction.js';
-import relativeId from './utils/relativeId.js';
 import error from './utils/error.js';
 import { dirname, isRelative, isAbsolute, normalize, relative, resolve } from './utils/path.js';
-import BundleScope from './ast/scopes/BundleScope.js';
 
 export default class Bundle {
-	constructor ( options ) {
-		this.cachedModules = new Map();
-		if ( options.cache ) {
-			options.cache.modules.forEach( module => {
-				this.cachedModules.set( module.id, module );
-			} );
-		}
-
-		this.plugins = ensureArray( options.plugins );
-
-		options = this.plugins.reduce( ( acc, plugin ) => {
-			if ( plugin.options ) return plugin.options( acc ) || acc;
-			return acc;
-		}, options );
-
-		if ( !options.input ) {
-			throw new Error( 'You must supply options.input to rollup' );
-		}
-
-		this.entry = options.input;
-		this.entryId = null;
-		this.entryModule = null;
-
-		this.treeshake = options.treeshake !== false;
-		if ( this.treeshake ) {
-			this.treeshakingOptions = {
-				propertyReadSideEffects: options.treeshake
-					? options.treeshake.propertyReadSideEffects !== false
-					: true,
-				pureExternalModules: options.treeshake
-					? options.treeshake.pureExternalModules
-					: false
-			};
-			if ( this.treeshakingOptions.pureExternalModules === true ) {
-				this.isPureExternalModule = () => true;
-			} else if ( typeof this.treeshakingOptions.pureExternalModules === 'function' ) {
-				this.isPureExternalModule = this.treeshakingOptions.pureExternalModules;
-			} else if ( Array.isArray( this.treeshakingOptions.pureExternalModules ) ) {
-				const pureExternalModules = new Set( this.treeshakingOptions.pureExternalModules );
-				this.isPureExternalModule = id => pureExternalModules.has( id );
-			} else {
-				this.isPureExternalModule = () => false;
-			}
-		} else {
-			this.isPureExternalModule = () => false;
-		}
-
-		this.resolveId = first(
-			[ ( id, parentId ) => this.isExternal( id, parentId, false ) ? false : null ]
-				.concat( this.plugins.map( plugin => plugin.resolveId ).filter( Boolean ) )
-				.concat( resolveId )
-		);
-
-		const loaders = this.plugins
-			.map( plugin => plugin.load )
-			.filter( Boolean );
-		this.hasLoaders = loaders.length !== 0;
-		this.load = first( loaders.concat( load ) );
-
-		this.scope = new BundleScope();
-		// TODO strictly speaking, this only applies with non-ES6, non-default-only bundles
-		[ 'module', 'exports', '_interopDefault' ].forEach( name => {
-			this.scope.findVariable( name ); // creates global variable as side-effect
-		} );
-
-		this.moduleById = new Map();
-		this.modules = [];
-		this.externalModules = [];
-
-		this.context = String( options.context );
-
-		const optionsModuleContext = options.moduleContext;
-		if ( typeof optionsModuleContext === 'function' ) {
-			this.getModuleContext = id => optionsModuleContext( id ) || this.context;
-		} else if ( typeof optionsModuleContext === 'object' ) {
-			const moduleContext = new Map();
-			Object.keys( optionsModuleContext ).forEach( key => {
-				moduleContext.set( resolve( key ), optionsModuleContext[ key ] );
-			} );
-			this.getModuleContext = id => moduleContext.get( id ) || this.context;
-		} else {
-			this.getModuleContext = () => this.context;
-		}
-
-		if ( typeof options.external === 'function' ) {
-			this.isExternal = options.external;
-		} else {
-			const ids = ensureArray( options.external );
-			this.isExternal = id => ids.indexOf( id ) !== -1;
-		}
-
-		this.onwarn = options.onwarn || makeOnwarn();
-
-		this.varOrConst = options.preferConst ? 'const' : 'var';
-		this.legacy = options.legacy;
-		this.acornOptions = options.acorn || {};
-	}
-
-	collectAddon ( initialAddon, addonName, sep = '\n' ) {
-		return runSequence(
-			 [ { pluginName: 'rollup', source: initialAddon } ]
-				.concat(this.plugins.map( (plugin, idx) => {
-					return {
-						pluginName: plugin.name || `Plugin at pos ${idx}`,
-						source: plugin[addonName]
-					};
-				} ))
-				.map( addon => {
-					addon.source = callIfFunction(addon.source);
-					return addon;
-				} )
-				.filter( addon => {
-					return addon.source;
-				} )
-				.map(({pluginName, source}) => {
-					return Promise.resolve(source)
-						.catch(err => {
-							error( {
-								code: 'ADDON_ERROR',
-								message:
-								`Could not retrieve ${addonName}. Check configuration of ${pluginName}.
-	Error Message: ${err.message}`
-							} );
-						});
-				})
-		 )
-		 .then(addons => addons.filter(Boolean).join(sep));
-	}
-
-	link () {
-		// Phase 1 – discovery. We load the entry module and find which
-		// modules it imports, and import those, until we have all
-		// of the entry module's dependencies
-		return this.resolveId( this.entry, undefined )
-		.then( id => {
-			if ( id === false ) {
-				error( {
-					code: 'UNRESOLVED_ENTRY',
-					message: `Entry module cannot be external`
-				} );
-			}
-
-			if ( id == null ) {
-				error( {
-					code: 'UNRESOLVED_ENTRY',
-					message: `Could not resolve entry (${this.entry})`
-				} );
-			}
-
-			this.entryId = id;
-			return this.fetchModule( id, undefined );
-		} )
-		.then( entryModule => {
-			this.entryModule = entryModule;
-
-			// Phase 2 – binding. We link references to their variables
-			// to generate a complete picture of the bundle
-
-			timeStart( 'phase 2' );
-
-			this.modules.forEach( module => module.bindImportSpecifiers() );
-			this.modules.forEach( module => module.bindReferences() );
-
-			timeEnd( 'phase 2');
-		} );
-	}
-
-	build () {
-		// Phase 3 – marking. We include all statements that should be included
-
-		timeStart( 'phase 3' );
-
-		// mark all export statements
-		this.entryModule.getExports().forEach( name => {
-			const variable = this.entryModule.traceExport( name );
-
-			variable.exportName = name;
-			variable.includeVariable();
-
-			if ( variable.isNamespace ) {
-				variable.needsNamespaceBlock = true;
-			}
-		} );
-
-		this.entryModule.getReexports().forEach( name => {
-			const variable = this.entryModule.traceExport( name );
-
-			if ( variable.isExternal ) {
-				variable.reexported = variable.module.reexported = true;
-			} else {
-				variable.exportName = name;
-				variable.includeVariable();
-			}
-		} );
-
-		// mark statements that should appear in the bundle
-		if ( this.treeshake ) {
-			let addedNewNodes;
-			do {
-				addedNewNodes = false;
-				this.modules.forEach( module => {
-					if ( module.includeInBundle() ) {
-						addedNewNodes = true;
-					}
-				} );
-			} while ( addedNewNodes );
-		} else {
-			// Necessary to properly replace namespace imports
-			this.modules.forEach( module => module.includeAllInBundle() );
-		}
-
-		timeEnd( 'phase 3' );
-
-		// Phase 4 – final preparation. We order the modules with an
-		// enhanced topological sort that accounts for cycles, then
-		// ensure that names are deconflicted throughout the bundle
-
-		timeStart( 'phase 4' );
-
-		// while we're here, check for unused external imports
-		this.externalModules.forEach( module => {
-			const unused = Object.keys( module.declarations )
-				.filter( name => name !== '*' )
-				.filter( name => !module.declarations[ name ].included && !module.declarations[ name ].reexported );
-
-			if ( unused.length === 0 ) return;
-
-			const names = unused.length === 1 ?
-				`'${unused[ 0 ]}' is` :
-				`${unused.slice( 0, -1 ).map( name => `'${name}'` ).join( ', ' )} and '${unused.slice( -1 )}' are`;
-
-			this.warn( {
-				code: 'UNUSED_EXTERNAL_IMPORT',
-				source: module.id,
-				names: unused,
-				message: `${names} imported from external module '${module.id}' but never used`
-			} );
-		} );
-
-		// prune unused external imports
-		this.externalModules = this.externalModules.filter( module => {
-			return module.used || !this.isPureExternalModule( module.id );
-		} );
-
-		this.orderedModules = this.sort();
-		this.deconflict();
-
-		timeEnd( 'phase 4' );
+	constructor ( entryModule, graph, globalScope ) {
+		this.graph = graph;
+		this.modules = graph.modules;
+		this.externalModules = graph.externalModules;
+		this.orderedModules = undefined;
+		this.entryModule = entryModule;
+		this.entryId = entryModule.id;
+		this.scope = globalScope;
 	}
 
 	deconflict () {
@@ -319,145 +71,7 @@ export default class Bundle {
 
 		this.scope.deshadow( toDeshadow );
 	}
-
-	fetchModule ( id, importer ) {
-		// short-circuit cycles
-		if ( this.moduleById.has( id ) ) return null;
-		this.moduleById.set( id, null );
-
-		return this.load( id )
-			.catch( err => {
-				let msg = `Could not load ${id}`;
-				if ( importer ) msg += ` (imported by ${importer})`;
-
-				msg += `: ${err.message}`;
-				throw new Error( msg );
-			} )
-			.then( source => {
-				if ( typeof source === 'string' ) return source;
-				if ( source && typeof source === 'object' && source.code ) return source;
-
-				// TODO report which plugin failed
-				error( {
-					code: 'BAD_LOADER',
-					message: `Error loading ${relativeId( id )}: plugin load hook should return a string, a { code, map } object, or nothing/null`
-				} );
-			} )
-			.then( source => {
-				if ( typeof source === 'string' ) {
-					source = {
-						code: source,
-						ast: null
-					};
-				}
-
-				if ( this.cachedModules.has( id ) && this.cachedModules.get( id ).originalCode === source.code ) {
-					return this.cachedModules.get( id );
-				}
-
-				return transform( this, source, id, this.plugins );
-			} )
-			.then( source => {
-				const { code, originalCode, originalSourcemap, ast, sourcemapChain, resolvedIds } = source;
-
-				const module = new Module( {
-					id,
-					code,
-					originalCode,
-					originalSourcemap,
-					ast,
-					sourcemapChain,
-					resolvedIds,
-					bundle: this
-				} );
-
-				this.modules.push( module );
-				this.moduleById.set( id, module );
-
-				return this.fetchAllDependencies( module ).then( () => {
-					keys( module.exports ).forEach( name => {
-						if ( name !== 'default' ) {
-							module.exportsAll[ name ] = module.id;
-						}
-					} );
-					module.exportAllSources.forEach( source => {
-						const id = module.resolvedIds[ source ] || module.resolvedExternalIds[ source ];
-						const exportAllModule = this.moduleById.get( id );
-						if ( exportAllModule.isExternal ) return;
-
-						keys( exportAllModule.exportsAll ).forEach( name => {
-							if ( name in module.exportsAll ) {
-								this.warn( {
-									code: 'NAMESPACE_CONFLICT',
-									reexporter: module.id,
-									name,
-									sources: [ module.exportsAll[ name ], exportAllModule.exportsAll[ name ] ],
-									message: `Conflicting namespaces: ${relativeId( module.id )} re-exports '${name}' from both ${relativeId(
-										module.exportsAll[ name ] )} and ${relativeId( exportAllModule.exportsAll[ name ] )} (will be ignored)`
-								} );
-							} else {
-								module.exportsAll[ name ] = exportAllModule.exportsAll[ name ];
-							}
-						} );
-					} );
-					return module;
-				} );
-			} );
-	}
-
-	fetchAllDependencies ( module ) {
-		return mapSequence( module.sources, source => {
-			const resolvedId = module.resolvedIds[ source ];
-			return ( resolvedId ? Promise.resolve( resolvedId ) : this.resolveId( source, module.id ) )
-				.then( resolvedId => {
-					const externalId = resolvedId || (isRelative( source ) ? resolve( module.id, '..', source ) : source);
-					let isExternal = this.isExternal( externalId, module.id, true );
-
-					if ( !resolvedId && !isExternal ) {
-						if ( isRelative( source ) ) {
-							error( {
-								code: 'UNRESOLVED_IMPORT',
-								message: `Could not resolve '${source}' from ${relativeId( module.id )}`
-							} );
-						}
-
-						this.warn( {
-							code: 'UNRESOLVED_IMPORT',
-							source,
-							importer: relativeId( module.id ),
-							message: `'${source}' is imported by ${relativeId(
-								module.id )}, but could not be resolved – treating it as an external dependency`,
-							url: 'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
-						} );
-						isExternal = true;
-					}
-
-					if ( isExternal ) {
-						module.resolvedExternalIds[ source ] = externalId;
-
-						if ( !this.moduleById.has( externalId ) ) {
-							const module = new ExternalModule( externalId );
-							this.externalModules.push( module );
-							this.moduleById.set( externalId, module );
-						}
-
-						const externalModule = this.moduleById.get( externalId );
-
-						// add external declarations so we can detect which are never used
-						Object.keys( module.imports ).forEach( name => {
-							const importDeclaration = module.imports[ name ];
-							if ( importDeclaration.source !== source ) return;
-
-							externalModule.traceExport( importDeclaration.name );
-						} );
-					} else {
-						module.resolvedIds[ source ] = resolvedId;
-						return this.fetchModule( resolvedId, module.id );
-					}
-				} );
-		} );
-	}
-
+	
 	getPathRelativeToEntryDirname ( resolvedId ) {
 		if ( isRelative( resolvedId ) || isAbsolute( resolvedId ) ) {
 			const entryDirname = dirname( this.entryId );
@@ -467,6 +81,37 @@ export default class Bundle {
 		}
 
 		return resolvedId;
+	}
+  
+	collectAddon ( initialAddon, addonName, sep = '\n' ) {
+		return runSequence(
+			 [ { pluginName: 'rollup', source: initialAddon } ]
+				.concat(this.graph.plugins.map( (plugin, idx) => {
+					return {
+						pluginName: plugin.name || `Plugin at pos ${idx}`,
+						source: plugin[addonName]
+					};
+				} ))
+				.map( addon => {
+					addon.source = callIfFunction(addon.source);
+					return addon;
+				} )
+				.filter( addon => {
+					return addon.source;
+				} )
+				.map(({pluginName, source}) => {
+					return Promise.resolve(source)
+						.catch(err => {
+							error( {
+								code: 'ADDON_ERROR',
+								message:
+								`Could not retrieve ${addonName}. Check configuration of ${pluginName}.
+	Error Message: ${err.message}`
+							} );
+						});
+				})
+		 )
+		 .then(addons => addons.filter(Boolean).join(sep));
 	}
 
 	render ( options = {} ) {
@@ -487,7 +132,7 @@ export default class Bundle {
 			timeStart( 'render modules' );
 
 			this.orderedModules.forEach( module => {
-				const source = module.render( options.format === 'es', this.legacy, options.freeze !== false );
+				const source = module.render( options.format === 'es', this.graph.legacy, options.freeze !== false );
 				if ( source.toString().length ) {
 					magicString.addSource( source );
 					usedModules.push( module );
@@ -495,7 +140,7 @@ export default class Bundle {
 			} );
 
 			if ( !magicString.toString().trim() && this.entryModule.getExports().length === 0 && this.entryModule.getReexports().length === 0 ) {
-				this.warn( {
+				this.graph.warn( {
 					code: 'EMPTY_BUNDLE',
 					message: 'Generated an empty bundle'
 				} );
@@ -539,14 +184,14 @@ export default class Bundle {
 			let map = null;
 			const bundleSourcemapChain = [];
 
-			return transformBundle( prevCode, this.plugins, bundleSourcemapChain, options ).then( code => {
+			return transformBundle( prevCode, this.graph.plugins, bundleSourcemapChain, options ).then( code => {
 				if ( options.sourcemap ) {
 					timeStart( 'sourcemap' );
 
 					let file = options.sourcemapFile || options.file;
 					if ( file ) file = resolve( typeof process !== 'undefined' ? process.cwd() : '', file );
 
-					if ( this.hasLoaders || find( this.plugins, plugin => plugin.transform || plugin.transformBundle ) ) {
+					if ( this.graph.hasLoaders || find( this.graph.plugins, plugin => plugin.transform || plugin.transformBundle ) ) {
 						map = magicString.generateMap( {} );
 						if ( typeof map.mappings === 'string' ) {
 							map.mappings = decode( map.mappings );
@@ -567,7 +212,7 @@ export default class Bundle {
 		} );
 	}
 
-	sort () {
+	sortOrderedModules () {
 		let hasCycles;
 		const seen = {};
 		const ordered = [];
@@ -640,7 +285,7 @@ export default class Bundle {
 
 						findParent( this.entryModule );
 
-						this.onwarn(
+						this.graph.onwarn(
 							`Module ${a.id} may be unable to evaluate without ${b.id}, but is included first due to a cyclical dependency. Consider swapping the import statements in ${parent} to ensure correct ordering`
 						);
 					}
@@ -648,20 +293,6 @@ export default class Bundle {
 			} );
 		}
 
-		return ordered;
-	}
-
-	warn ( warning ) {
-		warning.toString = () => {
-			let str = '';
-
-			if ( warning.plugin ) str += `(${warning.plugin} plugin) `;
-			if ( warning.loc ) str += `${relativeId( warning.loc.file )} (${warning.loc.line}:${warning.loc.column}) `;
-			str += warning.message;
-
-			return str;
-		};
-
-		this.onwarn( warning );
+		this.orderedModules = ordered;
 	}
 }

--- a/src/Graph.js
+++ b/src/Graph.js
@@ -1,0 +1,397 @@
+import { timeStart, timeEnd } from './utils/flushTime.js';
+import first from './utils/first.js';
+import { blank, keys } from './utils/object.js';
+import Module from './Module.js';
+import ExternalModule from './ExternalModule.js';
+import ensureArray from './utils/ensureArray.js';
+import { load, makeOnwarn, resolveId } from './utils/defaults.js';
+import { mapSequence } from './utils/promise.js';
+import transform from './utils/transform.js';
+import relativeId from './utils/relativeId.js';
+import error from './utils/error.js';
+import { isRelative, resolve } from './utils/path.js';
+import GlobalScope from './ast/scopes/GlobalScope.js';
+import Bundle from './Bundle.js';
+
+export default class Graph {
+	constructor ( options ) {
+		this.cachedModules = new Map();
+		if ( options.cache ) {
+			options.cache.modules.forEach( module => {
+				this.cachedModules.set( module.id, module );
+			} );
+		}
+
+		this.plugins = ensureArray( options.plugins );
+
+		options = this.plugins.reduce( ( acc, plugin ) => {
+			if ( plugin.options ) return plugin.options( acc ) || acc;
+			return acc;
+		}, options );
+
+		if ( !options.input ) {
+			throw new Error( 'You must supply options.input to rollup' );
+		}
+
+		this.treeshake = options.treeshake !== false;
+		if ( this.treeshake ) {
+			this.treeshakingOptions = {
+				propertyReadSideEffects: options.treeshake
+					? options.treeshake.propertyReadSideEffects !== false
+					: true,
+				pureExternalModules: options.treeshake
+					? options.treeshake.pureExternalModules
+					: false
+			};
+			if ( this.treeshakingOptions.pureExternalModules === true ) {
+				this.isPureExternalModule = () => true;
+			} else if ( typeof this.treeshakingOptions.pureExternalModules === 'function' ) {
+				this.isPureExternalModule = this.treeshakingOptions.pureExternalModules;
+			} else if ( Array.isArray( this.treeshakingOptions.pureExternalModules ) ) {
+				const pureExternalModules = new Set( this.treeshakingOptions.pureExternalModules );
+				this.isPureExternalModule = id => pureExternalModules.has( id );
+			} else {
+				this.isPureExternalModule = () => false;
+			}
+		} else {
+			this.isPureExternalModule = () => false;
+		}
+
+		this.resolveId = first(
+			[ ( id, parentId ) => this.isExternal( id, parentId, false ) ? false : null ]
+				.concat( this.plugins.map( plugin => plugin.resolveId ).filter( Boolean ) )
+				.concat( resolveId )
+		);
+
+		this.resolveDynamicImport = first( this.plugins.map( plugin => plugin.resolveDynamicImport ).filter( Boolean ) );
+
+		const loaders = this.plugins
+			.map( plugin => plugin.load )
+			.filter( Boolean );
+		this.hasLoaders = loaders.length !== 0;
+		this.load = first( loaders.concat( load ) );
+
+		this.moduleById = new Map();
+		this.modules = [];
+		this.externalModules = [];
+
+		this.context = String( options.context );
+
+		const optionsModuleContext = options.moduleContext;
+		if ( typeof optionsModuleContext === 'function' ) {
+			this.getModuleContext = id => optionsModuleContext( id ) || this.context;
+		} else if ( typeof optionsModuleContext === 'object' ) {
+			const moduleContext = new Map();
+			Object.keys( optionsModuleContext ).forEach( key => {
+				moduleContext.set( resolve( key ), optionsModuleContext[ key ] );
+			} );
+			this.getModuleContext = id => moduleContext.get( id ) || this.context;
+		} else {
+			this.getModuleContext = () => this.context;
+		}
+
+		if ( typeof options.external === 'function' ) {
+			this.isExternal = options.external;
+		} else {
+			const ids = ensureArray( options.external );
+			this.isExternal = id => ids.indexOf( id ) !== -1;
+		}
+
+		this.scope = new GlobalScope();
+
+		// TODO strictly speaking, this only applies with non-ES6, non-default-only bundles
+		[ 'module', 'exports', '_interopDefault' ].forEach( name => {
+			this.scope.findVariable( name ); // creates global variable as side-effect
+		} );
+
+		this.onwarn = options.onwarn || makeOnwarn();
+
+		this.varOrConst = options.preferConst ? 'const' : 'var';
+		this.legacy = options.legacy;
+		this.acornOptions = options.acorn || {};
+	}
+
+
+	link ( entryName ) {
+		// Phase 1 – discovery. We load the entry module and find which
+		// modules it imports, and import those, until we have all
+		// of the entry module's dependencies
+		return this.resolveId( entryName, undefined )
+		.then( id => {
+			if ( id === false ) {
+				error( {
+					code: 'UNRESOLVED_ENTRY',
+					message: `Entry module cannot be external`
+				} );
+			}
+
+			if ( id == null ) {
+				error( {
+					code: 'UNRESOLVED_ENTRY',
+					message: `Could not resolve entry (${entryName})`
+				} );
+			}
+
+			return this.fetchModule( id, undefined );
+		} )
+		.then( entryModule => {
+			// Phase 2 – binding. We link references to their variables
+			// to generate a complete picture of the bundle
+
+			timeStart( 'phase 2' );
+
+			this.modules.forEach( module => module.bindImportSpecifiers() );
+			this.modules.forEach( module => module.bindReferences() );
+
+			timeEnd( 'phase 2');
+
+			return entryModule.id;
+		} );
+	}
+
+	buildSingle ( entryModuleId ) {
+
+		const entryModule = this.moduleById.get( entryModuleId );
+
+		if ( !entryModule )
+			throw new Error(`Entry module ${entryModuleId} not found.`);
+
+		const bundle = new Bundle( entryModule, this, this.scope );
+
+		// Phase 3 – marking. We include all statements that should be included
+
+		timeStart( 'phase 3' );
+
+		// mark all export statements
+		entryModule.getExports().forEach( name => {
+			const variable = entryModule.traceExport( name );
+
+			variable.exportName = name;
+			variable.includeVariable();
+
+			if ( variable.isNamespace ) {
+				variable.needsNamespaceBlock = true;
+			}
+		} );
+
+		entryModule.getReexports().forEach( name => {
+			const variable = entryModule.traceExport( name );
+
+			if ( variable.isExternal ) {
+				variable.reexported = variable.module.reexported = true;
+			} else {
+				variable.exportName = name;
+				variable.includeVariable();
+			}
+		} );
+
+		// mark statements that should appear in the bundle
+		if ( this.treeshake ) {
+			let addedNewNodes;
+			do {
+				addedNewNodes = false;
+				this.modules.forEach( module => {
+					if ( module.includeInBundle() ) {
+						addedNewNodes = true;
+					}
+				} );
+			} while ( addedNewNodes );
+		} else {
+			// Necessary to properly replace namespace imports
+			this.modules.forEach( module => module.includeAllInBundle() );
+		}
+
+		timeEnd( 'phase 3' );
+
+		// Phase 4 – final preparation. We order the modules with an
+		// enhanced topological sort that accounts for cycles, then
+		// ensure that names are deconflicted throughout the bundle
+
+		timeStart( 'phase 4' );
+
+		// while we're here, check for unused external imports
+		this.externalModules.forEach( module => {
+			const unused = Object.keys( module.declarations )
+				.filter( name => name !== '*' )
+				.filter( name => !module.declarations[ name ].included && !module.declarations[ name ].reexported );
+
+			if ( unused.length === 0 ) return;
+
+			const names = unused.length === 1 ?
+				`'${unused[ 0 ]}' is` :
+				`${unused.slice( 0, -1 ).map( name => `'${name}'` ).join( ', ' )} and '${unused.slice( -1 )}' are`;
+
+			this.warn( {
+				code: 'UNUSED_EXTERNAL_IMPORT',
+				source: module.id,
+				names: unused,
+				message: `${names} imported from external module '${module.id}' but never used`
+			} );
+		} );
+
+		// prune unused external imports
+		this.externalModules = bundle.externalModules = this.externalModules.filter( module => {
+			return module.used || !this.isPureExternalModule( module.id );
+		} );
+
+		bundle.sortOrderedModules();
+		bundle.deconflict();
+
+		timeEnd( 'phase 4' );
+
+		return bundle;
+
+	}
+
+	fetchModule ( id, importer ) {
+		// short-circuit cycles
+		if ( this.moduleById.has( id ) ) return null;
+		this.moduleById.set( id, null );
+
+		return this.load( id )
+			.catch( err => {
+				let msg = `Could not load ${id}`;
+				if ( importer ) msg += ` (imported by ${importer})`;
+
+				msg += `: ${err.message}`;
+				throw new Error( msg );
+			} )
+			.then( source => {
+				if ( typeof source === 'string' ) return source;
+				if ( source && typeof source === 'object' && source.code ) return source;
+
+				// TODO report which plugin failed
+				error( {
+					code: 'BAD_LOADER',
+					message: `Error loading ${relativeId( id )}: plugin load hook should return a string, a { code, map } object, or nothing/null`
+				} );
+			} )
+			.then( source => {
+				if ( typeof source === 'string' ) {
+					source = {
+						code: source,
+						ast: null
+					};
+				}
+
+				if ( this.cachedModules.has( id ) && this.cachedModules.get( id ).originalCode === source.code ) {
+					return this.cachedModules.get( id );
+				}
+
+				return transform( this, source, id, this.plugins );
+			} )
+			.then( source => {
+				const { code, originalCode, originalSourcemap, ast, sourcemapChain, resolvedIds } = source;
+
+				const module = new Module( {
+					id,
+					code,
+					originalCode,
+					originalSourcemap,
+					ast,
+					sourcemapChain,
+					resolvedIds,
+					graph: this
+				} );
+
+				this.modules.push( module );
+				this.moduleById.set( id, module );
+
+				return this.fetchAllDependencies( module ).then( () => {
+					keys( module.exports ).forEach( name => {
+						if ( name !== 'default' ) {
+							module.exportsAll[ name ] = module.id;
+						}
+					} );
+					module.exportAllSources.forEach( source => {
+						const id = module.resolvedIds[ source ] || module.resolvedExternalIds[ source ];
+						const exportAllModule = this.moduleById.get( id );
+						if ( exportAllModule.isExternal ) return;
+
+						keys( exportAllModule.exportsAll ).forEach( name => {
+							if ( name in module.exportsAll ) {
+								this.warn( {
+									code: 'NAMESPACE_CONFLICT',
+									reexporter: module.id,
+									name,
+									sources: [ module.exportsAll[ name ], exportAllModule.exportsAll[ name ] ],
+									message: `Conflicting namespaces: ${relativeId( module.id )} re-exports '${name}' from both ${relativeId(
+										module.exportsAll[ name ] )} and ${relativeId( exportAllModule.exportsAll[ name ] )} (will be ignored)`
+								} );
+							} else {
+								module.exportsAll[ name ] = exportAllModule.exportsAll[ name ];
+							}
+						} );
+					} );
+					return module;
+				} );
+			} );
+	}
+
+	fetchAllDependencies ( module ) {
+		return mapSequence( module.sources, source => {
+			const resolvedId = module.resolvedIds[ source ];
+			return ( resolvedId ? Promise.resolve( resolvedId ) : this.resolveId( source, module.id ) )
+				.then( resolvedId => {
+					const externalId = resolvedId || (isRelative( source ) ? resolve( module.id, '..', source ) : source);
+					let isExternal = this.isExternal( externalId, module.id, true );
+
+					if ( !resolvedId && !isExternal ) {
+						if ( isRelative( source ) ) {
+							error( {
+								code: 'UNRESOLVED_IMPORT',
+								message: `Could not resolve '${source}' from ${relativeId( module.id )}`
+							} );
+						}
+
+						this.warn( {
+							code: 'UNRESOLVED_IMPORT',
+							source,
+							importer: relativeId( module.id ),
+							message: `'${source}' is imported by ${relativeId(
+								module.id )}, but could not be resolved – treating it as an external dependency`,
+							url: 'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
+						} );
+						isExternal = true;
+					}
+
+					if ( isExternal ) {
+						module.resolvedExternalIds[ source ] = externalId;
+
+						if ( !this.moduleById.has( externalId ) ) {
+							const module = new ExternalModule( externalId );
+							this.externalModules.push( module );
+							this.moduleById.set( externalId, module );
+						}
+
+						const externalModule = this.moduleById.get( externalId );
+
+						// add external declarations so we can detect which are never used
+						Object.keys( module.imports ).forEach( name => {
+							const importDeclaration = module.imports[ name ];
+							if ( importDeclaration.source !== source ) return;
+
+							externalModule.traceExport( importDeclaration.name );
+						} );
+					} else {
+						module.resolvedIds[ source ] = resolvedId;
+						return this.fetchModule( resolvedId, module.id );
+					}
+				} );
+		} );
+	}
+
+	warn ( warning ) {
+		warning.toString = () => {
+			let str = '';
+
+			if ( warning.plugin ) str += `(${warning.plugin} plugin) `;
+			if ( warning.loc ) str += `${relativeId( warning.loc.file )} (${warning.loc.line}:${warning.loc.column}) `;
+			str += warning.message;
+
+			return str;
+		};
+
+		this.onwarn( warning );
+	}
+}

--- a/src/ast/nodes/ClassDeclaration.js
+++ b/src/ast/nodes/ClassDeclaration.js
@@ -8,7 +8,7 @@ export default class ClassDeclaration extends ClassNode {
 	}
 
 	render ( code, es ) {
-		if ( !this.module.bundle.treeshake || this.included ) {
+		if ( !this.module.graph.treeshake || this.included ) {
 			super.render( code, es );
 		} else {
 			code.remove( this.leadingCommentStart || this.start, this.next || this.end );

--- a/src/ast/nodes/ConditionalExpression.js
+++ b/src/ast/nodes/ConditionalExpression.js
@@ -41,7 +41,7 @@ export default class ConditionalExpression extends Node {
 
 	initialiseChildren ( parentScope ) {
 		super.initialiseChildren( parentScope );
-		if ( this.module.bundle.treeshake ) {
+		if ( this.module.graph.treeshake ) {
 			this.testValue = this.test.getValue();
 
 			if ( this.testValue === UNKNOWN_VALUE ) {
@@ -55,7 +55,7 @@ export default class ConditionalExpression extends Node {
 	}
 
 	render ( code, es ) {
-		if ( !this.module.bundle.treeshake ) {
+		if ( !this.module.graph.treeshake ) {
 			super.render( code, es );
 		}
 

--- a/src/ast/nodes/ExportDefaultDeclaration.js
+++ b/src/ast/nodes/ExportDefaultDeclaration.js
@@ -46,7 +46,7 @@ export default class ExportDefaultDeclaration extends Node {
 		const remove = () => { code.remove( this.leadingCommentStart || this.start, this.next || this.end ); };
 		const removeExportDefault = () => { code.remove( this.start, declaration_start ); };
 
-		const treeshakeable = this.module.bundle.treeshake && !this.included && !this.declaration.included;
+		const treeshakeable = this.module.graph.treeshake && !this.included && !this.declaration.included;
 		const name = this.variable.getName( es );
 		const statementStr = code.original.slice( this.start, this.end );
 
@@ -78,7 +78,7 @@ export default class ExportDefaultDeclaration extends Node {
 
 			// Only output `var foo =` if `foo` is used
 			if ( this.included ) {
-				code.overwrite( this.start, declaration_start, `${this.module.bundle.varOrConst} ${name} = ` );
+				code.overwrite( this.start, declaration_start, `${this.module.graph.varOrConst} ${name} = ` );
 			} else {
 				removeExportDefault();
 			}

--- a/src/ast/nodes/FunctionDeclaration.js
+++ b/src/ast/nodes/FunctionDeclaration.js
@@ -9,7 +9,7 @@ export default class FunctionDeclaration extends FunctionNode {
 	}
 
 	render ( code, es ) {
-		if ( !this.module.bundle.treeshake || this.included ) {
+		if ( !this.module.graph.treeshake || this.included ) {
 			super.render( code, es );
 		} else {
 			code.remove( this.leadingCommentStart || this.start, this.next || this.end );

--- a/src/ast/nodes/IfStatement.js
+++ b/src/ast/nodes/IfStatement.js
@@ -40,7 +40,7 @@ function getHoistedVars ( node, scope ) {
 export default class IfStatement extends Statement {
 	initialiseChildren ( parentScope ) {
 		super.initialiseChildren( parentScope );
-		if ( this.module.bundle.treeshake ) {
+		if ( this.module.graph.treeshake ) {
 			this.testValue = this.test.getValue();
 
 			if ( this.testValue === UNKNOWN_VALUE ) {
@@ -59,7 +59,7 @@ export default class IfStatement extends Statement {
 	}
 
 	render ( code, es ) {
-		if ( this.module.bundle.treeshake ) {
+		if ( this.module.graph.treeshake ) {
 			if ( this.testValue === UNKNOWN_VALUE ) {
 				super.render( code, es );
 			}

--- a/src/ast/nodes/MemberExpression.js
+++ b/src/ast/nodes/MemberExpression.js
@@ -134,7 +134,7 @@ export default class MemberExpression extends Node {
 	}
 
 	initialiseNode () {
-		this._checkPropertyReadSideEffects = this.module.bundle.treeshake && this.module.bundle.treeshakingOptions.propertyReadSideEffects;
+		this._checkPropertyReadSideEffects = this.module.graph.treeshake && this.module.graph.treeshakingOptions.propertyReadSideEffects;
 	}
 
 	render ( code, es ) {

--- a/src/ast/nodes/SequenceExpression.js
+++ b/src/ast/nodes/SequenceExpression.js
@@ -26,7 +26,7 @@ export default class SequenceExpression extends Node {
 	}
 
 	render ( code, es ) {
-		if ( !this.module.bundle.treeshake ) {
+		if ( !this.module.graph.treeshake ) {
 			super.render( code, es );
 		}
 

--- a/src/ast/nodes/VariableDeclaration.js
+++ b/src/ast/nodes/VariableDeclaration.js
@@ -55,7 +55,7 @@ export default class VariableDeclaration extends Node {
 	}
 
 	render ( code, es ) {
-		const treeshake = this.module.bundle.treeshake;
+		const treeshake = this.module.graph.treeshake;
 
 		let shouldSeparate = false;
 		let separator;

--- a/src/ast/nodes/VariableDeclarator.js
+++ b/src/ast/nodes/VariableDeclarator.js
@@ -20,7 +20,7 @@ export default class VariableDeclarator extends Node {
 			if ( !es && variable.exportName && variable.isReassigned ) {
 				if ( this.init ) {
 					code.overwrite( this.start, this.id.end, variable.getName( es ) );
-				} else if ( this.module.bundle.treeshake ) {
+				} else if ( this.module.graph.treeshake ) {
 					code.remove( this.start, this.end );
 				}
 			}

--- a/src/ast/nodes/shared/Statement.js
+++ b/src/ast/nodes/shared/Statement.js
@@ -2,7 +2,7 @@ import Node from '../../Node.js';
 
 export default class Statement extends Node {
 	render ( code, es ) {
-		if ( !this.module.bundle.treeshake || this.included ) {
+		if ( !this.module.graph.treeshake || this.included ) {
 			super.render( code, es );
 		} else {
 			code.remove( this.leadingCommentStart || this.start, this.next || this.end );

--- a/src/ast/scopes/GlobalScope.js
+++ b/src/ast/scopes/GlobalScope.js
@@ -1,7 +1,7 @@
 import Scope from './Scope.js';
 import GlobalVariable from '../variables/GlobalVariable';
 
-export default class BundleScope extends Scope {
+export default class GlobalScope extends Scope {
 	findVariable ( name ) {
 		if ( !this.variables[ name ] ) {
 			this.variables[ name ] = new GlobalVariable( name );

--- a/src/ast/scopes/ModuleScope.js
+++ b/src/ast/scopes/ModuleScope.js
@@ -5,10 +5,10 @@ import LocalVariable from '../variables/LocalVariable';
 import { UNDEFINED_ASSIGNMENT } from '../values';
 
 export default class ModuleScope extends Scope {
-	constructor ( module ) {
+	constructor ( module, globalScope ) {
 		super( {
 			isModuleScope: true,
-			parent: module.bundle.scope
+			parent: globalScope
 		} );
 
 		this.module = module;

--- a/src/ast/variables/NamespaceVariable.js
+++ b/src/ast/variables/NamespaceVariable.js
@@ -41,6 +41,6 @@ export default class NamespaceVariable extends Variable {
 		} );
 
 		const callee = freeze ? ( legacy ? `(Object.freeze || Object)` : `Object.freeze` ) : '';
-		return `${this.module.bundle.varOrConst} ${this.getName( es )} = ${callee}({\n${members.join( ',\n' )}\n});\n\n`;
+		return `${this.module.graph.varOrConst} ${this.getName( es )} = ${callee}({\n${members.join( ',\n' )}\n});\n\n`;
 	}
 }

--- a/src/browser-entry.js
+++ b/src/browser-entry.js
@@ -1,3 +1,3 @@
 export { default as rollup } from './rollup/index.js';
-export { default as Bundle } from './Bundle.js';
+export { default as Graph } from './Graph.js';
 export { version as VERSION } from '../package.json';

--- a/src/browser-entry.js
+++ b/src/browser-entry.js
@@ -1,2 +1,3 @@
 export { default as rollup } from './rollup/index.js';
+export { default as Bundle } from './Bundle.js';
 export { version as VERSION } from '../package.json';

--- a/src/finalisers/cjs.js
+++ b/src/finalisers/cjs.js
@@ -7,7 +7,7 @@ export default function cjs ( bundle, magicString, { exportMode, getPath, intro,
 
 	let needsInterop = false;
 
-	const varOrConst = bundle.varOrConst;
+	const varOrConst = bundle.graph.varOrConst;
 	const interop = options.interop !== false;
 
 	// TODO handle empty imports, once they're supported

--- a/src/finalisers/iife.js
+++ b/src/finalisers/iife.js
@@ -51,7 +51,7 @@ export default function iife ( bundle, magicString, { exportMode, indentString, 
 	let wrapperIntro = `(function (${args}) {\n${useStrict}`;
 
 	if ( exportMode !== 'none' && !extend) {
-		wrapperIntro = ( isNamespaced ? thisProp(name) : `${bundle.varOrConst} ${name}` ) + ` = ${wrapperIntro}`;
+		wrapperIntro = ( isNamespaced ? thisProp(name) : `${bundle.graph.varOrConst} ${name}` ) + ` = ${wrapperIntro}`;
 	}
 
 	if ( isNamespaced ) {

--- a/src/finalisers/shared/getExportBlock.js
+++ b/src/finalisers/shared/getExportBlock.js
@@ -10,7 +10,7 @@ export default function getExportBlock ( bundle, exportMode, mechanism = 'return
 			if ( name[0] === '*' ) {
 				// export all from external
 				const id = name.slice( 1 );
-				const module = bundle.moduleById.get( id );
+				const module = bundle.graph.moduleById.get( id );
 
 				return `Object.keys(${module.name}).forEach(function (key) { exports[key] = ${module.name}[key]; });`;
 			}

--- a/src/finalisers/shared/getGlobalNameMaker.js
+++ b/src/finalisers/shared/getGlobalNameMaker.js
@@ -6,7 +6,7 @@ export default function getGlobalNameMaker ( globals, bundle, fallback = null ) 
 		if ( name ) return name;
 
 		if ( Object.keys( module.declarations ).length > 0 ) {
-			bundle.warn({
+			bundle.graph.warn({
 				code: 'MISSING_GLOBAL_NAME',
 				source: module.id,
 				guess: module.name,

--- a/src/finalisers/shared/getInteropBlock.js
+++ b/src/finalisers/shared/getInteropBlock.js
@@ -4,11 +4,11 @@ export default function getInteropBlock ( bundle, options ) {
 			if ( !module.declarations.default || options.interop === false ) return null;
 
 			if ( module.exportsNamespace ) {
-				return `${bundle.varOrConst} ${module.name}__default = ${module.name}['default'];`;
+				return `${bundle.graph.varOrConst} ${module.name}__default = ${module.name}['default'];`;
 			}
 
 			if ( module.exportsNames ) {
-				return `${bundle.varOrConst} ${module.name}__default = 'default' in ${module.name} ? ${module.name}['default'] : ${module.name};`;
+				return `${bundle.graph.varOrConst} ${module.name}__default = 'default' in ${module.name} ? ${module.name}['default'] : ${module.name};`;
 			}
 
 			return `${module.name} = ${module.name} && ${module.name}.hasOwnProperty('default') ? ${module.name}['default'] : ${module.name};`;

--- a/src/finalisers/shared/warnOnBuiltins.js
+++ b/src/finalisers/shared/warnOnBuiltins.js
@@ -35,7 +35,7 @@ export default function warnOnBuiltins ( bundle ) {
 		`module ('${externalBuiltins[0]}')` :
 		`modules (${externalBuiltins.slice( 0, -1 ).map( name => `'${name}'` ).join( ', ' )} and '${externalBuiltins.slice( -1 )}')`;
 
-	bundle.warn({
+	bundle.graph.warn({
 		code: 'MISSING_NODE_BUILTINS',
 		modules: externalBuiltins,
 		message: `Creating a browser bundle that depends on Node.js built-in ${detail}. You might need to include https://www.npmjs.com/package/rollup-plugin-node-builtins`

--- a/src/node-entry.js
+++ b/src/node-entry.js
@@ -1,3 +1,4 @@
 export { default as rollup } from './rollup/index.js';
 export { default as watch } from './watch/index.js';
 export { version as VERSION } from '../package.json';
+export { default as Bundle } from './Bundle.js';

--- a/src/node-entry.js
+++ b/src/node-entry.js
@@ -1,4 +1,4 @@
 export { default as rollup } from './rollup/index.js';
 export { default as watch } from './watch/index.js';
 export { version as VERSION } from '../package.json';
-export { default as Bundle } from './Bundle.js';
+export { default as Graph } from './Graph.js';

--- a/src/rollup/index.js
+++ b/src/rollup/index.js
@@ -167,7 +167,10 @@ export default function rollup ( inputOptions ) {
 
 		timeStart( '--BUILD--' );
 
-		return bundle.build().then( () => {
+		return bundle.link().then( () => {
+			return bundle.build();
+		} ).then( () => {
+			
 			timeEnd( '--BUILD--' );
 
 			function generate ( outputOptions ) {

--- a/src/rollup/index.js
+++ b/src/rollup/index.js
@@ -6,7 +6,7 @@ import { mapSequence } from '../utils/promise.js';
 import validateKeys from '../utils/validateKeys.js';
 import error from '../utils/error.js';
 import { SOURCEMAPPING_URL } from '../utils/sourceMappingURL.js';
-import Bundle from '../Bundle.js';
+import Graph from '../Graph.js';
 
 export const VERSION = '<@VERSION@>';
 
@@ -163,13 +163,12 @@ export default function rollup ( inputOptions ) {
 		const warn = inputOptions.onwarn || (warning => console.warn( warning.message )); // eslint-disable-line no-console
 
 		checkInputOptions( inputOptions, warn );
-		const bundle = new Bundle( inputOptions );
+		const graph = new Graph( inputOptions );
 
 		timeStart( '--BUILD--' );
 
-		return bundle.link().then( () => {
-			return bundle.build();
-		} ).then( () => {
+		return graph.link( inputOptions.input ).then( ( inputModuleId ) => {
+			const bundle = graph.buildSingle( inputModuleId );
 			
 			timeEnd( '--BUILD--' );
 
@@ -187,7 +186,7 @@ export default function rollup ( inputOptions ) {
 					.then( rendered => {
 						timeEnd( '--GENERATE--' );
 
-						bundle.plugins.forEach( plugin => {
+						graph.plugins.forEach( plugin => {
 							if ( plugin.ongenerate ) {
 								plugin.ongenerate( assign( {
 									bundle: result
@@ -241,7 +240,7 @@ export default function rollup ( inputOptions ) {
 
 						promises.push( writeFile( file, code ) );
 						return Promise.all( promises ).then( () => {
-							return mapSequence( bundle.plugins.filter( plugin => plugin.onwrite ), plugin => {
+							return mapSequence( graph.plugins.filter( plugin => plugin.onwrite ), plugin => {
 								return Promise.resolve( plugin.onwrite( assign( {
 									bundle: result
 								}, outputOptions ), result ) );

--- a/src/utils/collapseSourcemaps.js
+++ b/src/utils/collapseSourcemaps.js
@@ -133,7 +133,7 @@ export default function collapseSourcemaps ( bundle, file, map, modules, bundleS
 
 		sourcemapChain.forEach( map => {
 			if ( map.missing ) {
-				bundle.warn({
+				bundle.graph.warn({
 					code: 'SOURCEMAP_BROKEN',
 					plugin: map.plugin,
 					message: `Sourcemap is likely to be incorrect: a plugin${map.plugin ? ` ('${map.plugin}')` : ``} was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,

--- a/src/utils/getExportMode.js
+++ b/src/utils/getExportMode.js
@@ -28,7 +28,7 @@ export default function getExportMode ( bundle, {exports: exportMode, name, form
 			exportMode = 'default';
 		} else {
 			if ( bundle.entryModule.exports.default && format !== 'es') {
-				bundle.warn({
+				bundle.graph.warn({
 					code: 'MIXED_EXPORTS',
 					message: `Using named and default exports together. Consumers of your bundle will have to use ${name || 'bundle'}['default'] to access the default export, which may not be what you want. Use \`exports: 'named'\` to disable this warning`,
 					url: `https://rollupjs.org/#exports`

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -3,7 +3,7 @@ import { locate } from 'locate-character';
 import error from './error.js';
 import getCodeFrame from './getCodeFrame.js';
 
-export default function transform ( bundle, source, id, plugins ) {
+export default function transform ( graph, source, id, plugins ) {
 	const sourcemapChain = [];
 
 	const originalSourcemap = typeof source.map === 'string' ? JSON.parse( source.map ) : source.map;
@@ -54,7 +54,7 @@ export default function transform ( bundle, source, id, plugins ) {
 			const context = {
 				warn: ( warning, pos ) => {
 					warning = augment( warning, pos, 'PLUGIN_WARNING' );
-					bundle.warn( warning );
+					graph.warn( warning );
 				},
 
 				error ( err, pos ) {


### PR DESCRIPTION
In working on some of this dynamic import analysis and chunking code, it ends up that a lot of the graph analysis that is already in Rollup itself is being done twice, resulting in extra unnecessary build costs in double parsing etc.

What I've found is having direct access to the Bundle interface can share this analysis quite well.

This is my current refactoring of Rollup to handle this approach, separated from the dynamic import PR, which I've attempted to create as separate logical commits as much as possible with simple conceptual steps.

I'd like to keep this open as a PR so that it is clear what is going on here. Hopefully we can work towards a merge over time.

Currently this performs the following changes:
* Separates Bundle.js into Graph.js and Bundle.js
* Adds graph.link and graph.buildSingle
* Bundle is created only when graph.buildSingle is called
* Graph is exported from the main rollup build to allow deeper hooking in the wrapper project

Hopefully that makes it clearer where this is roughly going. Happy to discuss anytime.