### PR TITLE
Optionally pass CLI command arguments to config

### DIFF
--- a/bin/src/run/index.ts
+++ b/bin/src/run/index.ts
@@ -76,8 +76,8 @@ export default function runRollup (command: any) {
 
 		if (command.watch) process.env.ROLLUP_WATCH = 'true';
 
-		loadConfigFile(configFile, command.silent)
-			.then(normalized => execute(configFile, normalized, command))
+		loadConfigFile(configFile, command)
+			.then(configs => execute(configFile, configs, command))
 			.catch(handleError);
 	} else {
 		return execute(configFile, [{input: null}], command);

--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -164,7 +164,7 @@ export default function watch (configFile: string, configs: RollupWatchOptions[]
 
 			restarting = true;
 
-			loadConfigFile(configFile, silent)
+			loadConfigFile(configFile, command)
 				.then((configs: RollupWatchOptions[]) => {
 					restarting = false;
 

--- a/test/cli/samples/config-function/_config.js
+++ b/test/cli/samples/config-function/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'if config returns a function then this will be called with command args',
+	command: 'rollup --config rollup.config.js --silent --some-option="foo" --another-option=42',
+	execute: true
+};

--- a/test/cli/samples/config-function/main.js
+++ b/test/cli/samples/config-function/main.js
@@ -1,0 +1,8 @@
+assert.deepEqual(COMMAND_OPTIONS, {
+	_: [],
+	config: 'rollup.config.js',
+	c: 'rollup.config.js',
+	silent: true,
+	'some-option': 'foo',
+	'another-option': 42
+});

--- a/test/cli/samples/config-function/rollup.config.js
+++ b/test/cli/samples/config-function/rollup.config.js
@@ -1,0 +1,13 @@
+var replace = require( 'rollup-plugin-replace' );
+
+module.exports = function(commandOptions) {
+	return {
+		input: 'main.js',
+		output: {
+			format: 'cjs'
+		},
+		plugins: [
+			replace( { 'COMMAND_OPTIONS': JSON.stringify(commandOptions) } )
+		]
+	};
+};


### PR DESCRIPTION
Please see #1925 for a discussion relating to this pull request

If config file exports a function then call this function with `commandOptions` object. We expect this function to return a `config` object or `configs` array, the same as existing config files
