### PR TITLE
Fix two more ts compiler errors based on emitted d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "dist/rollup.es.js",
     "dist/rollup.js",
     "dist/**/*.d.ts",
-    "./typings/package.json.d.ts",
+    "typings/package.json.d.ts",
     "bin/rollup",
     "README.md"
   ],

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -9,6 +9,7 @@ import mergeOptions, { GenericConfigObject } from '../utils/mergeOptions';
 import { ModuleJSON } from '../Module';
 import { RawSourceMap } from 'source-map';
 import Program from '../ast/nodes/Program';
+import { Node } from '../ast/nodes/shared/Node';
 import { SourceMap } from 'magic-string';
 import { WatcherOptions } from '../watch/index';
 import { Deprecation } from '../utils/deprecateOptions';


### PR DESCRIPTION
This is a follow-up PR from #1864 that addresses the issue mentioned by @lukastaegert in [this comment](https://github.com/rollup/rollup/issues/1862#issuecomment-357146735) as well as fixes the wrong `files` entry for `typings/package.json.d.ts` as [noticed](https://github.com/rollup/rollup/pull/1864#issuecomment-357158638) by @alan-agius4.