### PR TITLE
use short-circuiting simplifications in LogicalExpression#render (#2004)

### DIFF
--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -7,6 +7,7 @@ import { ForEachReturnExpressionCallback, PredicateFunction, SomeReturnExpressio
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { RenderOptions } from '../../Module';
+import CallExpression from './CallExpression';
 
 export type LogicalOperator = '||' | '&&';
 
@@ -91,7 +92,9 @@ export default class LogicalExpression extends NodeBase {
 			const leftValue = this.left.getValue();
 			if (
 				leftValue === UNKNOWN_VALUE ||
-				(this.parent.type === NodeType.CallExpression && this.right.type === NodeType.MemberExpression)
+					(this.parent.type === NodeType.CallExpression &&
+						(<CallExpression>this.parent).callee === this &&
+						this.right.type === NodeType.MemberExpression)
 			) {
 				super.render(code, options);
 			} else {

--- a/test/form/samples/mutate-logical-expression/_expected/amd.js
+++ b/test/form/samples/mutate-logical-expression/_expected/amd.js
@@ -5,11 +5,11 @@ define(['exports'], function (exports) { 'use strict';
 	logicalAExp.bar = 1;
 
 	var bExp = {};
-	var logicalBExp = false || bExp;
+	var logicalBExp = bExp;
 	logicalBExp.bar = 1;
 
 	var cExp = {};
-	var logicalCExp = true && cExp;
+	var logicalCExp = cExp;
 	logicalCExp.bar = 1;
 
 	exports.aExp = aExp;

--- a/test/form/samples/mutate-logical-expression/_expected/cjs.js
+++ b/test/form/samples/mutate-logical-expression/_expected/cjs.js
@@ -7,11 +7,11 @@ var logicalAExp = aExp || {};
 logicalAExp.bar = 1;
 
 var bExp = {};
-var logicalBExp = false || bExp;
+var logicalBExp = bExp;
 logicalBExp.bar = 1;
 
 var cExp = {};
-var logicalCExp = true && cExp;
+var logicalCExp = cExp;
 logicalCExp.bar = 1;
 
 exports.aExp = aExp;

--- a/test/form/samples/mutate-logical-expression/_expected/es.js
+++ b/test/form/samples/mutate-logical-expression/_expected/es.js
@@ -3,11 +3,11 @@ var logicalAExp = aExp || {};
 logicalAExp.bar = 1;
 
 var bExp = {};
-var logicalBExp = false || bExp;
+var logicalBExp = bExp;
 logicalBExp.bar = 1;
 
 var cExp = {};
-var logicalCExp = true && cExp;
+var logicalCExp = cExp;
 logicalCExp.bar = 1;
 
 export { aExp, bExp, cExp };

--- a/test/form/samples/mutate-logical-expression/_expected/iife.js
+++ b/test/form/samples/mutate-logical-expression/_expected/iife.js
@@ -6,11 +6,11 @@ var bundle = (function (exports) {
 	logicalAExp.bar = 1;
 
 	var bExp = {};
-	var logicalBExp = false || bExp;
+	var logicalBExp = bExp;
 	logicalBExp.bar = 1;
 
 	var cExp = {};
-	var logicalCExp = true && cExp;
+	var logicalCExp = cExp;
 	logicalCExp.bar = 1;
 
 	exports.aExp = aExp;

--- a/test/form/samples/mutate-logical-expression/_expected/umd.js
+++ b/test/form/samples/mutate-logical-expression/_expected/umd.js
@@ -9,11 +9,11 @@
 	logicalAExp.bar = 1;
 
 	var bExp = {};
-	var logicalBExp = false || bExp;
+	var logicalBExp = bExp;
 	logicalBExp.bar = 1;
 
 	var cExp = {};
-	var logicalCExp = true && cExp;
+	var logicalCExp = cExp;
 	logicalCExp.bar = 1;
 
 	exports.aExp = aExp;

--- a/test/form/samples/side-effects-logical-expressions/_expected/amd.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/amd.js
@@ -1,8 +1,8 @@
 define(function () { 'use strict';
 
 	// effect
-	false || console.log( 'effect' );
-	true && console.log( 'effect' );
+	console.log( 'effect' );
+	console.log( 'effect' );
 	console.log( 'effect' ) || {};
 	console.log( 'effect' ) && {};
 
@@ -14,23 +14,27 @@ define(function () { 'use strict';
 	};
 
 	// effect
-	(false || foo).effect;
-	(true && foo).effect;
+	(foo).effect;
+	(foo).effect;
 
 	// effect
-	(false || null).foo = 1;
-	(true && null).foo = 1;
+	(null).foo = 1;
+	(null).foo = 1;
 
 	// effect
-	(true || (() => {}))();
-	(false && (() => {}))();
-	(false || (() => console.log( 'effect' )))();
-	(true && (() => console.log( 'effect' )))();
+	(true)();
+	(false)();
+	(() => console.log( 'effect' ))();
+	(() => console.log( 'effect' ))();
 
 	// effect
-	(true || (() => () => {}))()();
-	(false && (() => () => {}))()();
-	(false || (() => () => console.log( 'effect' )))()();
-	(true && (() => () => console.log( 'effect' )))()();
+	(true)()();
+	(false)()();
+	(() => () => console.log( 'effect' ))()();
+	(() => () => console.log( 'effect' ))()();
+
+	// should maintain this context
+	(true && x.y)();
+	(false || x.y)();
 
 });

--- a/test/form/samples/side-effects-logical-expressions/_expected/amd.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/amd.js
@@ -37,4 +37,10 @@ define(function () { 'use strict';
 	(true && x.y)();
 	(false || x.y)();
 
+	// do not need to maintain context
+	f(x.y);
+	f(true);
+	f(x.y);
+	f(false);
+
 });

--- a/test/form/samples/side-effects-logical-expressions/_expected/cjs.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/cjs.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // effect
-false || console.log( 'effect' );
-true && console.log( 'effect' );
+console.log( 'effect' );
+console.log( 'effect' );
 console.log( 'effect' ) || {};
 console.log( 'effect' ) && {};
 
@@ -14,21 +14,25 @@ const foo = {
 };
 
 // effect
-(false || foo).effect;
-(true && foo).effect;
+(foo).effect;
+(foo).effect;
 
 // effect
-(false || null).foo = 1;
-(true && null).foo = 1;
+(null).foo = 1;
+(null).foo = 1;
 
 // effect
-(true || (() => {}))();
-(false && (() => {}))();
-(false || (() => console.log( 'effect' )))();
-(true && (() => console.log( 'effect' )))();
+(true)();
+(false)();
+(() => console.log( 'effect' ))();
+(() => console.log( 'effect' ))();
 
 // effect
-(true || (() => () => {}))()();
-(false && (() => () => {}))()();
-(false || (() => () => console.log( 'effect' )))()();
-(true && (() => () => console.log( 'effect' )))()();
+(true)()();
+(false)()();
+(() => () => console.log( 'effect' ))()();
+(() => () => console.log( 'effect' ))()();
+
+// should maintain this context
+(true && x.y)();
+(false || x.y)();

--- a/test/form/samples/side-effects-logical-expressions/_expected/cjs.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/cjs.js
@@ -36,3 +36,9 @@ const foo = {
 // should maintain this context
 (true && x.y)();
 (false || x.y)();
+
+// do not need to maintain context
+f(x.y);
+f(true);
+f(x.y);
+f(false);

--- a/test/form/samples/side-effects-logical-expressions/_expected/es.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/es.js
@@ -34,3 +34,9 @@ const foo = {
 // should maintain this context
 (true && x.y)();
 (false || x.y)();
+
+// do not need to maintain context
+f(x.y);
+f(true);
+f(x.y);
+f(false);

--- a/test/form/samples/side-effects-logical-expressions/_expected/es.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/es.js
@@ -1,6 +1,6 @@
 // effect
-false || console.log( 'effect' );
-true && console.log( 'effect' );
+console.log( 'effect' );
+console.log( 'effect' );
 console.log( 'effect' ) || {};
 console.log( 'effect' ) && {};
 
@@ -12,21 +12,25 @@ const foo = {
 };
 
 // effect
-(false || foo).effect;
-(true && foo).effect;
+(foo).effect;
+(foo).effect;
 
 // effect
-(false || null).foo = 1;
-(true && null).foo = 1;
+(null).foo = 1;
+(null).foo = 1;
 
 // effect
-(true || (() => {}))();
-(false && (() => {}))();
-(false || (() => console.log( 'effect' )))();
-(true && (() => console.log( 'effect' )))();
+(true)();
+(false)();
+(() => console.log( 'effect' ))();
+(() => console.log( 'effect' ))();
 
 // effect
-(true || (() => () => {}))()();
-(false && (() => () => {}))()();
-(false || (() => () => console.log( 'effect' )))()();
-(true && (() => () => console.log( 'effect' )))()();
+(true)()();
+(false)()();
+(() => () => console.log( 'effect' ))()();
+(() => () => console.log( 'effect' ))()();
+
+// should maintain this context
+(true && x.y)();
+(false || x.y)();

--- a/test/form/samples/side-effects-logical-expressions/_expected/iife.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/iife.js
@@ -38,4 +38,10 @@
 	(true && x.y)();
 	(false || x.y)();
 
+	// do not need to maintain context
+	f(x.y);
+	f(true);
+	f(x.y);
+	f(false);
+
 }());

--- a/test/form/samples/side-effects-logical-expressions/_expected/iife.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/iife.js
@@ -2,8 +2,8 @@
 	'use strict';
 
 	// effect
-	false || console.log( 'effect' );
-	true && console.log( 'effect' );
+	console.log( 'effect' );
+	console.log( 'effect' );
 	console.log( 'effect' ) || {};
 	console.log( 'effect' ) && {};
 
@@ -15,23 +15,27 @@
 	};
 
 	// effect
-	(false || foo).effect;
-	(true && foo).effect;
+	(foo).effect;
+	(foo).effect;
 
 	// effect
-	(false || null).foo = 1;
-	(true && null).foo = 1;
+	(null).foo = 1;
+	(null).foo = 1;
 
 	// effect
-	(true || (() => {}))();
-	(false && (() => {}))();
-	(false || (() => console.log( 'effect' )))();
-	(true && (() => console.log( 'effect' )))();
+	(true)();
+	(false)();
+	(() => console.log( 'effect' ))();
+	(() => console.log( 'effect' ))();
 
 	// effect
-	(true || (() => () => {}))()();
-	(false && (() => () => {}))()();
-	(false || (() => () => console.log( 'effect' )))()();
-	(true && (() => () => console.log( 'effect' )))()();
+	(true)()();
+	(false)()();
+	(() => () => console.log( 'effect' ))()();
+	(() => () => console.log( 'effect' ))()();
+
+	// should maintain this context
+	(true && x.y)();
+	(false || x.y)();
 
 }());

--- a/test/form/samples/side-effects-logical-expressions/_expected/umd.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/umd.js
@@ -5,8 +5,8 @@
 }(this, (function () { 'use strict';
 
 	// effect
-	false || console.log( 'effect' );
-	true && console.log( 'effect' );
+	console.log( 'effect' );
+	console.log( 'effect' );
 	console.log( 'effect' ) || {};
 	console.log( 'effect' ) && {};
 
@@ -18,23 +18,27 @@
 	};
 
 	// effect
-	(false || foo).effect;
-	(true && foo).effect;
+	(foo).effect;
+	(foo).effect;
 
 	// effect
-	(false || null).foo = 1;
-	(true && null).foo = 1;
+	(null).foo = 1;
+	(null).foo = 1;
 
 	// effect
-	(true || (() => {}))();
-	(false && (() => {}))();
-	(false || (() => console.log( 'effect' )))();
-	(true && (() => console.log( 'effect' )))();
+	(true)();
+	(false)();
+	(() => console.log( 'effect' ))();
+	(() => console.log( 'effect' ))();
 
 	// effect
-	(true || (() => () => {}))()();
-	(false && (() => () => {}))()();
-	(false || (() => () => console.log( 'effect' )))()();
-	(true && (() => () => console.log( 'effect' )))()();
+	(true)()();
+	(false)()();
+	(() => () => console.log( 'effect' ))()();
+	(() => () => console.log( 'effect' ))()();
+
+	// should maintain this context
+	(true && x.y)();
+	(false || x.y)();
 
 })));

--- a/test/form/samples/side-effects-logical-expressions/_expected/umd.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/umd.js
@@ -41,4 +41,10 @@
 	(true && x.y)();
 	(false || x.y)();
 
+	// do not need to maintain context
+	f(x.y);
+	f(true);
+	f(x.y);
+	f(false);
+
 })));

--- a/test/form/samples/side-effects-logical-expressions/main.js
+++ b/test/form/samples/side-effects-logical-expressions/main.js
@@ -53,3 +53,7 @@ const foo = {
 (false && (() => () => {}))()();
 (false || (() => () => console.log( 'effect' )))()();
 (true && (() => () => console.log( 'effect' )))()();
+
+// should maintain this context
+(true && x.y)();
+(false || x.y)();

--- a/test/form/samples/side-effects-logical-expressions/main.js
+++ b/test/form/samples/side-effects-logical-expressions/main.js
@@ -57,3 +57,9 @@ const foo = {
 // should maintain this context
 (true && x.y)();
 (false || x.y)();
+
+// do not need to maintain context
+f(true && x.y);
+f(true || x.y);
+f(false || x.y);
+f(false && x.y);


### PR DESCRIPTION
Hopefully implements #2004 without changing the functionality of any code - including handling the `this` context case with `(true && x.y)()`.

A couple of the later test cases in `side-effects-logical-expressions` gave me pause when updating them, but I could just be overthinking them. Let me know if you'd like any changes made!