### PR TITLE
Export naming fix for #1976

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -181,11 +181,18 @@ export default class Chunk {
 		entryModule.getAllExports().forEach(exportName => {
 			const traced = this.traceExport(entryModule, exportName);
 			const variable = traced.module.traceExport(traced.name);
-			this.exports[exportName] = { module: traced.module, name: traced.name, variable };
-			// if we exposed an export in another module ensure it is exported there
-			if (traced.module.chunk !== this && !traced.module.isExternal) {
-				(<Module>traced.module).chunk.ensureExport(traced.module, variable);
+			let tracedName: string;
+			if (traced.module.chunk === this || traced.module.isExternal) {
+				tracedName = traced.name;
+			} else {
+				// if we exposed an export in another module ensure it is exported there
+				tracedName = (<Module>traced.module).chunk.ensureExport(traced.module, variable);
 			}
+			this.exports[exportName] = {
+				module: traced.module,
+				name: tracedName,
+				variable
+			};
 			this.exportedVariables.set(variable, exportName);
 		});
 	}

--- a/test/chunking-form/samples/chunk-export-renaming/_config.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'chunk export renaming',
+	options: {
+		input: ['main1.js', 'main2.js']
+	}
+};

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/amd/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/amd/chunk1.js
@@ -1,0 +1,14 @@
+define(['exports'], function (exports) { 'use strict';
+
+  class One {
+    test() {
+        return ONE_CONSTANT;
+    }
+  }
+
+  const ONE_CONSTANT = 'oneconstant';
+
+  exports.ItemOne = One;
+  exports.ONE_CONSTANT = ONE_CONSTANT;
+
+});

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/amd/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/amd/main1.js
@@ -1,0 +1,9 @@
+define(['exports', './chunk1.js'], function (exports, __chunk1_js) { 'use strict';
+
+
+
+	exports.ItemOne = __chunk1_js.ItemOne;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/amd/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/amd/main2.js
@@ -1,0 +1,13 @@
+define(['exports', './chunk1.js'], function (exports, __chunk1_js) { 'use strict';
+
+    class Two {
+        test() {
+            return __chunk1_js.ONE_CONSTANT;
+        }
+    }
+
+    exports.ItemTwo = Two;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/chunk1.js
@@ -1,0 +1,12 @@
+'use strict';
+
+class One {
+  test() {
+      return ONE_CONSTANT;
+  }
+}
+
+const ONE_CONSTANT = 'oneconstant';
+
+exports.ItemOne = One;
+exports.ONE_CONSTANT = ONE_CONSTANT;

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/main1.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __chunk1_js = require('./chunk1.js');
+
+
+
+exports.ItemOne = __chunk1_js.ItemOne;

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/main2.js
@@ -1,0 +1,13 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __chunk1_js = require('./chunk1.js');
+
+class Two {
+    test() {
+        return __chunk1_js.ONE_CONSTANT;
+    }
+}
+
+exports.ItemTwo = Two;

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk1.js
@@ -1,0 +1,9 @@
+class One {
+  test() {
+      return ONE_CONSTANT;
+  }
+}
+
+const ONE_CONSTANT = 'oneconstant';
+
+export { One as ItemOne, ONE_CONSTANT };

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/main1.js
@@ -1,0 +1,1 @@
+export { ItemOne } from './chunk1.js';

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/main2.js
@@ -1,0 +1,9 @@
+import { ONE_CONSTANT } from './chunk1.js';
+
+class Two {
+    test() {
+        return ONE_CONSTANT;
+    }
+}
+
+export { Two as ItemTwo };

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/chunk1.js
@@ -1,0 +1,16 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      class One {
+        test() {
+            return ONE_CONSTANT;
+        }
+      } exports('ItemOne', One);
+
+      const ONE_CONSTANT = exports('ONE_CONSTANT', 'oneconstant');
+
+    }
+  };
+});

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/main1.js
@@ -1,0 +1,13 @@
+System.register(['./chunk1.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('ItemOne', module.ItemOne);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/main2.js
@@ -1,0 +1,18 @@
+System.register(['./chunk1.js'], function (exports, module) {
+    'use strict';
+    var ONE_CONSTANT;
+    return {
+        setters: [function (module) {
+            ONE_CONSTANT = module.ONE_CONSTANT;
+        }],
+        execute: function () {
+
+            class Two {
+                test() {
+                    return ONE_CONSTANT;
+                }
+            } exports('ItemTwo', Two);
+
+        }
+    };
+});

--- a/test/chunking-form/samples/chunk-export-renaming/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/main1.js
@@ -1,0 +1,1 @@
+export { One as ItemOne } from './one.js';

--- a/test/chunking-form/samples/chunk-export-renaming/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/main2.js
@@ -1,0 +1,1 @@
+export { Two as ItemTwo } from './two.js';

--- a/test/chunking-form/samples/chunk-export-renaming/one.js
+++ b/test/chunking-form/samples/chunk-export-renaming/one.js
@@ -1,0 +1,7 @@
+export class One {
+  test() {
+      return ONE_CONSTANT;
+  }
+}
+
+export const ONE_CONSTANT = 'oneconstant';

--- a/test/chunking-form/samples/chunk-export-renaming/two.js
+++ b/test/chunking-form/samples/chunk-export-renaming/two.js
@@ -1,0 +1,7 @@
+import { ONE_CONSTANT } from './one';
+
+export class Two {
+    test() {
+        return ONE_CONSTANT;
+    }
+}


### PR DESCRIPTION
This provides a fix for #1976 where the re-export handling needs to be adjusted to deal with internally renamed exports instead of exporting the original variable name.