### PR TITLE
Update Rollup - fixes tests in Node 4 and Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "pretty-ms": "^3.1.0",
     "remap-istanbul": "^0.10.1",
     "require-relative": "^0.8.7",
-    "rollup": "^0.55.5",
+    "rollup": "^0.56.4",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-commonjs": "^8.3.0",
     "rollup-plugin-json": "^2.3.0",


### PR DESCRIPTION
Seems like the original issue from https://github.com/rollup/rollup-plugin-commonjs/pull/287 was surfacing internally without running the latest Rollup version exposing the parse method.