### PR TITLE
Add option to not follow symlinks

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -69,6 +69,7 @@ export default class Graph {
 	modules: Module[];
 	onwarn: WarningHandler;
 	plugins: Plugin[];
+	preserveSymlinks: boolean;
 	resolveDynamicImport: ResolveDynamicImportHandler;
 	resolveId: (id: string, parent: string) => Promise<string | boolean | void>;
 	scope: GlobalScope;
@@ -129,7 +130,7 @@ export default class Graph {
 		this.resolveId = first(
 			[((id: string, parentId: string) => (this.isExternal(id, parentId, false) ? false : null)) as ResolveIdHook]
 				.concat(this.plugins.map(plugin => plugin.resolveId).filter(Boolean))
-				.concat(resolveId)
+				.concat(resolveId(options))
 		);
 
 		const loaders = this.plugins.map(plugin => plugin.load).filter(Boolean);
@@ -194,6 +195,8 @@ export default class Graph {
 
 		acornPluginsToInject.push(...ensureArray(options.acornInjectPlugins));
 		this.acornParse = acornPluginsToInject.reduce((acc, plugin) => plugin(acc), acorn).parse;
+
+		this.preserveSymlinks = options.preserveSymlinks;
 	}
 
 	getPathRelativeToBaseDirname (resolvedId: string, parentId: string): string {

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -73,6 +73,7 @@ export interface InputOptions {
 	watch?: WatcherOptions;
 	experimentalDynamicImport?: boolean;
 	experimentalCodeSplitting?: boolean;
+	preserveSymlinks: boolean;
 
 	// undocumented?
 	pureExternalModules?: boolean;

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -5,16 +5,17 @@ import error from './error';
 import Module from '../Module';
 import ExternalModule from '../ExternalModule';
 import relativeId from './relativeId';
+import { InputOptions } from '../rollup';
 
 export function load (id: string) {
 	return readFileSync(id, 'utf-8');
 }
 
-function findFile (file: string): string | void {
+function findFile (file: string, preserveSymlinks: boolean): string | void {
 	try {
 		const stats = lstatSync(file);
-		if (stats.isSymbolicLink()) return findFile(realpathSync(file));
-		if (stats.isFile()) {
+		if (!preserveSymlinks && stats.isSymbolicLink()) return findFile(realpathSync(file), preserveSymlinks);
+		if ((preserveSymlinks && stats.isSymbolicLink()) || stats.isFile()) {
 			// check case
 			const name = basename(file);
 			const files = readdirSync(dirname(file));
@@ -26,31 +27,34 @@ function findFile (file: string): string | void {
 	}
 }
 
-function addJsExtensionIfNecessary (file: string) {
-	return findFile(file) || findFile(file + '.js');
+function addJsExtensionIfNecessary (file: string, preserveSymlinks: boolean) {
+	return findFile(file, preserveSymlinks) || findFile(file + '.js', preserveSymlinks);
 }
 
-export function resolveId (importee: string, importer: string) {
-	if (typeof process === 'undefined') {
-		error({
-			code: 'MISSING_PROCESS',
-			message: `It looks like you're using Rollup in a non-Node.js environment. This means you must supply a plugin with custom resolveId and load functions`,
-			url: 'https://github.com/rollup/rollup/wiki/Plugins'
-		});
+export function resolveId (options: InputOptions) {
+	return function (importee: string, importer: string) {
+		if (typeof process === 'undefined') {
+			error({
+				code: 'MISSING_PROCESS',
+				message: `It looks like you're using Rollup in a non-Node.js environment. This means you must supply a plugin with custom resolveId and load functions`,
+				url: 'https://github.com/rollup/rollup/wiki/Plugins'
+			});
+		}
+
+		// external modules (non-entry modules that start with neither '.' or '/')
+		// are skipped at this stage.
+		if (importer !== undefined && !isAbsolute(importee) && importee[0] !== '.')
+			return null;
+
+		// `resolve` processes paths from right to left, prepending them until an
+		// absolute path is created. Absolute importees therefore shortcircuit the
+		// resolve call and require no special handing on our part.
+		// See https://nodejs.org/api/path.html#path_path_resolve_paths
+		return addJsExtensionIfNecessary(
+			resolve(importer ? dirname(importer) : resolve(), importee),
+			options.preserveSymlinks
+		);
 	}
-
-	// external modules (non-entry modules that start with neither '.' or '/')
-	// are skipped at this stage.
-	if (importer !== undefined && !isAbsolute(importee) && importee[0] !== '.')
-		return null;
-
-	// `resolve` processes paths from right to left, prepending them until an
-	// absolute path is created. Absolute importees therefore shortcircuit the
-	// resolve call and require no special handing on our part.
-	// See https://nodejs.org/api/path.html#path_path_resolve_paths
-	return addJsExtensionIfNecessary(
-		resolve(importer ? dirname(importer) : resolve(), importee)
-	);
 }
 
 export function makeOnwarn () {

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -80,7 +80,8 @@ export default function mergeOptions ({
 		cache: getInputOption('cache'),
 		preferConst: getInputOption('preferConst'),
 		experimentalDynamicImport: getInputOption('experimentalDynamicImport'),
-		experimentalCodeSplitting: getInputOption('experimentalCodeSplitting')
+		experimentalCodeSplitting: getInputOption('experimentalCodeSplitting'),
+		preserveSymlinks: getInputOption('preserveSymlinks')
 	};
 
 	// legacy, to ensure e.g. commonjs plugin still works

--- a/test/cli/samples/config-deprecations/rollup.config.js
+++ b/test/cli/samples/config-deprecations/rollup.config.js
@@ -30,9 +30,8 @@ module.exports = {
 				warnings[1],
 				{
 					code: 'UNKNOWN_OPTION',
-					message: 'Unknown option found: abc. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
+					message: 'Unknown option found: abc. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, preserveSymlinks, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
 				}
-				
 			);
 		} else {
 			throw new Error('Unwanted warnings');

--- a/test/function/samples/preserve-symlink/_config.js
+++ b/test/function/samples/preserve-symlink/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	skip: process.platform === 'win32',
+	description: 'follows symlinks',
+	options: {
+		preserveSymlinks: true
+	}
+};

--- a/test/function/samples/preserve-symlink/bar.js
+++ b/test/function/samples/preserve-symlink/bar.js
@@ -1,0 +1,3 @@
+export default function () {
+	return 'BAR';
+}

--- a/test/function/samples/preserve-symlink/foo.js
+++ b/test/function/samples/preserve-symlink/foo.js
@@ -1,0 +1,1 @@
+symlinked/foo.js

--- a/test/function/samples/preserve-symlink/main.js
+++ b/test/function/samples/preserve-symlink/main.js
@@ -1,0 +1,2 @@
+import foo from './foo.js';
+assert.equal( foo, 'BAR' );

--- a/test/function/samples/preserve-symlink/symlinked/foo.js
+++ b/test/function/samples/preserve-symlink/symlinked/foo.js
@@ -1,0 +1,2 @@
+import bar from './bar.js';
+export default bar();

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -68,7 +68,7 @@ describe('sanity checks', () => {
 					warnings,
 					[{
 						code: 'UNKNOWN_OPTION',
-						message: 'Unknown option found: plUgins. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
+						message: 'Unknown option found: plUgins. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, preserveSymlinks, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
 					}]
 				);
 			}


### PR DESCRIPTION
I believe symlinks used to be preserved, but now are followed. This is hurting me because in broccolijs land, everything is a symlink. This makes using the node-resolve plugin a nightmare.

Can we discuss an opt-in option for preserving symlinks? This PR is just a sample of what would change, not a final product. I would like the option to by system-wide public API, because several rollup plugins also follow rollup's example and follow symlinks. It would be nice if they could inherit the public option.