### PR TITLE
RFC: preserve context in `first`

### DIFF
--- a/src/utils/first.ts
+++ b/src/utils/first.ts
@@ -1,11 +1,11 @@
 // Return the first non-null or -undefined result from an array of
 // maybe-sync, maybe-promise-returning functions
 export default function first<T> (candidates: ((...args: any[]) => Promise<T | void> | T | void)[]): (...args: any[]) => Promise<T | void> {
-	return function (...args: any[]) {
+	return function (this: any, ...args: any[]) {
 		return candidates.reduce((promise, candidate) => {
 			return promise.then(
 				result =>
-					result != null ? result : Promise.resolve(candidate(...args))
+					result != null ? result : Promise.resolve(candidate.apply(this, args))
 			);
 		}, Promise.resolve());
 	};

--- a/test/function/samples/plugin-overrides-receive-context/_config.js
+++ b/test/function/samples/plugin-overrides-receive-context/_config.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+const myPlugin = {
+	resolveId (id) {
+		assert.equal(this.plugins[0], myPlugin);
+		return id;
+	}
+};
+
+module.exports = {
+	description: 'plugin overrides receive context',
+	options: {
+		plugins: [
+			myPlugin
+		]
+	}
+};

--- a/test/function/samples/plugin-overrides-receive-context/main.js
+++ b/test/function/samples/plugin-overrides-receive-context/main.js
@@ -1,0 +1,1 @@
+export default 42;


### PR DESCRIPTION
This will allow you to access `this` (Bundle.js) in plugin override functions. This will be necessary for the multi-entry plugin's `load` override to load other modules via `this.fetchModule` to do additional smart things based on their ASTs.