### PR TITLE
Removes errors when output options is an array.

### DIFF
--- a/bin/src/run/batchWarnings.ts
+++ b/bin/src/run/batchWarnings.ts
@@ -88,6 +88,11 @@ export default function batchWarnings () {
 const immediateHandlers: {
 	[code: string]: (warning: RollupWarning) => void
 } = {
+	UNKNOWN_OPTION: warning => {
+		title(`You have passed an unrecognized option`);
+		stderr(warning.message);
+	},
+
 	DEPRECATED_OPTIONS: warning => {
 		title(`Some options have been renamed`);
 		info(

--- a/bin/src/run/index.ts
+++ b/bin/src/run/index.ts
@@ -91,7 +91,7 @@ function execute (configFile: string, configs: InputOptions[], command: any) {
 	} else {
 		return sequence( configs, config => {
 			const warnings = batchWarnings();
-			const { inputOptions, outputOptions, deprecations } = mergeOptions({ config, command, defaultOnWarnHandler: warnings.add });
+			const { inputOptions, outputOptions, deprecations, optionError } = mergeOptions({ config, command, defaultOnWarnHandler: warnings.add });
 
 			if (deprecations.length) {
 				inputOptions.onwarn({
@@ -102,6 +102,8 @@ function execute (configFile: string, configs: InputOptions[], command: any) {
 					deprecations
 				});
 			}
+
+			if (optionError)	inputOptions.onwarn({code: 'UNKNOWN_OPTION', message: optionError});
 
 			return build(inputOptions, outputOptions, warnings, command.silent);
 		});

--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -54,6 +54,8 @@ export default function watch (configFile: string, configs: RollupWatchOptions[]
 				(<{ _deprecations: any }>result.watch)._deprecations = merged.deprecations;
 			}
 
+			if (merged.optionError) merged.inputOptions.onwarn({message: merged.optionError, code: 'UNKNOWN_OPTION'});
+
 			if (
 				(<RollupWatchOptions>merged.inputOptions).watch &&
 				(<RollupWatchOptions>merged.inputOptions).watch.clearScreen === false

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -215,7 +215,7 @@ export default function rollup (rawInputOptions: GenericConfigObject) {
 			deprecateConfig: { input: true },
 		});
 
-		if (optionError) throw new Error(optionError);
+		if (optionError) inputOptions.onwarn({message: optionError, code: 'UNKNOWN_OPTION'});
 
 		if (deprecations.length) addDeprecations(deprecations, inputOptions.onwarn);
 		checkInputOptions(inputOptions);
@@ -243,7 +243,7 @@ export default function rollup (rawInputOptions: GenericConfigObject) {
 						deprecateConfig: { output: true },
 					});
 
-					if (mergedOptions.optionError) throw new Error(mergedOptions.optionError);
+					if (mergedOptions.optionError) mergedOptions.inputOptions.onwarn({message: mergedOptions.optionError, code: 'UNKNOWN_OPTION'});
 
 					// now outputOptions is an array, but rollup.rollup API doesn't support arrays
 					const outputOptions = mergedOptions.outputOptions[0];

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -1,6 +1,6 @@
 import ensureArray from './ensureArray.js';
 import deprecateOptions from './deprecateOptions.js';
-import { InputOptions, WarningHandler } from '../../src/rollup/index';
+import { InputOptions, WarningHandler, OutputOptions } from '../../src/rollup/index';
 import { Deprecation } from './deprecateOptions';
 
 function normalizeObjectOptionValue (optionValue: any) {
@@ -160,8 +160,13 @@ export default function mergeOptions ({
 		...Object.keys(baseOutputOptions),
 		'pureExternalModules' // (backward compatibility) till everyone moves to treeshake.pureExternalModules
 	];
-	const errors = [...Object.keys(config || {}), ...Object.keys(config.output || {})]
-		.filter(k => k !== 'output' && validKeys.indexOf(k) === -1);
+	const outputOptionKeys: string[] = Array.isArray(config.output)
+		? config.output.reduce((keys: string[], o: OutputOptions) => [...keys, ...Object.keys(o)], [])
+		: Object.keys(config.output || {});
+	const errors = [
+		...Object.keys(config || {}),
+		...outputOptionKeys
+	].filter(k => k !== 'output' && validKeys.indexOf(k) === -1);
 
 	return {
 		inputOptions,

--- a/test/cli/samples/config-deprecations/rollup.config.js
+++ b/test/cli/samples/config-deprecations/rollup.config.js
@@ -6,6 +6,7 @@ let warnings = [];
 module.exports = {
 	entry: 'main.js',
 	format: 'cjs',
+	abc: 1,
 	plugins: [
 		replace( { 'ANSWER': 42 } )
 	],
@@ -14,23 +15,25 @@ module.exports = {
 		// then again from rollup's main method.
 		// the tests are different because some deprecations are
 		// fixed the first time only
-		warnings.push(warning.deprecations);
+		warnings.push(warning);
 
-		const entryDeprecationTest = () => assert.deepEqual(
-			warnings[0].filter(d => d.old === 'entry')[0],
-			{new: 'input', old: 'entry'}
-		);
-		
-		const formatDeprecationTest = () => assert.deepEqual(
-			warnings[0].filter(d => d.old === 'format')[0],
-			{new: 'output.format', old: 'format'}
+		const deprecationTest = () => assert.deepEqual(
+			warnings[0].deprecations,
+			[{new: 'input', old: 'entry'}, {new: 'output.format', old: 'format'}]
 		);
 
 		if (warnings.length === 1) {
-			entryDeprecationTest();
-			formatDeprecationTest();
+			deprecationTest();
 		} else if (warnings.length === 2) {
-			entryDeprecationTest();
+			deprecationTest();
+			assert.deepEqual(
+				warnings[1],
+				{
+					code: 'UNKNOWN_OPTION',
+					message: 'Unknown option found: abc. Allowed keys: input, legacy, treeshake, acorn, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, pureExternalModules'
+				}
+				
+			);
 		} else {
 			throw new Error('Unwanted warnings');
 		}


### PR DESCRIPTION
See #1826. In instances when there's an `unrecognized option` we throw an error and it has bitten us in the past (when I accidently broke the REPL, I'm sorry!).

In this PR, I've instead changed it to a warning, so that we don't break out and try to bundle it with showing a warning to the user. I feel this approach is safer. Also, we're checking for the error only in `src/rollup/index.ts` not at other places.

There was no test which checked multiple targets for `rollup.rollup API`, I've added that too. Let me know if this (`changing Errors to warnings`) approach seems okay to you? @lukastaegert 

