### PR TITLE
revert chunking form test change

### DIFF
--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -62,11 +62,7 @@ describe('chunking form', () => {
 								expectedFiles = [];
 							}
 
-							assert.deepEqual(Object.keys(actualFiles), Object.keys(expectedFiles));
-
-							Object.keys(actualFiles).forEach(fileName => {
-								assert.strictEqual(actualFiles[fileName], expectedFiles[fileName], 'Unexpected output for ' + fileName);
-							});
+							assert.deepEqual(actualFiles, expectedFiles);
 						});
 					});
 				});

--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -62,7 +62,16 @@ describe('chunking form', () => {
 								expectedFiles = [];
 							}
 
-							assert.deepEqual(actualFiles, expectedFiles);
+							(function recurse(actualFiles, expectedFiles, dirs) {
+								const fileNames = Array.from(new Set(Object.keys(actualFiles).concat(Object.keys(expectedFiles))));
+								fileNames.forEach(fileName => {
+									const sections = dirs.concat(fileName);
+									if (typeof actualFiles[fileName] === 'object' && typeof expectedFiles[fileName] === 'object') {
+										return recurse(actualFiles[fileName], expectedFiles[fileName], sections);
+									}
+									assert.strictEqual(actualFiles[fileName], expectedFiles[fileName], 'Unexpected output for ' + sections.join('/'));
+								});
+							})(actualFiles, expectedFiles, []);
 						});
 					});
 				});


### PR DESCRIPTION
Extracted from #1922. Reverted from #1975.

`fixturify` comparisons where brought in because of the preserve modules work, where there can be a directory tree. The change to this file doesn't work because it only iterates top-level entries.