### PR TITLE
chore(build): update to `TypeScript 2.7.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4269,9 +4269,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "source-map": "^0.6.1",
     "source-map-support": "^0.5.3",
     "sourcemap-codec": "^1.4.0",
-    "typescript": "^2.7.1",
+    "typescript": "^2.7.2",
     "uglify-js": "^3.3.10"
   },
   "files": [

--- a/tsconfig-types.json
+++ b/tsconfig-types.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./dist/typings",
+        "emitDeclarationOnly": true,
         "declaration": true,
         "stripInternal": true
     },


### PR DESCRIPTION
This enable us to use the new flag `emitDeclarationOnly` which emits only `d.ts` when building the types