### PR TITLE
Reexport tracing shortpaths fix

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -309,9 +309,6 @@ export default class Chunk {
 
 	// trace a module export to its exposed chunk module export
 	// either in this chunk or in another
-	// we follow reexports if they are not entry points in the hope
-	// that we can get an entry point reexport to reduce the chance of
-	// tainting an entryModule chunk by exposing other unnecessary exports
 	traceExport (module: Module | ExternalModule, name: string): { name: string, module: Module | ExternalModule } {
 		if (name === '*') {
 			return { name, module };
@@ -321,8 +318,13 @@ export default class Chunk {
 			return { name, module };
 		}
 
-		if (module.chunk !== this && module.isEntryPoint) {
-			return { name, module };
+		if (module.chunk !== this) {
+			// we follow reexports if they are not entry points in the hope
+			// that we can get an entry point reexport to reduce the chance of
+			// tainting an entryModule chunk by exposing other unnecessary exports
+			if (module.isEntryPoint)
+				return { name, module };
+			return module.chunk.traceExport(module, name);
 		}
 
 		const exportDeclaration = module.exports[name];
@@ -568,6 +570,12 @@ export default class Chunk {
 		const reexportDeclarations = this.getCheckReexportDeclarations();
 
 		const dependencies: ChunkDependencies = [];
+
+		// shortcut cross-chunk relations can be added by traceExport
+		this.imports.forEach(impt => {
+			if (this.dependencies.indexOf(impt.module) === -1)
+				this.dependencies.push(impt.module);
+		});
 
 		this.dependencies.forEach(dep => {
 			const importSpecifiers = this.imports.find(impt => impt.module === dep);

--- a/test/chunking-form/samples/reexport-shortpaths/_config.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'Tracing reexport shortpaths to entry points',
+	options: {
+		input: ['main1.js', 'main2.js', 'main3.js']
+	}
+};

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/amd/chunk1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/amd/chunk1.js
@@ -1,0 +1,7 @@
+define(['exports'], function (exports) { 'use strict';
+
+	function foo() {}
+
+	exports.default = foo;
+
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/amd/chunk2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/amd/chunk2.js
@@ -1,0 +1,5 @@
+define(['exports', './chunk1.js'], function (exports, __chunk1_js) { 'use strict';
+
+
+
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main1.js
@@ -1,0 +1,7 @@
+define(['./chunk2.js', './chunk1.js'], function (__chunk2_js, __chunk1_js) { 'use strict';
+
+
+
+	return __chunk1_js.default;
+
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main2.js
@@ -1,0 +1,5 @@
+define(['./chunk2.js'], function (__chunk2_js) { 'use strict';
+
+
+
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main3.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main3.js
@@ -1,0 +1,5 @@
+define(['./chunk1.js'], function (__chunk1_js) { 'use strict';
+
+
+
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/chunk1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/chunk1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+function foo() {}
+
+exports.default = foo;

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/chunk2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/chunk2.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./chunk1.js');
+

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+require('./chunk2.js');
+var __chunk1_js = require('./chunk1.js');
+
+
+
+module.exports = __chunk1_js.default;

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main2.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./chunk2.js');
+

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main3.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main3.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require('./chunk1.js');
+

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk1.js
@@ -1,0 +1,3 @@
+function foo() {}
+
+export default foo;

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk2.js
@@ -1,0 +1,1 @@
+import './chunk1.js';

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
@@ -1,0 +1,6 @@
+import './chunk2.js';
+import foo from './chunk1.js';
+
+
+
+export default foo;

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/main2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/main2.js
@@ -1,0 +1,1 @@
+import './chunk2.js';

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/main3.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/main3.js
@@ -1,0 +1,1 @@
+import './chunk1.js';

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk1.js
@@ -1,0 +1,11 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			exports('default', foo);
+			function foo() {}
+
+		}
+	};
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk2.js
@@ -1,0 +1,13 @@
+System.register(['./chunk1.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
@@ -1,0 +1,16 @@
+System.register(['./chunk2.js', './chunk1.js'], function (exports, module) {
+	'use strict';
+	var foo;
+	return {
+		setters: [function (module) {
+			
+		}, function (module) {
+			foo = module.default;
+		}],
+		execute: function () {
+
+			exports('default', foo);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main2.js
@@ -1,0 +1,13 @@
+System.register(['./chunk2.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main3.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main3.js
@@ -1,0 +1,13 @@
+System.register(['./chunk1.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/reexport-shortpaths/dep1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/dep1.js
@@ -1,0 +1,1 @@
+export { default } from './dep2';

--- a/test/chunking-form/samples/reexport-shortpaths/dep2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/dep2.js
@@ -1,0 +1,1 @@
+export default function() {};

--- a/test/chunking-form/samples/reexport-shortpaths/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/main1.js
@@ -1,0 +1,3 @@
+import foo from './dep1';
+
+export default foo;

--- a/test/chunking-form/samples/reexport-shortpaths/main2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/main2.js
@@ -1,0 +1,1 @@
+import './dep1.js';

--- a/test/chunking-form/samples/reexport-shortpaths/main3.js
+++ b/test/chunking-form/samples/reexport-shortpaths/main3.js
@@ -1,0 +1,1 @@
+import './dep2.js';


### PR DESCRIPTION
This fixes an issue with imports over reexport short-circuit paths in chunk tracing not showing up properly in the rendered imports of the module, as well as a slightly more consistent shortpath tracing method.

@kellyselden this should resolve the issue you were getting in #1922 as well with the latest adjustments.
