### PR TITLE
failing test for default export renames

### DIFF
--- a/test/chunking-form/samples/default-export-rename/_config.js
+++ b/test/chunking-form/samples/default-export-rename/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'default export rename',
+	options: {
+		input: ['main.js', 'dep.js']
+	}
+};

--- a/test/chunking-form/samples/default-export-rename/_expected/amd/dep.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/amd/dep.js
@@ -1,0 +1,9 @@
+define(function () { 'use strict';
+
+    function name() {
+        console.log();
+    }
+
+    return name;
+
+});

--- a/test/chunking-form/samples/default-export-rename/_expected/amd/main.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(['./dep.js'], function (__dep_js) { 'use strict';
+
+	name();
+
+});

--- a/test/chunking-form/samples/default-export-rename/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/cjs/dep.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function name() {
+    console.log();
+}
+
+module.exports = name;

--- a/test/chunking-form/samples/default-export-rename/_expected/cjs/main.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/cjs/main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var __dep_js = require('./dep.js');
+
+name();

--- a/test/chunking-form/samples/default-export-rename/_expected/es/dep.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/es/dep.js
@@ -1,0 +1,5 @@
+function name() {
+    console.log();
+}
+
+export default name;

--- a/test/chunking-form/samples/default-export-rename/_expected/es/main.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/es/main.js
@@ -1,0 +1,3 @@
+import renamed from './dep.js';
+
+name();

--- a/test/chunking-form/samples/default-export-rename/_expected/system/dep.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/system/dep.js
@@ -1,0 +1,13 @@
+System.register([], function (exports, module) {
+    'use strict';
+    return {
+        execute: function () {
+
+            exports('default', name);
+            function name() {
+                console.log();
+            }
+
+        }
+    };
+});

--- a/test/chunking-form/samples/default-export-rename/_expected/system/main.js
+++ b/test/chunking-form/samples/default-export-rename/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register(['./dep.js'], function (exports, module) {
+	'use strict';
+	var renamed;
+	return {
+		setters: [function (module) {
+			renamed = module.default;
+		}],
+		execute: function () {
+
+			name();
+
+		}
+	};
+});

--- a/test/chunking-form/samples/default-export-rename/dep.js
+++ b/test/chunking-form/samples/default-export-rename/dep.js
@@ -1,0 +1,3 @@
+export default function name() {
+    console.log();
+};

--- a/test/chunking-form/samples/default-export-rename/main.js
+++ b/test/chunking-form/samples/default-export-rename/main.js
@@ -1,0 +1,3 @@
+import renamed from './dep';
+
+renamed();


### PR DESCRIPTION
_expected is _actual in this case, that's why tests are passing. This is so you can see the failed rename in main.js easily.