### PR TITLE
fix typescript compiler errors based on emitted d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "dist/rollup.es.js",
     "dist/rollup.js",
     "dist/**/*.d.ts",
+    "./typings/package.json.d.ts",
     "bin/rollup",
     "README.md"
   ],

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -135,7 +135,7 @@ export default class Module {
 	private astClone: Program;
 	declarations: {
 		'*'?: NamespaceVariable;
-		[name: string]: Variable;
+		[name: string]: Variable | undefined;
 	};
 	private exportAllModules: (Module | ExternalModule)[];
 	private dynamicImports: Import[];

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -1,3 +1,5 @@
+/// <reference path="../typings/package.json.d.ts" />
+
 export * from './rollup/index';
 export * from './watch/index';
 

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -1,6 +1,6 @@
 import ensureArray from './ensureArray.js';
 import deprecateOptions from './deprecateOptions.js';
-import { InputOptions, WarningHandler, OutputOptions } from '../../src/rollup/index';
+import { InputOptions, WarningHandler, OutputOptions } from '../rollup/index';
 import { Deprecation } from './deprecateOptions';
 
 function normalizeObjectOptionValue (optionValue: any) {

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -5,10 +5,6 @@ declare module 'help.md' {
 	export default str;
 }
 
-declare module 'package.json' {
-	const version: string;
-}
-
 // external libs
 declare module "ansi-escapes";
 declare module 'pretty-ms';

--- a/typings/package.json.d.ts
+++ b/typings/package.json.d.ts
@@ -1,0 +1,3 @@
+declare module 'package.json' {
+	const version: string;
+}


### PR DESCRIPTION
fixes #1862

To fix all compiler errors mentioned in #1862 a TypeScript project that imports Rollup additionally needs to add theses `devDependencies`:

- `@types/chokidar`
- `@types/source-map`
- `magic-string` (brings its own typing)
