### PR TITLE
Shares output options with plugins `transformBundle`. Fixes #1583

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -21,8 +21,8 @@ export type SourceDescription = { code: string, map?: RawSourceMap, ast?: Progra
 export type ResolveIdHook = (id: string, parent: string) => Promise<string | boolean | void> | string | boolean | void;
 export type IsExternalHook = (id: string, parentId: string, isResolved: boolean) => Promise<boolean | void> | boolean | void;
 export type LoadHook = (id: string) => Promise<SourceDescription | string | void> | SourceDescription | string | void;
-export type TransformHook = (code: string) => Promise<SourceDescription | string | void>;
-export type TransformBundleHook = (code: string, { format }: { format: string }) => Promise<SourceDescription | string>;
+export type TransformHook = (code: string, id: String) => Promise<SourceDescription | string | void>;
+export type TransformBundleHook = (code: string, options: OutputOptions) => Promise<SourceDescription | string>;
 export type ResolveDynamicImportHook = (specifier: string | Node, parentId: string) => Promise<string | void> | string | void
 
 export interface Plugin {

--- a/src/utils/transformBundle.ts
+++ b/src/utils/transformBundle.ts
@@ -15,7 +15,7 @@ export default function transformBundle (
 		return promise.then(code => {
 			return Promise.resolve()
 				.then(() => {
-					return plugin.transformBundle(code, { format: options.format });
+					return plugin.transformBundle(code, options);
 				})
 				.then(result => {
 					if (result == null) return code;

--- a/test/form/samples/transform-bundle-plugin-options/_config.js
+++ b/test/form/samples/transform-bundle-plugin-options/_config.js
@@ -4,7 +4,7 @@ module.exports = {
 		plugins: [
 			{
 				transformBundle: function (code, options) {
-					return JSON.stringify(options);
+					return JSON.stringify(Object.keys(options));
 				}
 			}
 		]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/amd.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/amd.js
@@ -1,1 +1,1 @@
-{"format":"amd"}
+["extend","amd","banner","footer","intro","format","outro","sourcemap","sourcemapFile","name","globals","interop","legacy","freeze","indent","strict","noConflict","paths","exports","file","plugins"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/cjs.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/cjs.js
@@ -1,1 +1,1 @@
-{"format":"cjs"}
+["extend","amd","banner","footer","intro","format","outro","sourcemap","sourcemapFile","name","globals","interop","legacy","freeze","indent","strict","noConflict","paths","exports","file","plugins"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/es.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/es.js
@@ -1,1 +1,1 @@
-{"format":"es"}
+["extend","amd","banner","footer","intro","format","outro","sourcemap","sourcemapFile","name","globals","interop","legacy","freeze","indent","strict","noConflict","paths","exports","file","plugins"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/iife.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/iife.js
@@ -1,1 +1,1 @@
-{"format":"iife"}
+["extend","amd","banner","footer","intro","format","outro","sourcemap","sourcemapFile","name","globals","interop","legacy","freeze","indent","strict","noConflict","paths","exports","file","plugins"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/umd.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/umd.js
@@ -1,1 +1,1 @@
-{"format":"umd"}
+["extend","amd","banner","footer","intro","format","outro","sourcemap","sourcemapFile","name","globals","interop","legacy","freeze","indent","strict","noConflict","paths","exports","file","plugins"]


### PR DESCRIPTION
See #1583 . Reopening this as #1808 was closed accidently after TS branch was merged.