### PR TITLE
RFC: add RenderOptions to render

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -38,6 +38,7 @@ import ExternalVariable from './ast/variables/ExternalVariable';
 import { isTemplateLiteral } from './ast/nodes/TemplateLiteral';
 import { isLiteral } from './ast/nodes/Literal';
 import { missingExport } from './utils/defaults';
+import { RenderOptions } from './rollup';
 
 wrapDynamicImportPlugin(acorn);
 
@@ -564,11 +565,11 @@ export default class Module {
 		return this.declarations['*'];
 	}
 
-	render (es: boolean, legacy: boolean, freeze: boolean): MagicString {
+	render (es: boolean, legacy: boolean, freeze: boolean, options: RenderOptions = {}): MagicString {
 		const magicString = this.magicString.clone();
 
 		for (const node of this.ast.body) {
-			node.render(magicString, es);
+			node.render(magicString, es, options);
 		}
 
 		if (this.namespace().needsNamespaceBlock) {

--- a/src/ast/nodes/BlockStatement.ts
+++ b/src/ast/nodes/BlockStatement.ts
@@ -6,6 +6,7 @@ import MagicString from 'magic-string';
 import { Node } from './shared/Node';
 import { StatementBase, StatementNode } from './shared/Statement';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export function isBlockStatement (node: Node): node is BlockStatement {
 	return node.type === NodeType.BlockStatement;
@@ -60,13 +61,13 @@ export default class BlockStatement extends StatementBase {
 		this.scope = new BlockScope({ parent: parentScope });
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (this.body.length) {
 			for (const node of this.body) {
-				node.render(code, es);
+				node.render(code, es, options);
 			}
 		} else {
-			super.render(code, es);
+			super.render(code, es, options);
 		}
 	}
 }

--- a/src/ast/nodes/ClassDeclaration.ts
+++ b/src/ast/nodes/ClassDeclaration.ts
@@ -3,6 +3,7 @@ import Scope from '../scopes/Scope';
 import Identifier from './Identifier';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class ClassDeclaration extends ClassNode {
 	type: NodeType.ClassDeclaration;
@@ -14,9 +15,9 @@ export default class ClassDeclaration extends ClassNode {
 		super.initialiseChildren(parentScope);
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (!this.module.graph.treeshake || this.included) {
-			super.render(code, es);
+			super.render(code, es, options);
 		} else {
 			code.remove(
 				this.leadingCommentStart || this.start,

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -7,6 +7,7 @@ import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
+import { RenderOptions } from '../../rollup';
 
 export default class ConditionalExpression extends NodeBase {
 	type: NodeType.ConditionalExpression;
@@ -90,12 +91,12 @@ export default class ConditionalExpression extends NodeBase {
 		}
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (!this.module.graph.treeshake) {
-			super.render(code, es);
+			super.render(code, es, options);
 		} else {
 			if (this.testValue === UNKNOWN_VALUE) {
-				super.render(code, es);
+				super.render(code, es, options);
 			} else {
 				const branchToRetain = this.testValue
 					? this.consequent
@@ -107,7 +108,7 @@ export default class ConditionalExpression extends NodeBase {
 					code.prependLeft(branchToRetain.start, '(');
 					code.appendRight(branchToRetain.end, ')');
 				}
-				branchToRetain.render(code, es);
+				branchToRetain.render(code, es, options);
 			}
 		}
 	}

--- a/src/ast/nodes/EmptyStatement.ts
+++ b/src/ast/nodes/EmptyStatement.ts
@@ -1,11 +1,12 @@
 import MagicString from 'magic-string';
 import { StatementBase } from './shared/Statement';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class EmptyStatement extends StatementBase {
 	type: NodeType.EmptyStatement;
 
-	render (code: MagicString, _es: boolean) {
+	render (code: MagicString, _es: boolean, _options: RenderOptions) {
 		if (
 			this.parent.type === NodeType.BlockStatement ||
 			this.parent.type === NodeType.Program

--- a/src/ast/nodes/ExportAllDeclaration.ts
+++ b/src/ast/nodes/ExportAllDeclaration.ts
@@ -2,6 +2,7 @@ import { NodeBase } from './shared/Node';
 import Literal from './Literal';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class ExportAllDeclaration extends NodeBase {
 	type: NodeType.ExportAllDeclaration;
@@ -12,7 +13,7 @@ export default class ExportAllDeclaration extends NodeBase {
 		this.isExportDeclaration = true;
 	}
 
-	render (code: MagicString, _es: boolean) {
+	render (code: MagicString, _es: boolean, _options: RenderOptions) {
 		code.remove(this.leadingCommentStart || this.start, this.next || this.end);
 	}
 }

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -6,6 +6,7 @@ import FunctionDeclaration from './FunctionDeclaration';
 import Identifier from './Identifier';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 const functionOrClassDeclaration = /^(?:Function|Class)Declaration/;
 
@@ -67,7 +68,7 @@ export default class ExportDefaultDeclaration extends NodeBase {
 		);
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		const remove = () => {
 			code.remove(
 				this.leadingCommentStart || this.start,
@@ -117,16 +118,16 @@ export default class ExportDefaultDeclaration extends NodeBase {
 
 			// Only output `var foo =` if `foo` is used
 			if (this.included) {
-				code.overwrite(
-					this.start,
-					declaration_start,
-					`${this.module.graph.varOrConst} ${name} = `
-				);
+					code.overwrite(
+						this.start,
+						declaration_start,
+						`${this.module.graph.varOrConst} ${name} = `
+					);
 			} else {
 				removeExportDefault();
 			}
 		}
-		super.render(code, es);
+		super.render(code, es, options);
 
 	}
 }

--- a/src/ast/nodes/ExportNamedDeclaration.ts
+++ b/src/ast/nodes/ExportNamedDeclaration.ts
@@ -7,6 +7,7 @@ import FunctionDeclaration from './FunctionDeclaration';
 import ClassDeclaration from './ClassDeclaration';
 import VariableDeclaration from './VariableDeclaration';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class ExportNamedDeclaration extends NodeBase {
 	type: NodeType.ExportNamedDeclaration;
@@ -29,10 +30,10 @@ export default class ExportNamedDeclaration extends NodeBase {
 		this.isExportDeclaration = true;
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (this.declaration) {
 			code.remove(this.start, this.declaration.start);
-			this.declaration.render(code, es);
+			this.declaration.render(code, es, options);
 		} else {
 			const start = this.leadingCommentStart || this.start;
 			const end = this.next || this.end;

--- a/src/ast/nodes/ExpressionStatement.ts
+++ b/src/ast/nodes/ExpressionStatement.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
 import { StatementBase } from './shared/Statement';
 import Scope from '../scopes/Scope';
+import { RenderOptions } from '../../rollup';
 
 export default class ExpressionStatement extends StatementBase {
 	directive?: string;
@@ -26,8 +27,8 @@ export default class ExpressionStatement extends StatementBase {
 		return super.shouldBeIncluded();
 	}
 
-	render (code: MagicString, es: boolean) {
-		super.render(code, es);
+	render (code: MagicString, es: boolean, options: RenderOptions) {
+		super.render(code, es, options);
 		if (this.included) this.insertSemicolon(code);
 	}
 }

--- a/src/ast/nodes/FunctionDeclaration.ts
+++ b/src/ast/nodes/FunctionDeclaration.ts
@@ -2,6 +2,7 @@ import FunctionNode from './shared/FunctionNode';
 import Scope from '../scopes/Scope';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class FunctionDeclaration extends FunctionNode {
 	type: NodeType.FunctionDeclaration;
@@ -14,9 +15,9 @@ export default class FunctionDeclaration extends FunctionNode {
 		this.body.initialiseAndReplaceScope(new Scope({ parent: this.scope }));
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (!this.module.graph.treeshake || this.included) {
-			super.render(code, es);
+			super.render(code, es, options);
 		} else {
 			code.remove(
 				this.leadingCommentStart || this.start,

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -11,6 +11,7 @@ import Property from './Property';
 import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ExpressionEntity, ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export function isIdentifier (node: Node): node is Identifier {
 	return node.type === NodeType.Identifier;
@@ -116,7 +117,7 @@ export default class Identifier extends NodeBase {
 		}
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, _options: RenderOptions) {
 		if (this.variable) {
 			const name = this.variable.getName(es);
 			if (name !== this.name) {

--- a/src/ast/nodes/IfStatement.ts
+++ b/src/ast/nodes/IfStatement.ts
@@ -6,6 +6,7 @@ import { isVariableDeclaration } from './VariableDeclaration';
 import MagicString from 'magic-string';
 import { StatementBase, StatementNode } from './shared/Statement';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 // Statement types which may contain if-statements as direct children.
 const statementsWithIfStatements = new Set([
@@ -69,10 +70,10 @@ export default class IfStatement extends StatementBase {
 		}
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (this.module.graph.treeshake) {
 			if (this.testValue === UNKNOWN_VALUE) {
-				super.render(code, es);
+				super.render(code, es, options);
 			} else {
 				code.overwrite(
 					this.test.start,
@@ -99,7 +100,7 @@ export default class IfStatement extends StatementBase {
 				if (this.testValue) {
 					code.remove(this.start, this.consequent.start);
 					code.remove(this.consequent.end, this.end);
-					this.consequent.render(code, es);
+					this.consequent.render(code, es, options);
 				} else {
 					code.remove(
 						this.start,
@@ -107,14 +108,14 @@ export default class IfStatement extends StatementBase {
 					);
 
 					if (this.alternate) {
-						this.alternate.render(code, es);
+						this.alternate.render(code, es, options);
 					} else if (statementsWithIfStatements.has(this.parent.type)) {
 						code.prependRight(this.start, '{}');
 					}
 				}
 			}
 		} else {
-			super.render(code, es);
+			super.render(code, es, options);
 		}
 	}
 }

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -3,6 +3,7 @@ import MagicString from 'magic-string';
 import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { Node, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export function isLiteral (node: Node): node is Literal {
 	return node.type === NodeType.Literal;
@@ -30,7 +31,7 @@ export default class Literal<T = string | boolean | null | number | RegExp> exte
 		return path.length > 1;
 	}
 
-	render (code: MagicString, _es: boolean) {
+	render (code: MagicString, _es: boolean, _options: RenderOptions) {
 		if (typeof this.value === 'string') {
 			(<any> code).indentExclusionRanges.push([this.start + 1, this.end - 1]); // TODO TypeScript: Awaiting MagicString PR
 		}

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -11,6 +11,7 @@ import { isNamespaceVariable } from '../variables/NamespaceVariable';
 import { isExternalVariable } from '../variables/ExternalVariable';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 const validProp = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 
@@ -223,7 +224,7 @@ export default class MemberExpression extends NodeBase {
 		}
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (this.variable) {
 			code.overwrite(this.start, this.end, this.variable.getName(es), {
 				storeName: true,
@@ -236,7 +237,7 @@ export default class MemberExpression extends NodeBase {
 			});
 		}
 
-		super.render(code, es);
+		super.render(code, es, options);
 	}
 
 	someReturnExpressionWhenCalledAtPath (

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -7,6 +7,7 @@ import MagicString from 'magic-string';
 import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ExpressionEntity, ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export function isProperty (node: Node): node is Property {
 	return node.type === NodeType.Property;
@@ -165,11 +166,11 @@ export default class Property extends NodeBase {
 		});
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (!this.shorthand) {
-			this.key.render(code, es);
+			this.key.render(code, es, options);
 		}
-		this.value.render(code, es);
+		this.value.render(code, es, options);
 	}
 
 	someReturnExpressionWhenCalledAtPath (

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -2,6 +2,7 @@ import ExecutionPathOptions from '../ExecutionPathOptions';
 import MagicString from 'magic-string';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class SequenceExpression extends NodeBase {
 	type: NodeType.SequenceExpression;
@@ -31,12 +32,12 @@ export default class SequenceExpression extends NodeBase {
 		return addedNewNodes;
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (!this.module.graph.treeshake) {
-			super.render(code, es);
+			super.render(code, es, options);
 		} else {
 			const last = this.expressions[this.expressions.length - 1];
-			last.render(code, es);
+			last.render(code, es, options);
 
 			if (
 				this.parent.type === NodeType.CallExpression &&
@@ -55,7 +56,7 @@ export default class SequenceExpression extends NodeBase {
 			} else {
 				let previousEnd = this.start;
 				for (const expression of included) {
-					expression.render(code, es);
+					expression.render(code, es, options);
 					code.remove(previousEnd, expression.start);
 					code.appendLeft(expression.end, ', ');
 					previousEnd = expression.end;

--- a/src/ast/nodes/TemplateLiteral.ts
+++ b/src/ast/nodes/TemplateLiteral.ts
@@ -2,6 +2,7 @@ import TemplateElement from './TemplateElement';
 import MagicString from 'magic-string';
 import { Node, ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export function isTemplateLiteral (node: Node): node is TemplateLiteral {
 	return node.type === NodeType.TemplateLiteral;
@@ -12,8 +13,8 @@ export default class TemplateLiteral extends NodeBase {
 	quasis: TemplateElement[];
 	expressions: ExpressionNode[];
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		(<any> code).indentExclusionRanges.push([this.start, this.end]); // TODO TypeScript: Awaiting PR
-		super.render(code, es);
+		super.render(code, es, options);
 	}
 }

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -4,6 +4,7 @@ import MagicString from 'magic-string';
 import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class ThisExpression extends NodeBase {
 	type: NodeType.ThisExpression;
@@ -44,7 +45,7 @@ export default class ThisExpression extends NodeBase {
 		return this.variable.hasEffectsWhenAssignedAtPath(path, options);
 	}
 
-	render (code: MagicString, _es: boolean) {
+	render (code: MagicString, _es: boolean, _options: RenderOptions) {
 		if (this.alias) {
 			code.overwrite(this.start, this.end, this.alias, {
 				storeName: true,

--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -9,6 +9,7 @@ import MagicString from 'magic-string';
 import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { isIdentifier } from './Identifier';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 function getSeparator (code: string, start: number) {
 	let c = start;
@@ -72,7 +73,7 @@ export default class VariableDeclaration extends NodeBase {
 		);
 	}
 
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		const treeshake = this.module.graph.treeshake;
 
 		let shouldSeparate = false;
@@ -139,7 +140,7 @@ export default class VariableDeclaration extends NodeBase {
 				}
 			}
 
-			declarator.render(code, es);
+			declarator.render(code, es, options);
 		}
 
 		if (treeshake && empty) {

--- a/src/ast/nodes/VariableDeclarator.ts
+++ b/src/ast/nodes/VariableDeclarator.ts
@@ -6,6 +6,7 @@ import MagicString from 'magic-string';
 import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { PatternNode } from './shared/Pattern';
 import { NodeType } from './NodeType';
+import { RenderOptions } from '../../rollup';
 
 export default class VariableDeclarator extends NodeBase {
 	type: NodeType.VariableDeclarator;
@@ -23,7 +24,7 @@ export default class VariableDeclarator extends NodeBase {
 	}
 
 	// TODO Deleting this does not break any tests. Find meaningful test or delete.
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		extractNames(this.id).forEach(name => {
 			const variable = this.scope.findVariable(name);
 
@@ -36,6 +37,6 @@ export default class VariableDeclarator extends NodeBase {
 			}
 		});
 
-		super.render(code, es);
+		super.render(code, es, options);
 	}
 }

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -9,6 +9,7 @@ import { ObjectPath } from '../../variables/VariableReassignmentTracker';
 import CallOptions from '../../CallOptions';
 import { UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../../values';
 import { Entity } from '../../Entity';
+import { RenderOptions } from '../../../rollup';
 
 export interface Node extends Entity {
 	end: number;
@@ -64,7 +65,7 @@ export interface Node extends Entity {
 	 */
 	initialise (parentScope: Scope): void;
 	initialiseAndDeclare (parentScope: Scope, kind: string, init: ExpressionEntity | null): void;
-	render(code: MagicString, es: boolean): void;
+	render(code: MagicString, es: boolean, options: RenderOptions): void;
 
 	/**
 	 * Start a new execution path to determine if this node has an effect on the bundle and
@@ -219,8 +220,8 @@ export class NodeBase implements ExpressionNode {
 
 	reassignPath (_path: ObjectPath, _options: ExecutionPathOptions) { }
 
-	render (code: MagicString, es: boolean) {
-		this.eachChild(child => child.render(code, es));
+	render (code: MagicString, es: boolean, options: RenderOptions) {
+		this.eachChild(child => child.render(code, es, options));
 	}
 
 	shouldBeIncluded () {

--- a/src/ast/nodes/shared/Statement.ts
+++ b/src/ast/nodes/shared/Statement.ts
@@ -1,12 +1,13 @@
 import { NodeBase, Node } from './Node';
 import MagicString from 'magic-string';
+import { RenderOptions } from '../../../rollup';
 
 export interface StatementNode extends Node {}
 
 export class StatementBase extends NodeBase implements StatementNode {
-	render (code: MagicString, es: boolean) {
+	render (code: MagicString, es: boolean, options: RenderOptions) {
 		if (!this.module.graph.treeshake || this.included) {
-			super.render(code, es);
+			super.render(code, es, options);
 		} else {
 			code.remove(
 				this.leadingCommentStart || this.start,

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -122,6 +122,9 @@ export interface OutputOptions {
 	moduleId?: string;
 }
 
+export interface RenderOptions {
+}
+
 export interface RollupWarning {
 	message?: string;
 	code?: string;


### PR DESCRIPTION
This will make #1878 a lot smaller. This would be a place for future expansion and option adding, without changing every file's override of render. Although it is currently empty, #1878 adds a few options to it. We could even add the `es` option to it after this merge, regardless of #1878.