### PR TITLE
RFC: add missingExport hook

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -37,7 +37,6 @@ import { NodeType } from './ast/nodes/index';
 import ExternalVariable from './ast/variables/ExternalVariable';
 import { isTemplateLiteral } from './ast/nodes/TemplateLiteral';
 import { isLiteral } from './ast/nodes/Literal';
-import { missingExport } from './utils/defaults';
 
 wrapDynamicImportPlugin(acorn);
 
@@ -612,7 +611,7 @@ export default class Module {
 			const declaration = otherModule.traceExport(importDeclaration.name);
 
 			if (!declaration) {
-				missingExport(this, importDeclaration.name, otherModule, importDeclaration.specifier.start);
+				this.graph.missingExport(this, importDeclaration.name, otherModule, importDeclaration.specifier.start);
 			}
 
 			return declaration;
@@ -636,7 +635,7 @@ export default class Module {
 			);
 
 			if (!declaration) {
-				missingExport(this, reexportDeclaration.localName, reexportDeclaration.module, reexportDeclaration.start);
+				this.graph.missingExport(this, reexportDeclaration.localName, reexportDeclaration.module, reexportDeclaration.start);
 			}
 
 			return declaration;

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -6,7 +6,8 @@ import { mapSequence } from '../utils/promise';
 import error from '../utils/error';
 import { SOURCEMAPPING_URL } from '../utils/sourceMappingURL';
 import mergeOptions, { GenericConfigObject } from '../utils/mergeOptions';
-import { ModuleJSON } from '../Module';
+import Module, { ModuleJSON } from '../Module';
+import ExternalModule from '../ExternalModule';
 import { RawSourceMap } from 'source-map';
 import Program from '../ast/nodes/Program';
 import { Node } from '../ast/nodes/shared/Node';
@@ -20,6 +21,7 @@ export const VERSION = '<@VERSION@>';
 export type SourceDescription = { code: string, map?: RawSourceMap, ast?: Program };
 
 export type ResolveIdHook = (id: string, parent: string) => Promise<string | boolean | void> | string | boolean | void;
+export type MissingExportHook = (module: Module, name: string, otherModule: Module | ExternalModule, start?: number) => void;
 export type IsExternalHook = (id: string, parentId: string, isResolved: boolean) => Promise<boolean | void> | boolean | void;
 export type LoadHook = (id: string) => Promise<SourceDescription | string | void> | SourceDescription | string | void;
 export type TransformHook = (code: string, id: String) => Promise<SourceDescription | string | void>;
@@ -31,6 +33,7 @@ export interface Plugin {
 	options?: (options: InputOptions) => void;
 	load?: LoadHook;
 	resolveId?: ResolveIdHook;
+	missingExport?: MissingExportHook;
 	transform?: TransformHook;
 	transformBundle?: TransformBundleHook;
 	ongenerate?: (options: OutputOptions, source: SourceDescription) => void;

--- a/src/utils/first-sync.ts
+++ b/src/utils/first-sync.ts
@@ -1,0 +1,9 @@
+// Return the first non-null or -undefined result from an array of
+// sync functions
+export default function firstSync<T> (candidates: ((...args: any[]) => T | void)[]): (...args: any[]) => T | void {
+	return function (...args: any[]) {
+		return candidates.reduce<T | void> ((result, candidate) => {
+			return result != null ? result : candidate(...args);
+		}, null);
+	};
+}

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -100,4 +100,28 @@ describe('hooks', () => {
 				return sander.unlink(file);
 			});
 	});
+
+	it('calls missingExport hook', () => {
+		let wasCalled;
+
+		return rollup
+			.rollup({
+				input: 'main',
+				plugins: [
+					loader({
+						main: `import def from 'foo'; console.log( def );`,
+						foo: `export const named = 42;`
+					}),
+					{
+						missingExport() {
+							wasCalled = true;
+							return true;
+						}
+					}
+				]
+			})
+			.then(() => {
+				assert.ok(wasCalled);
+			});
+	});
 });


### PR DESCRIPTION
It would be great to override the behavior of what to do when an export is not found. In most cases, an error is what you want, but in the Ember.js world, leniency would be better.

In Ember.js, ES6 code is transpiled to AMD modules for the browser. This has the side-effect of jamming all exports into a default export. This means that you can write invalid ES6 export/import code that "just works" because of the AMD transpilation.

I would like to gracefully handle this case with a hook. I will then be printing a deprecation warning to Ember users so that invalid Ember code will eventually self-correct,