### PR TITLE
send "bell" character to stderr on errors

### DIFF
--- a/bin/src/logging.ts
+++ b/bin/src/logging.ts
@@ -34,7 +34,7 @@ export function handleError(err: RollupError, recover = false) {
 		stderr(chalk.dim(err.stack));
 	}
 
-	stderr('');
+	stderr(chalk.enabled ? '\u0007' : '');
 
 	if (!recover) process.exit(1);
 }


### PR DESCRIPTION
This is a very minor proposal. I often have `rollup -w` run in a background terminal while coding and then it happens that I accidentally break the app which causes rollup to fail with the error message. But because rollup is running in a background terminal I don't realize it and waste minutes debugging the old code.

This happens to many developers, and one very simple solution is to send the "bell" character to the stdout/stderr whenever there's an error. The [bell character](https://en.wikipedia.org/wiki/Bell_character) is a device control character that does nothing but make terminals beep.

I am well aware that this is unnecessary in scenarios where the stderr is being piped into a log file which is why in my PR I am only sending the character if `chalk.enabled` is true. (Theoretically there's a scenario where someone is running `rollup` on a non-color enabled shell and thus wouldn't get the bell sound, but I think this is a very limited case)