### PR TITLE
Chunk interface mangling

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -188,14 +188,6 @@ export default class Chunk {
 		}
 	}
 
-	ensureExport(variable: Variable, module: Module | ExternalModule) {
-		// this may now be covered by deep inlining
-		/* const dep = module instanceof Module ? module.chunk : module;
-		if (this.dependencies.indexOf(dep) === -1)
-			this.dependencies.push(dep); */
-		this.exports.set(variable, module);
-	}
-
 	// note we assume the facade module chunk is itself linked
 	// with generateEntryExports called
 	linkFacade(entryFacade: Module) {
@@ -252,7 +244,7 @@ export default class Chunk {
 				continue;
 			}
 			if (traced.module.chunk) {
-				traced.module.chunk.ensureExport(traced.variable, traced.module);
+				traced.module.chunk.exports.set(traced.variable, traced.module);
 			}
 			const existingExport = this.exportNames[exportName];
 			// tainted entryModule boundary
@@ -303,7 +295,7 @@ export default class Chunk {
 				const original = namespaceVariables[importName];
 				if (original.included) {
 					if (traced.module.chunk) {
-						traced.module.chunk.ensureExport(original, traced.module);
+						traced.module.chunk.exports.set(original, traced.module);
 					}
 					this.imports.set(original, traced.module);
 				}
@@ -316,7 +308,7 @@ export default class Chunk {
 
 		this.imports.set(traced.variable, traced.module);
 		if (traced.module instanceof Module) {
-			traced.module.chunk.ensureExport(traced.variable, traced.module);
+			traced.module.chunk.exports.set(traced.variable, traced.module);
 		}
 		return traced;
 	}

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -284,7 +284,12 @@ export default class Chunk {
 				(<ExternalVariable>traced.variable).module.declarations;
 			for (let importName of Object.keys(namespaceVariables)) {
 				const original = namespaceVariables[importName];
-				if (original.included) this.imports.set(original, traced.module);
+				if (original.included) {
+					if (traced.module.chunk) {
+						traced.module.chunk.exports.set(original, traced.module);
+					}
+					this.imports.set(original, traced.module);
+				}
 			}
 		}
 
@@ -705,6 +710,7 @@ export default class Chunk {
 		// hash of addons
 		hash.update(addons.hash);
 
+		// output options
 		hash.update(options.format);
 
 		// import names of dependency sources

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -239,10 +239,7 @@ export default class Chunk {
 
 	// Note preserveModules implementation is not a comprehensive technique
 	// this will likely need to be reworked at some stage for edge cases
-	generateEntryExports(preserveModules: boolean) {
-		if (!this.entryModule) {
-			return;
-		}
+	populateEntryExports(preserveModules: boolean) {
 		const entryExportEntries = Array.from(this.entryModule.getAllExports().entries());
 		const tracedExports: { variable: Variable; module: Module | ExternalModule }[] = [];
 		for (let [index, exportName] of entryExportEntries) {
@@ -385,18 +382,12 @@ export default class Chunk {
 		}
 	}
 
-	generateExportNames(mangle: boolean) {
-		mangle = false;
-		const namedVariables: Variable[] = [];
-		for (let exportName of Object.keys(this.exportNames)) {
-			if (exportName[0] === '*') continue;
-			const variable = this.exportNames[exportName];
-			if (namedVariables.indexOf(variable) === -1) namedVariables.push(variable);
-		}
+	generateInternalExports(mangle: boolean = false) {
+		if (this.isEntryModuleFacade) return;
 		let i = 0,
 			safeExportName: string;
+		this.exportNames = {};
 		for (let variable of Array.from(this.exports.keys())) {
-			if (namedVariables.indexOf(variable) !== -1) continue;
 			if (mangle) {
 				do {
 					safeExportName = (i++).toString(36);

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -296,7 +296,7 @@ export default class Graph {
 			// generate the imports and exports for the output chunk file
 			const chunk = new Chunk(this, orderedModules);
 			chunk.link();
-			chunk.generateEntryExports(false);
+			chunk.populateEntryExports(false);
 
 			timeEnd('generate chunks', 2);
 
@@ -467,7 +467,9 @@ export default class Graph {
 
 				// then go over and ensure all entry chunks export their variables
 				for (const chunk of chunkList) {
-					chunk.generateEntryExports(preserveModules);
+					if (chunk.entryModule) {
+						chunk.populateEntryExports(preserveModules);
+					}
 				}
 
 				// create entry point facades for entry module chunks that have tainted exports

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -296,6 +296,7 @@ export default class Graph {
 			// generate the imports and exports for the output chunk file
 			const chunk = new Chunk(this, orderedModules);
 			chunk.link();
+			chunk.generateEntryExports(false);
 
 			timeEnd('generate chunks', 2);
 
@@ -454,7 +455,6 @@ export default class Graph {
 					for (const module of orderedModules) {
 						const chunkInstance = new Chunk(this, [module]);
 						chunkInstance.entryModule = module;
-						chunkInstance.isEntryModuleFacade = true;
 						chunkList.push(chunkInstance);
 					}
 				}
@@ -463,6 +463,11 @@ export default class Graph {
 				// chunks, if those variables are included after treeshaking
 				for (const chunk of chunkList) {
 					chunk.link();
+				}
+
+				// then go over and ensure all entry chunks export their variables
+				for (const chunk of chunkList) {
+					chunk.generateEntryExports(preserveModules);
 				}
 
 				// create entry point facades for entry module chunks that have tainted exports

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -295,9 +295,7 @@ export default class Graph {
 
 			// generate the imports and exports for the output chunk file
 			const chunk = new Chunk(this, orderedModules);
-			chunk.collectDependencies();
-			chunk.generateImports();
-			chunk.generateEntryExports(entryModule);
+			chunk.link();
 
 			timeEnd('generate chunks', 2);
 
@@ -461,29 +459,18 @@ export default class Graph {
 					}
 				}
 
-				// for each entry point module, ensure its exports
-				// are exported by the chunk itself, with safe name deduping
-				for (const entryModule of entryModules) {
-					entryModule.chunk.generateEntryExports(entryModule);
-				}
-
 				// for each chunk module, set up its imports to other
 				// chunks, if those variables are included after treeshaking
 				for (const chunk of chunkList) {
-					chunk.collectDependencies();
-					chunk.generateImports();
+					chunk.link();
 				}
 
 				// create entry point facades for entry module chunks that have tainted exports
 				if (!preserveModules) {
-					const chunkListLen = chunkList.length;
-					for (let i = 0; i < chunkListLen; i++) {
-						const chunk = chunkList[i];
-						if (chunk.entryModule && !chunk.isEntryModuleFacade) {
+					for (let entryModule of entryModules) {
+						if (!entryModule.chunk.isEntryModuleFacade) {
 							const entryPointFacade = new Chunk(this, []);
-							entryPointFacade.collectDependencies(chunk.entryModule);
-							entryPointFacade.generateImports();
-							entryPointFacade.generateEntryExports(chunk.entryModule);
+							entryPointFacade.linkFacade(entryModule);
 							chunkList.push(entryPointFacade);
 						}
 					}

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -343,6 +343,9 @@ export default function rollup(
 							return createAddons(graph, outputOptions);
 						})
 						.then(addons => {
+							chunk.generateExportNames(
+								outputOptions.format === 'system' || outputOptions.format === 'es'
+							);
 							chunk.preRender(outputOptions);
 							return chunk.render(outputOptions, addons);
 						})
@@ -500,9 +503,15 @@ export default function rollup(
 							return (
 								Promise.resolve()
 									.then(() => {
-										chunks.forEach(chunk => chunk.preRender(outputOptions));
-
-										chunks.forEach(chunk => {
+										const mangleExportNames =
+											outputOptions.format === 'system' || outputOptions.format === 'es';
+										for (let chunk of chunks) {
+											chunk.generateExportNames(mangleExportNames);
+										}
+										for (let chunk of chunks) {
+											chunk.preRender(outputOptions);
+										}
+										for (let chunk of chunks) {
 											if (inputOptions.experimentalPreserveModules) {
 												chunk.generateNamePreserveModules(preserveModulesBase);
 											} else {
@@ -514,7 +523,7 @@ export default function rollup(
 												}
 												chunk.generateName(pattern, addons, outputOptions, existingNames);
 											}
-										});
+										}
 									})
 									// second render chunks given known names
 									.then(() => {

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -343,9 +343,7 @@ export default function rollup(
 							return createAddons(graph, outputOptions);
 						})
 						.then(addons => {
-							chunk.generateExportNames(
-								outputOptions.format === 'system' || outputOptions.format === 'es'
-							);
+							chunk.generateInternalExports();
 							chunk.preRender(outputOptions);
 							return chunk.render(outputOptions, addons);
 						})
@@ -503,10 +501,12 @@ export default function rollup(
 							return (
 								Promise.resolve()
 									.then(() => {
-										const mangleExportNames =
-											outputOptions.format === 'system' || outputOptions.format === 'es';
-										for (let chunk of chunks) {
-											chunk.generateExportNames(mangleExportNames);
+										if (!inputOptions.experimentalPreserveModules) {
+											const mangleExportNames =
+												outputOptions.format === 'system' || outputOptions.format === 'es';
+											for (let chunk of chunks) {
+												chunk.generateInternalExports(mangleExportNames);
+											}
 										}
 										for (let chunk of chunks) {
 											chunk.preRender(outputOptions);

--- a/test/chunking-form/samples/basic-chunking/_expected/es/chunk-7e4b4a9e.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/es/chunk-7e4b4a9e.js
@@ -7,4 +7,4 @@ function fn$1 () {
   console.log('dep2 fn');
 }
 
-export { fn$1 as fn };
+export { fn$1 as a };

--- a/test/chunking-form/samples/basic-chunking/_expected/es/main1.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk-7e4b4a9e.js';
+import { a as fn } from './chunk-7e4b4a9e.js';
 
 function fn$1 () {
   console.log('dep1 fn');

--- a/test/chunking-form/samples/basic-chunking/_expected/es/main2.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk-7e4b4a9e.js';
+import { a as fn } from './chunk-7e4b4a9e.js';
 
 function fn$1 () {
   console.log('lib1 fn');

--- a/test/chunking-form/samples/basic-chunking/_expected/system/chunk-ff89a1a3.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/system/chunk-ff89a1a3.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$1);
+      exports('a', fn$1);
       function fn () {
         console.log('lib2 fn');
       }

--- a/test/chunking-form/samples/basic-chunking/_expected/system/main1.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-ff89a1a3.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/basic-chunking/_expected/system/main2.js
+++ b/test/chunking-form/samples/basic-chunking/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-ff89a1a3.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk-4502c1fc.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk-4502c1fc.js
@@ -2,6 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	var x = 43;
 
-	exports.default = x;
+	exports.x = x;
 
 });

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk-571404be.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk-571404be.js
@@ -2,6 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	var x = 42;
 
-	exports.default = x;
+	exports.x = x;
 
 });

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk-d3654724.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/chunk-d3654724.js
@@ -1,10 +1,10 @@
 define(['exports', './chunk-571404be.js', './chunk-4502c1fc.js'], function (exports, __chunk_1, __chunk_3) { 'use strict';
 
-	var x = __chunk_1.default + 1;
+	var x = __chunk_1.x + 1;
 
-	var y = __chunk_3.default + 1;
+	var y = __chunk_3.x + 1;
 
-	exports.default = x;
-	exports.default$1 = y;
+	exports.x = x;
+	exports.y = y;
 
 });

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/amd/main1.js
@@ -1,5 +1,5 @@
 define(['./chunk-d3654724.js', './chunk-571404be.js', './chunk-4502c1fc.js'], function (__chunk_2, __chunk_1, __chunk_3) { 'use strict';
 
-	console.log(__chunk_2.default + __chunk_2.default$1);
+	console.log(__chunk_2.x + __chunk_2.y);
 
 });

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk-39aa871e.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk-39aa871e.js
@@ -2,4 +2,4 @@
 
 var x = 43;
 
-exports.default = x;
+exports.x = x;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk-78384718.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk-78384718.js
@@ -3,9 +3,9 @@
 var __chunk_1 = require('./chunk-844f8975.js');
 var __chunk_3 = require('./chunk-39aa871e.js');
 
-var x = __chunk_1.default + 1;
+var x = __chunk_1.x + 1;
 
-var y = __chunk_3.default + 1;
+var y = __chunk_3.x + 1;
 
-exports.default = x;
-exports.default$1 = y;
+exports.x = x;
+exports.y = y;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk-844f8975.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/chunk-844f8975.js
@@ -2,4 +2,4 @@
 
 var x = 42;
 
-exports.default = x;
+exports.x = x;

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/cjs/main1.js
@@ -4,4 +4,4 @@ var __chunk_2 = require('./chunk-78384718.js');
 require('./chunk-844f8975.js');
 require('./chunk-39aa871e.js');
 
-console.log(__chunk_2.default + __chunk_2.default$1);
+console.log(__chunk_2.x + __chunk_2.y);

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-3b313c85.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-3b313c85.js
@@ -1,9 +1,8 @@
-import x from './chunk-562606a2.js';
-import x$1 from './chunk-462a7469.js';
+import { x } from './chunk-562606a2.js';
+import { x as x$1 } from './chunk-462a7469.js';
 
 var x$2 = x + 1;
 
 var y = x$1 + 1;
 
-export default x$2;
-export { y as default$1 };
+export { x$2 as x, y };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-3b313c85.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-3b313c85.js
@@ -1,8 +1,8 @@
-import { x } from './chunk-562606a2.js';
-import { x as x$1 } from './chunk-462a7469.js';
+import { a as x } from './chunk-562606a2.js';
+import { a as x$1 } from './chunk-462a7469.js';
 
 var x$2 = x + 1;
 
 var y = x$1 + 1;
 
-export { x$2 as x, y };
+export { x$2 as a, y as b };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-462a7469.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-462a7469.js
@@ -1,3 +1,3 @@
 var x = 43;
 
-export default x;
+export { x };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-462a7469.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-462a7469.js
@@ -1,3 +1,3 @@
 var x = 43;
 
-export { x };
+export { x as a };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-562606a2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-562606a2.js
@@ -1,3 +1,3 @@
 var x = 42;
 
-export { x };
+export { x as a };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-562606a2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/chunk-562606a2.js
@@ -1,3 +1,3 @@
 var x = 42;
 
-export default x;
+export { x };

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { x, y } from './chunk-3b313c85.js';
+import { a as x, b as y } from './chunk-3b313c85.js';
 import './chunk-562606a2.js';
 import './chunk-462a7469.js';
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import x, { default$1 as y } from './chunk-3b313c85.js';
+import { x, y } from './chunk-3b313c85.js';
 import './chunk-562606a2.js';
 import './chunk-462a7469.js';
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-2ec47290.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-2ec47290.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			var x = 42;
-			exports('default', x);
+			exports('x', x);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-2ec47290.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-2ec47290.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			var x = 42;
-			exports('x', x);
+			exports('a', x);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-9b7c35aa.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-9b7c35aa.js
@@ -3,15 +3,15 @@ System.register(['./chunk-2ec47290.js', './chunk-a5be984a.js'], function (export
 	var x, x$1;
 	return {
 		setters: [function (module) {
-			x = module.x;
+			x = module.a;
 		}, function (module) {
-			x$1 = module.x;
+			x$1 = module.a;
 		}],
 		execute: function () {
 
-			var x$2 = exports('x', x + 1);
+			var x$2 = exports('a', x + 1);
 
-			var y = exports('y', x$1 + 1);
+			var y = exports('b', x$1 + 1);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-9b7c35aa.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-9b7c35aa.js
@@ -3,15 +3,15 @@ System.register(['./chunk-2ec47290.js', './chunk-a5be984a.js'], function (export
 	var x, x$1;
 	return {
 		setters: [function (module) {
-			x = module.default;
+			x = module.x;
 		}, function (module) {
-			x$1 = module.default;
+			x$1 = module.x;
 		}],
 		execute: function () {
 
-			var x$2 = exports('default', x + 1);
+			var x$2 = exports('x', x + 1);
 
-			var y = exports('default$1', x$1 + 1);
+			var y = exports('y', x$1 + 1);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-a5be984a.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-a5be984a.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			var x = 43;
-			exports('default', x);
+			exports('x', x);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-a5be984a.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/chunk-a5be984a.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			var x = 43;
-			exports('x', x);
+			exports('a', x);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./chunk-9b7c35aa.js', './chunk-2ec47290.js', './chunk-a5be984a
 	var x, y;
 	return {
 		setters: [function (module) {
-			x = module.default;
-			y = module.default$1;
+			x = module.x;
+			y = module.y;
 		}, function () {}, function () {}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./chunk-9b7c35aa.js', './chunk-2ec47290.js', './chunk-a5be984a
 	var x, y;
 	return {
 		setters: [function (module) {
-			x = module.x;
-			y = module.y;
+			x = module.a;
+			y = module.b;
 		}, function () {}, function () {}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/chunk-3f5ecb92.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/chunk-3f5ecb92.js
@@ -15,4 +15,4 @@ function fn$2 () {
 
 var text$1 = 'dep2 fn';
 
-export { fn$2 as fn, fn$1 };
+export { fn$2 as a, fn$1 as b };

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk-3f5ecb92.js';
+import { a as fn } from './chunk-3f5ecb92.js';
 
 class Main1 {
   constructor () {

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn$1 as fn } from './chunk-3f5ecb92.js';
+import { b as fn } from './chunk-3f5ecb92.js';
 
 class Main2 {
   constructor () {

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/chunk-d691b515.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/chunk-d691b515.js
@@ -3,8 +3,8 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$2);
-      exports('fn$1', fn$1);
+      exports('a', fn$2);
+      exports('b', fn$1);
       function fn () {
         console.log('lib fn');
       }

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-d691b515.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-export-deshadowing/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-d691b515.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn$1;
+      fn = module.b;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/amd/chunk-312a5d4c.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/amd/chunk-312a5d4c.js
@@ -8,7 +8,7 @@ define(['exports'], function (exports) { 'use strict';
 
   const ONE_CONSTANT = 'oneconstant';
 
-  exports.One = One;
   exports.ONE_CONSTANT = ONE_CONSTANT;
+  exports.One = One;
 
 });

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/chunk-a89a857d.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/cjs/chunk-a89a857d.js
@@ -8,5 +8,5 @@ class One {
 
 const ONE_CONSTANT = 'oneconstant';
 
-exports.One = One;
 exports.ONE_CONSTANT = ONE_CONSTANT;
+exports.One = One;

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk-404bd162.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk-404bd162.js
@@ -6,4 +6,4 @@ class One {
 
 const ONE_CONSTANT = 'oneconstant';
 
-export { One, ONE_CONSTANT };
+export { ONE_CONSTANT, One };

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk-404bd162.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/chunk-404bd162.js
@@ -6,4 +6,4 @@ class One {
 
 const ONE_CONSTANT = 'oneconstant';
 
-export { ONE_CONSTANT, One };
+export { ONE_CONSTANT as a, One as b };

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/main1.js
@@ -1,1 +1,1 @@
-export { One as ItemOne } from './chunk-404bd162.js';
+export { b as ItemOne } from './chunk-404bd162.js';

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { ONE_CONSTANT } from './chunk-404bd162.js';
+import { a as ONE_CONSTANT } from './chunk-404bd162.js';
 
 class Two {
     test() {

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/chunk-8194d316.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/chunk-8194d316.js
@@ -7,9 +7,9 @@ System.register([], function (exports, module) {
         test() {
             return ONE_CONSTANT;
         }
-      } exports('One', One);
+      } exports('b', One);
 
-      const ONE_CONSTANT = exports('ONE_CONSTANT', 'oneconstant');
+      const ONE_CONSTANT = exports('a', 'oneconstant');
 
     }
   };

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/main1.js
@@ -2,7 +2,7 @@ System.register(['./chunk-8194d316.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('ItemOne', module.One);
+			exports('ItemOne', module.b);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-export-renaming/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-export-renaming/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-8194d316.js'], function (exports, module) {
     var ONE_CONSTANT;
     return {
         setters: [function (module) {
-            ONE_CONSTANT = module.ONE_CONSTANT;
+            ONE_CONSTANT = module.a;
         }],
         execute: function () {
 

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/es/chunk-9dea0e0e.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/es/chunk-9dea0e0e.js
@@ -17,4 +17,4 @@ function fn$2 () {
 
 var text$1 = 'dep2 fn';
 
-export { fn$2 as fn, text$1 as text, fn$1, text as text$1 };
+export { fn$2 as a, text$1 as b, fn$1 as c, text as d };

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn, text } from './chunk-9dea0e0e.js';
+import { a as fn, b as text } from './chunk-9dea0e0e.js';
 
 class Main1 {
   constructor () {

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn$1 as fn, text$1 as text } from './chunk-9dea0e0e.js';
+import { c as fn, d as text } from './chunk-9dea0e0e.js';
 
 class Main2 {
   constructor () {

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/system/chunk-3526f55f.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/system/chunk-3526f55f.js
@@ -3,8 +3,8 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$2);
-      exports('fn$1', fn$1);
+      exports('a', fn$2);
+      exports('c', fn$1);
       function fn () {
         console.log('lib fn');
       }
@@ -12,17 +12,17 @@ System.register([], function (exports, module) {
       function fn$1 () {
         fn();
         console.log(text$1);
-        text = exports('text$1', 'dep1 fn after dep2');
+        text = exports('d', 'dep1 fn after dep2');
       }
 
-      var text = exports('text$1', 'dep1 fn');
+      var text = exports('d', 'dep1 fn');
 
       function fn$2 () {
         console.log(text);
-        text$1 = exports('text', 'dep2 fn after dep1');
+        text$1 = exports('b', 'dep2 fn after dep1');
       }
 
-      var text$1 = exports('text', 'dep2 fn');
+      var text$1 = exports('b', 'dep2 fn');
 
     }
   };

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./chunk-3526f55f.js'], function (exports, module) {
   var fn, text;
   return {
     setters: [function (module) {
-      fn = module.fn;
-      text = module.text;
+      fn = module.a;
+      text = module.b;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-live-bindings/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-live-bindings/_expected/system/main2.js
@@ -3,8 +3,8 @@ System.register(['./chunk-3526f55f.js'], function (exports, module) {
   var fn, text;
   return {
     setters: [function (module) {
-      fn = module.fn$1;
-      text = module.text$1;
+      fn = module.c;
+      text = module.d;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/chunk-1825b42d.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/chunk-1825b42d.js
@@ -6,6 +6,6 @@ define(['exports'], function (exports) { 'use strict';
         var shared = commonjsGlobal.data;
 
         exports.commonjsGlobal = commonjsGlobal;
-        exports.default = shared;
+        exports.d = shared;
 
 });

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main1.js
@@ -3,7 +3,7 @@ define(['./chunk-1825b42d.js'], function (__chunk_1) { 'use strict';
 	__chunk_1.commonjsGlobal.fn = d => d + 1;
 	var cjs = __chunk_1.commonjsGlobal.fn;
 
-	var main1 = __chunk_1.default.map(cjs);
+	var main1 = __chunk_1.d.map(cjs);
 
 	return main1;
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main2.js
@@ -1,6 +1,6 @@
 define(['./chunk-1825b42d.js'], function (__chunk_1) { 'use strict';
 
-	var main2 = __chunk_1.default.map(d => d + 2);
+	var main2 = __chunk_1.d.map(d => d + 2);
 
 	return main2;
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/chunk-7da4a328.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/chunk-7da4a328.js
@@ -6,4 +6,4 @@ commonjsGlobal.data = [4, 5, 6];
 var shared = commonjsGlobal.data;
 
 exports.commonjsGlobal = commonjsGlobal;
-exports.default = shared;
+exports.d = shared;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main1.js
@@ -5,6 +5,6 @@ var __chunk_1 = require('./chunk-7da4a328.js');
 __chunk_1.commonjsGlobal.fn = d => d + 1;
 var cjs = __chunk_1.commonjsGlobal.fn;
 
-var main1 = __chunk_1.default.map(cjs);
+var main1 = __chunk_1.d.map(cjs);
 
 module.exports = main1;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main2.js
@@ -2,6 +2,6 @@
 
 var __chunk_1 = require('./chunk-7da4a328.js');
 
-var main2 = __chunk_1.default.map(d => d + 2);
+var main2 = __chunk_1.d.map(d => d + 2);
 
 module.exports = main2;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/chunk-b0747c87.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/chunk-b0747c87.js
@@ -3,5 +3,4 @@ var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 
 commonjsGlobal.data = [4, 5, 6];
 var shared = commonjsGlobal.data;
 
-export default shared;
-export { commonjsGlobal };
+export { commonjsGlobal, shared as d };

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/chunk-b0747c87.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/chunk-b0747c87.js
@@ -3,4 +3,4 @@ var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 
 commonjsGlobal.data = [4, 5, 6];
 var shared = commonjsGlobal.data;
 
-export { commonjsGlobal, shared as d };
+export { commonjsGlobal as a, shared as b };

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { commonjsGlobal, d } from './chunk-b0747c87.js';
+import { a as commonjsGlobal, b as d } from './chunk-b0747c87.js';
 
 commonjsGlobal.fn = d => d + 1;
 var cjs = commonjsGlobal.fn;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import d, { commonjsGlobal } from './chunk-b0747c87.js';
+import { commonjsGlobal, d } from './chunk-b0747c87.js';
 
 commonjsGlobal.fn = d => d + 1;
 var cjs = commonjsGlobal.fn;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import d from './chunk-b0747c87.js';
+import { d } from './chunk-b0747c87.js';
 
 var main2 = d.map(d => d + 2);
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { d } from './chunk-b0747c87.js';
+import { b as d } from './chunk-b0747c87.js';
 
 var main2 = d.map(d => d + 2);
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/chunk-1db0f417.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/chunk-1db0f417.js
@@ -7,7 +7,7 @@ System.register([], function (exports, module) {
 
                         commonjsGlobal.data = [4, 5, 6];
                         var shared = commonjsGlobal.data;
-                        exports('default', shared);
+                        exports('d', shared);
 
                 }
         };

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/chunk-1db0f417.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/chunk-1db0f417.js
@@ -3,11 +3,11 @@ System.register([], function (exports, module) {
         return {
                 execute: function () {
 
-                        var commonjsGlobal = exports('commonjsGlobal', typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {});
+                        var commonjsGlobal = exports('a', typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {});
 
                         commonjsGlobal.data = [4, 5, 6];
                         var shared = commonjsGlobal.data;
-                        exports('d', shared);
+                        exports('b', shared);
 
                 }
         };

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main1.js
@@ -4,7 +4,7 @@ System.register(['./chunk-1db0f417.js'], function (exports, module) {
 	return {
 		setters: [function (module) {
 			commonjsGlobal = module.commonjsGlobal;
-			d = module.default;
+			d = module.d;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./chunk-1db0f417.js'], function (exports, module) {
 	var commonjsGlobal, d;
 	return {
 		setters: [function (module) {
-			commonjsGlobal = module.commonjsGlobal;
-			d = module.d;
+			commonjsGlobal = module.a;
+			d = module.b;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-1db0f417.js'], function (exports, module) {
 	var d;
 	return {
 		setters: [function (module) {
-			d = module.default;
+			d = module.d;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-1db0f417.js'], function (exports, module) {
 	var d;
 	return {
 		setters: [function (module) {
-			d = module.d;
+			d = module.b;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-naming/_expected/es/chunks/chunk.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/es/chunks/chunk.js
@@ -1,3 +1,3 @@
 var num = 1;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/chunk-naming/_expected/es/chunks/chunk2.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/es/chunks/chunk2.js
@@ -1,3 +1,3 @@
 var num = 2;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/chunk-naming/_expected/es/chunks/chunk3.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/es/chunks/chunk3.js
@@ -1,3 +1,3 @@
 var num = 3;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/chunk-naming/_expected/es/custom/entryC.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/es/custom/entryC.js
@@ -1,4 +1,4 @@
-import { num } from '../chunks/chunk.js';
-import { num as num$1 } from '../chunks/chunk3.js';
+import { a as num } from '../chunks/chunk.js';
+import { a as num$1 } from '../chunks/chunk3.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming/_expected/es/entryA.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/es/entryA.js
@@ -1,4 +1,4 @@
-import { num } from './chunks/chunk.js';
-import { num as num$1 } from './chunks/chunk2.js';
+import { a as num } from './chunks/chunk.js';
+import { a as num$1 } from './chunks/chunk2.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming/_expected/es/entryB.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/es/entryB.js
@@ -1,4 +1,4 @@
-import { num } from './chunks/chunk2.js';
-import { num as num$1 } from './chunks/chunk3.js';
+import { a as num } from './chunks/chunk2.js';
+import { a as num$1 } from './chunks/chunk3.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming/_expected/system/chunks/chunk.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/system/chunks/chunk.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 1);
+			var num = exports('a', 1);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-naming/_expected/system/chunks/chunk2.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/system/chunks/chunk2.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 2);
+			var num = exports('a', 2);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-naming/_expected/system/chunks/chunk3.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/system/chunks/chunk3.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 3);
+			var num = exports('a', 3);
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-naming/_expected/system/custom/entryC.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/system/custom/entryC.js
@@ -3,9 +3,9 @@ System.register(['../chunks/chunk.js', '../chunks/chunk3.js'], function (exports
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-naming/_expected/system/entryA.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/system/entryA.js
@@ -3,9 +3,9 @@ System.register(['./chunks/chunk.js', './chunks/chunk2.js'], function (exports, 
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunk-naming/_expected/system/entryB.js
+++ b/test/chunking-form/samples/chunk-naming/_expected/system/entryB.js
@@ -3,9 +3,9 @@ System.register(['./chunks/chunk2.js', './chunks/chunk3.js'], function (exports,
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunking-externals/_expected/es/chunk-7e4b4a9e.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/es/chunk-7e4b4a9e.js
@@ -7,4 +7,4 @@ function fn$1 () {
   console.log('dep2 fn');
 }
 
-export { fn$1 as fn };
+export { fn$1 as a };

--- a/test/chunking-form/samples/chunking-externals/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk-7e4b4a9e.js';
+import { a as fn } from './chunk-7e4b4a9e.js';
 
 function fn$1 () {
   console.log('dep1 fn');

--- a/test/chunking-form/samples/chunking-externals/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/es/main2.js
@@ -1,5 +1,5 @@
 import { fn } from 'external';
-import { fn as fn$1 } from './chunk-7e4b4a9e.js';
+import { a as fn$1 } from './chunk-7e4b4a9e.js';
 
 function fn$2 () {
   console.log('lib1 fn');

--- a/test/chunking-form/samples/chunking-externals/_expected/system/chunk-ff89a1a3.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/system/chunk-ff89a1a3.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$1);
+      exports('a', fn$1);
       function fn () {
         console.log('lib2 fn');
       }

--- a/test/chunking-form/samples/chunking-externals/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-ff89a1a3.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-externals/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-externals/_expected/system/main2.js
@@ -5,7 +5,7 @@ System.register(['external', './chunk-ff89a1a3.js'], function (exports, module) 
     setters: [function (module) {
       fn = module.fn;
     }, function (module) {
-      fn$1 = module.fn;
+      fn$1 = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-source-maps/_expected/es/chunk-7e4b4a9e.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/es/chunk-7e4b4a9e.js
@@ -7,5 +7,5 @@ function fn$1 () {
   console.log('dep2 fn');
 }
 
-export { fn$1 as fn };
+export { fn$1 as a };
 //# sourceMappingURL=chunk-7e4b4a9e.js.map

--- a/test/chunking-form/samples/chunking-source-maps/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk-7e4b4a9e.js';
+import { a as fn } from './chunk-7e4b4a9e.js';
 
 function fn$1 () {
   console.log('dep1 fn');

--- a/test/chunking-form/samples/chunking-source-maps/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { fn } from './chunk-7e4b4a9e.js';
+import { a as fn } from './chunk-7e4b4a9e.js';
 
 function fn$1 () {
   console.log('lib1 fn');

--- a/test/chunking-form/samples/chunking-source-maps/_expected/system/chunk-ff89a1a3.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/system/chunk-ff89a1a3.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn$1);
+      exports('a', fn$1);
       function fn () {
         console.log('lib2 fn');
       }

--- a/test/chunking-form/samples/chunking-source-maps/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-ff89a1a3.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-source-maps/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-source-maps/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-ff89a1a3.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/amd/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/amd/main2.js
@@ -1,4 +1,4 @@
-define(['exports', './chunk-92d4fc32.js', 'external2', 'starexternal2'], function (exports, __chunk_1, external2, starexternal2) { 'use strict';
+define(['exports', './chunk-92d4fc32.js', 'starexternal2', 'external2'], function (exports, __chunk_1, starexternal2, external2) { 'use strict';
 
 	var main = '2';
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/cjs/main2.js
@@ -3,8 +3,8 @@
 Object.defineProperty(exports, '__esModule', { value: true });
 
 var __chunk_1 = require('./chunk-1a23f886.js');
-var external2 = require('external2');
 var starexternal2 = require('starexternal2');
+var external2 = require('external2');
 
 var main = '2';
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/es/chunk-7ef6daf7.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/es/chunk-7ef6daf7.js
@@ -3,4 +3,4 @@ import 'external2';
 
 var dep = 'dep';
 
-export { dep };
+export { dep as a };

--- a/test/chunking-form/samples/chunking-star-external/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/es/main1.js
@@ -1,6 +1,6 @@
 export * from 'starexternal1';
 export { e } from 'external1';
-export { dep } from './chunk-7ef6daf7.js';
+export { a as dep } from './chunk-7ef6daf7.js';
 import 'starexternal2';
 import 'external2';
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/es/main2.js
@@ -1,6 +1,6 @@
 export { dep } from './chunk-7ef6daf7.js';
-export { e } from 'external2';
 export * from 'starexternal2';
+export { e } from 'external2';
 
 var main = '2';
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/es/main2.js
@@ -1,4 +1,4 @@
-export { dep } from './chunk-7ef6daf7.js';
+export { a as dep } from './chunk-7ef6daf7.js';
 export * from 'starexternal2';
 export { e } from 'external2';
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/chunk-c79a883a.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/chunk-c79a883a.js
@@ -4,7 +4,7 @@ System.register(['starexternal2', 'external2'], function (exports, module) {
 		setters: [function () {}, function () {}],
 		execute: function () {
 
-			var dep = exports('dep', 'dep');
+			var dep = exports('a', 'dep');
 
 		}
 	};

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/main1.js
@@ -11,7 +11,7 @@ System.register(['starexternal1', 'external1', './chunk-c79a883a.js', 'starexter
 		}, function (module) {
 			exports('e', module.e);
 		}, function (module) {
-			exports('dep', module.dep);
+			exports('dep', module.a);
 		}, function () {}, function () {}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/main2.js
@@ -1,17 +1,17 @@
-System.register(['./chunk-c79a883a.js', 'external2', 'starexternal2'], function (exports, module) {
+System.register(['./chunk-c79a883a.js', 'starexternal2', 'external2'], function (exports, module) {
 	'use strict';
 	var _starExcludes = { main: 1, default: 1, dep: 1, e: 1 };
 	return {
 		setters: [function (module) {
 			exports('dep', module.dep);
 		}, function (module) {
-			exports('e', module.e);
-		}, function (module) {
 			var _setter = {};
 			for (var _$p in module) {
 				if (!_starExcludes[_$p]) _setter[_$p] = module[_$p];
 			}
 			exports(_setter);
+		}, function (module) {
+			exports('e', module.e);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-c79a883a.js', 'starexternal2', 'external2'], function 
 	var _starExcludes = { main: 1, default: 1, dep: 1, e: 1 };
 	return {
 		setters: [function (module) {
-			exports('dep', module.dep);
+			exports('dep', module.a);
 		}, function (module) {
 			var _setter = {};
 			for (var _$p in module) {

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/amd/chunk-07a63167.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/amd/chunk-07a63167.js
@@ -2,6 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	const data = [1, 2, 3];
 
-	exports.default = data;
+	exports.d = data;
 
 });

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main1.js
@@ -1,6 +1,6 @@
 define(['./chunk-07a63167.js'], function (__chunk_1) { 'use strict';
 
-	var main1 = __chunk_1.default.map(d => d + 1);
+	var main1 = __chunk_1.d.map(d => d + 1);
 
 	return main1;
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main2.js
@@ -1,6 +1,6 @@
 define(['./chunk-07a63167.js'], function (__chunk_1) { 'use strict';
 
-	var main2 = __chunk_1.default.map(d => d + 2);
+	var main2 = __chunk_1.d.map(d => d + 2);
 
 	return main2;
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/chunk-70b4a0a3.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/chunk-70b4a0a3.js
@@ -2,4 +2,4 @@
 
 const data = [1, 2, 3];
 
-exports.default = data;
+exports.d = data;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main1.js
@@ -2,6 +2,6 @@
 
 var __chunk_1 = require('./chunk-70b4a0a3.js');
 
-var main1 = __chunk_1.default.map(d => d + 1);
+var main1 = __chunk_1.d.map(d => d + 1);
 
 module.exports = main1;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main2.js
@@ -2,6 +2,6 @@
 
 var __chunk_1 = require('./chunk-70b4a0a3.js');
 
-var main2 = __chunk_1.default.map(d => d + 2);
+var main2 = __chunk_1.d.map(d => d + 2);
 
 module.exports = main2;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/chunk-839282ed.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/chunk-839282ed.js
@@ -1,3 +1,3 @@
 const data = [1, 2, 3];
 
-export default data;
+export { data as d };

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/chunk-839282ed.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/chunk-839282ed.js
@@ -1,3 +1,3 @@
 const data = [1, 2, 3];
 
-export { data as d };
+export { data as a };

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { d } from './chunk-839282ed.js';
+import { a as d } from './chunk-839282ed.js';
 
 var main1 = d.map(d => d + 1);
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import d from './chunk-839282ed.js';
+import { d } from './chunk-839282ed.js';
 
 var main1 = d.map(d => d + 1);
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import d from './chunk-839282ed.js';
+import { d } from './chunk-839282ed.js';
 
 var main2 = d.map(d => d + 2);
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { d } from './chunk-839282ed.js';
+import { a as d } from './chunk-839282ed.js';
 
 var main2 = d.map(d => d + 2);
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/chunk-b8e20cf6.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/chunk-b8e20cf6.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			const data = [1, 2, 3];
-			exports('d', data);
+			exports('a', data);
 
 		}
 	};

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/chunk-b8e20cf6.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/chunk-b8e20cf6.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			const data = [1, 2, 3];
-			exports('default', data);
+			exports('d', data);
 
 		}
 	};

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b8e20cf6.js'], function (exports, module) {
 	var d;
 	return {
 		setters: [function (module) {
-			d = module.d;
+			d = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b8e20cf6.js'], function (exports, module) {
 	var d;
 	return {
 		setters: [function (module) {
-			d = module.default;
+			d = module.d;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b8e20cf6.js'], function (exports, module) {
 	var d;
 	return {
 		setters: [function (module) {
-			d = module.d;
+			d = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/main2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b8e20cf6.js'], function (exports, module) {
 	var d;
 	return {
 		setters: [function (module) {
-			d = module.default;
+			d = module.d;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/es/chunk-a3e957af.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/es/chunk-a3e957af.js
@@ -1,3 +1,3 @@
 var multiplier = 7;
 
-export { multiplier };
+export { multiplier as a };

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/es/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/es/dep2.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk-a3e957af.js';
+import { a as multiplier } from './chunk-a3e957af.js';
 
 function mult (num) {
   return num + multiplier;

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/es/main.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk-a3e957af.js';
+import { a as multiplier } from './chunk-a3e957af.js';
 
 function calc (num) {
   return num * multiplier;

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/system/chunk-b2c58526.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/system/chunk-b2c58526.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var multiplier = exports('multiplier', 7);
+			var multiplier = exports('a', 7);
 
 		}
 	};

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/system/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/system/dep2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b2c58526.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b2c58526.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/chunk-a3e957af.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/chunk-a3e957af.js
@@ -1,3 +1,3 @@
 var multiplier = 7;
 
-export { multiplier };
+export { multiplier as a };

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/dep2.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk-a3e957af.js';
+import { a as multiplier } from './chunk-a3e957af.js';
 
 function mult (num) {
   return num + multiplier;

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/es/main.js
@@ -1,4 +1,4 @@
-import { multiplier } from './chunk-a3e957af.js';
+import { a as multiplier } from './chunk-a3e957af.js';
 
 function calc (num) {
   return num * multiplier;

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/chunk-b2c58526.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/chunk-b2c58526.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var multiplier = exports('multiplier', 7);
+			var multiplier = exports('a', 7);
 
 		}
 	};

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/dep2.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b2c58526.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-treeshaking/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./chunk-b2c58526.js'], function (exports, module) {
   var multiplier;
   return {
     setters: [function (module) {
-      multiplier = module.multiplier;
+      multiplier = module.a;
     }],
     execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main1alias.js
@@ -1,5 +1,5 @@
 define(['./main2alias-1bf8582d.js'], function (main2alias) { 'use strict';
 
-	main2alias.default(main2alias.default$1);
+	main2alias.default(main2alias.dep);
 
 });

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main1alias.js
@@ -1,5 +1,5 @@
 define(['./main2alias-1bf8582d.js'], function (main2alias) { 'use strict';
 
-	main2alias.default(main2alias.dep);
+	main2alias.log(main2alias.dep);
 
 });

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main2alias-1bf8582d.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main2alias-1bf8582d.js
@@ -9,6 +9,6 @@ define(['exports'], function (exports) { 'use strict';
   }
 
   exports.default = log;
-  exports.default$1 = dep;
+  exports.dep = dep;
 
 });

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main2alias-1bf8582d.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main2alias-1bf8582d.js
@@ -8,7 +8,7 @@ define(['exports'], function (exports) { 'use strict';
     }
   }
 
-  exports.default = log;
   exports.dep = dep;
+  exports.log = log;
 
 });

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/main2alias.js
@@ -2,6 +2,6 @@ define(['./main2alias-1bf8582d.js'], function (main2alias) { 'use strict';
 
 
 
-	return main2alias.default;
+	return main2alias.log;
 
 });

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main1alias.js
@@ -2,4 +2,4 @@
 
 var main2alias = require('./main2alias-6ba819ba.js');
 
-main2alias.default(main2alias.default$1);
+main2alias.default(main2alias.dep);

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main1alias.js
@@ -2,4 +2,4 @@
 
 var main2alias = require('./main2alias-6ba819ba.js');
 
-main2alias.default(main2alias.dep);
+main2alias.log(main2alias.dep);

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main2alias-6ba819ba.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main2alias-6ba819ba.js
@@ -8,5 +8,5 @@ function log (x) {
   }
 }
 
-exports.default = log;
 exports.dep = dep;
+exports.log = log;

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main2alias-6ba819ba.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main2alias-6ba819ba.js
@@ -9,4 +9,4 @@ function log (x) {
 }
 
 exports.default = log;
-exports.default$1 = dep;
+exports.dep = dep;

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/main2alias.js
@@ -4,4 +4,4 @@ var main2alias = require('./main2alias-6ba819ba.js');
 
 
 
-module.exports = main2alias.default;
+module.exports = main2alias.log;

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main1alias.js
@@ -1,3 +1,3 @@
-import log, { default$1 as dep } from './main2alias-78537ca8.js';
+import log, { dep } from './main2alias-78537ca8.js';
 
 log(dep);

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main1alias.js
@@ -1,3 +1,3 @@
-import { dep, log } from './main2alias-78537ca8.js';
+import { a as dep, b as log } from './main2alias-78537ca8.js';
 
 log(dep);

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main1alias.js
@@ -1,3 +1,3 @@
-import log, { dep } from './main2alias-78537ca8.js';
+import { dep, log } from './main2alias-78537ca8.js';
 
 log(dep);

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias-78537ca8.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias-78537ca8.js
@@ -6,5 +6,4 @@ function log (x) {
   }
 }
 
-export default log;
-export { dep };
+export { dep, log };

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias-78537ca8.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias-78537ca8.js
@@ -6,4 +6,4 @@ function log (x) {
   }
 }
 
-export { dep, log };
+export { dep as a, log as b };

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias-78537ca8.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias-78537ca8.js
@@ -7,4 +7,4 @@ function log (x) {
 }
 
 export default log;
-export { dep as default$1 };
+export { dep };

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias.js
@@ -1,1 +1,1 @@
-export { log as default } from './main2alias-78537ca8.js';
+export { b as default } from './main2alias-78537ca8.js';

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/es/main2alias.js
@@ -1,1 +1,1 @@
-export { default } from './main2alias-78537ca8.js';
+export { log as default } from './main2alias-78537ca8.js';

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main1alias.js
@@ -4,7 +4,7 @@ System.register(['./main2alias-9c0ea573.js'], function (exports, module) {
 	return {
 		setters: [function (module) {
 			dep = module.dep;
-			log = module.default;
+			log = module.log;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main1alias.js
@@ -3,7 +3,7 @@ System.register(['./main2alias-9c0ea573.js'], function (exports, module) {
 	var dep, log;
 	return {
 		setters: [function (module) {
-			dep = module.default$1;
+			dep = module.dep;
 			log = module.default;
 		}],
 		execute: function () {

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main1alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main1alias.js
@@ -3,8 +3,8 @@ System.register(['./main2alias-9c0ea573.js'], function (exports, module) {
 	var dep, log;
 	return {
 		setters: [function (module) {
-			dep = module.dep;
-			log = module.log;
+			dep = module.a;
+			log = module.b;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias-9c0ea573.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias-9c0ea573.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('default', log);
+      exports('log', log);
       var dep = exports('dep', { x: 42 })
 
       function log (x) {

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias-9c0ea573.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias-9c0ea573.js
@@ -3,8 +3,8 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('log', log);
-      var dep = exports('dep', { x: 42 })
+      exports('b', log);
+      var dep = exports('a', { x: 42 })
 
       function log (x) {
         if (dep) {

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias-9c0ea573.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias-9c0ea573.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
     execute: function () {
 
       exports('default', log);
-      var dep = exports('default$1', { x: 42 })
+      var dep = exports('dep', { x: 42 })
 
       function log (x) {
         if (dep) {

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias.js
@@ -2,7 +2,7 @@ System.register(['./main2alias-9c0ea573.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('default', module.log);
+			exports('default', module.b);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/system/main2alias.js
@@ -2,7 +2,7 @@ System.register(['./main2alias-9c0ea573.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('default', module.default);
+			exports('default', module.log);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-facade/_expected/amd/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/amd/main1.js
@@ -1,5 +1,5 @@
 define(['./main2-1bf8582d.js'], function (main2) { 'use strict';
 
-	main2.default(main2.default$1);
+	main2.default(main2.dep);
 
 });

--- a/test/chunking-form/samples/entrypoint-facade/_expected/amd/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/amd/main1.js
@@ -1,5 +1,5 @@
 define(['./main2-1bf8582d.js'], function (main2) { 'use strict';
 
-	main2.default(main2.dep);
+	main2.log(main2.dep);
 
 });

--- a/test/chunking-form/samples/entrypoint-facade/_expected/amd/main2-1bf8582d.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/amd/main2-1bf8582d.js
@@ -9,6 +9,6 @@ define(['exports'], function (exports) { 'use strict';
   }
 
   exports.default = log;
-  exports.default$1 = dep;
+  exports.dep = dep;
 
 });

--- a/test/chunking-form/samples/entrypoint-facade/_expected/amd/main2-1bf8582d.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/amd/main2-1bf8582d.js
@@ -8,7 +8,7 @@ define(['exports'], function (exports) { 'use strict';
     }
   }
 
-  exports.default = log;
   exports.dep = dep;
+  exports.log = log;
 
 });

--- a/test/chunking-form/samples/entrypoint-facade/_expected/amd/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/amd/main2.js
@@ -2,6 +2,6 @@ define(['./main2-1bf8582d.js'], function (main2) { 'use strict';
 
 
 
-	return main2.default;
+	return main2.log;
 
 });

--- a/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main1.js
@@ -2,4 +2,4 @@
 
 var main2 = require('./main2-6ba819ba.js');
 
-main2.default(main2.dep);
+main2.log(main2.dep);

--- a/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main1.js
@@ -2,4 +2,4 @@
 
 var main2 = require('./main2-6ba819ba.js');
 
-main2.default(main2.default$1);
+main2.default(main2.dep);

--- a/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main2-6ba819ba.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main2-6ba819ba.js
@@ -8,5 +8,5 @@ function log (x) {
   }
 }
 
-exports.default = log;
 exports.dep = dep;
+exports.log = log;

--- a/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main2-6ba819ba.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main2-6ba819ba.js
@@ -9,4 +9,4 @@ function log (x) {
 }
 
 exports.default = log;
-exports.default$1 = dep;
+exports.dep = dep;

--- a/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/cjs/main2.js
@@ -4,4 +4,4 @@ var main2 = require('./main2-6ba819ba.js');
 
 
 
-module.exports = main2.default;
+module.exports = main2.log;

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import { dep, log } from './main2-78537ca8.js';
+import { a as dep, b as log } from './main2-78537ca8.js';
 
 log(dep);

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import log, { dep } from './main2-78537ca8.js';
+import { dep, log } from './main2-78537ca8.js';
 
 log(dep);

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import log, { default$1 as dep } from './main2-78537ca8.js';
+import log, { dep } from './main2-78537ca8.js';
 
 log(dep);

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main2-78537ca8.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main2-78537ca8.js
@@ -6,5 +6,4 @@ function log (x) {
   }
 }
 
-export default log;
-export { dep };
+export { dep, log };

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main2-78537ca8.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main2-78537ca8.js
@@ -6,4 +6,4 @@ function log (x) {
   }
 }
 
-export { dep, log };
+export { dep as a, log as b };

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main2-78537ca8.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main2-78537ca8.js
@@ -7,4 +7,4 @@ function log (x) {
 }
 
 export default log;
-export { dep as default$1 };
+export { dep };

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main2.js
@@ -1,1 +1,1 @@
-export { log as default } from './main2-78537ca8.js';
+export { b as default } from './main2-78537ca8.js';

--- a/test/chunking-form/samples/entrypoint-facade/_expected/es/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/es/main2.js
@@ -1,1 +1,1 @@
-export { default } from './main2-78537ca8.js';
+export { log as default } from './main2-78537ca8.js';

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./main2-9c0ea573.js'], function (exports, module) {
 	var dep, log;
 	return {
 		setters: [function (module) {
-			dep = module.default$1;
+			dep = module.dep;
 			log = module.default;
 		}],
 		execute: function () {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./main2-9c0ea573.js'], function (exports, module) {
 	var dep, log;
 	return {
 		setters: [function (module) {
-			dep = module.dep;
-			log = module.log;
+			dep = module.a;
+			log = module.b;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main1.js
@@ -4,7 +4,7 @@ System.register(['./main2-9c0ea573.js'], function (exports, module) {
 	return {
 		setters: [function (module) {
 			dep = module.dep;
-			log = module.default;
+			log = module.log;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main2-9c0ea573.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main2-9c0ea573.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('default', log);
+      exports('log', log);
       var dep = exports('dep', { x: 42 })
 
       function log (x) {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main2-9c0ea573.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main2-9c0ea573.js
@@ -3,8 +3,8 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('log', log);
-      var dep = exports('dep', { x: 42 })
+      exports('b', log);
+      var dep = exports('a', { x: 42 })
 
       function log (x) {
         if (dep) {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main2-9c0ea573.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main2-9c0ea573.js
@@ -4,7 +4,7 @@ System.register([], function (exports, module) {
     execute: function () {
 
       exports('default', log);
-      var dep = exports('default$1', { x: 42 })
+      var dep = exports('dep', { x: 42 })
 
       function log (x) {
         if (dep) {

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main2.js
@@ -2,7 +2,7 @@ System.register(['./main2-9c0ea573.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('default', module.log);
+			exports('default', module.b);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/entrypoint-facade/_expected/system/main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/system/main2.js
@@ -2,7 +2,7 @@ System.register(['./main2-9c0ea573.js'], function (exports, module) {
 	'use strict';
 	return {
 		setters: [function (module) {
-			exports('default', module.default);
+			exports('default', module.log);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
@@ -1,6 +1,6 @@
 define(['./first.js', './head.js'], function (first, head) { 'use strict';
 
-	console.log(first.default);
-	console.log(first.default);
+	console.log(head.default);
+	console.log(head.default);
 
 });

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var first = require('./first.js');
-require('./head.js');
+require('./first.js');
+var head = require('./head.js');
 
-console.log(first.default);
-console.log(first.default);
+console.log(head.default);
+console.log(head.default);

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/es/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/es/main1.js
@@ -1,5 +1,5 @@
-import head2 from './first.js';
-import './head.js';
+import './first.js';
+import head2 from './head.js';
 
 console.log(head2);
 console.log(head2);

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/system/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/system/main1.js
@@ -2,9 +2,9 @@ System.register(['./first.js', './head.js'], function (exports, module) {
 	'use strict';
 	var head2;
 	return {
-		setters: [function (module) {
+		setters: [function () {}, function (module) {
 			head2 = module.default;
-		}, function () {}],
+		}],
 		execute: function () {
 
 			console.log(head2);

--- a/test/chunking-form/samples/manual-chunks/_expected/es/deps2and3-b1fa6e3b.js
+++ b/test/chunking-form/samples/manual-chunks/_expected/es/deps2and3-b1fa6e3b.js
@@ -1,4 +1,4 @@
-import { fn } from './lib1-9e470ebb.js';
+import { a as fn } from './lib1-9e470ebb.js';
 
 function fn$1 () {
   console.log('lib2 fn');
@@ -14,4 +14,4 @@ function fn$3 () {
   console.log('dep3 fn');
 }
 
-export { fn$2 as fn, fn$3 as fn$1 };
+export { fn$2 as a, fn$3 as b };

--- a/test/chunking-form/samples/manual-chunks/_expected/es/lib1-9e470ebb.js
+++ b/test/chunking-form/samples/manual-chunks/_expected/es/lib1-9e470ebb.js
@@ -2,4 +2,4 @@ function fn () {
   console.log('lib1 fn');
 }
 
-export { fn };
+export { fn as a };

--- a/test/chunking-form/samples/manual-chunks/_expected/es/main.js
+++ b/test/chunking-form/samples/manual-chunks/_expected/es/main.js
@@ -1,4 +1,4 @@
-import { fn, fn$1 } from './deps2and3-b1fa6e3b.js';
+import { a as fn, b as fn$1 } from './deps2and3-b1fa6e3b.js';
 import './lib1-9e470ebb.js';
 
 function fn$2 () {

--- a/test/chunking-form/samples/manual-chunks/_expected/system/deps2and3-0135c87a.js
+++ b/test/chunking-form/samples/manual-chunks/_expected/system/deps2and3-0135c87a.js
@@ -3,12 +3,12 @@ System.register(['./lib1-2ca2caed.js'], function (exports, module) {
   var fn;
   return {
     setters: [function (module) {
-      fn = module.fn;
+      fn = module.a;
     }],
     execute: function () {
 
-      exports('fn', fn$2);
-      exports('fn$1', fn$3);
+      exports('a', fn$2);
+      exports('b', fn$3);
       function fn$1 () {
         console.log('lib2 fn');
       }

--- a/test/chunking-form/samples/manual-chunks/_expected/system/lib1-2ca2caed.js
+++ b/test/chunking-form/samples/manual-chunks/_expected/system/lib1-2ca2caed.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
   return {
     execute: function () {
 
-      exports('fn', fn);
+      exports('a', fn);
       function fn () {
         console.log('lib1 fn');
       }

--- a/test/chunking-form/samples/manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/manual-chunks/_expected/system/main.js
@@ -3,8 +3,8 @@ System.register(['./deps2and3-0135c87a.js', './lib1-2ca2caed.js'], function (exp
   var fn, fn$1;
   return {
     setters: [function (module) {
-      fn = module.fn;
-      fn$1 = module.fn$1;
+      fn = module.a;
+      fn$1 = module.b;
     }, function () {}],
     execute: function () {
 

--- a/test/chunking-form/samples/multi-chunking/_expected/es/chunk-432cdde4.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/chunk-432cdde4.js
@@ -1,3 +1,3 @@
 var num = 3;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/multi-chunking/_expected/es/chunk-bfa0d41f.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/chunk-bfa0d41f.js
@@ -1,3 +1,3 @@
 var num = 2;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/multi-chunking/_expected/es/chunk-c93bd4b3.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/chunk-c93bd4b3.js
@@ -1,3 +1,3 @@
 var num = 1;
 
-export { num };
+export { num as a };

--- a/test/chunking-form/samples/multi-chunking/_expected/es/main1.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { num } from './chunk-c93bd4b3.js';
-import { num as num$1 } from './chunk-bfa0d41f.js';
+import { a as num } from './chunk-c93bd4b3.js';
+import { a as num$1 } from './chunk-bfa0d41f.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/multi-chunking/_expected/es/main2.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/main2.js
@@ -1,4 +1,4 @@
-import { num } from './chunk-bfa0d41f.js';
-import { num as num$1 } from './chunk-432cdde4.js';
+import { a as num } from './chunk-bfa0d41f.js';
+import { a as num$1 } from './chunk-432cdde4.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/multi-chunking/_expected/es/main3.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/es/main3.js
@@ -1,4 +1,4 @@
-import { num } from './chunk-c93bd4b3.js';
-import { num as num$1 } from './chunk-432cdde4.js';
+import { a as num } from './chunk-c93bd4b3.js';
+import { a as num$1 } from './chunk-432cdde4.js';
 
 console.log(num + num$1);

--- a/test/chunking-form/samples/multi-chunking/_expected/system/chunk-30fb479a.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/chunk-30fb479a.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 2);
+			var num = exports('a', 2);
 
 		}
 	};

--- a/test/chunking-form/samples/multi-chunking/_expected/system/chunk-ab8a85cd.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/chunk-ab8a85cd.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 1);
+			var num = exports('a', 1);
 
 		}
 	};

--- a/test/chunking-form/samples/multi-chunking/_expected/system/chunk-c3499ea0.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/chunk-c3499ea0.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var num = exports('num', 3);
+			var num = exports('a', 3);
 
 		}
 	};

--- a/test/chunking-form/samples/multi-chunking/_expected/system/main1.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/main1.js
@@ -3,9 +3,9 @@ System.register(['./chunk-ab8a85cd.js', './chunk-30fb479a.js'], function (export
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/multi-chunking/_expected/system/main2.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/main2.js
@@ -3,9 +3,9 @@ System.register(['./chunk-30fb479a.js', './chunk-c3499ea0.js'], function (export
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/multi-chunking/_expected/system/main3.js
+++ b/test/chunking-form/samples/multi-chunking/_expected/system/main3.js
@@ -3,9 +3,9 @@ System.register(['./chunk-ab8a85cd.js', './chunk-c3499ea0.js'], function (export
 	var num, num$1;
 	return {
 		setters: [function (module) {
-			num = module.num;
+			num = module.a;
 		}, function (module) {
-			num$1 = module.num;
+			num$1 = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/namespace-object-import/_expected/es/main1.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { main2, a, b } from './main2-08e916fb.js';
+import { a, b, main2 } from './main2-08e916fb.js';
 
 console.log(a);
 

--- a/test/chunking-form/samples/namespace-object-import/_expected/es/main1.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/es/main1.js
@@ -1,4 +1,4 @@
-import { a, b, main2 } from './main2-08e916fb.js';
+import { a, b, c as main2 } from './main2-08e916fb.js';
 
 console.log(a);
 

--- a/test/chunking-form/samples/namespace-object-import/_expected/es/main2-08e916fb.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/es/main2-08e916fb.js
@@ -6,4 +6,4 @@ var main2 = /*#__PURE__*/Object.freeze({
 	b: b
 });
 
-export { a, b, main2 };
+export { a, b, main2 as c };

--- a/test/chunking-form/samples/namespace-object-import/_expected/system/main1.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/system/main1.js
@@ -5,7 +5,7 @@ System.register(['./main2-57f8e8ca.js'], function (exports, module) {
 		setters: [function (module) {
 			a = module.a;
 			b = module.b;
-			main2 = module.main2;
+			main2 = module.c;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/namespace-object-import/_expected/system/main1.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/system/main1.js
@@ -1,11 +1,11 @@
 System.register(['./main2-57f8e8ca.js'], function (exports, module) {
 	'use strict';
-	var main2, a, b;
+	var a, b, main2;
 	return {
 		setters: [function (module) {
-			main2 = module.main2;
 			a = module.a;
 			b = module.b;
+			main2 = module.main2;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/namespace-object-import/_expected/system/main2-57f8e8ca.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/system/main2-57f8e8ca.js
@@ -10,7 +10,7 @@ System.register([], function (exports, module) {
 				a: a,
 				b: b
 			});
-			exports('main2', main2);
+			exports('c', main2);
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
@@ -3,5 +3,6 @@ define(['exports'], function (exports) { 'use strict';
 	const foo = 1;
 
 	exports.foo = foo;
+	exports.bar = foo;
 
 });

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
@@ -3,3 +3,4 @@
 const foo = 1;
 
 exports.foo = foo;
+exports.bar = foo;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
@@ -1,3 +1,3 @@
 const foo = 1;
 
-export { foo };
+export { foo, foo as bar };

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/dep.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			const foo = exports('foo', 1);
+			const foo = exports('bar', 1);
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/amd/dep1.js
@@ -1,5 +1,7 @@
-define(['./dep2.js'], function (__chunk_1) { 'use strict';
+define(['exports', './dep2.js'], function (exports, __chunk_1) { 'use strict';
 
 
+
+	exports.default = __chunk_1.default;
 
 });

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/cjs/dep1.js
@@ -1,4 +1,7 @@
 'use strict';
 
-require('./dep2.js');
+var __chunk_1 = require('./dep2.js');
 
+
+
+exports.default = __chunk_1.default;

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/dep1.js
@@ -1,1 +1,1 @@
-import './dep2.js';
+export { default } from './dep2.js';

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep1.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/dep1.js
@@ -1,7 +1,9 @@
 System.register(['./dep2.js'], function (exports, module) {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [function (module) {
+			exports('default', module.default);
+		}],
 		execute: function () {
 
 

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/amd/chunk-97d30bda.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/amd/chunk-97d30bda.js
@@ -2,6 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	function foo() {}
 
-	exports.default = foo;
+	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/amd/main1.js
@@ -2,6 +2,6 @@ define(['./chunk-b893bb82.js', './chunk-97d30bda.js'], function (__chunk_2, __ch
 
 
 
-	return __chunk_1.default;
+	return __chunk_1.foo;
 
 });

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/chunk-13350986.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/chunk-13350986.js
@@ -2,4 +2,4 @@
 
 function foo() {}
 
-exports.default = foo;
+exports.foo = foo;

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/cjs/main1.js
@@ -5,4 +5,4 @@ var __chunk_1 = require('./chunk-13350986.js');
 
 
 
-module.exports = __chunk_1.default;
+module.exports = __chunk_1.foo;

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk-248c6450.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk-248c6450.js
@@ -1,3 +1,3 @@
 function foo() {}
 
-export { foo };
+export { foo as a };

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk-248c6450.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/chunk-248c6450.js
@@ -1,3 +1,3 @@
 function foo() {}
 
-export default foo;
+export { foo };

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
@@ -1,5 +1,5 @@
 import './chunk-eb0a95fb.js';
-import { foo } from './chunk-248c6450.js';
+import { a as foo } from './chunk-248c6450.js';
 
 
 

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
@@ -1,5 +1,5 @@
 import './chunk-eb0a95fb.js';
-import foo from './chunk-248c6450.js';
+import { foo } from './chunk-248c6450.js';
 
 
 

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk-aa2ad1a6.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk-aa2ad1a6.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			exports('default', foo);
+			exports('foo', foo);
 			function foo() {}
 
 		}

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk-aa2ad1a6.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/chunk-aa2ad1a6.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			exports('foo', foo);
+			exports('a', foo);
 			function foo() {}
 
 		}

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-a87fa548.js', './chunk-aa2ad1a6.js'], function (export
 	var foo;
 	return {
 		setters: [function () {}, function (module) {
-			foo = module.foo;
+			foo = module.a;
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
@@ -3,7 +3,7 @@ System.register(['./chunk-a87fa548.js', './chunk-aa2ad1a6.js'], function (export
 	var foo;
 	return {
 		setters: [function () {}, function (module) {
-			foo = module.default;
+			foo = module.foo;
 		}],
 		execute: function () {
 


### PR DESCRIPTION
This reworks #1988 to fix #1983, building on top of the manual-chunks PR at #2084.

This provides a full refactoring of the chunking wiring in the process (note the negative diff despite the new feature!).

Instead of naming exports during the chunk tracing process, we simply work with variable objects as the main interfaces for wiring, only applying naming after all the variable wiring between chunks has been set up. This way, mangling is just part of naming, instead of a separate mapping process.

In the process it also fixes the preserve modules edge case of exporting the same variable twice.

There will be one more PR coming after this and that is for automated chunk merging work, which needs to build on top of this for more easily managing the chunk merging operation (the main reason for this actually).