### PR TITLE
Make the build reproducible

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ const commitHash = (function () {
 	}
 })();
 
-const now = new Date(process.env.SOURCE_DATE_EPOCH ? (process.env.SOURCE_DATE_EPOCH * 1000) : new Date().getTime()).getTime();
+const now = new Date(process.env.SOURCE_DATE_EPOCH ? (process.env.SOURCE_DATE_EPOCH * 1000) : new Date().getTime()).toUTCString();
 
 const banner = `/*
 	Rollup.js v${pkg.version}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,9 +15,11 @@ const commitHash = (function () {
 	}
 })();
 
+const now = new Date(process.env.SOURCE_DATE_EPOCH ? (process.env.SOURCE_DATE_EPOCH * 1000) : new Date().getTime()).getTime();
+
 const banner = `/*
 	Rollup.js v${pkg.version}
-	${new Date()} - commit ${commitHash}
+	${now} - commit ${commitHash}
 
 	https://github.com/rollup/rollup
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that node-rollup could not be built reproducibly as it encodes
the current build time via "new Date()".

This was originally filed in Debian as #891899.

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/891899

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
