### PR TITLE
Throw on rollup build warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import typescript from 'rollup-plugin-typescript';
-import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import json from 'rollup-plugin-json';
+import resolve from 'rollup-plugin-node-resolve';
 import string from 'rollup-plugin-string';
+import typescript from 'rollup-plugin-typescript';
 import pkg from './package.json';
 
 const commitHash = (function () {
@@ -23,6 +23,13 @@ const banner = `/*
 
 	Released under the MIT License.
 */`;
+
+const onwarn = warning => {
+	// eslint-disable-next-line no-console
+	console.error( 'Building Rollup produced warnings that need to be resolved. ' +
+		'Please keep in mind that the browser build may never have external dependencies!' );
+	throw new Error( warning.message );
+};
 
 const src = path.resolve( 'src' );
 const bin = path.resolve( 'bin' );
@@ -54,6 +61,7 @@ export default [
 	/* rollup.js and rollup.es.js */
 	{
 		input: 'src/node-entry.ts',
+		onwarn,
 		plugins: [
 			json(),
 			resolveTypescript(),
@@ -73,6 +81,7 @@ export default [
 	/* rollup.browser.js */
 	{
 		input: 'src/browser-entry.ts',
+		onwarn,
 		plugins: [
 			json(),
 			{
@@ -102,6 +111,7 @@ export default [
 	/* bin/rollup */
 	{
 		input: 'bin/src/index.ts',
+		onwarn,
 		plugins: [
 			string( { include: '**/*.md' } ),
 			json(),

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1,8 +1,8 @@
-import { timeStart, timeEnd } from './utils/flushTime';
+import { timeEnd, timeStart } from './utils/flushTime';
 import { decode } from 'sourcemap-codec';
 import { Bundle as MagicStringBundle } from 'magic-string';
 import { blank, forOwn } from './utils/object';
-import Module, { ModuleJSON, RenderOptions } from './Module';
+import Module, { ModuleJSON } from './Module';
 import finalisers from './finalisers/index';
 import getExportMode from './utils/getExportMode';
 import getIndentString from './utils/getIndentString';
@@ -23,6 +23,7 @@ import ExternalVariable from './ast/variables/ExternalVariable';
 import { makeLegal } from './utils/identifierHelpers';
 import LocalVariable from './ast/variables/LocalVariable';
 import { NodeType } from './ast/nodes/index';
+import { RenderOptions } from './utils/renderHelpers';
 
 export interface ModuleDeclarations {
 	exports: ChunkExports;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1,7 +1,7 @@
 import { IParse, Options as AcornOptions } from 'acorn';
 import MagicString from 'magic-string';
 import { locate } from 'locate-character';
-import { timeStart, timeEnd } from './utils/flushTime';
+import { timeEnd, timeStart } from './utils/flushTime';
 import { blank } from './utils/object';
 import { basename, extname } from './utils/path';
 import { makeLegal } from './utils/identifierHelpers';
@@ -36,7 +36,8 @@ import Import from './ast/nodes/Import';
 import { NodeType } from './ast/nodes/index';
 import { isTemplateLiteral } from './ast/nodes/TemplateLiteral';
 import { isLiteral } from './ast/nodes/Literal';
-import Chunk, { DynamicImportMechanism } from './Chunk';
+import Chunk from './Chunk';
+import { RenderOptions } from './utils/renderHelpers';
 
 export interface IdMap {[key: string]: string;}
 
@@ -105,21 +106,6 @@ export interface ModuleJSON {
 	sourcemapChain: RawSourceMap[];
 	resolvedIds: IdMap;
 }
-
-export interface RenderOptions {
-	legacy: boolean;
-	freeze: boolean;
-	importMechanism?: DynamicImportMechanism;
-	systemBindings: boolean;
-}
-
-export interface NodeRenderOptions {
-	start?: number,
-	end?: number,
-	isNoStatement?: boolean
-}
-
-export const NO_SEMICOLON: NodeRenderOptions = { isNoStatement: true };
 
 export default class Module {
 	type: 'Module';

--- a/src/ast/Entity.ts
+++ b/src/ast/Entity.ts
@@ -1,5 +1,5 @@
 import ExecutionPathOptions from './ExecutionPathOptions';
-import { ObjectPath } from './variables/VariableReassignmentTracker';
+import { ObjectPath } from './values';
 
 export interface Entity {
 	toString: () => string;

--- a/src/ast/ExecutionPathOptions.ts
+++ b/src/ast/ExecutionPathOptions.ts
@@ -3,10 +3,10 @@ import CallExpression from './nodes/CallExpression';
 import CallOptions from './CallOptions';
 import ThisVariable from './variables/ThisVariable';
 import ParameterVariable from './variables/ParameterVariable';
-import { ObjectPath } from './variables/VariableReassignmentTracker';
 import { Entity, WritableEntity } from './Entity';
 import Property from './nodes/Property';
 import { ExpressionEntity } from './nodes/shared/Expression';
+import { ObjectPath } from './values';
 
 export enum OptionTypes {
 	IGNORED_LABELS,

--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -1,11 +1,10 @@
 import SpreadElement from './SpreadElement';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { SomeReturnExpressionCallback } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
 import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { hasMemberEffectWhenCalled, arrayMembers, someMemberReturnExpressionWhenCalled } from '../values';
+import { arrayMembers, hasMemberEffectWhenCalled, ObjectPath, someMemberReturnExpressionWhenCalled } from '../values';
 
 export default class ArrayExpression extends NodeBase {
 	type: NodeType.ArrayExpression;

--- a/src/ast/nodes/ArrayPattern.ts
+++ b/src/ast/nodes/ArrayPattern.ts
@@ -1,7 +1,6 @@
-import { UNKNOWN_EXPRESSION } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import Scope from '../scopes/Scope';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { PatternNode } from './shared/Pattern';
 import { ExpressionEntity } from './shared/Expression';
 import { NodeBase } from './shared/Node';

--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -3,11 +3,11 @@ import ReturnValueScope from '../scopes/ReturnValueScope';
 import BlockStatement, { isBlockStatement } from './BlockStatement';
 import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { PatternNode } from './shared/Pattern';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
+import { ObjectPath } from '../values';
 
 export default class ArrowFunctionExpression extends NodeBase {
 	type: NodeType.ArrowFunctionExpression;

--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -1,8 +1,8 @@
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { PatternNode } from './shared/Pattern';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class AssignmentExpression extends NodeBase {
 	type: NodeType.AssignmentExpression;

--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -1,10 +1,10 @@
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import Scope from '../scopes/Scope';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { PatternNode } from './shared/Pattern';
 import { ExpressionEntity } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class AssignmentPattern extends NodeBase implements PatternNode {
 	type: NodeType.AssignmentPattern;

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -1,6 +1,5 @@
-import { UNKNOWN_VALUE } from '../values';
+import { ObjectPath, UNKNOWN_VALUE } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
 

--- a/src/ast/nodes/BlockStatement.ts
+++ b/src/ast/nodes/BlockStatement.ts
@@ -5,8 +5,7 @@ import Scope from '../scopes/Scope';
 import MagicString from 'magic-string';
 import { Node, StatementBase, StatementNode } from './shared/Node';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
-import { renderStatementList } from '../../utils/renderHelpers';
+import { RenderOptions, renderStatementList } from '../../utils/renderHelpers';
 
 export function isBlockStatement (node: Node): node is BlockStatement {
 	return node.type === NodeType.BlockStatement;

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -2,12 +2,12 @@ import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import SpreadElement from './SpreadElement';
 import { isGlobalVariable } from '../variables/GlobalVariable';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { isIdentifier } from './Identifier';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { isNamespaceVariable } from '../variables/NamespaceVariable';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
+import { ObjectPath } from '../values';
 
 export default class CallExpression extends NodeBase {
 	type: NodeType.CallExpression;

--- a/src/ast/nodes/ClassBody.ts
+++ b/src/ast/nodes/ClassBody.ts
@@ -2,8 +2,8 @@ import { NodeBase } from './shared/Node';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import CallOptions from '../CallOptions';
 import MethodDefinition from './MethodDefinition';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class ClassBody extends NodeBase {
 	type: NodeType.ClassBody;

--- a/src/ast/nodes/ClassDeclaration.ts
+++ b/src/ast/nodes/ClassDeclaration.ts
@@ -3,8 +3,8 @@ import Scope from '../scopes/Scope';
 import Identifier from './Identifier';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
 import { Node } from './shared/Node';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export function isClassDeclaration (node: Node): node is ClassDeclaration {
 	return node.type === NodeType.ClassDeclaration;

--- a/src/ast/nodes/ClassExpression.ts
+++ b/src/ast/nodes/ClassExpression.ts
@@ -1,8 +1,8 @@
 import ClassNode from './shared/ClassNode';
 import Scope from '../scopes/Scope';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class ClassExpression extends ClassNode {
 	type: NodeType.ClassExpression;

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -1,13 +1,12 @@
-import { UNKNOWN_VALUE } from '../values';
+import { ObjectPath, UNKNOWN_VALUE } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import CallOptions from '../CallOptions';
 import Scope from '../scopes/Scope';
 import MagicString from 'magic-string';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export default class ConditionalExpression extends NodeBase {
 	type: NodeType.ConditionalExpression;

--- a/src/ast/nodes/EmptyStatement.ts
+++ b/src/ast/nodes/EmptyStatement.ts
@@ -1,7 +1,7 @@
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
 import { StatementBase } from './shared/Node';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export default class EmptyStatement extends StatementBase {
 	type: NodeType.EmptyStatement;

--- a/src/ast/nodes/ExportAllDeclaration.ts
+++ b/src/ast/nodes/ExportAllDeclaration.ts
@@ -2,8 +2,8 @@ import { NodeBase } from './shared/Node';
 import Literal from './Literal';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
-import { NodeRenderOptions, RenderOptions } from '../../Module';
 import { BLANK } from '../../utils/object';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 
 export default class ExportAllDeclaration extends NodeBase {
 	type: NodeType.ExportAllDeclaration;

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -5,8 +5,7 @@ import FunctionDeclaration, { isFunctionDeclaration } from './FunctionDeclaratio
 import Identifier from './Identifier';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
-import { NodeRenderOptions, RenderOptions } from '../../Module';
-import { findFirstOccurrenceOutsideComment } from '../../utils/renderHelpers';
+import { findFirstOccurrenceOutsideComment, NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { isObjectExpression } from './ObjectExpression';
 import { BLANK } from '../../utils/object';
 

--- a/src/ast/nodes/ExportNamedDeclaration.ts
+++ b/src/ast/nodes/ExportNamedDeclaration.ts
@@ -1,4 +1,4 @@
-import { NodeBase, Node } from './shared/Node';
+import { Node, NodeBase } from './shared/Node';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import Literal from './Literal';
 import MagicString from 'magic-string';
@@ -7,8 +7,8 @@ import FunctionDeclaration from './FunctionDeclaration';
 import ClassDeclaration from './ClassDeclaration';
 import VariableDeclaration from './VariableDeclaration';
 import { NodeType } from './NodeType';
-import { NodeRenderOptions, RenderOptions } from '../../Module';
 import { BLANK } from '../../utils/object';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 
 export default class ExportNamedDeclaration extends NodeBase {
 	type: NodeType.ExportNamedDeclaration;

--- a/src/ast/nodes/ExpressionStatement.ts
+++ b/src/ast/nodes/ExpressionStatement.ts
@@ -1,7 +1,7 @@
 import MagicString from 'magic-string';
 import Scope from '../scopes/Scope';
-import { RenderOptions } from '../../Module';
 import { StatementBase } from './shared/Node';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export default class ExpressionStatement extends StatementBase {
 	directive?: string;

--- a/src/ast/nodes/ForInStatement.ts
+++ b/src/ast/nodes/ForInStatement.ts
@@ -6,8 +6,8 @@ import BlockStatement from './BlockStatement';
 import { PatternNode } from './shared/Pattern';
 import { NodeType } from './NodeType';
 import { ExpressionNode, Node, StatementBase, StatementNode } from './shared/Node';
-import { NO_SEMICOLON, RenderOptions } from '../../Module';
 import MagicString from 'magic-string';
+import { NO_SEMICOLON, RenderOptions } from '../../utils/renderHelpers';
 
 export function isForInStatement (node: Node): node is ForInStatement {
 	return node.type === NodeType.ForInStatement;

--- a/src/ast/nodes/ForOfStatement.ts
+++ b/src/ast/nodes/ForOfStatement.ts
@@ -6,8 +6,8 @@ import BlockStatement from './BlockStatement';
 import { PatternNode } from './shared/Pattern';
 import { NodeType } from './NodeType';
 import { ExpressionNode, Node, StatementBase, StatementNode } from './shared/Node';
-import { NO_SEMICOLON, RenderOptions } from '../../Module';
 import MagicString from 'magic-string';
+import { NO_SEMICOLON, RenderOptions } from '../../utils/renderHelpers';
 
 export function isForOfStatement (node: Node): node is ForOfStatement {
 	return node.type === NodeType.ForOfStatement;

--- a/src/ast/nodes/ForStatement.ts
+++ b/src/ast/nodes/ForStatement.ts
@@ -4,8 +4,8 @@ import ExecutionPathOptions from '../ExecutionPathOptions';
 import Scope from '../scopes/Scope';
 import { NodeType } from './NodeType';
 import { ExpressionNode, Node, StatementBase, StatementNode } from './shared/Node';
-import { NO_SEMICOLON, RenderOptions } from '../../Module';
 import MagicString from 'magic-string';
+import { NO_SEMICOLON, RenderOptions } from '../../utils/renderHelpers';
 
 export function isForStatement (node: Node): node is ForStatement {
 	return node.type === NodeType.ForStatement;

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -1,6 +1,6 @@
 import { Node, NodeBase } from './shared/Node';
 import isReference from 'is-reference';
-import { UNKNOWN_EXPRESSION } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import Scope from '../scopes/Scope';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import Variable from '../variables/Variable';
@@ -8,12 +8,11 @@ import CallOptions from '../CallOptions';
 import FunctionScope from '../scopes/FunctionScope';
 import MagicString from 'magic-string';
 import Property from './Property';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ExpressionEntity, ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
 import AssignmentExpression from './AssignmentExpression';
 import UpdateExpression from './UpdateExpression';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export function isIdentifier (node: Node): node is Identifier {
 	return node.type === NodeType.Identifier;

--- a/src/ast/nodes/IfStatement.ts
+++ b/src/ast/nodes/IfStatement.ts
@@ -5,7 +5,7 @@ import { ExpressionNode, Node, StatementBase, StatementNode } from './shared/Nod
 import { isVariableDeclaration } from './VariableDeclaration';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 // Statement types which may contain if-statements as direct children.
 const statementsWithIfStatements = new Set([

--- a/src/ast/nodes/Import.ts
+++ b/src/ast/nodes/Import.ts
@@ -3,7 +3,7 @@ import { NodeType } from './NodeType';
 import { NodeBase } from './shared/Node';
 import MagicString from 'magic-string';
 import NamespaceVariable from '../variables/NamespaceVariable';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export default class Import extends NodeBase {
 	type: NodeType.Import;

--- a/src/ast/nodes/ImportDeclaration.ts
+++ b/src/ast/nodes/ImportDeclaration.ts
@@ -5,8 +5,8 @@ import ImportDefaultSpecifier from './ImportDefaultSpecifier';
 import ImportNamespaceSpecifier from './ImportNamespaceSpecifier';
 import MagicString from 'magic-string';
 import { NodeType } from './NodeType';
-import { NodeRenderOptions, RenderOptions } from '../../Module';
 import { BLANK } from '../../utils/object';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 
 export default class ImportDeclaration extends NodeBase {
 	type: NodeType.ImportDeclaration;

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -1,12 +1,17 @@
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import MagicString from 'magic-string';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { SomeReturnExpressionCallback } from './shared/Expression';
 import { Node, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
 import CallOptions from '../CallOptions';
-import { RenderOptions } from '../../Module';
-import { getLiteralMembersForValue, hasMemberEffectWhenCalled, MemberDescription, someMemberReturnExpressionWhenCalled } from '../values';
+import {
+	getLiteralMembersForValue,
+	hasMemberEffectWhenCalled,
+	MemberDescription,
+	ObjectPath,
+	someMemberReturnExpressionWhenCalled
+} from '../values';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export type LiteralValueTypes = string | boolean | null | number | RegExp;
 

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -1,7 +1,6 @@
-import { UNKNOWN_VALUE } from '../values';
+import { ObjectPath, UNKNOWN_VALUE } from '../values';
 import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ForEachReturnExpressionCallback, PredicateFunction, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -1,6 +1,5 @@
 import relativeId from '../../utils/relativeId';
 import { ExpressionNode, Node, NodeBase } from './shared/Node';
-import { isUnknownKey, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../variables/VariableReassignmentTracker';
 import Variable from '../variables/Variable';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import { isLiteral } from './Literal';
@@ -11,7 +10,8 @@ import { isNamespaceVariable } from '../variables/NamespaceVariable';
 import { isExternalVariable } from '../variables/ExternalVariable';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
+import { isUnknownKey, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../values';
 
 const validProp = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 

--- a/src/ast/nodes/MethodDefinition.ts
+++ b/src/ast/nodes/MethodDefinition.ts
@@ -2,8 +2,8 @@ import { ExpressionNode, NodeBase } from './shared/Node';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import FunctionExpression from './FunctionExpression';
 import CallOptions from '../CallOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class MethodDefinition extends NodeBase {
 	type: NodeType.MethodDefinition;

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -1,8 +1,8 @@
 import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class NewExpression extends NodeBase {
 	type: NodeType.NewExpression;

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -1,10 +1,9 @@
-import { isUnknownKey, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../variables/VariableReassignmentTracker';
 import Property from './Property';
 import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import Identifier from './Identifier';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
-import { objectMembers } from '../values';
+import { isUnknownKey, objectMembers, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../values';
 import { Node, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
 

--- a/src/ast/nodes/ObjectPattern.ts
+++ b/src/ast/nodes/ObjectPattern.ts
@@ -1,11 +1,11 @@
 import AssignmentProperty from './AssignmentProperty';
 import Scope from '../scopes/Scope';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ExpressionEntity } from './shared/Expression';
 import { PatternNode } from './shared/Pattern';
 import { NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class ObjectPattern extends NodeBase implements PatternNode {
 	type: NodeType.ObjectPattern;

--- a/src/ast/nodes/Program.ts
+++ b/src/ast/nodes/Program.ts
@@ -1,8 +1,7 @@
 import MagicString from 'magic-string';
 import { NodeBase, StatementNode } from './shared/Node';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
-import { renderStatementList } from '../../utils/renderHelpers';
+import { RenderOptions, renderStatementList } from '../../utils/renderHelpers';
 
 export default class Program extends NodeBase {
 	type: NodeType.Program;

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -1,13 +1,12 @@
-import { NodeBase, Node, ExpressionNode } from './shared/Node';
+import { ExpressionNode, Node, NodeBase } from './shared/Node';
 import CallOptions from '../CallOptions';
-import { UNKNOWN_EXPRESSION } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import Scope from '../scopes/Scope';
 import MagicString from 'magic-string';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { ExpressionEntity, ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export function isProperty (node: Node): node is Property {
 	return node.type === NodeType.Property;

--- a/src/ast/nodes/RestElement.ts
+++ b/src/ast/nodes/RestElement.ts
@@ -1,7 +1,6 @@
-import { UNKNOWN_EXPRESSION } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import Scope from '../scopes/Scope';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { PatternNode } from './shared/Pattern';
 import { ExpressionEntity } from './shared/Expression';
 import { NodeBase } from './shared/Node';

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -2,7 +2,7 @@ import ExecutionPathOptions from '../ExecutionPathOptions';
 import MagicString from 'magic-string';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export default class SequenceExpression extends NodeBase {
 	type: NodeType.SequenceExpression;

--- a/src/ast/nodes/SwitchCase.ts
+++ b/src/ast/nodes/SwitchCase.ts
@@ -1,7 +1,6 @@
 import { ExpressionNode, NodeBase, StatementNode } from './shared/Node';
 import { NodeType } from './NodeType';
-import { findFirstOccurrenceOutsideComment, renderStatementList } from '../../utils/renderHelpers';
-import { RenderOptions } from '../../Module';
+import { findFirstOccurrenceOutsideComment, RenderOptions, renderStatementList } from '../../utils/renderHelpers';
 import MagicString from 'magic-string';
 
 export default class SwitchCase extends NodeBase {

--- a/src/ast/nodes/TemplateLiteral.ts
+++ b/src/ast/nodes/TemplateLiteral.ts
@@ -1,8 +1,8 @@
 import TemplateElement from './TemplateElement';
 import MagicString from 'magic-string';
-import { Node, ExpressionNode, NodeBase } from './shared/Node';
+import { ExpressionNode, Node, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
 
 export function isTemplateLiteral (node: Node): node is TemplateLiteral {
 	return node.type === NodeType.TemplateLiteral;

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -1,10 +1,10 @@
 import ThisVariable from '../variables/ThisVariable';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import MagicString from 'magic-string';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../Module';
+import { RenderOptions } from '../../utils/renderHelpers';
+import { ObjectPath } from '../values';
 
 export default class ThisExpression extends NodeBase {
 	type: NodeType.ThisExpression;

--- a/src/ast/nodes/UnaryExpression.ts
+++ b/src/ast/nodes/UnaryExpression.ts
@@ -1,6 +1,5 @@
-import { UNKNOWN_VALUE } from '../values';
+import { ObjectPath, UNKNOWN_VALUE } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
 

--- a/src/ast/nodes/UpdateExpression.ts
+++ b/src/ast/nodes/UpdateExpression.ts
@@ -1,8 +1,8 @@
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { isIdentifier } from './Identifier';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
+import { ObjectPath } from '../values';
 
 export default class UpdateExpression extends NodeBase {
 	type: NodeType.UpdateExpression;

--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -2,13 +2,12 @@ import { Node, NodeBase } from './shared/Node';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import VariableDeclarator from './VariableDeclarator';
 import MagicString from 'magic-string';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { NodeType } from './NodeType';
-import { NodeRenderOptions, RenderOptions } from '../../Module';
-import { getCommaSeparatedNodesWithBoundaries } from '../../utils/renderHelpers';
+import { getCommaSeparatedNodesWithBoundaries, NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { isIdentifier } from './Identifier';
 import Variable from '../variables/Variable';
 import { BLANK } from '../../utils/object';
+import { ObjectPath } from '../values';
 
 function isReassignedExportsMember (variable: Variable): boolean {
 	return variable.safeName && variable.safeName.indexOf('.') !== -1 && variable.exportName && variable.isReassigned;

--- a/src/ast/nodes/VariableDeclarator.ts
+++ b/src/ast/nodes/VariableDeclarator.ts
@@ -1,9 +1,9 @@
-import { NodeBase, ExpressionNode } from './shared/Node';
+import { ExpressionNode, NodeBase } from './shared/Node';
 import Scope from '../scopes/Scope';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { ObjectPath } from '../variables/VariableReassignmentTracker';
 import { PatternNode } from './shared/Pattern';
 import { NodeType } from './NodeType';
+import { ObjectPath } from '../values';
 
 export default class VariableDeclarator extends NodeBase {
 	type: NodeType.VariableDeclarator;

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -2,9 +2,9 @@ import Scope from '../../scopes/Scope';
 import CallOptions from '../../CallOptions';
 import ExecutionPathOptions from '../../ExecutionPathOptions';
 import Identifier from '../Identifier';
-import { ObjectPath } from '../../variables/VariableReassignmentTracker';
 import ClassBody from '../ClassBody';
 import { ExpressionNode, NodeBase } from './Node';
+import { ObjectPath } from '../../values';
 
 export default class ClassNode extends NodeBase {
 	body: ClassBody;

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -1,7 +1,7 @@
 import { WritableEntity } from '../../Entity';
-import { ObjectPath } from '../../variables/VariableReassignmentTracker';
 import CallOptions from '../../CallOptions';
 import ExecutionPathOptions from '../../ExecutionPathOptions';
+import { ObjectPath } from '../../values';
 
 export type PredicateFunction = (node: ExpressionEntity) => boolean;
 export type SomeReturnExpressionCallback = (options: ExecutionPathOptions) => PredicateFunction;

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -4,10 +4,10 @@ import BlockStatement from '../BlockStatement';
 import Identifier from '../Identifier';
 import CallOptions from '../../CallOptions';
 import ExecutionPathOptions from '../../ExecutionPathOptions';
-import { ObjectPath } from '../../variables/VariableReassignmentTracker';
 import { PatternNode } from './Pattern';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './Expression';
 import { NodeBase } from './Node';
+import { ObjectPath } from '../../values';
 
 export default class FunctionNode extends NodeBase {
 	id: Identifier;

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -1,14 +1,14 @@
 import { locate } from 'locate-character';
 import ExecutionPathOptions from '../../ExecutionPathOptions';
 import Scope from '../../scopes/Scope';
-import Module, { NodeRenderOptions, RenderOptions } from '../../../Module';
+import Module from '../../../Module';
 import MagicString from 'magic-string';
 import Variable from '../../variables/Variable';
 import { ExpressionEntity, ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './Expression';
-import { ObjectPath } from '../../variables/VariableReassignmentTracker';
 import CallOptions from '../../CallOptions';
-import { UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../../values';
+import { ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../../values';
 import { Entity } from '../../Entity';
+import { NodeRenderOptions, RenderOptions } from '../../../utils/renderHelpers';
 
 export interface Node extends Entity {
 	end: number;

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -1,9 +1,24 @@
 import { ExpressionEntity, SomeReturnExpressionCallback } from './nodes/shared/Expression';
 import { blank } from '../utils/object';
 import CallOptions from './CallOptions';
-import { isUnknownKey, ObjectPath, ObjectPathKey } from './variables/VariableReassignmentTracker';
 import { LiteralValueTypes } from './nodes/Literal';
 import ExecutionPathOptions from './ExecutionPathOptions';
+
+export interface UnknownKey {
+	type: 'UNKNOWN_KEY';
+}
+
+export type ObjectPathKey = string | UnknownKey
+export type ObjectPath = ObjectPathKey[];
+
+export function isUnknownKey (key: ObjectPathKey): key is UnknownKey {
+	return key === UNKNOWN_KEY;
+}
+
+export const UNKNOWN_KEY: UnknownKey = { type: 'UNKNOWN_KEY' };
+
+export type PathCallback = (path: ObjectPath, expression: ExpressionEntity) => void;
+export type PathPredicate = (path: ObjectPath, expression: ExpressionEntity) => boolean;
 
 export interface MemberDescription {
 	returns: ExpressionEntity,

--- a/src/ast/variables/ArgumentsVariable.ts
+++ b/src/ast/variables/ArgumentsVariable.ts
@@ -1,9 +1,8 @@
 import LocalVariable from './LocalVariable';
-import { UNKNOWN_EXPRESSION } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import CallOptions from '../CallOptions';
 import ParameterVariable from './ParameterVariable';
-import { ObjectPath } from './VariableReassignmentTracker';
 import { SomeReturnExpressionCallback } from '../nodes/shared/Expression';
 
 const getParameterVariable = (path: ObjectPath, options: ExecutionPathOptions) => {

--- a/src/ast/variables/GlobalVariable.ts
+++ b/src/ast/variables/GlobalVariable.ts
@@ -1,6 +1,6 @@
 import Variable from './Variable';
 import pureFunctions from '../nodes/shared/pureFunctions';
-import { ObjectPath } from './VariableReassignmentTracker';
+import { ObjectPath } from '../values';
 
 export function isGlobalVariable (variable: Variable): variable is GlobalVariable {
 	return variable.isGlobal;

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -1,10 +1,11 @@
 import Variable from './Variable';
-import VariableReassignmentTracker, { ObjectPath } from './VariableReassignmentTracker';
+import VariableReassignmentTracker from './VariableReassignmentTracker';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import CallOptions from '../CallOptions';
 import Identifier from '../nodes/Identifier';
 import ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import { ExpressionEntity, ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from '../nodes/shared/Expression';
+import { ObjectPath } from '../values';
 
 // To avoid infinite recursions
 const MAX_PATH_DEPTH = 7;

--- a/src/ast/variables/ReplaceableInitializationVariable.ts
+++ b/src/ast/variables/ReplaceableInitializationVariable.ts
@@ -1,9 +1,8 @@
 import LocalVariable from './LocalVariable';
-import { UNKNOWN_EXPRESSION } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import CallOptions from '../CallOptions';
 import Identifier from '../nodes/Identifier';
-import { ObjectPath } from './VariableReassignmentTracker';
 import { ExpressionEntity, SomeReturnExpressionCallback } from '../nodes/shared/Expression';
 
 export default class ReplaceableInitializationVariable extends LocalVariable {

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -1,8 +1,7 @@
-import { UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../values';
 import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import Identifier from '../nodes/Identifier';
-import { ObjectPath } from './VariableReassignmentTracker';
 import { ExpressionEntity, ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from '../nodes/shared/Expression';
 
 export default class Variable implements ExpressionEntity {

--- a/src/ast/variables/VariableReassignmentTracker.ts
+++ b/src/ast/variables/VariableReassignmentTracker.ts
@@ -1,22 +1,6 @@
-import { UNKNOWN_EXPRESSION } from '../values';
+import { ObjectPath, ObjectPathKey, PathCallback, PathPredicate, UNKNOWN_EXPRESSION, UNKNOWN_KEY } from '../values';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import { ExpressionEntity } from '../nodes/shared/Expression';
-
-export interface UnknownKey {
-	type: 'UNKNOWN_KEY';
-}
-
-export type ObjectPathKey = string | UnknownKey
-export type ObjectPath = ObjectPathKey[];
-
-export function isUnknownKey (key: ObjectPathKey): key is UnknownKey {
-	return key === UNKNOWN_KEY;
-}
-
-export const UNKNOWN_KEY: UnknownKey = { type: 'UNKNOWN_KEY' };
-
-export type PathCallback = (path: ObjectPath, expression: ExpressionEntity) => void;
-export type PathPredicate = (path: ObjectPath, expression: ExpressionEntity) => boolean;
 
 class ReassignedPathTracker {
 	_reassigned: boolean;

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -1,6 +1,21 @@
 import { Node } from '../ast/nodes/shared/Node';
 import MagicString from 'magic-string';
-import { RenderOptions } from '../Module';
+import { DynamicImportMechanism } from '../Chunk';
+
+export interface RenderOptions {
+	legacy: boolean;
+	freeze: boolean;
+	importMechanism?: DynamicImportMechanism;
+	systemBindings: boolean;
+}
+
+export interface NodeRenderOptions {
+	start?: number,
+	end?: number,
+	isNoStatement?: boolean
+}
+
+export const NO_SEMICOLON: NodeRenderOptions = { isNoStatement: true };
 
 export function findFirstOccurrenceOutsideComment (code: string, searchString: string, start: number = 0) {
 	let commentStart, searchPos;


### PR DESCRIPTION
This PR will throw if building rollup itself displays a warning.

In the past, we often had issues with PRs that accidentally introduced external dependencies (usually node builtins) into the browser build. The main reason was that warnings in the build process were easily overlooked. This is now changed by throwing an error in these situations that will prevent a successful build until all warnings are fixed.

Errors will be thrown for any kind of warnings, including circular dependencies. To make this possible, some definitions had to be moved around to resolve the existing circles. Should there ever be a situation where circular dependencies cannot be avoided, I would suggest to add an exception to the `onwarn` handler. However I would find it preferable to avoid them altogether as they can always be an indication of architectural problems.
