### PR TITLE
Isolated test case and fix for #2015

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -252,14 +252,14 @@ export default class Chunk {
 			exportName = variable.name;
 		}
 
+		// if we already import this variable skip
+		if (this.imports.some(impt => impt.variables.some(v => v.variable === variable))) {
+			return;
+		}
+
 		let impt = this.imports.find(impt => impt.module === importModule);
 		if (!impt) {
 			this.imports.push(impt = { module: importModule, variables: [] });
-		}
-
-		// if we already import this variable skip
-		if (impt.variables.some(v => v.module === tracedExport.module && v.variable === variable)) {
-			return;
 		}
 
 		impt.variables.push({

--- a/test/chunking-form/samples/import-variable-duplicates/_config.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'chunk duplicate import deshadowing',
+	options: {
+		input: ['main1.js', 'main2.js', 'first.js', 'head.js']
+	}
+};

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/first.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/first.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var head2 = 'first';
+
+	return head2;
+
+});

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/head.js
@@ -1,0 +1,7 @@
+define(['./first.js'], function (__first_js) { 'use strict';
+
+
+
+	return __first_js.default;
+
+});

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
@@ -1,0 +1,6 @@
+define(['./first.js', './head.js'], function (__first_js, __head_js) { 'use strict';
+
+	console.log(__first_js.default);
+	console.log(__first_js.default);
+
+});

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main2.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main2.js
@@ -1,0 +1,5 @@
+define(['./first.js', './head.js'], function (__first_js, __head_js) { 'use strict';
+
+
+
+});

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/first.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/first.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var head2 = 'first';
+
+module.exports = head2;

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/head.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var __first_js = require('./first.js');
+
+
+
+module.exports = __first_js.default;

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var __first_js = require('./first.js');
+require('./head.js');
+
+console.log(__first_js.default);
+console.log(__first_js.default);

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require('./first.js');
+require('./head.js');
+

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/es/first.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/es/first.js
@@ -1,0 +1,3 @@
+var head2 = 'first';
+
+export default head2;

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/es/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/es/head.js
@@ -1,0 +1,1 @@
+export { default } from './first.js';

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/es/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/es/main1.js
@@ -1,0 +1,5 @@
+import head2 from './first.js';
+import './head.js';
+
+console.log(head2);
+console.log(head2);

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/es/main2.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/es/main2.js
@@ -1,0 +1,2 @@
+import './first.js';
+import './head.js';

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/system/first.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/system/first.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var head2 = exports('default', 'first');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/system/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/system/head.js
@@ -1,0 +1,13 @@
+System.register(['./first.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('default', module.default);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/system/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/system/main1.js
@@ -1,0 +1,17 @@
+System.register(['./first.js', './head.js'], function (exports, module) {
+	'use strict';
+	var head2;
+	return {
+		setters: [function (module) {
+			head2 = module.default;
+		}, function (module) {
+			
+		}],
+		execute: function () {
+
+			console.log(head2);
+			console.log(head2);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/system/main2.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/system/main2.js
@@ -1,0 +1,15 @@
+System.register(['./first.js', './head.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			
+		}, function (module) {
+			
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/import-variable-duplicates/first.js
+++ b/test/chunking-form/samples/import-variable-duplicates/first.js
@@ -1,0 +1,1 @@
+export default 'first';

--- a/test/chunking-form/samples/import-variable-duplicates/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/head.js
@@ -1,0 +1,1 @@
+export { default } from './first.js';

--- a/test/chunking-form/samples/import-variable-duplicates/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/main1.js
@@ -1,0 +1,5 @@
+import head1 from './first.js';
+import head2 from './head.js';
+
+console.log(head1);
+console.log(head2);

--- a/test/chunking-form/samples/import-variable-duplicates/main2.js
+++ b/test/chunking-form/samples/import-variable-duplicates/main2.js
@@ -1,0 +1,2 @@
+import './first.js';
+import './head.js';


### PR DESCRIPTION
The issue here is that because we do tracing and deshadowing with variable as the unit of deshadowing, we always need to ensure that imports of chunks always dedupe to one usage of a variable even if that same variable is imported multiple times.