### PR TITLE
Faster source map generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -537,7 +537,6 @@
         "acorn-dynamic-import": "3.0.0",
         "acorn-jsx": "4.1.1",
         "chalk": "2.3.2",
-        "magic-string": "0.22.5",
         "minimist": "1.2.0",
         "os-homedir": "1.0.2",
         "vlq": "1.0.0"
@@ -4780,12 +4779,12 @@
       }
     },
     "magic-string": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.23.2.tgz",
+      "integrity": "sha512-oIUZaAxbcxYIp4AyLafV6OVKoB3YouZs0UTCJ8mOKBHNyJgGDaMJ4TgA+VylJh6fx7EQCC52XkbURxxG9IoJXA==",
       "dev": true,
       "requires": {
-        "vlq": "0.2.3"
+        "sourcemap-codec": "1.4.1"
       }
     },
     "map-cache": {
@@ -6050,7 +6049,6 @@
       "dev": true,
       "requires": {
         "estree-walker": "0.5.1",
-        "magic-string": "0.22.5",
         "resolve": "1.5.0",
         "rollup-pluginutils": "2.0.1"
       },
@@ -6097,7 +6095,6 @@
       "integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
       "dev": true,
       "requires": {
-        "magic-string": "0.22.5",
         "minimatch": "3.0.4",
         "rollup-pluginutils": "2.0.1"
       }
@@ -7342,12 +7339,6 @@
           "dev": true
         }
       }
-    },
-    "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
-      "dev": true
     },
     "vorpal": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "immutable": "^3.8.2",
     "istanbul": "^0.4.3",
     "lint-staged": "^7.0.0",
-    "magic-string": "^0.22.5",
+    "magic-string": "^0.23.2",
     "minimist": "^1.2.0",
     "mocha": "^5.0.4",
     "prettier": "^1.10.2",


### PR DESCRIPTION
Removes redundant source map encoding roundtrip between `magic-string` and `rollup`, which should speed up source map generation by up to 40%. For example, Mapbox GL JS bundle takes ~400-500ms less time after this PR. 

Also contains some minor code clean up in `collapseSourcemaps.ts` that I forgot to commit separately.

Fixes #2061. cc @guybedford @lukastaegert 