### PR TITLE
add the ability to rewrite modules in-place

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -162,10 +162,13 @@ export default class Chunk {
 		return safeExportName;
 	}
 
-	generateEntryExports(entryModule: Module) {
+	generateEntryExports(entryModule: Module, onlyIncluded: boolean = false) {
 		entryModule.getAllExports().forEach(exportName => {
 			const traced = this.traceExport(entryModule, exportName);
 			const variable = traced.module.traceExport(traced.name);
+			if (onlyIncluded && !variable.included) {
+				return;
+			}
 			let tracedName: string;
 			if (traced.module.chunk === this || traced.module.isExternal) {
 				tracedName = traced.name;

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -103,6 +103,7 @@ export interface InputOptions {
 	experimentalDynamicImport?: boolean;
 	experimentalCodeSplitting?: boolean;
 	preserveSymlinks?: boolean;
+	experimentalPreserveModules?: boolean;
 
 	// undocumented?
 	pureExternalModules?: boolean;
@@ -262,7 +263,8 @@ export default function rollup(rawInputOptions: GenericConfigObject) {
 		timeStart('--BUILD--');
 
 		const codeSplitting =
-			inputOptions.experimentalCodeSplitting && inputOptions.input instanceof Array;
+			(inputOptions.experimentalCodeSplitting && inputOptions.input instanceof Array) ||
+			inputOptions.experimentalPreserveModules;
 
 		if (!codeSplitting)
 			return graph.buildSingle(inputOptions.input).then(chunk => {
@@ -407,7 +409,12 @@ export default function rollup(rawInputOptions: GenericConfigObject) {
 				return result;
 			});
 
-		return graph.buildChunks(inputOptions.input).then(bundle => {
+		const input =
+			inputOptions.experimentalPreserveModules && !(inputOptions.input instanceof Array)
+				? [inputOptions.input]
+				: inputOptions.input;
+
+		return graph.buildChunks(input, inputOptions.experimentalPreserveModules).then(bundle => {
 			const chunks: {
 				[name: string]: {
 					name: string;

--- a/src/utils/commondir.ts
+++ b/src/utils/commondir.ts
@@ -1,0 +1,17 @@
+// ported from https://github.com/substack/node-commondir
+export default function commondir(files: string[]) {
+	const commonSegments = files.slice(1).reduce((commonSegments, file) => {
+		const pathSegements = file.split(/\/+|\\+/);
+		let i;
+		for (
+			i = 0;
+			commonSegments[i] === pathSegements[i] &&
+			i < Math.min(commonSegments.length, pathSegements.length);
+			i++
+		);
+		return commonSegments.slice(0, i);
+	}, files[0].split(/\/+|\\+/));
+
+	// Windows correctly handles paths with forward-slashes
+	return commonSegments.length > 1 ? commonSegments.join('/') : '/';
+}

--- a/src/utils/entryHashing.ts
+++ b/src/utils/entryHashing.ts
@@ -28,12 +28,3 @@ export function randomUint8Array(len: number) {
 	for (let i = 0; i < buffer.length; i++) buffer[i] = Math.random() * (2 << 8);
 	return buffer;
 }
-
-export function isZero(buffer: Uint8Array) {
-	for (let i = 0; i < buffer.length; i++) {
-		if (buffer[i] !== 0) {
-			return false;
-		}
-	}
-	return true;
-}

--- a/src/utils/entryHashing.ts
+++ b/src/utils/entryHashing.ts
@@ -28,3 +28,12 @@ export function randomUint8Array(len: number) {
 	for (let i = 0; i < buffer.length; i++) buffer[i] = Math.random() * (2 << 8);
 	return buffer;
 }
+
+export function isZero(buffer: Uint8Array) {
+	for (let i = 0; i < buffer.length; i++) {
+		if (buffer[i] !== 0) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -81,7 +81,8 @@ export default function mergeOptions({
 		preferConst: getInputOption('preferConst'),
 		experimentalDynamicImport: getInputOption('experimentalDynamicImport'),
 		experimentalCodeSplitting: getInputOption('experimentalCodeSplitting'),
-		preserveSymlinks: getInputOption('preserveSymlinks')
+		preserveSymlinks: getInputOption('preserveSymlinks'),
+		experimentalPreserveModules: getInputOption('experimentalPreserveModules')
 	};
 
 	// legacy, to ensure e.g. commonjs plugin still works

--- a/test/chunking-form/samples/preserve-modules-export-alias/_config.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'confirm export aliases are preserved in modules',
+	options: {
+		input: ['main1.js', 'main2.js'],
+		experimentalPreserveModules: true
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
@@ -1,0 +1,10 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = 1;
+
+	exports.foo = foo;
+	exports.bar = foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
@@ -3,8 +3,5 @@ define(['exports'], function (exports) { 'use strict';
 	const foo = 1;
 
 	exports.foo = foo;
-	exports.bar = foo;
-
-	Object.defineProperty(exports, '__esModule', { value: true });
 
 });

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/main1.js
@@ -1,0 +1,10 @@
+define(['exports', './dep.js'], function (exports, __dep_js) { 'use strict';
+
+
+
+	exports.foo = __dep_js.foo;
+	exports.bar = __dep_js.foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/main2.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/main2.js
@@ -1,0 +1,9 @@
+define(['exports', './dep.js'], function (exports, __dep_js) { 'use strict';
+
+
+
+	exports.bar = __dep_js.foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
@@ -1,0 +1,8 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const foo = 1;
+
+exports.foo = foo;
+exports.bar = foo;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
@@ -1,8 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 const foo = 1;
 
 exports.foo = foo;
-exports.bar = foo;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/main1.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __dep_js = require('./dep.js');
+
+
+
+exports.foo = __dep_js.foo;
+exports.bar = __dep_js.foo;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/main2.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __dep_js = require('./dep.js');
+
+
+
+exports.bar = __dep_js.foo;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
@@ -1,3 +1,3 @@
 const foo = 1;
 
-export { foo, foo as bar };
+export { foo };

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export { foo, foo as bar };

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/main1.js
@@ -1,0 +1,1 @@
+export { foo, foo as bar } from './dep.js';

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/main2.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/main2.js
@@ -1,0 +1,1 @@
+export { foo as bar } from './dep.js';

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/dep.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = exports('foo', 1);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/main1.js
@@ -1,0 +1,16 @@
+System.register(['./dep.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			var _setter = {};
+			_setter.foo = module.foo;
+			_setter.bar = module.foo;
+			exports(_setter);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/main2.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/main2.js
@@ -1,0 +1,13 @@
+System.register(['./dep.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('bar', module.foo);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-export-alias/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/dep.js
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export { foo, foo as bar };

--- a/test/chunking-form/samples/preserve-modules-export-alias/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/main1.js
@@ -1,0 +1,1 @@
+export { foo, bar } from './dep';

--- a/test/chunking-form/samples/preserve-modules-export-alias/main2.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/main2.js
@@ -1,0 +1,1 @@
+export { bar } from './dep';

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_config.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'imports and exports of non-entry points are tracked',
+	options: {
+		input: 'main.js',
+		experimentalPreserveModules: true
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep1.js
@@ -2,6 +2,4 @@ define(['./dep2.js'], function (__dep2_js) { 'use strict';
 
 
 
-	return __dep2_js.default;
-
 });

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep1.js
@@ -1,0 +1,7 @@
+define(['./dep2.js'], function (__dep2_js) { 'use strict';
+
+
+
+	return __dep2_js.default;
+
+});

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep2.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep2.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	function foo() {}
+
+	return foo;
+
+});

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep2.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep2.js
@@ -1,7 +1,7 @@
-define(function () { 'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	function foo() {}
 
-	return foo;
+	exports.default = foo;
 
 });

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/main.js
@@ -1,7 +1,7 @@
-define(['./dep1.js'], function (__dep1_js) { 'use strict';
+define(['./dep1.js', './dep2.js'], function (__dep1_js, __dep2_js) { 'use strict';
 
 
 
-	return __dep1_js.default;
+	return __dep2_js.default;
 
 });

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/main.js
@@ -1,0 +1,7 @@
+define(['./dep1.js'], function (__dep1_js) { 'use strict';
+
+
+
+	return __dep1_js.default;
+
+});

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep1.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var __dep2_js = require('./dep2.js');
+
+
+
+module.exports = __dep2_js.default;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep1.js
@@ -1,7 +1,4 @@
 'use strict';
 
-var __dep2_js = require('./dep2.js');
+require('./dep2.js');
 
-
-
-module.exports = __dep2_js.default;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep2.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep2.js
@@ -2,4 +2,4 @@
 
 function foo() {}
 
-module.exports = foo;
+exports.default = foo;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep2.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function foo() {}
+
+module.exports = foo;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var __dep1_js = require('./dep1.js');
+
+
+
+module.exports = __dep1_js.default;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/main.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var __dep1_js = require('./dep1.js');
+require('./dep1.js');
+var __dep2_js = require('./dep2.js');
 
 
 
-module.exports = __dep1_js.default;
+module.exports = __dep2_js.default;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep1.js
@@ -1,0 +1,1 @@
+export { default } from './dep2.js';

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep1.js
@@ -1,1 +1,1 @@
-export { default } from './dep2.js';
+import './dep2.js';

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep2.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep2.js
@@ -1,0 +1,3 @@
+function foo() {}
+
+export default foo;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/main.js
@@ -1,4 +1,5 @@
-import foo from './dep1.js';
+import './dep1.js';
+import foo from './dep2.js';
 
 
 

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/main.js
@@ -1,0 +1,5 @@
+import foo from './dep1.js';
+
+
+
+export default foo;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep1.js
@@ -1,0 +1,13 @@
+System.register(['./dep2.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('default', module.default);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep1.js
@@ -2,7 +2,7 @@ System.register(['./dep2.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('default', module.default);
+			
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep2.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep2.js
@@ -1,0 +1,11 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			exports('default', foo);
+			function foo() {}
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/main.js
@@ -1,8 +1,10 @@
-System.register(['./dep1.js'], function (exports, module) {
+System.register(['./dep1.js', './dep2.js'], function (exports, module) {
 	'use strict';
 	var foo;
 	return {
 		setters: [function (module) {
+			
+		}, function (module) {
 			foo = module.default;
 		}],
 		execute: function () {

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register(['./dep1.js'], function (exports, module) {
+	'use strict';
+	var foo;
+	return {
+		setters: [function (module) {
+			foo = module.default;
+		}],
+		execute: function () {
+
+			exports('default', foo);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/dep1.js
@@ -1,0 +1,1 @@
+export { default } from './dep2';

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/dep2.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/dep2.js
@@ -1,0 +1,1 @@
+export default function() {};

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/main.js
@@ -1,0 +1,3 @@
+import foo from './dep1';
+
+export default foo;

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_config.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'change the module destination',
+	options: {
+		input: 'lib/main.js',
+		experimentalPreserveModules: true
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/amd/dep.js
@@ -1,0 +1,11 @@
+define(['exports'], function (exports) { 'use strict';
+
+  function fn () {
+    console.log('dep fn');
+  }
+
+  exports.fn = fn;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/amd/dep.js
@@ -6,6 +6,4 @@ define(['exports'], function (exports) { 'use strict';
 
   exports.fn = fn;
 
-  Object.defineProperty(exports, '__esModule', { value: true });
-
 });

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/amd/lib/main.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/amd/lib/main.js
@@ -1,0 +1,11 @@
+define(['../dep.js'], function (__dep_js) { 'use strict';
+
+  class Main {
+    constructor () {
+      __dep_js.fn();
+    }
+  }
+
+  return Main;
+
+});

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/cjs/dep.js
@@ -1,7 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 function fn () {
   console.log('dep fn');
 }

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/cjs/dep.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function fn () {
+  console.log('dep fn');
+}
+
+exports.fn = fn;

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/cjs/lib/main.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/cjs/lib/main.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var __dep_js = require('../dep.js');
+
+class Main {
+  constructor () {
+    __dep_js.fn();
+  }
+}
+
+module.exports = Main;

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/es/dep.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/es/dep.js
@@ -1,0 +1,5 @@
+function fn () {
+  console.log('dep fn');
+}
+
+export { fn };

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/es/lib/main.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/es/lib/main.js
@@ -1,0 +1,9 @@
+import { fn } from '../dep.js';
+
+class Main {
+  constructor () {
+    fn();
+  }
+}
+
+export default Main;

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/system/dep.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/system/dep.js
@@ -1,0 +1,13 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      exports('fn', fn);
+      function fn () {
+        console.log('dep fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/system/lib/main.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/_expected/system/lib/main.js
@@ -1,0 +1,18 @@
+System.register(['../dep.js'], function (exports, module) {
+  'use strict';
+  var fn;
+  return {
+    setters: [function (module) {
+      fn = module.fn;
+    }],
+    execute: function () {
+
+      class Main {
+        constructor () {
+          fn();
+        }
+      } exports('default', Main);
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/dep.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/dep.js
@@ -1,0 +1,3 @@
+export function fn () {
+  console.log('dep fn');
+}

--- a/test/chunking-form/samples/preserve-modules-reaching-outside/lib/main.js
+++ b/test/chunking-form/samples/preserve-modules-reaching-outside/lib/main.js
@@ -1,0 +1,7 @@
+import { fn } from '../dep';
+
+export default class Main {
+  constructor () {
+    fn();
+  }
+}

--- a/test/chunking-form/samples/preserve-modules-single-entry/_config.js
+++ b/test/chunking-form/samples/preserve-modules-single-entry/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'single entry names file correctly',
+	options: {
+		input: 'main.js',
+		experimentalPreserveModules: true
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-single-entry/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-single-entry/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(function () { 'use strict';
+
+	console.log();
+
+});

--- a/test/chunking-form/samples/preserve-modules-single-entry/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-single-entry/_expected/cjs/main.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log();

--- a/test/chunking-form/samples/preserve-modules-single-entry/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-single-entry/_expected/es/main.js
@@ -1,0 +1,1 @@
+console.log();

--- a/test/chunking-form/samples/preserve-modules-single-entry/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-single-entry/_expected/system/main.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			console.log();
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-single-entry/main.js
+++ b/test/chunking-form/samples/preserve-modules-single-entry/main.js
@@ -1,0 +1,1 @@
+console.log()

--- a/test/chunking-form/samples/preserve-modules/_config.js
+++ b/test/chunking-form/samples/preserve-modules/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'Rewrite modules in-place',
+	options: {
+		input: ['main1.js', 'main2.js'],
+		experimentalPreserveModules: true
+	}
+};

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep1.js
@@ -1,0 +1,11 @@
+define(['exports'], function (exports) { 'use strict';
+
+  function fn () {
+    console.log('dep1 fn');
+  }
+
+  exports.fn = fn;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep1.js
@@ -6,6 +6,4 @@ define(['exports'], function (exports) { 'use strict';
 
   exports.fn = fn;
 
-  Object.defineProperty(exports, '__esModule', { value: true });
-
 });

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep2.js
@@ -1,0 +1,12 @@
+define(['exports', '../lib/lib2.js'], function (exports, __lib_lib2_js) { 'use strict';
+
+  function fn () {
+    __lib_lib2_js.fn();
+    console.log('dep2 fn');
+  }
+
+  exports.fn = fn;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep2.js
@@ -7,6 +7,4 @@ define(['exports', '../lib/lib2.js'], function (exports, __lib_lib2_js) { 'use s
 
   exports.fn = fn;
 
-  Object.defineProperty(exports, '__esModule', { value: true });
-
 });

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep3.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep3.js
@@ -7,6 +7,4 @@ define(['exports', '../lib/lib1.js'], function (exports, __lib_lib1_js) { 'use s
 
   exports.fn = fn;
 
-  Object.defineProperty(exports, '__esModule', { value: true });
-
 });

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep3.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/deps/dep3.js
@@ -1,0 +1,12 @@
+define(['exports', '../lib/lib1.js'], function (exports, __lib_lib1_js) { 'use strict';
+
+  function fn () {
+    __lib_lib1_js.fn();
+    console.log('dep3 fn');
+  }
+
+  exports.fn = fn;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib1.js
@@ -6,6 +6,4 @@ define(['exports'], function (exports) { 'use strict';
 
   exports.fn = fn;
 
-  Object.defineProperty(exports, '__esModule', { value: true });
-
 });

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib1.js
@@ -1,0 +1,11 @@
+define(['exports'], function (exports) { 'use strict';
+
+  function fn () {
+    console.log('lib1 fn');
+  }
+
+  exports.fn = fn;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib2.js
@@ -1,0 +1,11 @@
+define(['exports'], function (exports) { 'use strict';
+
+  function fn () {
+    console.log('lib2 fn');
+  }
+
+  exports.fn = fn;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/lib/lib2.js
@@ -6,6 +6,4 @@ define(['exports'], function (exports) { 'use strict';
 
   exports.fn = fn;
 
-  Object.defineProperty(exports, '__esModule', { value: true });
-
 });

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/main1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/main1.js
@@ -1,0 +1,12 @@
+define(['./deps/dep1.js', './deps/dep2.js'], function (__deps_dep1_js, __deps_dep2_js) { 'use strict';
+
+  class Main1 {
+    constructor () {
+      __deps_dep1_js.fn();
+      __deps_dep2_js.fn();
+    }
+  }
+
+  return Main1;
+
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/amd/main2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/amd/main2.js
@@ -1,0 +1,12 @@
+define(['./deps/dep2.js', './deps/dep3.js'], function (__deps_dep2_js, __deps_dep3_js) { 'use strict';
+
+  class Main2 {
+    constructor () {
+      __deps_dep3_js.fn();
+      __deps_dep2_js.fn();
+    }
+  }
+
+  return Main2;
+
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep1.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function fn () {
+  console.log('dep1 fn');
+}
+
+exports.fn = fn;

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep1.js
@@ -1,7 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 function fn () {
   console.log('dep1 fn');
 }

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep2.js
@@ -1,0 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __lib_lib2_js = require('../lib/lib2.js');
+
+function fn () {
+  __lib_lib2_js.fn();
+  console.log('dep2 fn');
+}
+
+exports.fn = fn;

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep2.js
@@ -1,7 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 var __lib_lib2_js = require('../lib/lib2.js');
 
 function fn () {

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep3.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep3.js
@@ -1,7 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 var __lib_lib1_js = require('../lib/lib1.js');
 
 function fn () {

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep3.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/deps/dep3.js
@@ -1,0 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __lib_lib1_js = require('../lib/lib1.js');
+
+function fn () {
+  __lib_lib1_js.fn();
+  console.log('dep3 fn');
+}
+
+exports.fn = fn;

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib1.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function fn () {
+  console.log('lib1 fn');
+}
+
+exports.fn = fn;

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib1.js
@@ -1,7 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 function fn () {
   console.log('lib1 fn');
 }

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib2.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function fn () {
+  console.log('lib2 fn');
+}
+
+exports.fn = fn;

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/lib/lib2.js
@@ -1,7 +1,5 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 function fn () {
   console.log('lib2 fn');
 }

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/main1.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var __deps_dep1_js = require('./deps/dep1.js');
+var __deps_dep2_js = require('./deps/dep2.js');
+
+class Main1 {
+  constructor () {
+    __deps_dep1_js.fn();
+    __deps_dep2_js.fn();
+  }
+}
+
+module.exports = Main1;

--- a/test/chunking-form/samples/preserve-modules/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/cjs/main2.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var __deps_dep2_js = require('./deps/dep2.js');
+var __deps_dep3_js = require('./deps/dep3.js');
+
+class Main2 {
+  constructor () {
+    __deps_dep3_js.fn();
+    __deps_dep2_js.fn();
+  }
+}
+
+module.exports = Main2;

--- a/test/chunking-form/samples/preserve-modules/_expected/es/deps/dep1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/es/deps/dep1.js
@@ -1,0 +1,5 @@
+function fn () {
+  console.log('dep1 fn');
+}
+
+export { fn };

--- a/test/chunking-form/samples/preserve-modules/_expected/es/deps/dep2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/es/deps/dep2.js
@@ -1,0 +1,8 @@
+import { fn } from '../lib/lib2.js';
+
+function fn$1 () {
+  fn();
+  console.log('dep2 fn');
+}
+
+export { fn$1 as fn };

--- a/test/chunking-form/samples/preserve-modules/_expected/es/deps/dep3.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/es/deps/dep3.js
@@ -1,0 +1,8 @@
+import { fn } from '../lib/lib1.js';
+
+function fn$1 () {
+  fn();
+  console.log('dep3 fn');
+}
+
+export { fn$1 as fn };

--- a/test/chunking-form/samples/preserve-modules/_expected/es/lib/lib1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/es/lib/lib1.js
@@ -1,0 +1,5 @@
+function fn () {
+  console.log('lib1 fn');
+}
+
+export { fn };

--- a/test/chunking-form/samples/preserve-modules/_expected/es/lib/lib2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/es/lib/lib2.js
@@ -1,0 +1,5 @@
+function fn () {
+  console.log('lib2 fn');
+}
+
+export { fn };

--- a/test/chunking-form/samples/preserve-modules/_expected/es/main1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/es/main1.js
@@ -1,0 +1,11 @@
+import { fn } from './deps/dep1.js';
+import { fn as fn$1 } from './deps/dep2.js';
+
+class Main1 {
+  constructor () {
+    fn();
+    fn$1();
+  }
+}
+
+export default Main1;

--- a/test/chunking-form/samples/preserve-modules/_expected/es/main2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/es/main2.js
@@ -1,0 +1,11 @@
+import { fn } from './deps/dep2.js';
+import { fn as fn$1 } from './deps/dep3.js';
+
+class Main2 {
+  constructor () {
+    fn$1();
+    fn();
+  }
+}
+
+export default Main2;

--- a/test/chunking-form/samples/preserve-modules/_expected/system/deps/dep1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/system/deps/dep1.js
@@ -1,0 +1,13 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      exports('fn', fn);
+      function fn () {
+        console.log('dep1 fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/system/deps/dep2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/system/deps/dep2.js
@@ -1,0 +1,18 @@
+System.register(['../lib/lib2.js'], function (exports, module) {
+  'use strict';
+  var fn;
+  return {
+    setters: [function (module) {
+      fn = module.fn;
+    }],
+    execute: function () {
+
+      exports('fn', fn$1);
+      function fn$1 () {
+        fn();
+        console.log('dep2 fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/system/deps/dep3.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/system/deps/dep3.js
@@ -1,0 +1,18 @@
+System.register(['../lib/lib1.js'], function (exports, module) {
+  'use strict';
+  var fn;
+  return {
+    setters: [function (module) {
+      fn = module.fn;
+    }],
+    execute: function () {
+
+      exports('fn', fn$1);
+      function fn$1 () {
+        fn();
+        console.log('dep3 fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/system/lib/lib1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/system/lib/lib1.js
@@ -1,0 +1,13 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      exports('fn', fn);
+      function fn () {
+        console.log('lib1 fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/system/lib/lib2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/system/lib/lib2.js
@@ -1,0 +1,13 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      exports('fn', fn);
+      function fn () {
+        console.log('lib2 fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/system/main1.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/system/main1.js
@@ -1,0 +1,21 @@
+System.register(['./deps/dep1.js', './deps/dep2.js'], function (exports, module) {
+  'use strict';
+  var fn, fn$1;
+  return {
+    setters: [function (module) {
+      fn = module.fn;
+    }, function (module) {
+      fn$1 = module.fn;
+    }],
+    execute: function () {
+
+      class Main1 {
+        constructor () {
+          fn();
+          fn$1();
+        }
+      } exports('default', Main1);
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules/_expected/system/main2.js
+++ b/test/chunking-form/samples/preserve-modules/_expected/system/main2.js
@@ -1,0 +1,21 @@
+System.register(['./deps/dep2.js', './deps/dep3.js'], function (exports, module) {
+  'use strict';
+  var fn, fn$1;
+  return {
+    setters: [function (module) {
+      fn = module.fn;
+    }, function (module) {
+      fn$1 = module.fn;
+    }],
+    execute: function () {
+
+      class Main2 {
+        constructor () {
+          fn$1();
+          fn();
+        }
+      } exports('default', Main2);
+
+    }
+  };
+});

--- a/test/chunking-form/samples/preserve-modules/deps/dep1.js
+++ b/test/chunking-form/samples/preserve-modules/deps/dep1.js
@@ -1,0 +1,3 @@
+export function fn () {
+  console.log('dep1 fn');
+}

--- a/test/chunking-form/samples/preserve-modules/deps/dep2.js
+++ b/test/chunking-form/samples/preserve-modules/deps/dep2.js
@@ -1,0 +1,6 @@
+import { fn as libfn } from '../lib/lib2.js';
+
+export function fn () {
+  libfn();
+  console.log('dep2 fn');
+}

--- a/test/chunking-form/samples/preserve-modules/deps/dep3.js
+++ b/test/chunking-form/samples/preserve-modules/deps/dep3.js
@@ -1,0 +1,8 @@
+import { fn as libfn, treeshaked } from '../lib/lib1.js';
+
+export function fn () {
+  libfn();
+  console.log('dep3 fn');
+}
+
+export default treeshaked;

--- a/test/chunking-form/samples/preserve-modules/lib/lib1.js
+++ b/test/chunking-form/samples/preserve-modules/lib/lib1.js
@@ -1,0 +1,7 @@
+export function fn () {
+  console.log('lib1 fn');
+}
+
+export function treeshaked () {
+  console.log('this is tree shaken!');
+}

--- a/test/chunking-form/samples/preserve-modules/lib/lib2.js
+++ b/test/chunking-form/samples/preserve-modules/lib/lib2.js
@@ -1,0 +1,3 @@
+export function fn () {
+  console.log('lib2 fn');
+}

--- a/test/chunking-form/samples/preserve-modules/main1.js
+++ b/test/chunking-form/samples/preserve-modules/main1.js
@@ -1,0 +1,9 @@
+import { fn } from './deps/dep1.js';
+import { fn as fn2 } from './deps/dep2.js';
+
+export default class Main1 {
+  constructor () {
+    fn();
+    fn2();
+  }
+}

--- a/test/chunking-form/samples/preserve-modules/main2.js
+++ b/test/chunking-form/samples/preserve-modules/main2.js
@@ -1,0 +1,13 @@
+import { fn } from './deps/dep2.js';
+import { fn as fn2, default as treeshaked } from './deps/dep3.js';
+
+if (false) {
+  treeshaked();
+}
+
+export default class Main2 {
+  constructor () {
+    fn2();
+    fn();
+  }
+}

--- a/test/cli/samples/config-deprecations/rollup.config.js
+++ b/test/cli/samples/config-deprecations/rollup.config.js
@@ -30,7 +30,7 @@ module.exports = {
 				warnings[1],
 				{
 					code: 'UNKNOWN_OPTION',
-					message: 'Unknown option found: abc. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, preserveSymlinks, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
+					message: 'Unknown option found: abc. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, preserveSymlinks, experimentalPreserveModules, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
 				}
 			);
 		} else {

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -72,11 +72,11 @@ describe('sanity checks', () => {
 				assert.deepEqual(warnings, [
 					{
 						code: 'UNKNOWN_OPTION',
-						message:
-							'Unknown option found: plUgins. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, preserveSymlinks, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
-					}
-				]);
-			});
+						message: 'Unknown option found: plUgins. Allowed keys: input, legacy, treeshake, acorn, acornInjectPlugins, context, moduleContext, plugins, onwarn, watch, cache, preferConst, experimentalDynamicImport, experimentalCodeSplitting, preserveSymlinks, experimentalPreserveModules, entry, external, extend, amd, banner, footer, intro, format, outro, sourcemap, sourcemapFile, name, globals, interop, legacy, freeze, indent, strict, noConflict, paths, exports, file, dir, pureExternalModules'
+					}]
+				);
+			}
+		);
 	});
 
 	it('treats Literals as leaf nodes, even if first literal encountered is null', () => {


### PR DESCRIPTION
Closes #1878.

This turned out to be remarkably simpler once @guybedford laid the foundational work with dynamic imports and chunking. I essentially tapped into the dynamic imports system and made every import behave like a dynamic import.

To try this out, all you have to do is add the `experimentalPreserveModules` to your existing `experimentalCodeSplitting` setup. Then, the directory tree should be preserved in your output dir.