### PR TITLE
fix: use chalk.supportColors rather than isTTY so colors can be forced

### DIFF
--- a/bin/src/logging.ts
+++ b/bin/src/logging.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import relativeId from '../../src/utils/relativeId.js';
 import { RollupError } from '../../src/utils/error';
 
-if (!process.stderr.isTTY) chalk.enabled = false;
+if (!chalk.supportsColor) chalk.enabled = false;
 
 // log to stderr to keep `rollup main.js > bundle.js` from breaking
 export const stderr = console.error.bind(console); // eslint-disable-line no-console


### PR DESCRIPTION
## Change
Use [`chalk.supportsColors`](https://github.com/chalk/chalk#chalksupportscolor) rather than checking if `stderr` is a `TTY`. 

This should be equivalent to the current code except when `--colors` or `--no-colors` is passed as a command line option or `FORCE_COLORS` is an environment variable. This allows users to force colors in non-interactive shells. 

## Why
I am working with `rollup` and `child_processes` and I want to be able to edit the `child` `stderr`/`stdout` but I also want colors to show up. There isn't a good way to do that right now without using a [`node-pty`](https://github.com/Tyriar/node-pty) but that gets rid of the notion of `stderr` and `stdout`, which also won't work.