### PR TITLE
refactor: refactor watch to use `extends` directly

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -19,20 +19,18 @@ export interface WatcherOptions {
 	clearScreen?: boolean;
 }
 
-export type InputAndOutputOptions = InputOptions & OutputOptions;
-
-export interface RollupWatchOptions extends InputAndOutputOptions {
+export interface RollupWatchOptions extends InputOptions {
 	output?: OutputOptions;
 	watch?: WatcherOptions;
 }
 
-export class Watcher extends (<{ new(): any }>EventEmitter) {
+export class Watcher extends EventEmitter {
 	dirty: boolean;
 	running: boolean;
 	tasks: Task[];
 	succeeded: boolean;
 
-	constructor (configs: (RollupWatchOptions)[]) {
+	constructor (configs: RollupWatchOptions[]) {
 		super();
 
 		this.dirty = true;


### PR DESCRIPTION
Some minor typescript cleanup, with this it will remove `Watcher_base` and `InputAndOutputOptions` as an export
  