### PR TITLE
Quick fix to enable tree-shaking babel-helpers again

### DIFF
--- a/src/ast/variables/GlobalVariable.ts
+++ b/src/ast/variables/GlobalVariable.ts
@@ -17,18 +17,19 @@ export default class GlobalVariable extends Variable {
 	hasEffectsWhenAccessedAtPath (path: ObjectPath) {
 		// path.length == 0 can also have an effect but we postpone this for now
 		return (
-			path.length > 0 &&
-			!pureFunctions[[this.name, ...path].join('.')] &&
-			!pureFunctions[[this.name, ...path.slice(0, -1)].join('.')] &&
-			!(
-				path.length > 1 &&
-				pureFunctions[[this.name, ...path.slice(0, -2)].join('.')] &&
-				path[path.length - 2] === 'prototype'
-			)
+			path.length > 0
+				&& !this.isPureFunctionMember(path)
+				&& !(this.name === 'Reflect' && path.length === 1)
 		);
 	}
 
 	hasEffectsWhenCalledAtPath (path: ObjectPath) {
 		return !pureFunctions[[this.name, ...path].join('.')];
+	}
+
+	private isPureFunctionMember (path: ObjectPath) {
+		return pureFunctions[[this.name, ...path].join('.')]
+			|| (path.length >= 1 && pureFunctions[[this.name, ...path.slice(0, -1)].join('.')])
+			|| (path.length >= 2 && pureFunctions[[this.name, ...path.slice(0, -2)].join('.')] && path[path.length - 2] === 'prototype');
 	}
 }

--- a/test/form/samples/removes-unused-babel-helpers/_config.js
+++ b/test/form/samples/removes-unused-babel-helpers/_config.js
@@ -1,5 +1,5 @@
 const assert = require( 'assert' );
 
 module.exports = {
-	description: 'Removes unused babel helpers from the build (#1595)'
+	description: 'Removes unused babel helpers from the build (#1595)',
 };

--- a/test/form/samples/removes-unused-babel-helpers/main.js
+++ b/test/form/samples/removes-unused-babel-helpers/main.js
@@ -5,6 +5,19 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 	return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
 };
 
+var _sPO = Object.setPrototypeOf || function _sPO(o, p) {
+	o.__proto__ = p;
+	return o;
+};
+
+var _construct = typeof Reflect === "object" && Reflect.construct || function _construct(Parent, args, Class) {
+	var Constructor,
+		a = [null];
+	a.push.apply(a, args);
+	Constructor = Parent.bind.apply(Parent, a);
+	return _sPO(new Constructor(), Class.prototype);
+};
+
 var jsx = function () {
 	var REACT_ELEMENT_TYPE = typeof Symbol === "function" && Symbol.for && Symbol.for("react.element") || 0xeac7;
 	return function createRawReactElement(type, props, key, children) {


### PR DESCRIPTION
Resolves #1823

This will declare accesses to members of `Reflect` as safe und thus enable tree-shaking babel helpers again. This is just a quick fix which will be replaced by a proper solution once I have finished reworking the handling of global variables and which I will put into the next release if there are no objections.