### PR TITLE
Revert "add missingExport hook"

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -36,6 +36,7 @@ import Import from './ast/nodes/Import';
 import { NodeType } from './ast/nodes/index';
 import { isTemplateLiteral } from './ast/nodes/TemplateLiteral';
 import { isLiteral } from './ast/nodes/Literal';
+import { handleMissingExport } from './utils/defaults';
 import Chunk, { DynamicImportMechanism } from './Chunk';
 
 export interface IdMap {[key: string]: string;}
@@ -633,7 +634,7 @@ export default class Module {
 			const declaration = otherModule.traceExport(importDeclaration.name);
 
 			if (!declaration) {
-				this.graph.handleMissingExport(this, importDeclaration.name, otherModule, importDeclaration.specifier.start);
+				handleMissingExport(this, importDeclaration.name, otherModule, importDeclaration.specifier.start);
 			}
 
 			return declaration;
@@ -661,7 +662,7 @@ export default class Module {
 			const declaration = reexportDeclaration.module.traceExport(reexportDeclaration.localName);
 
 			if (!declaration) {
-				this.graph.handleMissingExport(this, reexportDeclaration.localName, reexportDeclaration.module, reexportDeclaration.start);
+				handleMissingExport(this, reexportDeclaration.localName, reexportDeclaration.module, reexportDeclaration.start);
 			}
 
 			return declaration;

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -6,8 +6,7 @@ import { mapSequence } from '../utils/promise';
 import error from '../utils/error';
 import { SOURCEMAPPING_URL } from '../utils/sourceMappingURL';
 import mergeOptions, { GenericConfigObject } from '../utils/mergeOptions';
-import Module, { ModuleJSON } from '../Module';
-import ExternalModule from '../ExternalModule';
+import { ModuleJSON } from '../Module';
 import { RawSourceMap } from 'source-map';
 import Program from '../ast/nodes/Program';
 import { Node } from '../ast/nodes/shared/Node';
@@ -22,7 +21,6 @@ export const VERSION = '<@VERSION@>';
 export type SourceDescription = { code: string, map?: RawSourceMap, ast?: Program };
 
 export type ResolveIdHook = (id: string, parent: string) => Promise<string | boolean | void> | string | boolean | void;
-export type MissingExportHook = (module: Module, name: string, otherModule: Module | ExternalModule, start?: number) => void;
 export type IsExternalHook = (id: string, parentId: string, isResolved: boolean) => Promise<boolean | void> | boolean | void;
 export type LoadHook = (id: string) => Promise<SourceDescription | string | void> | SourceDescription | string | void;
 export type TransformHook = (this: TransformContext, code: string, id: String) => Promise<SourceDescription | string | void>;
@@ -34,7 +32,6 @@ export interface Plugin {
 	options?: (options: InputOptions) => void;
 	load?: LoadHook;
 	resolveId?: ResolveIdHook;
-	missingExport?: MissingExportHook;
 	transform?: TransformHook;
 	transformBundle?: TransformBundleHook;
 	ongenerate?: (options: OutputOptions, source: SourceDescription) => void;

--- a/src/utils/first-sync.ts
+++ b/src/utils/first-sync.ts
@@ -1,9 +1,0 @@
-// Return the first non-null or -undefined result from an array of
-// sync functions
-export default function firstSync<T> (candidates: ((...args: any[]) => T | void)[]): (...args: any[]) => T | void {
-	return function (...args: any[]) {
-		return candidates.reduce<T | void> ((result, candidate) => {
-			return result != null ? result : candidate(...args);
-		}, null);
-	};
-}

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -100,28 +100,4 @@ describe('hooks', () => {
 				return sander.unlink(file);
 			});
 	});
-
-	it('calls missingExport hook', () => {
-		let wasCalled;
-
-		return rollup
-			.rollup({
-				input: 'main',
-				plugins: [
-					loader({
-						main: `import def from 'foo'; console.log( def );`,
-						foo: `export const named = 42;`
-					}),
-					{
-						missingExport() {
-							wasCalled = true;
-							return true;
-						}
-					}
-				]
-			})
-			.then(() => {
-				assert.ok(wasCalled);
-			});
-	});
 });


### PR DESCRIPTION
This reverts commit de3ba8c6622d06ae1a897258ffbf4af6adc0ae54.

As mentioned in https://github.com/rollup/rollup/pull/1887#issuecomment-366187428 I don't think we should be exposing the internal Module interface to plugin hooks as we do not version this API which will place unnecessary versioning constraints on the project. If we do want to do something like this we should make sure we do a full review on the public `Module` API first I think.

@kellyselden as mentioned there it would be interesting to hear what fix you are using this hook for and how we can solve that in a way that doesn't expose a private API like this. I'm happy to have this hook without the `Module` argument as well.