### PR TITLE
Disable external warnings when resolve returns false

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -568,7 +568,7 @@ export default class Graph {
 			return (resolvedId
 				? Promise.resolve(resolvedId)
 				: this.resolveId(source, module.id)
-			).then((resolvedId: string) => {
+			).then(resolvedId => {
 				const externalId =
 					resolvedId ||
 					(isRelative(source) ? resolve(module.id, '..', source) : source);
@@ -584,16 +584,18 @@ export default class Graph {
 						});
 					}
 
-					this.warn({
-						code: 'UNRESOLVED_IMPORT',
-						source,
-						importer: relativeId(module.id),
-						message: `'${source}' is imported by ${relativeId(
-							module.id
-						)}, but could not be resolved – treating it as an external dependency`,
-						url:
-							'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
-					});
+					if (resolvedId !== false) {
+						this.warn({
+							code: 'UNRESOLVED_IMPORT',
+							source,
+							importer: relativeId(module.id),
+							message: `'${source}' is imported by ${relativeId(
+								module.id
+							)}, but could not be resolved – treating it as an external dependency`,
+							url:
+								'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
+						});
+					}
 					isExternal = true;
 				}
 

--- a/test/function/samples/custom-path-resolver-async/_config.js
+++ b/test/function/samples/custom-path-resolver-async/_config.js
@@ -20,15 +20,6 @@ module.exports = {
 			}
 		}]
 	},
-	warnings: [
-		{
-			code: 'UNRESOLVED_IMPORT',
-			importer: 'main.js',
-			source: 'path',
-			message: `'path' is imported by main.js, but could not be resolved – treating it as an external dependency`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`
-		}
-	],
 	exports: function ( exports ) {
 		assert.strictEqual( exports.path, require( 'path' ) );
 	}

--- a/test/function/samples/custom-path-resolver-sync/_config.js
+++ b/test/function/samples/custom-path-resolver-sync/_config.js
@@ -13,15 +13,6 @@ module.exports = {
 			}
 		}]
 	},
-	warnings: [
-		{
-			code: 'UNRESOLVED_IMPORT',
-			importer: 'main.js',
-			source: 'path',
-			message: `'path' is imported by main.js, but could not be resolved – treating it as an external dependency`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`
-		}
-	],
 	exports: function ( exports ) {
 		assert.strictEqual( exports.path, require( 'path' ) );
 	}


### PR DESCRIPTION
This keeps the warnings fine when a module is not found through the resolver, but an explicit `false` return is taken to mean that the resolver expects the given module to be an external, and as such no warning should be necessary.