### PR TITLE
Fix for #2018

### DIFF
--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -105,7 +105,7 @@ export default class ExportDefaultDeclaration extends NodeBase {
 			`${this.module.graph.varOrConst} ${this.variable.getName()} = ${systemBinding}`
 		);
 		if (systemBinding) {
-			code.prependRight(this.end - 1, ')');
+			code.appendRight(code.original[this.end - 1] === ';' ? this.end - 1 : this.end, ')');
 		}
 	}
 

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -149,7 +149,7 @@ export default class Identifier extends NodeBase {
 						break;
 					}
 					code.overwrite(expression.start, expression.end,
-						`(exports(${this.variable.exportName}, ${op}), ${name}${expression.operator})`);
+						`(exports('${this.variable.exportName}', ${op}), ${name}${expression.operator})`);
 				}
 			}
 			break;

--- a/test/chunking-form/samples/entrypoint-facade/_expected/amd/chunk1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/amd/chunk1.js
@@ -1,6 +1,6 @@
 define(['exports'], function (exports) { 'use strict';
 
-  var dep = 42;
+  var dep = { x: 42 }
 
   function log (x) {
     if (dep) {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/cjs/chunk1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/cjs/chunk1.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var dep = 42;
+var dep = { x: 42 }
 
 function log (x) {
   if (dep) {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/chunk1.js
@@ -1,4 +1,4 @@
-var dep = 42;
+var dep = { x: 42 }
 
 function log (x) {
   if (dep) {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/chunk1.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
     execute: function () {
 
       exports('default', log);
-      var dep = exports('default$1', 42);
+      var dep = exports('default$1', { x: 42 })
 
       function log (x) {
         if (dep) {

--- a/test/chunking-form/samples/entrypoint-facade/dep.js
+++ b/test/chunking-form/samples/entrypoint-facade/dep.js
@@ -1,1 +1,1 @@
-export default 42;
+export default { x: 42 }


### PR DESCRIPTION
Fixes the `export default { obj }` case being output as `exports('default', { obj )}` instead of `exports('default', { obj })`.