### PR TITLE
Entry point failing to render in the face of circular dependencies

### DIFF
--- a/test/chunking-form/samples/circular-entry-points-2/_config.js
+++ b/test/chunking-form/samples/circular-entry-points-2/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'chunking circular entry points',
+	options: {
+		input: [ 'main1.js', 'main2.js' ]
+	},
+	solo: true
+};

--- a/test/chunking-form/samples/circular-entry-points-2/dep.js
+++ b/test/chunking-form/samples/circular-entry-points-2/dep.js
@@ -1,0 +1,5 @@
+import './main2.js';
+
+console.log( 'dep' );
+
+export const x = 'dep';

--- a/test/chunking-form/samples/circular-entry-points-2/main1.js
+++ b/test/chunking-form/samples/circular-entry-points-2/main1.js
@@ -1,0 +1,3 @@
+import { x } from './dep.js';
+
+console.log( 'main1', x );

--- a/test/chunking-form/samples/circular-entry-points-2/main2.js
+++ b/test/chunking-form/samples/circular-entry-points-2/main2.js
@@ -1,0 +1,3 @@
+import { x } from './dep.js';
+
+console.log( 'main2', x );


### PR DESCRIPTION
In this test, we have entry points A1 and A2 which both import the non-entry point B. B in turn imports A2. In this scenario, no chunk is generated for entry point A1.
Instead, we receive two generic chunks, one that includes the code of both A1 and A2 and one that is basically B, as well as a facade chunk for A2 (but, as I said, none for A1).

I did not include an explicit expectation but ideally, I would expect that
* one generic chunks is created that contains the code for A2 and B
* A1 is a chunk of its own, importing from the generic chunk what it would usually import from B
* A2 is created as a facade to the generic chunk

This may or may not be related to what I noted at my review of the chunking algorithm about circular references to entry points always removing (not always rightfully) the entry point from the chunk.