### PR TITLE
Enable watcher in code-splitting mode

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -12,6 +12,8 @@ import relativeId from './utils/relativeId';
 import error from './utils/error';
 import { isAbsolute, isRelative, normalize, relative, resolve } from './utils/path';
 import {
+	CachedChunk,
+	CachedChunkSet,
 	InputOptions,
 	IsExternalHook,
 	MissingExportHook,
@@ -86,9 +88,18 @@ export default class Graph {
 	constructor(options: InputOptions) {
 		this.cachedModules = new Map();
 		if (options.cache) {
-			options.cache.modules.forEach(module => {
-				this.cachedModules.set(module.id, module);
-			});
+			if ((<CachedChunk>options.cache).modules) {
+				(<CachedChunk>options.cache).modules.forEach(module => {
+					this.cachedModules.set(module.id, module);
+				})
+			} else {
+				const chunks = (<CachedChunkSet>options.cache).chunks;
+				for (const chunkName in chunks) {
+					chunks[chunkName].modules.forEach(module => {
+						this.cachedModules.set(module.id, module);
+					});
+				}
+			}
 		}
 		delete options.cache; // TODO not deleting it here causes a memory leak; needs further investigation
 

--- a/test/watch/samples/code-splitting/main1.js
+++ b/test/watch/samples/code-splitting/main1.js
@@ -1,0 +1,2 @@
+import {value} from './shared';
+export default value;

--- a/test/watch/samples/code-splitting/main2.js
+++ b/test/watch/samples/code-splitting/main2.js
@@ -1,0 +1,2 @@
+import {value} from './shared';
+export default value * 2;

--- a/test/watch/samples/code-splitting/shared.js
+++ b/test/watch/samples/code-splitting/shared.js
@@ -1,0 +1,1 @@
+export const value = 21;


### PR DESCRIPTION
Closes #1950 

- [x] Update typing for `rollup.rollup()` to reflect code-splitting output type.
- [x] Update watcher to handle code-splitting output.
- [x] Add tests for watcher in code-splitting mode.
- [x] Lint