### PR TITLE
Add simple warning for circular dependencies

### DIFF
--- a/test/function/samples/already-deshadowed-import/_config.js
+++ b/test/function/samples/already-deshadowed-import/_config.js
@@ -1,3 +1,10 @@
 module.exports = {
 	description: 'handle already module import names correctly if they are have already been deshadowed',
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'bob.js',
+			message: 'Circular dependency: bob.js -> alice.js -> bob.js'
+		}
+	]
 };

--- a/test/function/samples/can-import-self-treeshake/_config.js
+++ b/test/function/samples/can-import-self-treeshake/_config.js
@@ -2,6 +2,11 @@ module.exports = {
 	description: 'direct self import',
 	warnings: [
 		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'lib.js',
+			message: 'Circular dependency: lib.js -> lib.js'
+		},
+		{
 			code: 'EMPTY_BUNDLE',
 			message: `Generated an empty bundle`
 		}

--- a/test/function/samples/can-import-self/_config.js
+++ b/test/function/samples/can-import-self/_config.js
@@ -4,5 +4,12 @@ module.exports = {
 	description: 'a module importing its own bindings',
 	exports: function ( exports ) {
 		assert.equal( exports.result, 4 );
-	}
+	},
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'lib.js',
+			message: 'Circular dependency: lib.js -> lib.js'
+		}
+	]
 };

--- a/test/function/samples/cycles-default-anonymous-function-hoisted/_config.js
+++ b/test/function/samples/cycles-default-anonymous-function-hoisted/_config.js
@@ -1,3 +1,10 @@
 module.exports = {
-	description: 'Anonymous function declarations are hoisted'
+	description: 'Anonymous function declarations are hoisted',
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'f.js',
+			message: 'Circular dependency: f.js -> g.js -> f.js'
+		}
+	]
 };

--- a/test/function/samples/cycles-defaults/_config.js
+++ b/test/function/samples/cycles-defaults/_config.js
@@ -1,5 +1,12 @@
 module.exports = {
-	description: 'cycles work with default exports'
+	description: 'cycles work with default exports',
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'a.js',
+			message: 'Circular dependency: a.js -> b.js -> a.js'
+		}
+	]
 };
 
 // test copied from https://github.com/esnext/es6-module-transpiler/tree/master/test/examples/cycles-defaults

--- a/test/function/samples/cycles-immediate/_config.js
+++ b/test/function/samples/cycles-immediate/_config.js
@@ -1,5 +1,12 @@
 module.exports = {
-	description: 'handles cycles where imports are immediately used'
+	description: 'handles cycles where imports are immediately used',
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'evens.js',
+			message: 'Circular dependency: evens.js -> odds.js -> evens.js'
+		}
+	]
 };
 
 // Test copied from https://github.com/esnext/es6-module-transpiler/tree/master/test/examples/cycles-immediate

--- a/test/function/samples/cycles-pathological-2/_config.js
+++ b/test/function/samples/cycles-pathological-2/_config.js
@@ -3,9 +3,21 @@ var assert = require( 'assert' );
 module.exports = {
 	description: 'resolves even more pathological cyclical dependencies gracefully',
 	buble: true,
-	options: {
-		onwarn: function ( message ) {
-			assert.ok( /unable to evaluate without/.test( message ) );
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'main.js',
+			message: 'Circular dependency: main.js -> b.js -> main.js'
+		},
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'b.js',
+			message: 'Circular dependency: b.js -> d.js -> c.js -> b.js'
+		},
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'main.js',
+			message: 'Circular dependency: main.js -> b.js -> d.js -> c.js -> main.js'
 		}
-	}
+	]
 };

--- a/test/function/samples/cycles-pathological/_config.js
+++ b/test/function/samples/cycles-pathological/_config.js
@@ -4,8 +4,16 @@ module.exports = {
 	skip: true,
 	description: 'resolves pathological cyclical dependencies gracefully',
 	buble: true,
-	warnings: warnings => {
-		assert.equal( warnings.length, warnings );
-		assert.ok( /Module .+B\.js may be unable to evaluate without .+A\.js, but is included first due to a cyclical dependency. Consider swapping the import statements in .+main\.js to ensure correct ordering/.test( warnings[0] ) );
-	}
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'A.js',
+			message: 'Circular dependency: A.js -> B.js -> A.js'
+		},
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'C.js',
+			message: 'Circular dependency: C.js -> D.js -> C.js'
+		}
+	]
 };

--- a/test/function/samples/cycles-stack-overflow/_config.js
+++ b/test/function/samples/cycles-stack-overflow/_config.js
@@ -1,3 +1,15 @@
 module.exports = {
-	description: 'does not stack overflow on crazy cyclical dependencies'
+	description: 'does not stack overflow on crazy cyclical dependencies',
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'c.js',
+			message: 'Circular dependency: c.js -> d.js -> b.js -> c.js'
+		},
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'c.js',
+			message: 'Circular dependency: c.js -> d.js -> c.js'
+		}
+	]
 };

--- a/test/function/samples/iife-strong-dependencies/_config.js
+++ b/test/function/samples/iife-strong-dependencies/_config.js
@@ -3,8 +3,16 @@ var assert = require( 'assert' );
 module.exports = {
 	skip: true,
 	description: 'does not treat references inside IIFEs as weak dependencies', // edge case encountered in THREE.js codebase
-	warnings: warnings => {
-		assert.equal( warnings.length, 1 );
-		assert.ok( /Module .+D\.js may be unable to evaluate without .+C\.js, but is included first due to a cyclical dependency. Consider swapping the import statements in .+main\.js to ensure correct ordering/.test( warnings[0] ) );
-	}
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'A.js',
+			message: 'Circular dependency: A.js -> B.js -> A.js'
+		},
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'C.js',
+			message: 'Circular dependency: C.js -> D.js -> C.js'
+		}
+	]
 };


### PR DESCRIPTION
See #1941. This is very primitive and doesn't warn through rollup's logging system.