### PR TITLE
Remove duplicate and broken link readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@
     <img src='https://badges.gitter.im/rollup/rollup.svg'
          alt='Join the chat at https://gitter.im/rollup/rollup'>
   </a>
-  <a href='https://opencollective.com/rollup/backers'>
-    <img src='https://opencollective.com/rollup/backers/badge.svg'
-         alt='Backers on Open Collective'>
-  </a>
-  <a href='https://opencollective.com/rollup/sponsors'>
-    <img src='https://opencollective.com/rollup/sponsors/badge.svg'
-         alt='Sponsors on Open Collective'>
-  </a>
 </p>
 
 


### PR DESCRIPTION
These badges are currently both repeated. In addition the links in these repeated ones don't work when clicked.