### PR TITLE
Add custom CLI option namespace and improve warnings

### DIFF
--- a/bin/src/help.md
+++ b/bin/src/help.md
@@ -11,8 +11,8 @@ Basic options:
                               is unspecified, defaults to rollup.config.js)
 -w, --watch                 Watch files in bundle and rebuild on changes
 -i, --input                 Input (alternative to <entry file>)
--o, --output.file <output>  Output (if absent, prints to stdout)
--f, --output.format [es]    Type of output (amd, cjs, es, iife, umd)
+-o, --file <output>         Output (if absent, prints to stdout)
+-f, --format [es]           Type of output (amd, cjs, es, iife, umd)
 -e, --external              Comma-separate list of module IDs to exclude
 -g, --globals               Comma-separate list of `module ID:Global` pairs
                               Any module IDs defined here are added to external
@@ -31,7 +31,7 @@ Basic options:
 --outro                     Content to insert at end of bundle (inside wrapper)
 --banner                    Content to insert at top of bundle (outside wrapper)
 --footer                    Content to insert at end of bundle (outside wrapper)
---interop                   Include interop block (true by default)
+--no-interop                Do not include interop block
 
 Examples:
 
@@ -43,7 +43,7 @@ rollup -c
 rollup -c --environment INCLUDE_DEPS,BUILD:production
 
 # create CommonJS bundle.js from src/main.js
-rollup --format=cjs --output=bundle.js -- src/main.js
+rollup --format=cjs --file=bundle.js -- src/main.js
 
 # create self-executing IIFE using `window.jQuery`
 # and `window._` as external globals

--- a/bin/src/index.ts
+++ b/bin/src/index.ts
@@ -2,28 +2,10 @@ import minimist from 'minimist';
 import help from 'help.md';
 import { version } from 'package.json';
 import run from './run/index';
+import { commandAliases } from '../../src/utils/mergeOptions';
 
 const command = minimist(process.argv.slice(2), {
-	alias: {
-		// Aliases
-		strict: 'useStrict',
-		dir: 'output.dir',
-
-		// Short options
-		c: 'config',
-		d: 'indent',
-		e: 'external',
-		f: 'output.format',
-		g: 'globals',
-		h: 'help',
-		i: 'input',
-		l: 'legacy',
-		m: 'sourcemap',
-		n: 'name',
-		o: 'output.file',
-		v: 'version',
-		w: 'watch'
-	}
+	alias: commandAliases
 });
 
 if (command.help || (process.argv.length <= 2 && process.stdin.isTTY)) {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -702,7 +702,7 @@ export default class Chunk {
 				const indentString = getIndentString(this.orderedModules, options);
 
 				const renderOptions: RenderOptions = {
-					legacy: this.graph.legacy,
+					legacy: options.legacy,
 					freeze: options.freeze !== false,
 					namespaceToStringTag: options.namespaceToStringTag === true,
 					indent: indentString,

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -75,7 +75,6 @@ export default class Graph {
 	hasLoaders: boolean;
 	isExternal: IsExternalHook;
 	isPureExternalModule: (id: string) => boolean;
-	legacy: boolean;
 	load: (id: string) => Promise<SourceDescription | string | void>;
 	handleMissingExport: (
 		exportName: string,
@@ -210,7 +209,6 @@ export default class Graph {
 		this.onwarn = options.onwarn || makeOnwarn();
 
 		this.varOrConst = options.preferConst ? 'const' : 'var';
-		this.legacy = options.legacy;
 
 		this.acornOptions = options.acorn || {};
 		const acornPluginsToInject = [];

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -104,7 +104,6 @@ export interface InputOptions {
 	treeshake?: boolean | TreeshakingOptions;
 	context?: string;
 	moduleContext?: string | ((id: string) => string) | { [id: string]: string };
-	legacy?: boolean;
 	watch?: WatcherOptions;
 	experimentalDynamicImport?: boolean;
 	experimentalCodeSplitting?: boolean;
@@ -156,8 +155,6 @@ export interface OutputOptions {
 	strict?: boolean;
 	freeze?: boolean;
 	namespaceToStringTag?: boolean;
-
-	// shared?
 	legacy?: boolean;
 
 	// undocumented?

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -1,8 +1,18 @@
 import ensureArray from './ensureArray';
 import deprecateOptions, { Deprecation } from './deprecateOptions';
-import { InputOptions, WarningHandler } from '../rollup/index';
+import { InputOptions, OutputOptions, WarningHandler } from '../rollup/index';
 
-function normalizeObjectOptionValue(optionValue: any) {
+export type GenericConfigObject = { [key: string]: any };
+
+const createGetOption = (config: GenericConfigObject, command: GenericConfigObject) => (
+	name: string,
+	defaultValue?: any
+) =>
+	command[name] !== undefined
+		? command[name]
+		: config[name] !== undefined ? config[name] : defaultValue;
+
+const normalizeObjectOptionValue = (optionValue: any) => {
 	if (!optionValue) {
 		return optionValue;
 	}
@@ -10,7 +20,22 @@ function normalizeObjectOptionValue(optionValue: any) {
 		return {};
 	}
 	return optionValue;
-}
+};
+
+const getObjectOption = (
+	config: GenericConfigObject,
+	command: GenericConfigObject,
+	name: string
+) => {
+	const commandOption = normalizeObjectOptionValue(command[name]);
+	const configOption = normalizeObjectOptionValue(config[name]);
+	if (commandOption !== undefined) {
+		return commandOption && configOption
+			? Object.assign({}, configOption, commandOption)
+			: commandOption;
+	}
+	return configOption;
+};
 
 const defaultOnWarn: WarningHandler = warning => {
 	if (typeof warning === 'string') {
@@ -20,34 +45,46 @@ const defaultOnWarn: WarningHandler = warning => {
 	}
 };
 
-export type GenericConfigObject = { [key: string]: any };
+const getOnWarn = (
+	config: GenericConfigObject,
+	command: GenericConfigObject,
+	defaultOnWarnHandler: WarningHandler = defaultOnWarn
+): WarningHandler =>
+	command.silent
+		? () => {}
+		: config.onwarn
+			? warning => config.onwarn(warning, defaultOnWarnHandler)
+			: defaultOnWarnHandler;
+
+const getExternal = (config: GenericConfigObject, command: GenericConfigObject) => {
+	const configExternal = config.external;
+	return typeof configExternal === 'function'
+		? (id: string, ...rest: string[]) =>
+				configExternal(id, ...rest) || command.external.indexOf(id) !== -1
+		: (configExternal || []).concat(command.external);
+};
 
 export const commandAliases: { [key: string]: string } = {
-	// Aliases
-	strict: 'useStrict',
-	dir: 'output.dir',
-
-	// Short options
 	c: 'config',
 	d: 'indent',
 	e: 'external',
-	f: 'output.format',
+	f: 'format',
 	g: 'globals',
 	h: 'help',
 	i: 'input',
 	l: 'legacy',
 	m: 'sourcemap',
 	n: 'name',
-	o: 'output.file',
+	o: 'file',
 	v: 'version',
 	w: 'watch'
 };
 
 export default function mergeOptions({
 	config = {},
-	command = {},
+	command: rawCommandOptions = {},
 	deprecateConfig,
-	defaultOnWarnHandler = defaultOnWarn
+	defaultOnWarnHandler
 }: {
 	config: GenericConfigObject;
 	command?: GenericConfigObject;
@@ -59,174 +96,61 @@ export default function mergeOptions({
 	deprecations: Deprecation[];
 	optionError: string | null;
 } {
-	const deprecations = deprecate(config, command, deprecateConfig);
+	const deprecations = deprecate(config, rawCommandOptions, deprecateConfig);
+	const command = getCommandOptions(rawCommandOptions);
+	const inputOptions = getInputOptions(config, command, defaultOnWarnHandler);
 
-	const getOption = (config: GenericConfigObject) => (name: string) =>
-		command[name] !== undefined ? command[name] : config[name];
-
-	const getInputOption = getOption(config);
-	const getOutputOption = getOption(config.output || {});
-
-	function getObjectOption(name: string) {
-		const commandOption = normalizeObjectOptionValue(command[name]);
-		const configOption = normalizeObjectOptionValue(config[name]);
-		if (commandOption !== undefined) {
-			return commandOption && configOption
-				? Object.assign({}, configOption, commandOption)
-				: commandOption;
-		}
-		return configOption;
+	if (command.output) {
+		Object.assign(command, command.output);
 	}
 
-	const onwarn = config.onwarn;
-	let warn: WarningHandler;
+	const normalizedOutputOptions = ensureArray(config.output);
+	if (normalizedOutputOptions.length === 0) normalizedOutputOptions.push({});
+	const outputOptions = normalizedOutputOptions.map(singleOutputOptions =>
+		getOutputOptions(singleOutputOptions, command)
+	);
 
-	if (onwarn) {
-		warn = warning => onwarn(warning, defaultOnWarnHandler);
-	} else {
-		warn = defaultOnWarnHandler;
-	}
-
-	const baseInputOptions: InputOptions = {
-		acorn: config.acorn,
-		acornInjectPlugins: config.acornInjectPlugins,
-		cache: getInputOption('cache'),
-		context: config.context,
-		experimentalCodeSplitting: getInputOption('experimentalCodeSplitting'),
-		experimentalDynamicImport: getInputOption('experimentalDynamicImport'),
-		experimentalPreserveModules: getInputOption('experimentalPreserveModules'),
-		input: getInputOption('input'),
-		legacy: getInputOption('legacy'),
-		moduleContext: config.moduleContext,
-		onwarn: warn,
-		perf: getInputOption('perf'),
-		plugins: config.plugins,
-		preferConst: getInputOption('preferConst'),
-		preserveSymlinks: getInputOption('preserveSymlinks'),
-		treeshake: getObjectOption('treeshake'),
-		watch: config.watch
-	};
-
-	// legacy, to ensure e.g. commonjs plugin still works
-	(<any>baseInputOptions).entry = baseInputOptions.input;
-
-	const commandExternal = (command.external || '').split(',');
-	const configExternal = config.external;
-
-	if (command.globals) {
-		const globals = Object.create(null);
-
-		command.globals.split(',').forEach((str: string) => {
-			const names = str.split(':');
-			globals[names[0]] = names[1];
-
-			// Add missing Module IDs to external.
-			if (commandExternal.indexOf(names[0]) === -1) {
-				commandExternal.push(names[0]);
-			}
-		});
-
-		command.globals = globals;
-	}
-
-	if (typeof configExternal === 'function') {
-		baseInputOptions.external = (id, ...rest: any[]) =>
-			configExternal(id, ...rest) || commandExternal.indexOf(id) !== -1;
-	} else {
-		baseInputOptions.external = (configExternal || []).concat(commandExternal);
-	}
-
-	if (command.silent) {
-		baseInputOptions.onwarn = () => {};
-	}
-
-	// Make sure the CLI treats this the same way as when we are code-splitting
-	if (baseInputOptions.experimentalPreserveModules && !Array.isArray(baseInputOptions.input)) {
-		baseInputOptions.input = [baseInputOptions.input];
-	}
-
-	const baseOutputOptions = {
-		amd: Object.assign({}, config.amd, command.amd),
-		banner: getOutputOption('banner'),
-		dir: getOutputOption('dir'),
-		exports: getOutputOption('exports'),
-		extend: getOutputOption('extend'),
-		file: getOutputOption('file'),
-		footer: getOutputOption('footer'),
-		format: getOutputOption('format'),
-		freeze: getOutputOption('freeze'),
-		globals: getOutputOption('globals'),
-		indent: getOutputOption('indent'),
-		interop: getOutputOption('interop'),
-		intro: getOutputOption('intro'),
-		legacy: getOutputOption('legacy'),
-		name: getOutputOption('name'),
-		namespaceToStringTag: getOutputOption('namespaceToStringTag'),
-		noConflict: getOutputOption('noConflict'),
-		outro: getOutputOption('outro'),
-		paths: getOutputOption('paths'),
-		sourcemap: getOutputOption('sourcemap'),
-		sourcemapFile: getOutputOption('sourcemapFile'),
-		strict: getOutputOption('strict')
-	};
-
-	let mergedOutputOptions;
-	if (Array.isArray(config.output)) {
-		mergedOutputOptions = config.output.map((output: any) =>
-			Object.assign({}, output, command.output)
-		);
-	} else if (config.output && command.output) {
-		mergedOutputOptions = [Object.assign({}, config.output, command.output)];
-	} else {
-		mergedOutputOptions =
-			command.output || config.output
-				? ensureArray(command.output || config.output)
-				: [
-						{
-							file: command.output ? command.output.file : null,
-							format: command.output ? command.output.format : null
-						}
-				  ];
-	}
-
-	const outputOptions = mergedOutputOptions.map((output: any) => {
-		return Object.assign({}, baseOutputOptions, output);
-	});
-
-	const missingOptionErrors: string[] = [];
-	const validInputOptions = Object.keys(baseInputOptions);
-	addMissingOptionErrors(
-		missingOptionErrors,
+	const unknownOptionErrors: string[] = [];
+	const validInputOptions = Object.keys(inputOptions);
+	addUnknownOptionErrors(
+		unknownOptionErrors,
 		Object.keys(config),
 		validInputOptions,
 		'input',
 		/^output$/
 	);
-	addMissingOptionErrors(
-		missingOptionErrors,
-		Array.isArray(config.output)
-			? config.output.reduce((allOptions, options) => allOptions.concat(Object.keys(options)), [])
-			: Object.keys(config.output || {}),
-		Object.keys(baseOutputOptions),
+
+	const validOutputOptions = Object.keys(outputOptions[0]);
+	addUnknownOptionErrors(
+		unknownOptionErrors,
+		outputOptions.reduce((allKeys, options) => allKeys.concat(Object.keys(options)), []),
+		validOutputOptions,
 		'output'
 	);
-	addMissingOptionErrors(
-		missingOptionErrors,
+
+	addUnknownOptionErrors(
+		unknownOptionErrors,
 		Object.keys(command),
-		validInputOptions.concat('config', 'output', Object.keys(commandAliases)),
+		validInputOptions.concat(
+			validOutputOptions,
+			Object.keys(commandAliases),
+			'config',
+			'environment',
+			'silent'
+		),
 		'CLI',
-		/^_|(config.*)$/
+		/^_|output|(config.*)$/
 	);
 
 	return {
-		inputOptions: baseInputOptions,
+		inputOptions,
 		outputOptions,
 		deprecations,
-		optionError: missingOptionErrors.length > 0 ? missingOptionErrors.join('\n') : null
+		optionError: unknownOptionErrors.length > 0 ? unknownOptionErrors.join('\n') : null
 	};
 }
 
-function addMissingOptionErrors(
+function addUnknownOptionErrors(
 	errors: string[],
 	options: string[],
 	validOptions: string[],
@@ -242,6 +166,95 @@ function addMissingOptionErrors(
 				', '
 			)}. Allowed options: ${validOptions.sort().join(', ')}`
 		);
+}
+
+function getCommandOptions(rawCommandOptions: GenericConfigObject): GenericConfigObject {
+	const command = Object.assign({}, rawCommandOptions);
+	command.external = (rawCommandOptions.external || '').split(',');
+
+	if (rawCommandOptions.globals) {
+		command.globals = Object.create(null);
+
+		rawCommandOptions.globals.split(',').forEach((str: string) => {
+			const names = str.split(':');
+			command.globals[names[0]] = names[1];
+
+			// Add missing Module IDs to external.
+			if (command.external.indexOf(names[0]) === -1) {
+				command.external.push(names[0]);
+			}
+		});
+	}
+	return command;
+}
+
+function getInputOptions(
+	config: GenericConfigObject,
+	command: GenericConfigObject = {},
+	defaultOnWarnHandler: WarningHandler
+): InputOptions {
+	const getOption = createGetOption(config, command);
+
+	const inputOptions: InputOptions = {
+		acorn: config.acorn,
+		acornInjectPlugins: config.acornInjectPlugins,
+		cache: getOption('cache'),
+		context: config.context,
+		experimentalCodeSplitting: getOption('experimentalCodeSplitting'),
+		experimentalDynamicImport: getOption('experimentalDynamicImport'),
+		experimentalPreserveModules: getOption('experimentalPreserveModules'),
+		external: getExternal(config, command),
+		input: getOption('input'),
+		moduleContext: config.moduleContext,
+		onwarn: getOnWarn(config, command, defaultOnWarnHandler),
+		perf: getOption('perf', false),
+		plugins: config.plugins,
+		preferConst: getOption('preferConst'),
+		preserveSymlinks: getOption('preserveSymlinks'),
+		treeshake: getObjectOption(config, command, 'treeshake'),
+		watch: config.watch
+	};
+
+	if (inputOptions.experimentalPreserveModules && !Array.isArray(inputOptions.input)) {
+		inputOptions.input = [inputOptions.input];
+	}
+	// legacy to make sure certain plugins still work
+	inputOptions.entry = Array.isArray(inputOptions.input)
+		? inputOptions.input[0]
+		: inputOptions.input;
+	return inputOptions;
+}
+
+function getOutputOptions(
+	config: GenericConfigObject,
+	command: GenericConfigObject = {}
+): OutputOptions {
+	const getOption = createGetOption(config, command);
+
+	return {
+		amd: Object.assign({}, config.amd, command.amd),
+		banner: getOption('banner'),
+		dir: getOption('dir'),
+		exports: getOption('exports'),
+		extend: getOption('extend'),
+		file: getOption('file'),
+		footer: getOption('footer'),
+		format: getOption('format'),
+		freeze: getOption('freeze'),
+		globals: getOption('globals'),
+		indent: getOption('indent', true),
+		interop: getOption('interop', true),
+		intro: getOption('intro'),
+		legacy: getOption('legacy', false),
+		name: getOption('name'),
+		namespaceToStringTag: getOption('namespaceToStringTag'),
+		noConflict: getOption('noConflict'),
+		outro: getOption('outro'),
+		paths: getOption('paths'),
+		sourcemap: getOption('sourcemap'),
+		sourcemapFile: getOption('sourcemapFile'),
+		strict: getOption('strict', true)
+	};
 }
 
 function deprecate(
@@ -263,17 +276,9 @@ function deprecate(
 	if (typeof command.output === 'string') {
 		deprecations.push({
 			old: '--output',
-			new: '--output.file'
+			new: '--file'
 		});
 		command.output = { file: command.output };
-	}
-
-	if (command.format) {
-		deprecations.push({
-			old: '--format',
-			new: '--output.format'
-		});
-		(command.output || (command.output = {})).format = command.format;
 	}
 
 	// config file

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -116,7 +116,7 @@ export default function mergeOptions({
 		unknownOptionErrors,
 		Object.keys(config),
 		validInputOptions,
-		'input',
+		'input option',
 		/^output$/
 	);
 
@@ -125,7 +125,7 @@ export default function mergeOptions({
 		unknownOptionErrors,
 		outputOptions.reduce((allKeys, options) => allKeys.concat(Object.keys(options)), []),
 		validOutputOptions,
-		'output'
+		'output option'
 	);
 
 	addUnknownOptionErrors(
@@ -138,7 +138,7 @@ export default function mergeOptions({
 			'environment',
 			'silent'
 		),
-		'CLI',
+		'CLI flag',
 		/^_|output|(config.*)$/
 	);
 
@@ -162,7 +162,7 @@ function addUnknownOptionErrors(
 	);
 	if (unknownOptions.length > 0)
 		errors.push(
-			`Unknown ${optionType} option: ${unknownOptions.join(
+			`Unknown ${optionType}: ${unknownOptions.join(
 				', '
 			)}. Allowed options: ${validOptions.sort().join(', ')}`
 		);

--- a/src/utils/transformBundle.ts
+++ b/src/utils/transformBundle.ts
@@ -14,9 +14,7 @@ export default function transformBundle(
 
 		return promise.then(code => {
 			return Promise.resolve()
-				.then(() => {
-					return plugin.transformBundle(code, options);
-				})
+				.then(() => plugin.transformBundle(code, options))
 				.then(result => {
 					if (result == null) return code;
 

--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -23,7 +23,7 @@ describe('chunking form', () => {
 				config.options = {};
 			}
 
-			const options = extend(
+			const inputOptions = extend(
 				{},
 				{
 					input: [samples + '/' + dir + '/main.js'],
@@ -40,22 +40,22 @@ describe('chunking form', () => {
 
 			(config.skip ? describe.skip : config.solo ? describe.only : describe)(dir, () => {
 				let promise;
-				const createBundle = () => promise || (promise = rollup.rollup(options));
+				const createBundle = () => promise || (promise = rollup.rollup(inputOptions));
 
 				FORMATS.forEach(format => {
 					it('generates ' + format, () => {
 						process.chdir(samples + '/' + dir);
 
 						return createBundle().then(bundle => {
-							const options = extend({}, config.options, {
+							const outputOptions = extend({}, config.options.output || {}, {
 								dir: samples + '/' + dir + '/_actual/' + format,
 								format,
 								indent: !('indent' in config.options) ? true : config.options.indent
 							});
 
-							sander.rimrafSync(options.dir);
+							sander.rimrafSync(outputOptions.dir);
 
-							return bundle.write(options).then(() => {
+							return bundle.write(outputOptions).then(() => {
 								const actualFiles = fixturify.readSync(path.join(samples, dir, '_actual', format));
 
 								let expectedFiles;

--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -47,11 +47,14 @@ describe('chunking form', () => {
 						process.chdir(samples + '/' + dir);
 
 						return createBundle().then(bundle => {
-							const outputOptions = extend({}, config.options.output || {}, {
-								dir: samples + '/' + dir + '/_actual/' + format,
-								format,
-								indent: !('indent' in config.options) ? true : config.options.indent
-							});
+							const outputOptions = extend(
+								{},
+								{
+									dir: samples + '/' + dir + '/_actual/' + format,
+									format
+								},
+								inputOptions.output || {}
+							);
 
 							sander.rimrafSync(outputOptions.dir);
 

--- a/test/chunking-form/samples/chunking-source-maps/_config.js
+++ b/test/chunking-form/samples/chunking-source-maps/_config.js
@@ -1,7 +1,9 @@
 module.exports = {
 	description: 'simple chunking',
 	options: {
-		sourcemap: true,
-		input: ['main1.js', 'main2.js']
+		input: ['main1.js', 'main2.js'],
+		output: {
+			sourcemap: true
+		}
 	}
 };

--- a/test/cli/samples/allow-output-prefix/_config.js
+++ b/test/cli/samples/allow-output-prefix/_config.js
@@ -1,5 +1,4 @@
 module.exports = {
 	description: 'allows output options to be prefixed with "output."',
-	command: 'rollup main.js --output.format es --output.footer "console.log(\'Rollup!\')"',
-	solo: true
+	command: 'rollup main.js --output.format es --output.footer "console.log(\'Rollup!\')"'
 };

--- a/test/cli/samples/allow-output-prefix/_config.js
+++ b/test/cli/samples/allow-output-prefix/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'allows output options to be prefixed with "output."',
+	command: 'rollup main.js --output.format es --output.footer "console.log(\'Rollup!\')"',
+	solo: true
+};

--- a/test/cli/samples/allow-output-prefix/_expected.js
+++ b/test/cli/samples/allow-output-prefix/_expected.js
@@ -1,0 +1,2 @@
+assert.equal( 1 + 1, 2 );
+console.log('Rollup!')

--- a/test/cli/samples/allow-output-prefix/main.js
+++ b/test/cli/samples/allow-output-prefix/main.js
@@ -1,0 +1,1 @@
+assert.equal( 1 + 1, 2 );

--- a/test/cli/samples/amd/_expected.js
+++ b/test/cli/samples/amd/_expected.js
@@ -1,7 +1,7 @@
 defn('foo', function () { 'use strict';
 
-var main = 42;
+	var main = 42;
 
-return main;
+	return main;
 
 });

--- a/test/cli/samples/config-deprecations/rollup.config.js
+++ b/test/cli/samples/config-deprecations/rollup.config.js
@@ -30,7 +30,7 @@ module.exports = {
 				warnings[1],
 				{
 					code: 'UNKNOWN_OPTION',
-					message: 'Unknown input option: abc. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, legacy, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
+					message: 'Unknown input option: abc. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
 				}
 			);
 		} else {

--- a/test/cli/samples/config-deprecations/rollup.config.js
+++ b/test/cli/samples/config-deprecations/rollup.config.js
@@ -30,7 +30,7 @@ module.exports = {
 				warnings[1],
 				{
 					code: 'UNKNOWN_OPTION',
-					message: 'Unknown option found: abc. Allowed keys: acorn, acornInjectPlugins, cache, context, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, input, legacy, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch, entry, external, amd, banner, dir, exports, extend, file, footer, format, freeze, globals, indent, interop, intro, legacy, name, namespaceToStringTag, noConflict, outro, paths, sourcemap, sourcemapFile, strict, pureExternalModules'
+					message: 'Unknown input option: abc. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, legacy, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
 				}
 			);
 		} else {

--- a/test/cli/samples/external-modules-auto-global/_config.js
+++ b/test/cli/samples/external-modules-auto-global/_config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	description: 'populates options.external with --global keys',
-	command: 'rollup main.js --output.format iife --globals mathematics:Math',
+	command: 'rollup main.js --format iife --globals mathematics:Math',
 	execute: true
 };

--- a/test/cli/samples/external-modules/_config.js
+++ b/test/cli/samples/external-modules/_config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	description: 'allows external modules to be specified with --external=foo,bar,baz',
-	command: 'rollup main.js --output.format cjs --external path,util',
+	command: 'rollup main.js --format cjs --external path,util',
 	execute: true
 };

--- a/test/cli/samples/indent-none/_config.js
+++ b/test/cli/samples/indent-none/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'disables indentation with --no-indent',
-	command: 'rollup main.js --output.format umd --no-indent'
+	command: 'rollup main.js --format umd --no-indent'
 };

--- a/test/cli/samples/module-name/_config.js
+++ b/test/cli/samples/module-name/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'generates UMD export with correct name',
-	command: 'rollup main.js --output.format umd --name myBundle --indent'
+	command: 'rollup main.js --format umd --name myBundle --indent'
 };

--- a/test/cli/samples/multiple-targets-shared-config/rollup.config.js
+++ b/test/cli/samples/multiple-targets-shared-config/rollup.config.js
@@ -1,14 +1,15 @@
 export default {
 	input: 'main.js',
-	sourcemap: true,
 	targets: [
 		{
 			format: 'cjs',
-			file: '_actual/cjs.js'
+			file: '_actual/cjs.js',
+			sourcemap: true
 		},
 		{
 			format: 'es',
-			file: '_actual/es.js'
+			file: '_actual/es.js',
+			sourcemap: true
 		}
 	]
 };

--- a/test/cli/samples/no-conflict/_expected.js
+++ b/test/cli/samples/no-conflict/_expected.js
@@ -9,8 +9,8 @@
 	})();
 }(this, (function () { 'use strict';
 
-var main = {};
+	var main = {};
 
-return main;
+	return main;
 
 })));

--- a/test/cli/samples/no-conflict/rollup.config.js
+++ b/test/cli/samples/no-conflict/rollup.config.js
@@ -1,8 +1,8 @@
 module.exports = {
 	input: 'main.js',
 	output: {
-		format: 'umd'
+		format: 'umd',
+		noConflict: true
 	},
-	name: 'conflictyName',
-	noConflict: true
+	name: 'conflictyName'
 };

--- a/test/cli/samples/no-treeshake/rollup.config.js
+++ b/test/cli/samples/no-treeshake/rollup.config.js
@@ -1,6 +1,5 @@
 module.exports = {
 	input: 'main.js',
-	indent: true,
 	treeshake: {
 		propertyReadSideEffects: false
 	},

--- a/test/cli/samples/property-read-side-effects/_config.js
+++ b/test/cli/samples/property-read-side-effects/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'allows disabling side-effects when accessing properties',
-	command: 'rollup main.js --output.format es --no-treeshake.propertyReadSideEffects'
+	command: 'rollup main.js --format es --no-treeshake.propertyReadSideEffects'
 };

--- a/test/cli/samples/pure-external-modules/_config.js
+++ b/test/cli/samples/pure-external-modules/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'prunes pure unused external imports',
-	command: 'rollup main.js --output.format es --external external --treeshake.pureExternalModules'
+	command: 'rollup main.js --format es --external external --treeshake.pureExternalModules'
 };

--- a/test/cli/samples/warn-unknown-options/_config.js
+++ b/test/cli/samples/warn-unknown-options/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'warns about unknown CLI options',
-	command: 'rollup --config rollup.config.js --output.format es --configAnswer 42 --unknownOption'
+	command: 'rollup --config rollup.config.js --format es --configAnswer 42 --unknownOption'
 };

--- a/test/cli/samples/warn-unknown-options/_config.js
+++ b/test/cli/samples/warn-unknown-options/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'warns about unknown CLI options',
+	command: 'rollup --config rollup.config.js --output.format es --configAnswer 42 --unknownOption'
+};

--- a/test/cli/samples/warn-unknown-options/_expected.js
+++ b/test/cli/samples/warn-unknown-options/_expected.js
@@ -1,0 +1,1 @@
+assert.equal( 42, 42 );

--- a/test/cli/samples/warn-unknown-options/main.js
+++ b/test/cli/samples/warn-unknown-options/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/samples/warn-unknown-options/rollup.config.js
+++ b/test/cli/samples/warn-unknown-options/rollup.config.js
@@ -17,6 +17,6 @@ module.exports = commands => ({
 		warnings++;
 		assert.equal(warning.code, 'UNKNOWN_OPTION');
 		assert.equal(warning.message,
-			'Unknown CLI option: unknownOption. Allowed options: acorn, acornInjectPlugins, c, cache, config, context, d, dir, e, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, f, g, h, i, input, l, legacy, m, moduleContext, n, o, onwarn, output, perf, plugins, preferConst, preserveSymlinks, strict, treeshake, v, w, watch');
+			'Unknown CLI option: unknownOption. Allowed options: acorn, acornInjectPlugins, amd, banner, c, cache, config, context, d, dir, e, entry, environment, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, exports, extend, external, f, file, footer, format, freeze, g, globals, h, i, indent, input, interop, intro, l, legacy, m, moduleContext, n, name, namespaceToStringTag, noConflict, o, onwarn, outro, paths, perf, plugins, preferConst, preserveSymlinks, silent, sourcemap, sourcemapFile, strict, treeshake, v, w, watch');
 	}
 });

--- a/test/cli/samples/warn-unknown-options/rollup.config.js
+++ b/test/cli/samples/warn-unknown-options/rollup.config.js
@@ -1,0 +1,22 @@
+var replace = require('rollup-plugin-replace');
+var assert = require('assert');
+
+let warnings = 0;
+
+module.exports = commands => ({
+	input: 'main.js',
+	plugins: [
+		{
+			ongenerate() {
+				assert.equal(warnings, 1);
+			}
+		},
+		replace({ 'ANSWER': commands.configAnswer }),
+	],
+	onwarn(warning) {
+		warnings++;
+		assert.equal(warning.code, 'UNKNOWN_OPTION');
+		assert.equal(warning.message,
+			'Unknown CLI option: unknownOption. Allowed options: acorn, acornInjectPlugins, c, cache, config, context, d, dir, e, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, f, g, h, i, input, l, legacy, m, moduleContext, n, o, onwarn, output, perf, plugins, preferConst, preserveSymlinks, strict, treeshake, v, w, watch');
+	}
+});

--- a/test/cli/samples/warn-unknown-options/rollup.config.js
+++ b/test/cli/samples/warn-unknown-options/rollup.config.js
@@ -17,6 +17,6 @@ module.exports = commands => ({
 		warnings++;
 		assert.equal(warning.code, 'UNKNOWN_OPTION');
 		assert.equal(warning.message,
-			'Unknown CLI option: unknownOption. Allowed options: acorn, acornInjectPlugins, amd, banner, c, cache, config, context, d, dir, e, entry, environment, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, exports, extend, external, f, file, footer, format, freeze, g, globals, h, i, indent, input, interop, intro, l, legacy, m, moduleContext, n, name, namespaceToStringTag, noConflict, o, onwarn, outro, paths, perf, plugins, preferConst, preserveSymlinks, silent, sourcemap, sourcemapFile, strict, treeshake, v, w, watch');
+			'Unknown CLI flag: unknownOption. Allowed options: acorn, acornInjectPlugins, amd, banner, c, cache, config, context, d, dir, e, entry, environment, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, exports, extend, external, f, file, footer, format, freeze, g, globals, h, i, indent, input, interop, intro, l, legacy, m, moduleContext, n, name, namespaceToStringTag, noConflict, o, onwarn, outro, paths, perf, plugins, preferConst, preserveSymlinks, silent, sourcemap, sourcemapFile, strict, treeshake, v, w, watch');
 	}
 });

--- a/test/form/index.js
+++ b/test/form/index.js
@@ -22,7 +22,7 @@ describe('form', () => {
 				config.options = {};
 			}
 
-			const options = extend(
+			const inputOptions = extend(
 				{},
 				{
 					input: samples + '/' + dir + '/main.js',
@@ -37,20 +37,23 @@ describe('form', () => {
 
 			(config.skip ? describe.skip : config.solo ? describe.only : describe)(dir, () => {
 				let promise;
-				const createBundle = () => promise || (promise = rollup.rollup(options));
+				const createBundle = () => promise || (promise = rollup.rollup(inputOptions));
 
 				FORMATS.forEach(format => {
 					it('generates ' + format, () => {
 						process.chdir(samples + '/' + dir);
 
 						return createBundle().then(bundle => {
-							const options = extend({}, config.options, {
-								file: samples + '/' + dir + '/_actual/' + format + '.js',
-								format,
-								indent: !('indent' in config.options) ? true : config.options.indent
-							});
+							const outputOptions = extend(
+								{},
+								{
+									file: samples + '/' + dir + '/_actual/' + format + '.js',
+									format
+								},
+								inputOptions.output || {}
+							);
 
-							return bundle.write(options).then(() => {
+							return bundle.write(outputOptions).then(() => {
 								const actualCode = normaliseOutput(
 									sander.readFileSync(samples, dir, '_actual', format + '.js')
 								);

--- a/test/form/samples/define-replacement/_config.js
+++ b/test/form/samples/define-replacement/_config.js
@@ -1,6 +1,8 @@
 module.exports = {
 	description: 'amd.define',
 	options: {
-		amd: { define: 'enifed' }
+		output: {
+			amd: { define: 'enifed' }
+		}
 	}
 };

--- a/test/form/samples/export-globals/_config.js
+++ b/test/form/samples/export-globals/_config.js
@@ -1,6 +1,8 @@
 module.exports = {
 	description: 'Supports reexports of globals with namespace access',
 	options: {
-		name: 'myBundle'
+		output: {
+			name: 'myBundle'
+		}
 	}
 };

--- a/test/form/samples/external-deshadowing/_config.js
+++ b/test/form/samples/external-deshadowing/_config.js
@@ -1,6 +1,8 @@
 module.exports = {
 	description: 'Externals aliases with deshadowing',
 	options: {
-		name: 'myBundle'
+		output: {
+			name: 'myBundle'
+		}
 	}
 };

--- a/test/form/samples/freeze/_config.js
+++ b/test/form/samples/freeze/_config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	description: 'supports opt-ing out of usage of Object.freeze',
 	options: {
-		output: { name: 'myBundle' },
-		freeze: false
+		output: { name: 'myBundle', freeze: false }
 	}
 };

--- a/test/form/samples/interop-false/_config.js
+++ b/test/form/samples/interop-false/_config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	description: 'getInterop with interop: false',
 	options: {
-		output: { name: 'foo' },
-		interop: false
+		output: { name: 'foo', interop: false },
 	}
 };

--- a/test/form/samples/legacy-getter/_config.js
+++ b/test/form/samples/legacy-getter/_config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	description: 'Does not output getters when in legacy',
 	options: {
-		legacy: true,
-		output: { name: 'foo' }
+		output: { name: 'foo', legacy: true }
 	}
 };

--- a/test/form/samples/legacy-reified-namespace/_config.js
+++ b/test/form/samples/legacy-reified-namespace/_config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	description: 'quotes reserved words in object literals',
 	options: {
-		output: { name: 'myBundle' },
-		legacy: true
+		output: { name: 'myBundle', legacy: true }
 	}
 };

--- a/test/form/samples/legacy/_config.js
+++ b/test/form/samples/legacy/_config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	description: 'supports environments without Object.freeze, Object.defined',
 	options: {
-		output: { name: 'myBundle' },
-		legacy: true
+		output: { name: 'myBundle', legacy: true },
 	}
 };

--- a/test/form/samples/render-named-export-declarations/_config.js
+++ b/test/form/samples/render-named-export-declarations/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'renders named export declarations',
-	options: { name: 'bundle' }
+	options: { output: { name: 'bundle' } }
 };

--- a/test/form/samples/sourcemaps-external/_config.js
+++ b/test/form/samples/sourcemaps-external/_config.js
@@ -2,6 +2,6 @@ module.exports = {
 	description: 'correct sourcemaps are written (separate file)',
 	skipIfWindows: true,
 	options: {
-		sourcemap: true
+		output: { sourcemap: true }
 	}
 };

--- a/test/form/samples/sourcemaps-inline/_config.js
+++ b/test/form/samples/sourcemaps-inline/_config.js
@@ -2,6 +2,6 @@ module.exports = {
 	description: 'correct sourcemaps are written (inline)',
 	skipIfWindows: true,
 	options: {
-		sourcemap: 'inline'
+		output: {sourcemap: 'inline'}
 	}
 };

--- a/test/form/samples/transform-bundle-plugin-options/_expected/amd.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/amd.js
@@ -1,1 +1,1 @@
-["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict","plugins"]
+["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/cjs.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/cjs.js
@@ -1,1 +1,1 @@
-["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict","plugins"]
+["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/es.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/es.js
@@ -1,1 +1,1 @@
-["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict","plugins"]
+["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/iife.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/iife.js
@@ -1,1 +1,1 @@
-["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict","plugins"]
+["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/system.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/system.js
@@ -1,1 +1,1 @@
-["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict","plugins"]
+["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict"]

--- a/test/form/samples/transform-bundle-plugin-options/_expected/umd.js
+++ b/test/form/samples/transform-bundle-plugin-options/_expected/umd.js
@@ -1,1 +1,1 @@
-["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict","plugins"]
+["amd","banner","dir","exports","extend","file","footer","format","freeze","globals","indent","interop","intro","legacy","name","namespaceToStringTag","noConflict","outro","paths","sourcemap","sourcemapFile","strict"]

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -68,7 +68,7 @@ describe('sanity checks', () => {
 					{
 						code: 'UNKNOWN_OPTION',
 						message:
-							'Unknown option found: plUgins. Allowed keys: acorn, acornInjectPlugins, cache, context, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, input, legacy, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch, entry, external, amd, banner, dir, exports, extend, file, footer, format, freeze, globals, indent, interop, intro, legacy, name, namespaceToStringTag, noConflict, outro, paths, sourcemap, sourcemapFile, strict, pureExternalModules'
+							'Unknown input option: plUgins. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, legacy, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
 					}
 				]);
 			});

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -68,7 +68,7 @@ describe('sanity checks', () => {
 					{
 						code: 'UNKNOWN_OPTION',
 						message:
-							'Unknown input option: plUgins. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, legacy, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
+							'Unknown input option: plUgins. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
 					}
 				]);
 			});

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -23,7 +23,7 @@ describe('sourcemaps', () => {
 
 				let warnings;
 
-				const options = extend({}, config.options, {
+				const inputOptions = extend({}, config.options, {
 					input,
 					onwarn: warning => warnings.push(warning)
 				});
@@ -33,24 +33,24 @@ describe('sourcemaps', () => {
 						warnings = [];
 
 						const testBundle = bundle => {
-							const options = extend(
+							const outputOptions = extend(
 								{},
 								{
 									format,
 									sourcemap: true,
 									file: `${output}.${format}.js`
 								},
-								config.options
+								inputOptions.output || {}
 							);
 
-							return bundle.write(options).then(() => {
+							return bundle.write(outputOptions).then(() => {
 								if (config.warnings) {
 									compareWarnings(warnings, config.warnings);
 								} else if (warnings.length) {
 									throw new Error(`Unexpected warnings`);
 								}
 
-								return bundle.generate(options).then(({ code, map }) => {
+								return bundle.generate(outputOptions).then(({ code, map }) => {
 									if (config.test) {
 										config.test(code, map, { format });
 									}
@@ -58,14 +58,14 @@ describe('sourcemaps', () => {
 							});
 						};
 
-						return rollup.rollup(options).then(bundle => {
+						return rollup.rollup(inputOptions).then(bundle => {
 							return testBundle(bundle).then(() => {
 								// cache rebuild does not reemit warnings.
 								if (config.warnings) {
 									return;
 								}
 								// test cache noop rebuild
-								return rollup.rollup(extend({ cache: bundle }, options)).then(bundle => {
+								return rollup.rollup(extend({ cache: bundle }, inputOptions)).then(bundle => {
 									testBundle(bundle);
 								});
 							});

--- a/test/sourcemaps/samples/transform-bundle-babili/_config.js
+++ b/test/sourcemaps/samples/transform-bundle-babili/_config.js
@@ -14,7 +14,8 @@ module.exports = {
 					return babiliResults[format];
 				}
 			}
-		]
+		],
+		output: { indent: false }
 	},
 	test: function(code, map) {
 		var smc = new SourceMapConsumer(map);

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -64,7 +64,6 @@ describe('rollup.watch', () => {
 	}
 
 	function runTests(chokidar) {
-
 		it('watches a file', () => {
 			return sander
 				.copydir('test/watch/samples/basic')
@@ -124,10 +123,7 @@ describe('rollup.watch', () => {
 							delete require.cache[require.resolve('../_tmp/output/chunk1.js')];
 							assert.equal(run('../_tmp/output/main1.js'), 21);
 							assert.equal(run('../_tmp/output/main2.js'), 42);
-							sander.writeFileSync(
-								'test/_tmp/input/shared.js',
-								'export const value = 22;'
-							);
+							sander.writeFileSync('test/_tmp/input/shared.js', 'export const value = 22;');
 						},
 						'START',
 						'BUNDLE_START',
@@ -371,7 +367,7 @@ describe('rollup.watch', () => {
 				});
 		});
 
-		it('respects options.globals', () => {
+		it('respects output.globals', () => {
 			return sander
 				.copydir('test/watch/samples/globals')
 				.to('test/_tmp/input')
@@ -380,13 +376,13 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main.js',
 						output: {
 							file: 'test/_tmp/output/bundle.js',
-							format: 'iife'
+							format: 'iife',
+							globals: {
+								jquery: 'jQuery'
+							}
 						},
 						watch: { chokidar },
-						external: ['jquery'],
-						globals: {
-							jquery: 'jQuery'
-						}
+						external: ['jquery']
 					});
 
 					return sequence(watcher, [


### PR DESCRIPTION
As discussed in #1926:

* Using an unknown CLI option will now trigger a warning
* There are now separate warnings for CLI, input and output options that will *only validate against their respective sets of options*
* There will be no warnings for CLI options starting with `config` i.e. these options can be safely used for custom functionality

**Update**: To not have lots of warnings in the tests, this soon turned into a much larger refactoring and cleanup of the option handling. These are the most prominent changes and improvements:
* `legacy`/`output.legacy` was completely broken as some parts of the code assumed this to be an output option while others assumed it to be an input option. I have now turned this into an output option only (which means I should not forget to adjust the docs accordingly).
* CLI option handling was very confused as to what the names of options could be. I decided to allow accessing both input and output options without the need for `output.` which is also much more in-line with the documentation. To avoid regressions, using the `output.` prefix will still work but is not advertised e.g. in the CLI help. Will need to check the website for this as well.
* Default values for options can now be specified in `mergeOptions` which should make some unpleasant checks when boolean flags are `true` by default much more pleasant.