### PR TITLE
Fix rollup watch crashes in cmd or PowerShell

### DIFF
--- a/bin/src/run/alternateScreen.ts
+++ b/bin/src/run/alternateScreen.ts
@@ -4,6 +4,11 @@ import { stderr } from '../logging';
 const SHOW_ALTERNATE_SCREEN = '\u001B[?1049h';
 const HIDE_ALTERNATE_SCREEN = '\u001B[?1049l';
 
+const isWindows = process.platform === 'win32';
+const isMintty = isWindows && !!(process.env.SHELL || process.env.TERM);
+const isConEmuAnsiOn = (process.env.ConEmuANSI || '').toLowerCase() === 'on';
+const supportsAnsi = !isWindows || isMintty || isConEmuAnsiOn;
+
 export default function alternateScreen (enabled: boolean) {
 	if (!enabled) {
 		let needAnnounce = true;
@@ -21,10 +26,14 @@ export default function alternateScreen (enabled: boolean) {
 
 	return {
 		open () {
-			process.stderr.write(SHOW_ALTERNATE_SCREEN);
+			if (supportsAnsi) {
+				process.stderr.write(SHOW_ALTERNATE_SCREEN);
+			}
 		},
 		close () {
-			process.stderr.write(HIDE_ALTERNATE_SCREEN);
+			if (supportsAnsi) {
+				process.stderr.write(HIDE_ALTERNATE_SCREEN);
+			}
 		},
 		reset (heading: string) {
 			stderr(`${ansiEscape.eraseScreen}${ansiEscape.cursorTo(0, 0)}${heading}`);


### PR DESCRIPTION
Fixes #1739 

Check the preconditions before alternate screen buffer.

The terminal crashes because cmd or PowerShell can't process ANSI escape sequences correctly for now.

Fortunately, ANSI escape sequences, including CSI codes, is supported by [Mintty](https://mintty.github.io/) and [ConEmu](https://conemu.github.io/) on the Windows platforms.

Mintty is the default terminal emulator of Cygwin/MYSY2/MinGW-w64/Git for Windows(Git Bash)/Babun/etc. Users can get environment variable `SHELL` or `TERM` on mintty, just like on Unix-like systems. ConEmu can process ANSI sequences too (when the environment variable `ConEmuANSI` is set to `ON`).

## Related Links

- [CtrlSeqs - Mintty](https://github.com/mintty/mintty/blob/master/wiki/CtrlSeqs.md)
- [ANSI X3.64 and Xterm 256 colors - ConEmu](https://conemu.github.io/en/AnsiEscapeCodes.html)
