### PR TITLE
fix undefined warn output from a plugin

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -156,7 +156,7 @@ export interface RollupWarning {
 	pluginCode?: string;
 }
 
-export type WarningHandler = (warning: RollupWarning) => void;
+export type WarningHandler = (warning: string | RollupWarning) => void;
 
 function addDeprecations (deprecations: Deprecation[], warn: WarningHandler) {
 	const message = `The following options have been renamed — please update your config: ${deprecations.map(

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -12,7 +12,13 @@ function normalizeObjectOptionValue (optionValue: any) {
 	return optionValue;
 }
 
-const defaultOnWarn: WarningHandler = warning => console.warn(warning.message); // eslint-disable-line no-console
+const defaultOnWarn: WarningHandler = warning => {
+	if (typeof warning === 'string') {
+		console.warn(warning); // eslint-disable-line no-console
+	} else {
+		console.warn(warning.message); // eslint-disable-line no-console
+	}
+}
 
 export type GenericConfigObject = { [key: string]: any };
 


### PR DESCRIPTION
This is a follow-up PR of #1316.

Summary: Apparently some plugins call the given `onwarn` function with a string instead of an object. (e.g. [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel/blob/master/src/index.js#L59)) leading to logged `undefined`s.

This PR enhances the `defaultOnWarn` handler to be able to handle a `string` as well as a `RollupWarning` object.