### PR TITLE
Import specifier deshadowing fix

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -480,6 +480,9 @@ export default class Chunk {
 					} else {
 						safeName = (es || system) ? getSafeName(variable.name) : `${module.name}.${name}`;
 					}
+					if (es || system) {
+						toDeshadow.add(safeName);
+					}
 				} else if (es || system) {
 					safeName = getSafeName(variable.name);
 				} else {

--- a/src/ast/scopes/Scope.ts
+++ b/src/ast/scopes/Scope.ts
@@ -88,7 +88,7 @@ export default class Scope {
 			// we can disregard exports.foo etc
 			if (declaration.exportName && declaration.isReassigned) return;
 
-			let name = declaration.getName();
+			let name = declaration.getName(true);
 
 			if (!names.has(name)) {
 				return;

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -36,7 +36,13 @@ export default class Variable implements ExpressionEntity {
 		_options: ExecutionPathOptions
 	) { }
 
-	getName (): string {
+	getName (reset?: boolean): string {
+		if (reset && this.safeName && this.safeName !== this.name && 
+				this.safeName[this.name.length] === '$' &&
+				this.safeName[this.name.length + 1] === '$') {
+			this.safeName = undefined;
+			return this.name;
+		}
 		return this.safeName || this.name;
 	}
 

--- a/test/form/samples/import-specifier-deshadowing/_config.js
+++ b/test/form/samples/import-specifier-deshadowing/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'deshadows aliased import bindings',
+	options: {
+		name: 'Sticky'
+	}
+};

--- a/test/form/samples/import-specifier-deshadowing/_expected/amd.js
+++ b/test/form/samples/import-specifier-deshadowing/_expected/amd.js
@@ -1,0 +1,13 @@
+define(['react-sticky'], function (reactSticky) { 'use strict';
+
+	var Sticky = function () {
+		function Sticky() {}
+
+		Sticky.foo = reactSticky.Sticky;
+
+		return Sticky;
+	}();
+
+	return Sticky;
+
+});

--- a/test/form/samples/import-specifier-deshadowing/_expected/cjs.js
+++ b/test/form/samples/import-specifier-deshadowing/_expected/cjs.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var reactSticky = require('react-sticky');
+
+var Sticky = function () {
+	function Sticky() {}
+
+	Sticky.foo = reactSticky.Sticky;
+
+	return Sticky;
+}();
+
+module.exports = Sticky;

--- a/test/form/samples/import-specifier-deshadowing/_expected/es.js
+++ b/test/form/samples/import-specifier-deshadowing/_expected/es.js
@@ -1,0 +1,11 @@
+import { Sticky } from 'react-sticky';
+
+var Sticky$1 = function () {
+	function Sticky$$1() {}
+
+	Sticky$$1.foo = Sticky;
+
+	return Sticky$$1;
+}();
+
+export default Sticky$1;

--- a/test/form/samples/import-specifier-deshadowing/_expected/iife.js
+++ b/test/form/samples/import-specifier-deshadowing/_expected/iife.js
@@ -1,0 +1,14 @@
+var Sticky = (function (reactSticky) {
+	'use strict';
+
+	var Sticky = function () {
+		function Sticky() {}
+
+		Sticky.foo = reactSticky.Sticky;
+
+		return Sticky;
+	}();
+
+	return Sticky;
+
+}(reactSticky));

--- a/test/form/samples/import-specifier-deshadowing/_expected/umd.js
+++ b/test/form/samples/import-specifier-deshadowing/_expected/umd.js
@@ -1,0 +1,17 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('react-sticky')) :
+	typeof define === 'function' && define.amd ? define(['react-sticky'], factory) :
+	(global.Sticky = factory(global.reactSticky));
+}(this, (function (reactSticky) { 'use strict';
+
+	var Sticky = function () {
+		function Sticky() {}
+
+		Sticky.foo = reactSticky.Sticky;
+
+		return Sticky;
+	}();
+
+	return Sticky;
+
+})));

--- a/test/form/samples/import-specifier-deshadowing/main.js
+++ b/test/form/samples/import-specifier-deshadowing/main.js
@@ -1,0 +1,11 @@
+import { Sticky as ReactSticky } from 'react-sticky';
+
+var Sticky = function () {
+	function Sticky() {}
+
+	Sticky.foo = ReactSticky;
+
+	return Sticky;
+}();
+
+export { Sticky as default };


### PR DESCRIPTION
This fixes #1910.

The main fix is just the line in `src/Chunk.ts`, but in the process this exposed an idempotency bug in the deshadowing process itself in that `safeName` results from previous deshadowing runs can affect future runs.

I've fixed the idempotency bug with a reliable but hacky approach for now, hopefully we can put some thought to something better here, but correctness comes first I feel. Just let me know if I can help explain it at all further.