### PR TITLE
Fix for #1992, along with chunk interface refactoring

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -545,7 +545,7 @@ export default class Chunk {
 		this.graph.scope.deshadow(toDeshadow, this.orderedModules.map(module => module.scope));
 	}
 
-	getModuleDeclarations (): ModuleDeclarations {
+	private getCheckReexportDeclarations (): { [id: string]: ReexportSpecifier[] } {
 		const reexportDeclarations: {
 			[id: string]: ReexportSpecifier[]
 		} = {};
@@ -567,6 +567,12 @@ export default class Chunk {
 				reexported: name[0] === '*' ? '*' : name
 			});
 		}
+
+		return reexportDeclarations;
+	}
+
+	private getChunkDependencyDeclarations (): ChunkDependencies {
+		const reexportDeclarations = this.getCheckReexportDeclarations();
 
 		const dependencies: ChunkDependencies = [];
 
@@ -610,6 +616,10 @@ export default class Chunk {
 			});
 		});
 
+		return dependencies;
+	}
+
+	private getChunkExportDeclarations (): ChunkExports {
 		const exports: ChunkExports = [];
 		for (let name in this.exports) {
 			const expt = this.exports[name];
@@ -637,8 +647,14 @@ export default class Chunk {
 				hoisted
 			});
 		}
+		return exports;
+	}
 
-		return { dependencies, exports };
+	getModuleDeclarations (): ModuleDeclarations {
+		return {
+			dependencies: this.getChunkDependencyDeclarations(),
+			exports: this.getChunkExportDeclarations()
+		};
 	}
 
 	render (options: OutputOptions) {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -27,7 +27,7 @@ import { NodeType } from './ast/nodes/index';
 export interface ModuleDeclarations {
 	exports: ChunkExports;
 	dependencies: ModuleDeclarationDependency[];
-};
+}
 
 export interface ModuleDeclarationDependency {
 	id: string;
@@ -39,7 +39,7 @@ export interface ModuleDeclarationDependency {
 	exportsNamespace: boolean;
 	reexports?: ReexportSpecifier[];
 	imports?: ImportSpecifier[];
-};
+}
 
 export type ChunkDependencies = ModuleDeclarationDependency[];
 
@@ -52,19 +52,19 @@ export type ChunkExports = {
 export interface ReexportSpecifier {
 	reexported: string;
 	imported: string;
-};
+}
 
 export interface ImportSpecifier {
 	local: string;
 	imported: string;
-};
+}
 
 export interface DynamicImportMechanism {
 	left: string;
 	right: string;
 	interopLeft?: string;
 	interopRight?: string;
-};
+}
 
 export default class Chunk {
 	id: string;
@@ -586,9 +586,8 @@ export default class Chunk {
 			}
 
 			let reexports = reexportDeclarations[dep.id];
-			const isExternal = !!(<ExternalModule>dep).isExternal;
 			let exportsNames: boolean, exportsNamespace: boolean, exportsDefault: boolean;
-			if (isExternal) {
+			if ((<ExternalModule>dep).isExternal) {
 				exportsNames = (<ExternalModule>dep).exportsNames;
 				exportsNamespace = (<ExternalModule>dep).exportsNamespace;
 				exportsDefault = 'default' in (<ExternalModule>dep).declarations;

--- a/src/finalisers/amd.ts
+++ b/src/finalisers/amd.ts
@@ -49,7 +49,7 @@ export default function amd (
 	)}) {${useStrict}\n\n`;
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
-	const interopBlock = getInteropBlock(chunk, options);
+	const interopBlock = getInteropBlock(dependencies, options, chunk.graph.varOrConst);
 	if (interopBlock) magicString.prepend(interopBlock + '\n\n');
 
 	if (intro) magicString.prepend(intro);

--- a/src/finalisers/iife.ts
+++ b/src/finalisers/iife.ts
@@ -11,7 +11,6 @@ import { isLegal } from '../utils/identifierHelpers';
 import Chunk from '../Chunk';
 import { Bundle as MagicStringBundle } from 'magic-string';
 import { OutputOptions } from '../rollup/index';
-import ExternalModule from '../ExternalModule';
 
 const thisProp = (name: string) => `this${keypath(name)}`;
 
@@ -29,7 +28,7 @@ export default function iife (
 ) {
 	const globalNameMaker = getGlobalNameMaker(
 		options.globals || blank(),
-		chunk,
+		chunk.graph,
 		'null'
 	);
 
@@ -48,9 +47,9 @@ export default function iife (
 
 	warnOnBuiltins(chunk);
 
-	const external = trimEmptyImports(chunk.externalModules);
+	const external = trimEmptyImports(moduleDeclarations.dependencies);
 	const dependencies = external.map(globalNameMaker);
-	const args = (<ExternalModule[]>external).map(m => m.name);
+	const args = external.map(m => m.name);
 
 	if (exportMode !== 'none' && !name) {
 		error({
@@ -90,7 +89,7 @@ export default function iife (
 	}
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
-	const interopBlock = getInteropBlock(chunk, options);
+	const interopBlock = getInteropBlock(moduleDeclarations.dependencies, options, chunk.graph.varOrConst);
 	if (interopBlock) magicString.prepend(interopBlock + '\n\n');
 
 	if (intro) magicString.prepend(intro);

--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -1,29 +1,19 @@
 import { OutputOptions } from "../../rollup/index";
-import Chunk from "../../Chunk";
+import { ModuleDeclarationDependency } from "../../Chunk";
 
-export default function getInteropBlock (chunk: Chunk, options: OutputOptions) {
-	return chunk.externalModules
-		.map(module => {
-			if (!module.declarations.default || options.interop === false)
+export default function getInteropBlock (dependencies: ModuleDeclarationDependency[], options: OutputOptions, varOrConst: string) {
+	return dependencies
+		.map(({ name, exportsNamespace, exportsNames, exportsDefault }) => {
+			if (!exportsDefault || options.interop === false)
 				return null;
 
-			if (module.exportsNamespace) {
-				return `${chunk.graph.varOrConst} ${module.name}__default = ${
-					module.name
-					}['default'];`;
-			}
+			if (exportsNamespace)
+				return `${varOrConst} ${name}__default = ${name}['default'];`;
 
-			if (module.exportsNames) {
-				return `${chunk.graph.varOrConst} ${module.name}__default = 'default' in ${
-					module.name
-					} ? ${module.name}['default'] : ${module.name};`;
-			}
+			if (exportsNames)
+				return `${varOrConst} ${name}__default = 'default' in ${name} ? ${name}['default'] : ${name};`;
 
-			return `${module.name} = ${module.name} && ${
-				module.name
-				}.hasOwnProperty('default') ? ${module.name}['default'] : ${
-				module.name
-				};`;
+			return `${name} = ${name} && ${name}.hasOwnProperty('default') ? ${name}['default'] : ${name};`;
 		})
 		.filter(Boolean)
 		.join('\n');

--- a/src/finalisers/shared/trimEmptyImports.ts
+++ b/src/finalisers/shared/trimEmptyImports.ts
@@ -1,13 +1,14 @@
-import Module from "../../Module";
-import ExternalModule from "../../ExternalModule";
+import { ModuleDeclarationDependency } from "../../Chunk";
 
-export default function trimEmptyImports (modules: (Module | ExternalModule)[]) {
-	let i = modules.length;
+export default function trimEmptyImports (dependencies: ModuleDeclarationDependency[]) {
+	let i = dependencies.length;
 
 	while (i--) {
-		const module = modules[i];
-		if (Object.keys(module.declarations).length > 0) {
-			return modules.slice(0, i + 1);
+		const dependency = dependencies[i];
+		if (dependency.exportsDefault ||
+				dependency.exportsNames ||
+				dependency.exportsNamespace) {
+			return dependencies.slice(0, i + 1);
 		}
 	}
 


### PR DESCRIPTION
Resolves #1992.

The fix for #1992 was relatively straightforward here.

While I was at it I noticed `chunk.externalModules` is a kind of semi-public interface used by finalisers, which could easily get out of sync with further optimization, so I refactored the usage here to be entirely dependent on the data structure created by chunks for their boundaries instead of needing to reach into internals like this. It's not the prettiest of code, but it provides the encapsulation which is necessary to separate thinking about the input graph from thinking about the output graph.