### PR TITLE
RFC: return array from traceExport

### DIFF
--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -73,13 +73,13 @@ export default class ExternalModule {
 		});
 	}
 
-	traceExport (name: string): Variable {
+	traceExport (name: string): Variable[] {
 		if (name !== 'default' && name !== '*') this.exportsNames = true;
 		if (name === '*') this.exportsNamespace = true;
 
-		return (
+		return [(
 			this.declarations[name] ||
 			(this.declarations[name] = new ExternalVariable(this, name))
-		);
+		)];
 	}
 }

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -91,7 +91,7 @@ export default class MemberExpression extends NodeBase {
 		if (path.length === 0) return baseVariable;
 		if (!isNamespaceVariable(baseVariable)) return null;
 		const exportName = path[0].key;
-		const variable = baseVariable.module.traceExport(exportName);
+		const [variable] = baseVariable.module.traceExport(exportName);
 		if (!variable) {
 			this.module.warn(
 				{

--- a/src/ast/scopes/ModuleScope.ts
+++ b/src/ast/scopes/ModuleScope.ts
@@ -32,18 +32,18 @@ export default class ModuleScope extends Scope {
 			const addDeclaration = (declaration: Variable) => {
 				if (isNamespaceVariable(declaration) && !isExternalVariable(declaration)) {
 					declaration.module.getExports()
-						.forEach(name => addDeclaration(declaration.module.traceExport(name)));
+						.forEach(name => addDeclaration(declaration.module.traceExport(name)[0]));
 				}
 
 				localNames.add(declaration.name);
 			};
 
 			(<Module>specifier.module).getExports().forEach(name => {
-				addDeclaration(specifier.module.traceExport(name));
+				addDeclaration(specifier.module.traceExport(name)[0]);
 			});
 
 			if (specifier.name !== '*') {
-				const declaration = specifier.module.traceExport(specifier.name);
+				const [declaration] = specifier.module.traceExport(specifier.name);
 				if (!declaration) {
 					this.module.warn(
 						{

--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -27,7 +27,7 @@ export default class NamespaceVariable extends Variable {
 			.getExports()
 			.concat(module.getReexports())
 			.forEach(name => {
-				this.originals[name] = module.traceExport(name);
+				this.originals[name] = module.traceExport(name)[0];
 			});
 	}
 

--- a/src/finalisers/es.ts
+++ b/src/finalisers/es.ts
@@ -88,7 +88,7 @@ export default function es (bundle: Bundle, magicString: MagicStringBundle, { ge
 		.getExports()
 		.filter(notDefault)
 		.forEach(name => {
-			const declaration = module.traceExport(name);
+			const [declaration] = module.traceExport(name);
 			const rendered = declaration.getName(true);
 			exportInternalSpecifiers.push(
 				rendered === name ? name : `${rendered} as ${name}`
@@ -96,7 +96,7 @@ export default function es (bundle: Bundle, magicString: MagicStringBundle, { ge
 		});
 
 	module.getReexports().forEach(name => {
-		const declaration = module.traceExport(name);
+		const [declaration] = module.traceExport(name);
 
 		if (isExternalVariable(declaration)) {
 			if (name[0] === '*') {
@@ -125,7 +125,7 @@ export default function es (bundle: Bundle, magicString: MagicStringBundle, { ge
 		exportBlock.push(`export { ${exportInternalSpecifiers.join(', ')} };`);
 	if (module.exports.default)
 		exportBlock.push(
-			`export default ${module.traceExport('default').getName(true)};`
+			`export default ${module.traceExport('default')[0].getName(true)};`
 		);
 	if (exportAllDeclarations.length)
 		exportBlock.push(exportAllDeclarations.join('\n'));

--- a/src/finalisers/shared/getExportBlock.ts
+++ b/src/finalisers/shared/getExportBlock.ts
@@ -9,7 +9,7 @@ export default function getExportBlock (
 	const entryModule = bundle.entryModule;
 
 	if (exportMode === 'default') {
-		return `${mechanism} ${entryModule.traceExport('default').getName(false)};`;
+		return `${mechanism} ${entryModule.traceExport('default')[0].getName(false)};`;
 	}
 
 	const exports = entryModule
@@ -27,7 +27,7 @@ export default function getExportBlock (
 			}
 
 			const prop = name === 'default' ? `['default']` : `.${name}`;
-			const declaration = entryModule.traceExport(name);
+			const [declaration] = entryModule.traceExport(name);
 
 			const lhs = `exports${prop}`;
 			const rhs = declaration ? declaration.getName(false) : name; // exporting a global


### PR DESCRIPTION
Taken from #1878. In the current bundling strategy, a duplicate export found from multiple `export *`s will be deduped, the first found winning. With bundling disabled, we no longer want to dedupe. In this PR, the capability is added but disabled.