### PR TITLE
Internal export name mangling for chunking

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -407,7 +407,11 @@ export default class Graph {
 							entryPointFacade.generateImports();
 							entryPointFacade.generateEntryExports(chunk.entryModule);
 							chunks['./' + entryName] = entryPointFacade;
+							chunk.generateMangledExportNames();
 						}
+					}
+					else {
+						chunk.generateMangledExportNames();
 					}
 					// name the chunk itself
 					const chunkName = generateChunkName('chunk', chunkNames);

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -111,6 +111,9 @@ export interface RenderOptions {
 	freeze: boolean;
 	importMechanism?: DynamicImportMechanism;
 	systemBindings: boolean;
+	mangledExportNameMap?: {
+		[name: string]: string
+	}
 }
 
 export interface NodeRenderOptions {

--- a/src/ast/nodes/ClassDeclaration.ts
+++ b/src/ast/nodes/ClassDeclaration.ts
@@ -25,7 +25,10 @@ export default class ClassDeclaration extends ClassNode {
 
 	render (code: MagicString, options: RenderOptions) {
 		if (options.systemBindings && this.id.variable.exportName) {
-			code.appendRight(this.end, ` exports('${this.id.variable.exportName}', ${this.id.variable.getName()});`);
+			let exportName = this.id.variable.exportName;
+			if (options.mangledExportNameMap)
+				exportName = options.mangledExportNameMap[exportName] || exportName;
+			code.appendRight(this.end, ` exports('${exportName}', ${this.id.variable.getName()});`);
 		}
 		super.render(code, options);
 	}

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -71,7 +71,10 @@ export default class ExportDefaultDeclaration extends NodeBase {
 			if (!options.systemBindings) {
 				code.remove(start, end);
 			} else {
-				code.overwrite(start, end, `exports('${this.variable.exportName}', ${this.variable.getName()});`);
+				let exportName = this.variable.exportName;
+				if (options.mangledExportNameMap)
+					exportName = options.mangledExportNameMap[exportName] || exportName;
+				code.overwrite(start, end, `exports('${exportName}', ${this.variable.getName()});`);
 			}
 			return;
 		} else if (this.variable.included) {
@@ -93,12 +96,18 @@ export default class ExportDefaultDeclaration extends NodeBase {
 			code.appendLeft(getIdInsertPosition(code.original, declarationKeyword, declarationStart), ` ${name}`);
 		}
 		if (options.systemBindings && isClassDeclaration(this.declaration)) {
-			code.appendRight(this.end, ` exports('default', ${name});`);
+			let exportName = this.variable.exportName;
+			if (options.mangledExportNameMap)
+				exportName = options.mangledExportNameMap[exportName] || exportName;
+			code.appendRight(this.end, ` exports('${exportName}', ${name});`);
 		}
 	}
 
 	private renderVariableDeclaration (code: MagicString, declarationStart: number, options: RenderOptions) {
-		const systemBinding = options.systemBindings ? `exports('${this.variable.exportName}', ` : '';
+		let exportName = this.variable.exportName;
+		if (options.mangledExportNameMap)
+			exportName = options.mangledExportNameMap[exportName] || exportName;
+		const systemBinding = options.systemBindings ? `exports('${exportName}', ` : '';
 		code.overwrite(
 			this.start,
 			declarationStart,

--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -110,7 +110,10 @@ export default class VariableDeclaration extends NodeBase {
 				isInDeclaration = false;
 			} else {
 				if (options.systemBindings && node.init !== null && isIdentifier(node.id) && node.id.variable.exportName) {
-					code.prependLeft(node.init.start, `exports('${node.id.variable.exportName}', `);
+					let exportName = node.id.variable.exportName;
+					if (options.mangledExportNameMap)
+						exportName = options.mangledExportNameMap[exportName] || exportName;
+					code.prependLeft(node.init.start, `exports('${exportName}', `);
 					nextSeparatorString += ')';
 				}
 				if (isInDeclaration) {

--- a/src/finalisers/es.ts
+++ b/src/finalisers/es.ts
@@ -8,7 +8,7 @@ export default function es (chunk: Chunk, magicString: MagicStringBundle, { getP
 	intro: string;
 	outro: string
 }) {
-	const { dependencies, exports } = chunk.getModuleDeclarations();
+	const { dependencies, exports } = chunk.getModuleDeclarations(true);
 	const importBlock = dependencies.map(({ id, reexports, imports, name }) => {
 		if (!reexports && !imports) {
 			return `import '${getPath(id)}';`;

--- a/src/finalisers/system.ts
+++ b/src/finalisers/system.ts
@@ -26,7 +26,7 @@ export default function system (
 		outro: string
 	}
 ) {
-	const { dependencies, exports } = chunk.getModuleDeclarations();
+	const { dependencies, exports } = chunk.getModuleDeclarations(true);
 
 	const dependencyIds = dependencies.map(m => `'${getPath(m.id)}'`);
 

--- a/test/chunking-form/samples/basic-chunking/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/es/chunk1.js
@@ -7,4 +7,4 @@ function fn$1 () {
   console.log('dep2 fn');
 }
 
-export { fn$1 as fn };
+export { fn$1 as a };

--- a/test/chunking-form/samples/basic-chunking/_expected/es/main1.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk1.js';
+import { a as fn } from './chunk1.js';
 
 function fn$1 () {
   console.log('dep1 fn');

--- a/test/chunking-form/samples/basic-chunking/_expected/es/main2.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk1.js';
+import { a as fn } from './chunk1.js';
 
 function fn$1 () {
   console.log('lib1 fn');

--- a/test/chunking-form/samples/basic-chunking/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/system/chunk1.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$1);
+      exports('a', fn$1);
       function fn () {
         console.log('lib2 fn');
       }

--- a/test/chunking-form/samples/basic-chunking/_expected/system/main1.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/basic-chunking/_expected/system/main2.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk1.js
@@ -1,3 +1,3 @@
 var x = 42;
 
-export { x };
+export { x as a };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk2.js
@@ -1,8 +1,8 @@
-import { x } from './chunk1.js';
-import { x as x$1 } from './chunk3.js';
+import { a as x } from './chunk1.js';
+import { a as x$1 } from './chunk3.js';
 
 var x$2 = x + 1;
 
 var y = x + 1;
 
-export { x$2 as x, y };
+export { x$2 as a, y as b };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk3.js
@@ -1,3 +1,3 @@
 var x = 43;
 
-export { x };
+export { x as a };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import { x, y } from './chunk2.js';
+import { a as x, b as y } from './chunk2.js';
 
 console.log(x + y);

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk1.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			var x = 42;
-			exports('x', x);
+			exports('a', x);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk2.js
@@ -3,15 +3,15 @@ System.register(['./chunk1.js', './chunk3.js'], function (exports, module) {
 	var x, x$1;
 	return {
 		setters: [function (module) {
-			x = module.x;
+			x = module.a;
 		}, function (module) {
-			x$1 = module.x;
+			x$1 = module.a;
 		}],
 		execute: function () {
 
-			var x$2 = exports('x', x + 1);
+			var x$2 = exports('a', x + 1);
 
-			var y = exports('y', x + 1);
+			var y = exports('b', x + 1);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk3.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			var x = 43;
-			exports('x', x);
+			exports('a', x);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./chunk2.js'], function (exports, module) {
 	var x, y;
 	return {
 		setters: [function (module) {
-			x = module.x;
-			y = module.y;
+			x = module.a;
+			y = module.b;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/chunk1.js
@@ -15,4 +15,4 @@ function fn$2 () {
 
 var text$1 = 'dep2 fn';
 
-export { fn$2 as fn, fn$1 };
+export { fn$2 as a, fn$1 as b };

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk1.js';
+import { a as fn } from './chunk1.js';
 
 class Main1 {
   constructor () {

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn$1 as fn } from './chunk1.js';
+import { b as fn } from './chunk1.js';
 
 class Main2 {
   constructor () {

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/chunk1.js
@@ -3,8 +3,8 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$2);
-      exports('fn$1', fn$1);
+      exports('a', fn$2);
+      exports('b', fn$1);
       function fn () {
         console.log('lib fn');
       }

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn$1;
+      fn = module.b;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk1.js
@@ -6,4 +6,4 @@ class One {
 
 const ONE_CONSTANT = 'oneconstant';
 
-export { One as ItemOne, ONE_CONSTANT };
+export { One as a, ONE_CONSTANT as b };

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/main1.js
@@ -1,1 +1,1 @@
-export { ItemOne } from './chunk1.js';
+export { a as ItemOne } from './chunk1.js';

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { ONE_CONSTANT } from './chunk1.js';
+import { b as ONE_CONSTANT } from './chunk1.js';
 
 class Two {
     test() {

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/chunk1.js
@@ -7,9 +7,9 @@ System.register([], function (exports, module) {
         test() {
             return ONE_CONSTANT;
         }
-      } exports('ItemOne', One);
+      } exports('a', One);
 
-      const ONE_CONSTANT = exports('ONE_CONSTANT', 'oneconstant');
+      const ONE_CONSTANT = exports('b', 'oneconstant');
 
     }
   };

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/main1.js
@@ -2,7 +2,7 @@ System.register(['./chunk1.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('ItemOne', module.ItemOne);
+			exports('ItemOne', module.a);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
     var ONE_CONSTANT;
     return {
         setters: [function (module) {
-            ONE_CONSTANT = module.ONE_CONSTANT;
+            ONE_CONSTANT = module.b;
         }],
         execute: function () {
 

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/es/chunk1.js
@@ -17,4 +17,4 @@ function fn$2 () {
 
 var text$1 = 'dep2 fn';
 
-export { fn$2 as fn, text$1 as text, fn$1, text as text$1 };
+export { fn$2 as a, text$1 as b, fn$1 as c, text as d };

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn, text } from './chunk1.js';
+import { a as fn, b as text } from './chunk1.js';
 
 class Main1 {
   constructor () {

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn$1 as fn, text$1 as text } from './chunk1.js';
+import { c as fn, d as text } from './chunk1.js';
 
 class Main2 {
   constructor () {

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/system/chunk1.js
@@ -3,8 +3,8 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$2);
-      exports('fn$1', fn$1);
+      exports('a', fn$2);
+      exports('c', fn$1);
       function fn () {
         console.log('lib fn');
       }
@@ -12,17 +12,17 @@ System.register([], function (exports, module) {
       function fn$1 () {
         fn();
         console.log(text$1);
-        text = exports('text$1', 'dep1 fn after dep2');
+        text = exports('d', 'dep1 fn after dep2');
       }
 
-      var text = exports('text$1', 'dep1 fn');
+      var text = exports('d', 'dep1 fn');
 
       function fn$2 () {
         console.log(text);
-        text$1 = exports('text', 'dep2 fn after dep1');
+        text$1 = exports('b', 'dep2 fn after dep1');
       }
 
-      var text$1 = exports('text', 'dep2 fn');
+      var text$1 = exports('b', 'dep2 fn');
 
     }
   };

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn, text;
   return {
     setters: [function (module) {
-      fn = module.fn;
-      text = module.text;
+      fn = module.a;
+      text = module.b;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/system/main2.js
@@ -3,8 +3,8 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn, text;
   return {
     setters: [function (module) {
-      fn = module.fn$1;
-      text = module.text$1;
+      fn = module.c;
+      text = module.d;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-externals/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/es/chunk1.js
@@ -7,4 +7,4 @@ function fn$1 () {
   console.log('dep2 fn');
 }
 
-export { fn$1 as fn };
+export { fn$1 as a };

--- a/test/chunking-form/samples/chunking-externals/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk1.js';
+import { a as fn } from './chunk1.js';
 
 function fn$1 () {
   console.log('dep1 fn');

--- a/test/chunking-form/samples/chunking-externals/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/es/main2.js
@@ -1,5 +1,5 @@
 import { fn } from 'external';
-import { fn as fn$1 } from './chunk1.js';
+import { a as fn$1 } from './chunk1.js';
 
 function fn$2 () {
   console.log('lib1 fn');

--- a/test/chunking-form/samples/chunking-externals/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/system/chunk1.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$1);
+      exports('a', fn$1);
       function fn () {
         console.log('lib2 fn');
       }

--- a/test/chunking-form/samples/chunking-externals/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-externals/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/system/main2.js
@@ -5,7 +5,7 @@ System.register(['external', './chunk1.js'], function (exports, module) {
     setters: [function (module) {
       fn = module.fn;
     }, function (module) {
-      fn$1 = module.fn;
+      fn$1 = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-source-maps/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/es/chunk1.js
@@ -7,5 +7,5 @@ function fn$1 () {
   console.log('dep2 fn');
 }
 
-export { fn$1 as fn };
+export { fn$1 as a };
 //# sourceMappingURL=./chunk1.js.map

--- a/test/chunking-form/samples/chunking-source-maps/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk1.js';
+import { a as fn } from './chunk1.js';
 
 function fn$1 () {
   console.log('dep1 fn');

--- a/test/chunking-form/samples/chunking-source-maps/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk1.js';
+import { a as fn } from './chunk1.js';
 
 function fn$1 () {
   console.log('lib1 fn');

--- a/test/chunking-form/samples/chunking-source-maps/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/system/chunk1.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$1);
+      exports('a', fn$1);
       function fn () {
         console.log('lib2 fn');
       }

--- a/test/chunking-form/samples/chunking-source-maps/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-source-maps/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/es/chunk1.js
@@ -3,4 +3,4 @@ import 'external2';
 
 var dep = 'dep';
 
-export { dep };
+export { dep as a };

--- a/test/chunking-form/samples/chunking-star-external/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/es/main1.js
@@ -1,6 +1,6 @@
 export * from 'starexternal1';
 export { e } from 'external1';
-export { dep } from './chunk1.js';
+export { a as dep } from './chunk1.js';
 
 var main = '1';
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/es/main2.js
@@ -1,4 +1,4 @@
-export { dep } from './chunk1.js';
+export { a as dep } from './chunk1.js';
 export { e } from 'external2';
 export * from 'starexternal2';
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/chunk1.js
@@ -8,7 +8,7 @@ System.register(['starexternal2', 'external2'], function (exports, module) {
 		}],
 		execute: function () {
 
-			var dep = exports('dep', 'dep');
+			var dep = exports('a', 'dep');
 
 		}
 	};

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/main1.js
@@ -11,7 +11,7 @@ System.register(['starexternal1', 'external1', './chunk1.js'], function (exports
 		}, function (module) {
 			exports('e', module.e);
 		}, function (module) {
-			exports('dep', module.dep);
+			exports('dep', module.a);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js', 'external2', 'starexternal2'], function (exports
 	var _starExcludes = { main: 1, default: 1, dep: 1, e: 1 };
 	return {
 		setters: [function (module) {
-			exports('dep', module.dep);
+			exports('dep', module.a);
 		}, function (module) {
 			exports('e', module.e);
 		}, function (module) {

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/es/chunk1.js
@@ -1,3 +1,3 @@
 var multiplier = 7;
 
-export { multiplier };
+export { multiplier as a };

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/es/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/es/dep2.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk1.js';
+import { a as multiplier } from './chunk1.js';
 
 function mult (num) {
   return num + multiplier;

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/es/main.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk1.js';
+import { a as multiplier } from './chunk1.js';
 
 function calc (num) {
   return num * multiplier;

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/system/chunk1.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var multiplier = exports('multiplier', 7);
+			var multiplier = exports('a', 7);
 
 		}
 	};

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/system/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/system/dep2.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/chunk1.js
@@ -1,3 +1,3 @@
 var multiplier = 7;
 
-export { multiplier };
+export { multiplier as a };

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/dep2.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk1.js';
+import { a as multiplier } from './chunk1.js';
 
 function mult (num) {
   return num + multiplier;

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/main.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk1.js';
+import { a as multiplier } from './chunk1.js';
 
 function calc (num) {
   return num * multiplier;

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/chunk1.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var multiplier = exports('multiplier', 7);
+			var multiplier = exports('a', 7);
 
 		}
 	};

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/dep2.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./chunk1.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/chunk1.js
@@ -6,5 +6,4 @@ function log (x) {
   }
 }
 
-export default log;
-export { dep };
+export { log as a, dep as b };

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import log, { dep } from './chunk1.js';
+import { b as dep, a as log } from './chunk1.js';
 
 log(dep);

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main2.js
@@ -1,1 +1,1 @@
-export { default } from './chunk1.js';
+export { a as default } from './chunk1.js';

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/chunk1.js
@@ -3,8 +3,8 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('default', log);
-      var dep = exports('dep', 42);
+      exports('a', log);
+      var dep = exports('b', 42);
 
       function log (x) {
         if (dep) {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./chunk1.js'], function (exports, module) {
 	var dep, log;
 	return {
 		setters: [function (module) {
-			dep = module.dep;
-			log = module.default;
+			dep = module.b;
+			log = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main2.js
@@ -2,7 +2,7 @@ System.register(['./chunk1.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('default', module.default);
+			exports('default', module.a);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/multi-chunking/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/chunk1.js
@@ -1,3 +1,3 @@
 var num = 1;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/multi-chunking/_expected/es/chunk2.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/chunk2.js
@@ -1,3 +1,3 @@
 var num = 2;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/multi-chunking/_expected/es/chunk3.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/chunk3.js
@@ -1,3 +1,3 @@
 var num = 3;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/multi-chunking/_expected/es/main1.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { num } from './chunk1.js';
-import { num as num$1 } from './chunk2.js';
+import { a as num } from './chunk1.js';
+import { a as num$1 } from './chunk2.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/multi-chunking/_expected/es/main2.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { num } from './chunk2.js';
-import { num as num$1 } from './chunk3.js';
+import { a as num } from './chunk2.js';
+import { a as num$1 } from './chunk3.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/multi-chunking/_expected/es/main3.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/main3.js
@@ -1,4 +1,4 @@
-import { num } from './chunk1.js';
-import { num as num$1 } from './chunk3.js';
+import { a as num } from './chunk1.js';
+import { a as num$1 } from './chunk3.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/multi-chunking/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/chunk1.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 1);
+			var num = exports('a', 1);
 
 		}
 	};

--- a/test/chunking-form/samples/multi-chunking/_expected/system/chunk2.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/chunk2.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 2);
+			var num = exports('a', 2);
 
 		}
 	};

--- a/test/chunking-form/samples/multi-chunking/_expected/system/chunk3.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/chunk3.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 3);
+			var num = exports('a', 3);
 
 		}
 	};

--- a/test/chunking-form/samples/multi-chunking/_expected/system/main1.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/main1.js
@@ -3,9 +3,9 @@ System.register(['./chunk1.js', './chunk2.js'], function (exports, module) {
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/multi-chunking/_expected/system/main2.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/main2.js
@@ -3,9 +3,9 @@ System.register(['./chunk2.js', './chunk3.js'], function (exports, module) {
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/multi-chunking/_expected/system/main3.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/main3.js
@@ -3,9 +3,9 @@ System.register(['./chunk1.js', './chunk3.js'], function (exports, module) {
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 


### PR DESCRIPTION
This implements #1983, making sure that internal chunk exports use mangled short names.

When combined with a minifier this should provide a better overall output file size and it shouldn't affect code readabililty without minification because at both the export site and the import site, the original names are being used.