### PR TITLE
Reexport namespace deshadow

### DIFF
--- a/src/ast/scopes/ModuleScope.ts
+++ b/src/ast/scopes/ModuleScope.ts
@@ -40,7 +40,7 @@ export default class ModuleScope extends Scope {
 				localNames.add(declaration.getName());
 			};
 
-			(<Module>specifier.module).getExports().forEach(name => {
+			(<Module>specifier.module).getAllExports().forEach(name => {
 				addDeclaration(specifier.module.traceExport(name));
 			});
 

--- a/src/ast/scopes/Scope.ts
+++ b/src/ast/scopes/Scope.ts
@@ -86,7 +86,8 @@ export default class Scope {
 			const declaration = this.variables[key];
 
 			// we can disregard exports.foo etc
-			if (declaration.exportName && declaration.isReassigned) return;
+			if (declaration.exportName && declaration.isReassigned)
+				return;
 
 			let name = declaration.getName(true);
 

--- a/test/form/samples/reexport-star-deshadow/_config.js
+++ b/test/form/samples/reexport-star-deshadow/_config.js
@@ -1,0 +1,8 @@
+const assert = require( 'assert' );
+
+module.exports = {
+	description: 'Star reexports scope deshadowing',
+	options: {
+		name: 'myBundle'
+	}
+};

--- a/test/form/samples/reexport-star-deshadow/_config.js
+++ b/test/form/samples/reexport-star-deshadow/_config.js
@@ -3,6 +3,8 @@ const assert = require( 'assert' );
 module.exports = {
 	description: 'Star reexports scope deshadowing',
 	options: {
-		name: 'myBundle'
+		output: {
+			name: 'myBundle'
+		}
 	}
 };

--- a/test/form/samples/reexport-star-deshadow/_expected/amd.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/amd.js
@@ -1,0 +1,11 @@
+define(function () { 'use strict';
+
+	function foo() { return true; }
+
+	var baz = function foo$$1() {
+		return foo();
+	};
+
+	console.log(baz());
+
+});

--- a/test/form/samples/reexport-star-deshadow/_expected/cjs.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/cjs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function foo() { return true; }
+
+var baz = function foo$$1() {
+	return foo();
+};
+
+console.log(baz());

--- a/test/form/samples/reexport-star-deshadow/_expected/es.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/es.js
@@ -1,0 +1,1 @@
+export * from 'external';

--- a/test/form/samples/reexport-star-deshadow/_expected/es.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/es.js
@@ -1,1 +1,7 @@
-export * from 'external';
+function foo() { return true; }
+
+var baz = function foo$$1() {
+	return foo();
+};
+
+console.log(baz());

--- a/test/form/samples/reexport-star-deshadow/_expected/iife.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/iife.js
@@ -1,10 +1,12 @@
-var myBundle = (function (exports,external) {
+(function () {
 	'use strict';
 
+	function foo() { return true; }
 
+	var baz = function foo$$1() {
+		return foo();
+	};
 
-	Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+	console.log(baz());
 
-	return exports;
-
-}({},external));
+}());

--- a/test/form/samples/reexport-star-deshadow/_expected/iife.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/iife.js
@@ -1,0 +1,10 @@
+var myBundle = (function (exports,external) {
+	'use strict';
+
+
+
+	Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+
+	return exports;
+
+}({},external));

--- a/test/form/samples/reexport-star-deshadow/_expected/umd.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/umd.js
@@ -1,11 +1,15 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('external')) :
-	typeof define === 'function' && define.amd ? define(['exports', 'external'], factory) :
-	(factory((global.myBundle = {}),global.external));
-}(this, (function (exports,external) { 'use strict';
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
 
-	Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+	function foo() { return true; }
 
-	Object.defineProperty(exports, '__esModule', { value: true });
+	var baz = function foo$$1() {
+		return foo();
+	};
+
+	console.log(baz());
 
 })));

--- a/test/form/samples/reexport-star-deshadow/_expected/umd.js
+++ b/test/form/samples/reexport-star-deshadow/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('external')) :
+	typeof define === 'function' && define.amd ? define(['exports', 'external'], factory) :
+	(factory((global.myBundle = {}),global.external));
+}(this, (function (exports,external) { 'use strict';
+
+	Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/samples/reexport-star-deshadow/foo.js
+++ b/test/form/samples/reexport-star-deshadow/foo.js
@@ -1,0 +1,1 @@
+export function foo() { return true; }

--- a/test/form/samples/reexport-star-deshadow/main.js
+++ b/test/form/samples/reexport-star-deshadow/main.js
@@ -1,0 +1,7 @@
+import * as bar from './reexport.js';
+
+var baz = function foo() {
+	return bar.foo();
+};
+
+console.log(baz())

--- a/test/form/samples/reexport-star-deshadow/reexport.js
+++ b/test/form/samples/reexport-star-deshadow/reexport.js
@@ -1,0 +1,1 @@
+export * from './foo.js';


### PR DESCRIPTION
This fixes #1338 ensuring namespace exports which are in turn reexported are properly traced during deshadowing.