### PR TITLE
Add name option to iife example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For browsers:
 
 ```bash
 # compile to a <script> containing a self-executing function
-$ rollup main.js --output.format iife --output.file bundle.js
+$ rollup main.js --output.format iife --name "myBundle" --output.file bundle.js
 ```
 
 For Node.js:


### PR DESCRIPTION
The first example in the README fails with the error `You must supply output.name for IIFE bundles`.  A brief review of the git history indicates this has been required for quite some time.