### PR TITLE
use consistent strings in tests

### DIFF
--- a/test/form/samples/define-replacement/main.js
+++ b/test/form/samples/define-replacement/main.js
@@ -1,4 +1,4 @@
-import { a } from "./a.js";
-import { a as b } from "./a.js";
+import { a } from './a.js';
+import { a as b } from './a.js';
 a();
 b();

--- a/test/form/samples/export-default-anonymous-declarations/main.js
+++ b/test/form/samples/export-default-anonymous-declarations/main.js
@@ -1,7 +1,7 @@
-import Fn from "./fn.js"
-import Async from "./async.js";
-import Generator from "./generator.js";
-import Class from "./class.js";
+import Fn from './fn.js';
+import Async from './async.js';
+import Generator from './generator.js';
+import Class from './class.js';
 
 Fn();
 Async();


### PR DESCRIPTION
This is an issue in #1878, where I use the existing import collapsing code from finalisers/es.js, which rewrites code using single tick ' strings.