### PR TITLE
Fix performance timers

### DIFF
--- a/src/utils/flushTime.ts
+++ b/src/utils/flushTime.ts
@@ -41,9 +41,9 @@ export function timeEnd (label: string) {
 }
 
 export function flushTime (log = defaultLog) {
-	for (const item of <any> map.entries()) {
-		log(item[0], item[1].time);
-	}
+	map.forEach((value, key) => {
+		log(key, value.time);
+	});
 	map.clear();
 }
 


### PR DESCRIPTION
There's some weird stuff happening with iterators due to use using an old version of TypeScript... somehow the `entries()` gets converted into a `values()` incorrectly.