### PR TITLE
remove private api from MissingExport hook

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -14,7 +14,6 @@ import { isAbsolute, isRelative, normalize, relative, resolve } from './utils/pa
 import {
 	InputOptions,
 	IsExternalHook,
-	MissingExportHook,
 	Plugin,
 	ResolveIdHook,
 	RollupWarning,
@@ -69,7 +68,12 @@ export default class Graph {
 	isPureExternalModule: (id: string) => boolean;
 	legacy: boolean;
 	load: (id: string) => Promise<SourceDescription | string | void>;
-	handleMissingExport: MissingExportHook;
+	handleMissingExport: (
+		exportName: string,
+		importingModule: Module,
+		importedModule: string,
+		importerStart?: number
+	) => void;
 	moduleById: Map<string, Module | ExternalModule>;
 	modules: Module[];
 	onwarn: WarningHandler;
@@ -144,6 +148,16 @@ export default class Graph {
 			this.plugins
 				.map(plugin => plugin.missingExport)
 				.filter(Boolean)
+				.map(missingExport => {
+					return (
+						exportName: string,
+						importingModule: Module,
+						importedModule: string,
+						importerStart?: number
+					) => {
+						return missingExport(importingModule.id, exportName, importedModule, importerStart);
+					};
+				})
 				.concat(handleMissingExport)
 		);
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -641,9 +641,9 @@ export default class Module {
 
 			if (!declaration) {
 				this.graph.handleMissingExport(
-					this,
 					importDeclaration.name,
-					otherModule,
+					this,
+					otherModule.id,
 					importDeclaration.specifier.start
 				);
 			}
@@ -673,9 +673,9 @@ export default class Module {
 
 			if (!declaration) {
 				this.graph.handleMissingExport(
-					this,
 					reexportDeclaration.localName,
-					reexportDeclaration.module,
+					this,
+					reexportDeclaration.module.id,
 					reexportDeclaration.start
 				);
 			}

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -6,8 +6,7 @@ import { mapSequence } from '../utils/promise';
 import error from '../utils/error';
 import { SOURCEMAPPING_URL } from '../utils/sourceMappingURL';
 import mergeOptions, { GenericConfigObject } from '../utils/mergeOptions';
-import Module, { ModuleJSON } from '../Module';
-import ExternalModule from '../ExternalModule';
+import { ModuleJSON } from '../Module';
 import { RawSourceMap } from 'source-map';
 import Program from '../ast/nodes/Program';
 import { Node } from '../ast/nodes/shared/Node';
@@ -30,10 +29,10 @@ export type ResolveIdHook = (
 	parent: string
 ) => Promise<string | boolean | void> | string | boolean | void;
 export type MissingExportHook = (
-	module: Module,
-	name: string,
-	otherModule: Module | ExternalModule,
-	start?: number
+	exportName: string,
+	importingModule: string,
+	importedModule: string,
+	importerStart?: number
 ) => void;
 export type IsExternalHook = (
 	id: string,

--- a/src/utils/defaults.ts
+++ b/src/utils/defaults.ts
@@ -3,7 +3,6 @@ import { basename, dirname, isAbsolute, resolve } from './path';
 import { blank } from './object';
 import error from './error';
 import Module from '../Module';
-import ExternalModule from '../ExternalModule';
 import relativeId from './relativeId';
 import { InputOptions } from '../rollup';
 
@@ -69,17 +68,17 @@ export function makeOnwarn() {
 }
 
 export function handleMissingExport(
-	module: Module,
-	name: string,
-	otherModule: Module | ExternalModule,
-	start?: number
+	exportName: string,
+	importingModule: Module,
+	importedModule: string,
+	importerStart?: number
 ) {
-	module.error(
+	importingModule.error(
 		{
 			code: 'MISSING_EXPORT',
-			message: `'${name}' is not exported by ${relativeId(otherModule.id)}`,
+			message: `'${exportName}' is not exported by ${relativeId(importedModule)}`,
 			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module`
 		},
-		start
+		importerStart
 	);
 }


### PR DESCRIPTION
Closes #1973.

I don't think calling `Module` functions is going to be necessary after all.