### PR TITLE
Do not add superfluous semicolons after declarations

### DIFF
--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -68,9 +68,9 @@ export default class VariableDeclaration extends NodeBase {
 		) {
 			for (const declarator of this.declarations) {
 				declarator.render(code, options);
-				if (!nodeRenderOptions.isNoStatement && code.original.charCodeAt(this.end - 1) !== 59 /*";"*/) {
-					code.appendLeft(this.end, ';');
-				}
+			}
+			if (!nodeRenderOptions.isNoStatement && code.original.charCodeAt(this.end - 1) !== 59 /*";"*/) {
+				code.appendLeft(this.end, ';');
 			}
 		} else {
 			this.renderReplacedDeclarations(code, options, nodeRenderOptions);

--- a/test/form/samples/render-declaration-semicolons/_config.js
+++ b/test/form/samples/render-declaration-semicolons/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'properly inserts semi-colons after declarations (#1993)',
+	options: { output: { name: 'bundle' } }
+};

--- a/test/form/samples/render-declaration-semicolons/_expected/amd.js
+++ b/test/form/samples/render-declaration-semicolons/_expected/amd.js
@@ -1,0 +1,34 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var a, b;
+	console.log(a, b);
+
+	var c, d;
+	console.log(c, d);
+
+	const e = 1, f = 2;
+	console.log(e, f);
+
+	const g = 3, h = 4;
+	console.log(g, h);
+
+	var i, j;
+
+	var k, l;
+
+	const m = 1, n = 2;
+
+	const o = 3, p = 4;
+
+	exports.i = i;
+	exports.j = j;
+	exports.k = k;
+	exports.l = l;
+	exports.m = m;
+	exports.n = n;
+	exports.o = o;
+	exports.p = p;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/render-declaration-semicolons/_expected/cjs.js
+++ b/test/form/samples/render-declaration-semicolons/_expected/cjs.js
@@ -1,0 +1,32 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var a, b;
+console.log(a, b);
+
+var c, d;
+console.log(c, d);
+
+const e = 1, f = 2;
+console.log(e, f);
+
+const g = 3, h = 4;
+console.log(g, h);
+
+var i, j;
+
+var k, l;
+
+const m = 1, n = 2;
+
+const o = 3, p = 4;
+
+exports.i = i;
+exports.j = j;
+exports.k = k;
+exports.l = l;
+exports.m = m;
+exports.n = n;
+exports.o = o;
+exports.p = p;

--- a/test/form/samples/render-declaration-semicolons/_expected/es.js
+++ b/test/form/samples/render-declaration-semicolons/_expected/es.js
@@ -1,0 +1,21 @@
+var a, b;
+console.log(a, b);
+
+var c, d;
+console.log(c, d);
+
+const e = 1, f = 2;
+console.log(e, f);
+
+const g = 3, h = 4;
+console.log(g, h);
+
+var i, j;
+
+var k, l;
+
+const m = 1, n = 2;
+
+const o = 3, p = 4;
+
+export { i, j, k, l, m, n, o, p };

--- a/test/form/samples/render-declaration-semicolons/_expected/iife.js
+++ b/test/form/samples/render-declaration-semicolons/_expected/iife.js
@@ -1,0 +1,35 @@
+var bundle = (function (exports) {
+	'use strict';
+
+	var a, b;
+	console.log(a, b);
+
+	var c, d;
+	console.log(c, d);
+
+	const e = 1, f = 2;
+	console.log(e, f);
+
+	const g = 3, h = 4;
+	console.log(g, h);
+
+	var i, j;
+
+	var k, l;
+
+	const m = 1, n = 2;
+
+	const o = 3, p = 4;
+
+	exports.i = i;
+	exports.j = j;
+	exports.k = k;
+	exports.l = l;
+	exports.m = m;
+	exports.n = n;
+	exports.o = o;
+	exports.p = p;
+
+	return exports;
+
+}({}));

--- a/test/form/samples/render-declaration-semicolons/_expected/umd.js
+++ b/test/form/samples/render-declaration-semicolons/_expected/umd.js
@@ -1,0 +1,38 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(factory((global.bundle = {})));
+}(this, (function (exports) { 'use strict';
+
+	var a, b;
+	console.log(a, b);
+
+	var c, d;
+	console.log(c, d);
+
+	const e = 1, f = 2;
+	console.log(e, f);
+
+	const g = 3, h = 4;
+	console.log(g, h);
+
+	var i, j;
+
+	var k, l;
+
+	const m = 1, n = 2;
+
+	const o = 3, p = 4;
+
+	exports.i = i;
+	exports.j = j;
+	exports.k = k;
+	exports.l = l;
+	exports.m = m;
+	exports.n = n;
+	exports.o = o;
+	exports.p = p;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/test/form/samples/render-declaration-semicolons/main.js
+++ b/test/form/samples/render-declaration-semicolons/main.js
@@ -1,0 +1,19 @@
+var a, b;
+console.log(a, b);
+
+var c, d
+console.log(c, d)
+
+const e = 1, f = 2;
+console.log(e, f);
+
+const g = 3, h = 4
+console.log(g, h)
+
+export var i, j;
+
+export var k, l
+
+export const m = 1, n = 2;
+
+export const o = 3, p = 4


### PR DESCRIPTION
This was a regression from 0.56.0 due to the semicolon insertion code being put into the wrong place when rendering declarations where nothing was removed. Resolves #1993.