### PR TITLE
Allow plugin load() to return empty string

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -515,7 +515,7 @@ export default class Graph {
 			})
 			.then(source => {
 				if (typeof source === 'string') return source;
-				if (source && typeof source === 'object' && source.code) return source;
+				if (source && typeof source === 'object' && typeof source.code === 'string') return source;
 
 				// TODO report which plugin failed
 				error({

--- a/test/function/samples/load-returns-empty-string/_config.js
+++ b/test/function/samples/load-returns-empty-string/_config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	description: 'loaders are permitted to return the empty string',
+	options: {
+		plugins: [
+			{
+				load: function ( id ) {
+					if ( /foo\.js/.test( id ) ) {
+						return '';
+					}
+				}
+			},
+			{
+				load: function ( id ) {
+					if ( /bar\.js/.test( id ) ) {
+						return { code: '', map: null };
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/load-returns-empty-string/bar.js
+++ b/test/function/samples/load-returns-empty-string/bar.js
@@ -1,0 +1,1 @@
+throw new Error('should not be reached');

--- a/test/function/samples/load-returns-empty-string/foo.js
+++ b/test/function/samples/load-returns-empty-string/foo.js
@@ -1,0 +1,1 @@
+throw new Error('should not be reached');

--- a/test/function/samples/load-returns-empty-string/main.js
+++ b/test/function/samples/load-returns-empty-string/main.js
@@ -1,0 +1,4 @@
+import './foo.js';
+import './bar.js';
+
+assert(true);


### PR DESCRIPTION
Previously, this was only allowed when returning a source code string, not a `{ code, map }` object, because `source.code` was checked for truthiness.