### PR TITLE
Update readme examples not to use --output. pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For Node.js:
 
 ```bash
 # compile to a CommonJS module
-$ rollup main.js --format cjs --output.file bundle.js
+$ rollup main.js --format cjs --file bundle.js
 ```
 
 For both browsers and Node.js:

--- a/README.md
+++ b/README.md
@@ -46,21 +46,21 @@ For browsers:
 
 ```bash
 # compile to a <script> containing a self-executing function
-$ rollup main.js --output.format iife --name "myBundle" --output.file bundle.js
+$ rollup main.js --format iife --name "myBundle" --file bundle.js
 ```
 
 For Node.js:
 
 ```bash
 # compile to a CommonJS module
-$ rollup main.js --output.format cjs --output.file bundle.js
+$ rollup main.js --format cjs --output.file bundle.js
 ```
 
 For both browsers and Node.js:
 
 ```bash
 # UMD format requires a bundle name
-$ rollup main.js --output.format umd --name "myBundle" --output.file bundle.js
+$ rollup main.js --format umd --name "myBundle" --file bundle.js
 ```
 
 ## Why


### PR DESCRIPTION
I'm not pushing hard on this, but just think it may be a nicer interface to encourage ease-of-use? Although it is nice to make users aware of the output options distinction from the start too.