### PR TITLE
Fix dynamic import module deduplication

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -503,7 +503,9 @@ export default class Graph {
 				throw new Error(`Cannot fetch external module ${id}`);
 			return Promise.resolve(<Module>existingModule);
 		}
-		this.moduleById.set(id, null);
+
+		const module: Module = new Module(this, id);
+		this.moduleById.set(id, module);
 
 		return this.load(id)
 			.catch((err: Error) => {
@@ -548,25 +550,7 @@ export default class Graph {
 				sourcemapChain: RawSourceMap[],
 				resolvedIds?: IdMap
 			}) => {
-				const {
-					code,
-					originalCode,
-					originalSourcemap,
-					ast,
-					sourcemapChain,
-					resolvedIds
-				} = source;
-
-				const module: Module = new Module({
-					id,
-					code,
-					originalCode,
-					originalSourcemap,
-					ast,
-					sourcemapChain,
-					resolvedIds,
-					graph: this
-				});
+				module.setSource(source);
 
 				this.modules.push(module);
 				this.moduleById.set(id, module);

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -154,32 +154,9 @@ export default class Module {
 	};
 	exportAllModules: (Module | ExternalModule)[];
 
-	constructor ({
-		id,
-		code,
-		originalCode,
-		originalSourcemap,
-		ast,
-		sourcemapChain,
-		resolvedIds,
-		graph
-	}: {
-		id: string,
-		code: string,
-		originalCode: string,
-		originalSourcemap: RawSourceMap,
-		ast: Program,
-		sourcemapChain: RawSourceMap[],
-		resolvedIds: IdMap,
-		resolvedExternalIds?: IdMap,
-		graph: Graph
-	}) {
-		this.code = code;
+	constructor (graph: Graph, id: string) {
 		this.id = id;
 		this.graph = graph;
-		this.originalCode = originalCode;
-		this.originalSourcemap = originalSourcemap;
-		this.sourcemapChain = sourcemapChain;
 		this.comments = [];
 
 		if (graph.dynamicImport) {
@@ -190,28 +167,12 @@ export default class Module {
 		this.execIndex = null;
 		this.entryPointsHash = new Uint8Array(10);
 
-		timeStart('ast');
-
-		if (ast) {
-			// prevent mutating the provided AST, as it may be reused on
-			// subsequent incremental rebuilds
-			this.ast = clone(ast);
-			this.astClone = ast;
-		} else {
-			// TODO what happens to comments if AST is provided?
-			this.ast = <any>tryParse(this, graph.acornParse, graph.acornOptions);
-			this.astClone = clone(this.ast);
-		}
-
-		timeEnd('ast');
-
 		this.excludeFromSourcemap = /\0/.test(id);
 		this.context = graph.getModuleContext(id);
 
 		// all dependencies
 		this.sources = [];
 		this.dependencies = [];
-		this.resolvedIds = resolvedIds || blank();
 
 		// imports and exports, indexed by local name
 		this.imports = blank();
@@ -222,10 +183,51 @@ export default class Module {
 		this.exportAllSources = [];
 		this.exportAllModules = null;
 
+		this.declarations = blank();
+		this.scope = new ModuleScope(this);
+	}
+
+	setSource ({
+		code,
+		originalCode,
+		originalSourcemap,
+		ast,
+		sourcemapChain,
+		resolvedIds
+	}: {
+		code: string,
+		originalCode: string,
+		originalSourcemap: RawSourceMap,
+		ast: Program,
+		sourcemapChain: RawSourceMap[],
+		resolvedIds?: IdMap
+	}) {
+		this.code = code;
+		this.originalCode = originalCode;
+		this.originalSourcemap = originalSourcemap;
+		this.sourcemapChain = sourcemapChain;
+
+		timeStart('ast');
+
+		if (ast) {
+			// prevent mutating the provided AST, as it may be reused on
+			// subsequent incremental rebuilds
+			this.ast = clone(ast);
+			this.astClone = ast;
+		} else {
+			// TODO what happens to comments if AST is provided?
+			this.ast = <any>tryParse(this, this.graph.acornParse, this.graph.acornOptions);
+			this.astClone = clone(this.ast);
+		}
+
+		timeEnd('ast');
+
+		this.resolvedIds = resolvedIds || blank();
+
 		// By default, `id` is the filename. Custom resolvers and loaders
 		// can change that, but it makes sense to use it for the source filename
 		this.magicString = new MagicString(code, {
-			filename: this.excludeFromSourcemap ? null : id, // don't include plugin helpers in sourcemap
+			filename: this.excludeFromSourcemap ? null : this.id, // don't include plugin helpers in sourcemap
 			indentExclusionRanges: []
 		});
 
@@ -239,9 +241,6 @@ export default class Module {
 			}
 			return !isSourceMapComment;
 		});
-
-		this.declarations = blank();
-		this.scope = new ModuleScope(this);
 
 		timeStart('analyse');
 

--- a/test/function/samples/dynamic-import-duplicates/_config.js
+++ b/test/function/samples/dynamic-import-duplicates/_config.js
@@ -1,0 +1,21 @@
+var assert = require('assert');
+var path = require('path');
+
+module.exports = {
+	description: 'Dynamic import inlining',
+	options: {
+		experimentalDynamicImport: true,
+		plugins: [{
+			resolveDynamicImport (specifier, parent) {
+				if (specifier === './main')
+					return path.resolve(__dirname, 'main.js');
+			}
+		}]
+	},
+	exports: function (exports) {
+		assert.equal(exports.x, 41);
+		return exports.promise.then(y => {
+			assert.equal(y, 42);
+		});
+	}
+};

--- a/test/function/samples/dynamic-import-duplicates/foo.js
+++ b/test/function/samples/dynamic-import-duplicates/foo.js
@@ -1,0 +1,1 @@
+export var x = 42;

--- a/test/function/samples/dynamic-import-duplicates/main.js
+++ b/test/function/samples/dynamic-import-duplicates/main.js
@@ -1,0 +1,5 @@
+export var x = 41;
+
+export var promise = Promise.all([import('./foo'), import('./foo')]).then(([foo]) => {
+  return foo.x;
+});

--- a/test/function/samples/dynamic-import-duplicates/main.js
+++ b/test/function/samples/dynamic-import-duplicates/main.js
@@ -1,5 +1,5 @@
 export var x = 41;
 
-export var promise = Promise.all([import('./foo'), import('./foo')]).then(([foo]) => {
-  return foo.x;
+export var promise = Promise.all([import('./foo'), import('./foo')]).then(foos => {
+  return foos[0].x;
 });


### PR DESCRIPTION
This fixes #1909.

The exact issue here is that the fetch cache in https://github.com/rollup/rollup/blob/master/src/Graph.ts#L500 continues in the null case, resulting in duplicate module loads. The other issue is that the dynamic import use of `fetchModule` expects to be able to get back a Module object so that it can store the reference, which can't work out in the null return case.

One option would be to store all the fetch promises here in their own fetch registry, but simpler was just to instantiate Module upfront so we can make the references, then separate out the source-setting part of the module construction into a separate function which is what I've done here.

Test case is exactly from #1909.