### PR TITLE
Fixes #1968 handling of default export reassignment cases

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -575,7 +575,7 @@ export default class Chunk {
 				for (let i = 0; i < importSpecifiers.variables.length; i++) {
 					const impt = importSpecifiers.variables[i];
 					imports.push({
-						local: impt.variable.getName(),
+						local: impt.variable.safeName || impt.variable.name,
 						imported: impt.name
 					});
 				}

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -68,7 +68,11 @@ export default class ExportDefaultDeclaration extends NodeBase {
 			this.renderNamedDeclaration(code, declarationStart, 'class', this.declaration.id === null, options);
 		} else if (this.variable.getOriginalVariableName() === this.variable.getName()) {
 			// Remove altogether to prevent re-declaring the same variable
-			code.remove(start, end);
+			if (!options.systemBindings) {
+				code.remove(start, end);
+			} else {
+				code.overwrite(start, end, `exports('${this.variable.exportName}', ${this.variable.getName()});`);
+			}
 			return;
 		} else if (this.variable.included) {
 			this.renderVariableDeclaration(code, declarationStart, options);

--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -62,7 +62,11 @@ describe('chunking form', () => {
 								expectedFiles = [];
 							}
 
-							assert.deepEqual(actualFiles, expectedFiles);
+							assert.deepEqual(Object.keys(actualFiles), Object.keys(expectedFiles));
+
+							Object.keys(actualFiles).forEach(fileName => {
+								assert.strictEqual(actualFiles[fileName], expectedFiles[fileName], 'Unexpected output for ' + fileName);
+							});
 						});
 					});
 				});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_config.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'chunk reassignment import deshadowing',
+	options: {
+		input: ['main1.js', 'main2.js', 'main3.js', 'main4.js']
+	}
+};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk1.js
@@ -1,0 +1,7 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var x = 42;
+
+	exports.x = x;
+
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk2.js
@@ -1,0 +1,10 @@
+define(['exports', './chunk1.js', './chunk3.js'], function (exports, __chunk1_js, __chunk3_js) { 'use strict';
+
+	var x = x + 1;
+
+	var y = x + 1;
+
+	exports.x = x;
+	exports.y = y;
+
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk3.js
@@ -1,0 +1,7 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var x = 43;
+
+	exports.x = x;
+
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main1.js
@@ -1,0 +1,5 @@
+define(['./chunk2.js'], function (__chunk2_js) { 'use strict';
+
+	console.log(__chunk2_js.x + __chunk2_js.y);
+
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main2.js
@@ -1,0 +1,5 @@
+define(['./chunk2.js'], function (__chunk2_js) { 'use strict';
+
+
+
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main3.js
@@ -1,0 +1,5 @@
+define(['./chunk1.js'], function (__chunk1_js) { 'use strict';
+
+
+
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main4.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main4.js
@@ -1,0 +1,5 @@
+define(['./chunk3.js'], function (__chunk3_js) { 'use strict';
+
+
+
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var x = 42;
+
+exports.x = x;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk2.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var __chunk1_js = require('./chunk1.js');
+var __chunk3_js = require('./chunk3.js');
+
+var x = x + 1;
+
+var y = x + 1;
+
+exports.x = x;
+exports.y = y;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk3.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var x = 43;
+
+exports.x = x;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var __chunk2_js = require('./chunk2.js');
+
+console.log(__chunk2_js.x + __chunk2_js.y);

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main2.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./chunk2.js');
+

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main3.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./chunk1.js');
+

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main4.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main4.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./chunk3.js');
+

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk1.js
@@ -1,0 +1,3 @@
+var x = 42;
+
+export { x };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk2.js
@@ -1,0 +1,8 @@
+import { x } from './chunk1.js';
+import { x as x$1 } from './chunk3.js';
+
+var x$2 = x + 1;
+
+var y = x + 1;
+
+export { x$2 as x, y };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk3.js
@@ -1,0 +1,3 @@
+var x = 43;
+
+export { x };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
@@ -1,0 +1,3 @@
+import { x, y } from './chunk2.js';
+
+console.log(x + y);

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main2.js
@@ -1,0 +1,1 @@
+import './chunk2.js';

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main3.js
@@ -1,0 +1,1 @@
+import './chunk1.js';

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main4.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main4.js
@@ -1,0 +1,1 @@
+import './chunk3.js';

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk1.js
@@ -1,0 +1,11 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var x = 42;
+			exports('x', x);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk2.js
@@ -1,0 +1,18 @@
+System.register(['./chunk1.js', './chunk3.js'], function (exports, module) {
+	'use strict';
+	var x, x$1;
+	return {
+		setters: [function (module) {
+			x = module.x;
+		}, function (module) {
+			x$1 = module.x;
+		}],
+		execute: function () {
+
+			var x$2 = exports('x', x + 1);
+
+			var y = exports('y', x + 1);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk3.js
@@ -1,0 +1,11 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var x = 43;
+			exports('x', x);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
@@ -1,0 +1,15 @@
+System.register(['./chunk2.js'], function (exports, module) {
+	'use strict';
+	var x, y;
+	return {
+		setters: [function (module) {
+			x = module.x;
+			y = module.y;
+		}],
+		execute: function () {
+
+			console.log(x + y);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main2.js
@@ -1,0 +1,13 @@
+System.register(['./chunk2.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main3.js
@@ -1,0 +1,13 @@
+System.register(['./chunk1.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main4.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main4.js
@@ -1,0 +1,13 @@
+System.register(['./chunk3.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/dep1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/dep1.js
@@ -1,0 +1,2 @@
+var x = 42;
+export default x;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/dep2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/dep2.js
@@ -1,0 +1,2 @@
+var x = 43;
+export default x;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/main1.js
@@ -1,0 +1,4 @@
+import x from './shared1.js';
+import y from './shared2.js';
+
+console.log(x + y);

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/main2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/main2.js
@@ -1,0 +1,2 @@
+import './shared1.js';
+import './shared2.js';

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/main3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/main3.js
@@ -1,0 +1,1 @@
+import './dep1.js';

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/main4.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/main4.js
@@ -1,0 +1,1 @@
+import './dep2.js';

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/shared1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/shared1.js
@@ -1,0 +1,3 @@
+import './dep1.js';
+import x from './dep1.js';
+export default x + 1;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/shared2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/shared2.js
@@ -1,0 +1,3 @@
+import './dep2.js';
+import x from './dep2.js';
+export default x + 1;


### PR DESCRIPTION
The `default` reassignment case requires some exceptions in the code to be handled properly. Ideally we should treat the traced variable of the `default` as the expression statement of the default itself, as it seems like this inconsistency with the conceptual model is causing these exception cases, but I understand it was used to ensure tracing can get the most sensible variable name in the output which makes sense.

The hardest part of cracking this was coming up with just the right chunking scenario to replicate it, but it should be cracked now.

This is quite an important fix as the commonjs plugin outputs this pattern so it would be affecting many users testing out the code splitting with commonjs currently.