### PR TITLE
RFC: add includeNamespaceConflicts option

### DIFF
--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -73,13 +73,13 @@ export default class ExternalModule {
 		});
 	}
 
-	traceExport (name: string): Variable {
+	traceExport (name: string): Variable[] {
 		if (name !== 'default' && name !== '*') this.exportsNames = true;
 		if (name === '*') this.exportsNamespace = true;
 
-		return (
+		return [(
 			this.declarations[name] ||
 			(this.declarations[name] = new ExternalVariable(this, name))
-		);
+		)];
 	}
 }

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -36,6 +36,7 @@ export default class Graph {
 	externalModules: ExternalModule[];
 	getModuleContext: (id: string) => string;
 	hasLoaders: boolean;
+	includeNamespaceConflicts: boolean;
 	isExternal: IsExternalHook;
 	isPureExternalModule: (id: string) => boolean;
 	legacy: boolean;
@@ -160,6 +161,8 @@ export default class Graph {
 			this.acornOptions.plugins = this.acornOptions.plugins || {};
 			this.acornOptions.plugins.dynamicImport = true;
 		}
+
+		this.includeNamespaceConflicts = options.includeNamespaceConflicts;
 	}
 
 	private loadModule (entryName: string) {
@@ -447,7 +450,7 @@ export default class Graph {
 						if (exportAllModule.isExternal) return;
 
 						keys((<Module>exportAllModule).exportsAll).forEach(name => {
-							if (name in module.exportsAll) {
+							if (!this.includeNamespaceConflicts && name in module.exportsAll) {
 								this.warn({
 									code: 'NAMESPACE_CONFLICT',
 									reexporter: module.id,

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -674,7 +674,7 @@ export default class Module {
 		for (let i = 0; i < this.exportAllModules.length; i += 1) {
 			const module = this.exportAllModules[i];
 			declarations = declarations.concat(module.traceExport(name));
-			if (declarations.length) {
+			if (!this.graph.includeNamespaceConflicts && declarations.length) {
 				// future code will utilize more than one
 				break;
 			}

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -91,7 +91,7 @@ export default class MemberExpression extends NodeBase {
 		if (path.length === 0) return baseVariable;
 		if (!isNamespaceVariable(baseVariable)) return null;
 		const exportName = path[0].key;
-		const variable = baseVariable.module.traceExport(exportName);
+		const [variable] = baseVariable.module.traceExport(exportName);
 		if (!variable) {
 			this.module.warn(
 				{

--- a/src/ast/scopes/ModuleScope.ts
+++ b/src/ast/scopes/ModuleScope.ts
@@ -32,18 +32,18 @@ export default class ModuleScope extends Scope {
 			const addDeclaration = (declaration: Variable) => {
 				if (isNamespaceVariable(declaration) && !isExternalVariable(declaration)) {
 					declaration.module.getExports()
-						.forEach(name => addDeclaration(declaration.module.traceExport(name)));
+						.forEach(name => addDeclaration(declaration.module.traceExport(name)[0]));
 				}
 
 				localNames.add(declaration.name);
 			};
 
 			(<Module>specifier.module).getExports().forEach(name => {
-				addDeclaration(specifier.module.traceExport(name));
+				addDeclaration(specifier.module.traceExport(name)[0]);
 			});
 
 			if (specifier.name !== '*') {
-				const declaration = specifier.module.traceExport(specifier.name);
+				const [declaration] = specifier.module.traceExport(specifier.name);
 				if (!declaration) {
 					this.module.warn(
 						{

--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -27,7 +27,7 @@ export default class NamespaceVariable extends Variable {
 			.getExports()
 			.concat(module.getReexports())
 			.forEach(name => {
-				this.originals[name] = module.traceExport(name);
+				this.originals[name] = module.traceExport(name)[0];
 			});
 	}
 

--- a/src/finalisers/es.ts
+++ b/src/finalisers/es.ts
@@ -88,7 +88,7 @@ export default function es (bundle: Bundle, magicString: MagicStringBundle, { ge
 		.getExports()
 		.filter(notDefault)
 		.forEach(name => {
-			const declaration = module.traceExport(name);
+			const [declaration] = module.traceExport(name);
 			const rendered = declaration.getName(true);
 			exportInternalSpecifiers.push(
 				rendered === name ? name : `${rendered} as ${name}`
@@ -96,7 +96,7 @@ export default function es (bundle: Bundle, magicString: MagicStringBundle, { ge
 		});
 
 	module.getReexports().forEach(name => {
-		const declaration = module.traceExport(name);
+		const [declaration] = module.traceExport(name);
 
 		if (isExternalVariable(declaration)) {
 			if (name[0] === '*') {
@@ -125,7 +125,7 @@ export default function es (bundle: Bundle, magicString: MagicStringBundle, { ge
 		exportBlock.push(`export { ${exportInternalSpecifiers.join(', ')} };`);
 	if (module.exports.default)
 		exportBlock.push(
-			`export default ${module.traceExport('default').getName(true)};`
+			`export default ${module.traceExport('default')[0].getName(true)};`
 		);
 	if (exportAllDeclarations.length)
 		exportBlock.push(exportAllDeclarations.join('\n'));

--- a/src/finalisers/shared/getExportBlock.ts
+++ b/src/finalisers/shared/getExportBlock.ts
@@ -9,7 +9,7 @@ export default function getExportBlock (
 	const entryModule = bundle.entryModule;
 
 	if (exportMode === 'default') {
-		return `${mechanism} ${entryModule.traceExport('default').getName(false)};`;
+		return `${mechanism} ${entryModule.traceExport('default')[0].getName(false)};`;
 	}
 
 	const exports = entryModule
@@ -27,7 +27,7 @@ export default function getExportBlock (
 			}
 
 			const prop = name === 'default' ? `['default']` : `.${name}`;
-			const declaration = entryModule.traceExport(name);
+			const [declaration] = entryModule.traceExport(name);
 
 			const lhs = `exports${prop}`;
 			const rhs = declaration ? declaration.getName(false) : name; // exporting a global

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -68,6 +68,7 @@ export interface InputOptions {
 	legacy?: boolean;
 	watch?: WatcherOptions;
 	experimentalDynamicImport?: boolean;
+	includeNamespaceConflicts?: boolean;
 
 	// undocumented?
 	pureExternalModules?: boolean;

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -73,6 +73,7 @@ export default function mergeOptions ({
 		cache: getInputOption('cache'),
 		preferConst: getInputOption('preferConst'),
 		experimentalDynamicImport: getInputOption('experimentalDynamicImport'),
+		includeNamespaceConflicts: config.includeNamespaceConflicts,
 	};
 
 	// legacy, to ensure e.g. commonjs plugin still works

--- a/test/cli/samples/config-deprecations/rollup.config.js
+++ b/test/cli/samples/config-deprecations/rollup.config.js
@@ -30,7 +30,7 @@ module.exports = {
 				warnings[1],
 				{
 					code: 'UNKNOWN_OPTION',
-					message: 'Unknown option found: abc. Allowed keys: input, legacy, treeshake, acorn, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, pureExternalModules'
+					message: 'Unknown option found: abc. Allowed keys: input, legacy, treeshake, acorn, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, includeNamespaceConflicts, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, pureExternalModules'
 				}
 				
 			);

--- a/test/form/samples/namespace-conflict/_config.js
+++ b/test/form/samples/namespace-conflict/_config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	description: 'duplicate export * from',
+	options: {
+		includeNamespaceConflicts: true,
+		output: {
+			name: 'myBundle'
+		}
+	}
+};

--- a/test/form/samples/namespace-conflict/_expected/amd.js
+++ b/test/form/samples/namespace-conflict/_expected/amd.js
@@ -1,0 +1,13 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var foo = 1;
+
+	var foo$1 = 1;
+
+	var foo$2 = 1;
+
+	exports.foo = foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/namespace-conflict/_expected/cjs.js
+++ b/test/form/samples/namespace-conflict/_expected/cjs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var foo = 1;
+
+var foo$1 = 1;
+
+var foo$2 = 1;
+
+exports.foo = foo;

--- a/test/form/samples/namespace-conflict/_expected/es.js
+++ b/test/form/samples/namespace-conflict/_expected/es.js
@@ -1,0 +1,7 @@
+var foo = 1;
+
+var foo$1 = 1;
+
+var foo$2 = 1;
+
+export { foo };

--- a/test/form/samples/namespace-conflict/_expected/iife.js
+++ b/test/form/samples/namespace-conflict/_expected/iife.js
@@ -1,0 +1,14 @@
+var myBundle = (function (exports) {
+	'use strict';
+
+	var foo = 1;
+
+	var foo$1 = 1;
+
+	var foo$2 = 1;
+
+	exports.foo = foo;
+
+	return exports;
+
+}({}));

--- a/test/form/samples/namespace-conflict/_expected/umd.js
+++ b/test/form/samples/namespace-conflict/_expected/umd.js
@@ -1,0 +1,17 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.myBundle = {})));
+}(this, (function (exports) { 'use strict';
+
+	var foo = 1;
+
+	var foo$1 = 1;
+
+	var foo$2 = 1;
+
+	exports.foo = foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/samples/namespace-conflict/bar.js
+++ b/test/form/samples/namespace-conflict/bar.js
@@ -1,0 +1,2 @@
+export * from './baz';
+export * from './quux';

--- a/test/form/samples/namespace-conflict/baz.js
+++ b/test/form/samples/namespace-conflict/baz.js
@@ -1,0 +1,1 @@
+export var foo = 1;

--- a/test/form/samples/namespace-conflict/foo.js
+++ b/test/form/samples/namespace-conflict/foo.js
@@ -1,0 +1,1 @@
+export var foo = 1;

--- a/test/form/samples/namespace-conflict/main.js
+++ b/test/form/samples/namespace-conflict/main.js
@@ -1,0 +1,2 @@
+export * from './foo';
+export * from './bar';

--- a/test/form/samples/namespace-conflict/quux.js
+++ b/test/form/samples/namespace-conflict/quux.js
@@ -1,0 +1,1 @@
+export var foo = 1;

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -68,7 +68,7 @@ describe('sanity checks', () => {
 					warnings,
 					[{
 						code: 'UNKNOWN_OPTION',
-						message: 'Unknown option found: plUgins. Allowed keys: input, legacy, treeshake, acorn, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, pureExternalModules'
+						message: 'Unknown option found: plUgins. Allowed keys: input, legacy, treeshake, acorn, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, includeNamespaceConflicts, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, pureExternalModules'
 					}]
 				);
 			}


### PR DESCRIPTION
Requires #1883 as a base. Extracted from #1878.

Current behavior is when two `export *`s are encountered with conflicting exports, the system will choose one and ignore the other. This allows using both with a variable deconflict. This feature is useful regardless of #1878.