### PR TITLE
Expose parse function to plugins

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -51,7 +51,7 @@ function generateChunkName (id: string, chunkNames: { [name: string ]: boolean }
 }
 
 export default class Graph {
-	acornOptions: any;
+	acornOptions: acorn.Options;
 	acornParse: acorn.IParse;
 	cachedModules: Map<string, ModuleJSON>;
 	context: string;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -74,10 +74,10 @@ export const defaultAcornOptions: AcornOptions = {
 
 function tryParse (module: Module, parse: IParse, acornOptions: AcornOptions) {
 	try {
-		return parse(module.code, Object.assign({}, defaultAcornOptions, {
+		return parse(module.code, Object.assign({}, defaultAcornOptions, acornOptions, {
 			onComment: (block: boolean, text: string, start: number, end: number) =>
 				module.comments.push({ block, text, start, end })
-		}, acornOptions));
+		}));
 	} catch (err) {
 		module.error({
 			code: 'PARSE_ERROR',

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1,4 +1,4 @@
-import { IParse } from 'acorn';
+import { IParse, Options as AcornOptions } from 'acorn';
 import MagicString from 'magic-string';
 import { locate } from 'locate-character';
 import { timeStart, timeEnd } from './utils/flushTime';
@@ -66,14 +66,17 @@ export interface ReexportDescription {
 	module: Module;
 }
 
-function tryParse (module: Module, parse: IParse, acornOptions: Object) {
+export const defaultAcornOptions: AcornOptions = {
+	ecmaVersion: 8,
+	sourceType: 'module',
+	preserveParens: false
+};
+
+function tryParse (module: Module, parse: IParse, acornOptions: AcornOptions) {
 	try {
-		return parse(module.code, Object.assign({
-			ecmaVersion: 8,
-			sourceType: 'module',
+		return parse(module.code, Object.assign({}, defaultAcornOptions, {
 			onComment: (block: boolean, text: string, start: number, end: number) =>
-				module.comments.push({ block, text, start, end }),
-			preserveParens: false
+				module.comments.push({ block, text, start, end })
 		}, acornOptions));
 	} catch (err) {
 		module.error({

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -15,6 +15,7 @@ import { SourceMap } from 'magic-string';
 import { WatcherOptions } from '../watch/index';
 import { Deprecation } from '../utils/deprecateOptions';
 import Graph from '../Graph';
+import { TransformContext } from '../utils/transform';
 
 export const VERSION = '<@VERSION@>';
 
@@ -24,7 +25,7 @@ export type ResolveIdHook = (id: string, parent: string) => Promise<string | boo
 export type MissingExportHook = (module: Module, name: string, otherModule: Module | ExternalModule, start?: number) => void;
 export type IsExternalHook = (id: string, parentId: string, isResolved: boolean) => Promise<boolean | void> | boolean | void;
 export type LoadHook = (id: string) => Promise<SourceDescription | string | void> | SourceDescription | string | void;
-export type TransformHook = (code: string, id: String) => Promise<SourceDescription | string | void>;
+export type TransformHook = (this: TransformContext, code: string, id: String) => Promise<SourceDescription | string | void>;
 export type TransformBundleHook = (code: string, options: OutputOptions) => Promise<SourceDescription | string>;
 export type ResolveDynamicImportHook = (specifier: string | Node, parentId: string) => Promise<string | void> | string | void
 

--- a/test/function/samples/plugin-parse/_config.js
+++ b/test/function/samples/plugin-parse/_config.js
@@ -1,0 +1,27 @@
+const MagicString = require('magic-string');
+
+module.exports = {
+	description: 'plugin transform hooks can use `this.parse(code, options)`',
+	options: {
+		plugins: [{
+			name: 'test',
+			transform (code, id) {
+				const magicString = new MagicString(code);
+				enforceTheAnswer(this.parse(code), magicString);
+				return magicString.toString();
+			}
+		}]
+	}
+};
+
+function enforceTheAnswer(ast, magicString) {
+	ast.body.forEach(node => {
+		if (node.type === 'VariableDeclaration') {
+			node.declarations.forEach(decl => {
+				if (decl.id.name === 'answer') {
+					magicString.overwrite(decl.init.start, decl.init.end, '42');
+				}
+			});
+		}
+	});
+}

--- a/test/function/samples/plugin-parse/main.js
+++ b/test/function/samples/plugin-parse/main.js
@@ -1,0 +1,5 @@
+const foo = 1;
+const answer = 41;
+
+assert.equal(foo, 1);
+assert.equal(answer, 42);


### PR DESCRIPTION
This is motivated by #1512 and basically implements what @Rich-Harris [was suggesting a few weeks ago](https://github.com/rollup/rollup/pull/1816#issuecomment-356946057).

By exposing rollup's `parse` function to plugins (via the `transform` context) these plugins can use the same acorn configuration (including injected plugins) if they need to operate on an ast. The most prominent example for this is probably `rollup-plugin-commonjs`, as mentioned in #1512. I opened a [PR](https://github.com/rollup/rollup-plugin-commonjs/pull/287) there as well to switch to the `parse` method of the transform context.