### PR TITLE
Avoid duplicate `npm run build` on ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 env:
   global:
     - BUILD_TIMEOUT=10000
-install: npm install
+install: npm install --ignore-scripts
 before_install:
   - if [[ $TRAVIS_NODE_VERSION -lt 7 ]]; then npm install --global npm@4; fi
 # script: npm run ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - IF %nodejs_version% LSS 7 npm -g install npm@4
-  - npm install
+  - npm install --ignore-scripts
 
 build: off
 


### PR DESCRIPTION
In #1670 a `prepare` script with `npm run build` was introduced. This means for ci runs that `npm run build` is called twice: the first time after `npm install` and the second time before `npm test`. Using `npm install --ignore-scripts` disables the `prepare` script (and all other scripts) for the install run.