### PR TITLE
Automatically remove directories of missing tests

### DIFF
--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -15,7 +15,7 @@ describe('chunking form', () => {
 
 		const config = loadConfig(samples + '/' + dir + '/_config.js');
 
-		if (config.skipIfWindows && process.platform === 'win32') return;
+		if ( !config || (config.skipIfWindows && process.platform === 'win32') ) return;
 		if (!config.options) {
 			config.options = {};
 		}

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -21,6 +21,7 @@ describe('cli', () => {
 		if (dir[0] === '.') return; // .DS_Store...
 
 		const config = loadConfig(samples + '/' + dir + '/_config.js');
+		if ( !config ) return;
 
 		(config.skip ? it.skip : config.solo ? it.only : it)(dir, done => {
 			process.chdir(config.cwd || path.resolve(samples, dir));

--- a/test/form/index.js
+++ b/test/form/index.js
@@ -14,7 +14,7 @@ describe('form', () => {
 
 		const config = loadConfig(samples + '/' + dir + '/_config.js');
 
-		if (config.skipIfWindows && process.platform === 'win32') return;
+		if ( !config || (config.skipIfWindows && process.platform === 'win32') ) return;
 		if (!config.options) {
 			config.options = {};
 		}

--- a/test/function/index.js
+++ b/test/function/index.js
@@ -17,6 +17,8 @@ describe('function', () => {
 		if (dir[0] === '.') return; // .DS_Store...
 
 		const config = loadConfig(samples + '/' + dir + '/_config.js');
+		if ( !config ) return;
+
 		(config.skip ? it.skip : config.solo ? it.only : it)(dir, () => {
 			process.chdir(samples + '/' + dir);
 

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -11,9 +11,10 @@ describe('sourcemaps', () => {
 	sander.readdirSync(samples).sort().forEach(dir => {
 		if (dir[0] === '.') return; // .DS_Store...
 
-		describe(dir, () => {
-			const config = loadConfig(samples + '/' + dir + '/_config.js');
+		const config = loadConfig( samples + '/' + dir + '/_config.js' );
+		if ( !config ) return;
 
+		describe( dir, () => {
 			const input = path.resolve(samples, dir, 'main.js');
 			const output = path.resolve(samples, dir, '_actual/bundle');
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -85,8 +85,10 @@ function loadConfig ( configFile ) {
 	} catch ( err ) {
 		if ( err.code === 'MODULE_NOT_FOUND' ) {
 			const dir = path.dirname( configFile );
-			console.warn( `Test configuration ${configFile} not found.\nRemoving directory as this test probably no longer exists.` );
-			sander.rimrafSync( dir );
+			console.warn( `Test configuration ${configFile} not found.\nTrying to clean up no longer existing test...` );
+			sander.rimrafSync( path.join( dir, '_actual' ) );
+			sander.rmdirSync( dir );
+			console.warn( 'Directory removed.' );
 		} else {
 			throw new Error( `Failed to load ${path}: ${err.message}` );
 		}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,6 @@
-const assert = require('assert');
+const assert = require( 'assert' );
+const path = require( 'path' );
+const sander = require( 'sander' );
 
 exports.compareError = compareError;
 exports.compareWarnings = compareWarnings;
@@ -77,15 +79,17 @@ function extend(target) {
 	return target;
 }
 
-function loadConfig(path) {
+function loadConfig ( configFile ) {
 	try {
-		return require(path);
-	} catch (err) {
-		console.error(err.message);
-		console.error(err.stack);
-		throw new Error(
-			`Failed to load ${path}. An old test perhaps? You should probably delete the directory`
-		);
+		return require( configFile );
+	} catch ( err ) {
+		if ( err.code === 'MODULE_NOT_FOUND' ) {
+			const dir = path.dirname( configFile );
+			console.warn( `Test configuration ${configFile} not found.\nRemoving directory as this test probably no longer exists.` );
+			sander.rimrafSync( dir );
+		} else {
+			throw new Error( `Failed to load ${path}: ${err.message}` );
+		}
 	}
 }
 


### PR DESCRIPTION
This removes a common nuisance when switching between different branches. Previously when there was no `_config.js` file in a test folder, an error would be thrown and the tests would not execute at all until the folder in question was removed.

As in 100% of the cases I experienced this folder could always be safely removed, this will now just display a warning and remove the folder in question. My hope is that if this should ever misfire (due to e.g. larger refactorings of the test system), we will always have the git history to rely on.