### PR TITLE
Generate an interop default block for external modules on iife/umd

### DIFF
--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -10,10 +10,10 @@ export default function getInteropBlock(
 		.map(({ name, exportsNamespace, exportsNames, exportsDefault }) => {
 			if (!exportsDefault || options.interop === false) return null;
 
-			if (exportsNamespace) return `${varOrConst} ${name}__default = ${name}['default'];`;
-
 			if (exportsNames)
 				return `${varOrConst} ${name}__default = 'default' in ${name} ? ${name}['default'] : ${name};`;
+
+			if (exportsNamespace) return `${varOrConst} ${name}__default = ${name}['default'];`;
 
 			return `${name} = ${name} && ${name}.hasOwnProperty('default') ? ${name}['default'] : ${name};`;
 		})

--- a/test/form/samples/import-external-namespace-and-default/_expected/amd.js
+++ b/test/form/samples/import-external-namespace-and-default/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['foo'], function (foo) { 'use strict';
 
-	var foo__default = foo['default'];
+	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	console.log( foo.bar );
 

--- a/test/form/samples/import-external-namespace-and-default/_expected/iife.js
+++ b/test/form/samples/import-external-namespace-and-default/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	var foo__default = foo['default'];
+	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	console.log( foo.bar );
 

--- a/test/form/samples/import-external-namespace-and-default/_expected/umd.js
+++ b/test/form/samples/import-external-namespace-and-default/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	var foo__default = foo['default'];
+	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	console.log( foo.bar );
 


### PR DESCRIPTION
Currently, when options.interop == true (default) and an external
module is imported, cjs generates an interop block that looks
like this:

```js
  function _interopDefault (ex) { return (ex && (typeof ex === 'object')
&& 'default' in ex) ? ex['default'] : ex; }
```

for iife and umd, there's a simliar block generated by `getInteropBlock()`
that looks like this:

```js
  var foo__default = 'default' in foo ? foo['default'] : foo;
```

but for external modules that export as a namespace, it's generated as:

```js
  var foo__default = ${name}['default'];
```
(I don't know why this is more appropriate for namespace exports, but
it's not the issue I'm facing)

Now, when an external module is traced (ExternalModule.traceExports)
to have both namespace and named imports, the namespace case takes
priority.

Changed to generate the latter expression whenever named imports are
found, regardless of namespace imports.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
