### PR TITLE
No longer use buble when parsing config files

### DIFF
--- a/bin/src/run/loadConfigFile.ts
+++ b/bin/src/run/loadConfigFile.ts
@@ -1,4 +1,3 @@
-import buble from 'rollup-plugin-buble';
 import path from 'path';
 import chalk from 'chalk';
 import * as rollup from 'rollup';
@@ -20,7 +19,6 @@ export default function loadConfigFile (configFile: string, silent = false): Pro
 				);
 			},
 			onwarn: warnings.add,
-			plugins: [buble({ objectAssign: 'Object.assign' })]
 		})
 		.then((bundle: OutputChunk) => {
 			if (!silent && warnings.count > 0) {


### PR DESCRIPTION
This will revert #1759 to resolve #1873 and resolve #1875 as outlined in the discussions of #1875 and #1759.
