### PR TITLE
Allow customizing the folder/file layout of experimentalPreserveModules

### DIFF
--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -204,6 +204,7 @@ function getInputOptions(
 		experimentalPreserveModules: getOption('experimentalPreserveModules'),
 		external: getExternal(config, command),
 		input: getOption('input'),
+		inputRelativeDir: getOption('inputRelativeDir'),
 		moduleContext: config.moduleContext,
 		onwarn: getOnWarn(config, command, defaultOnWarnHandler),
 		perf: getOption('perf', false),

--- a/test/chunking-form/samples/module-dest/_config.js
+++ b/test/chunking-form/samples/module-dest/_config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+	description: 'change the module destination',
+	options: {
+		input: ['lib/main.js'],
+		experimentalPreserveModules: true,
+		inputRelativeDir: path.join(__dirname, 'lib'),
+		paths(id) {
+			if (id === '../deps/dep.js') {
+				return 'dep';
+			}
+		},
+		plugins: [
+			{
+				resolveId(importee) {
+					if (importee === 'dep') {
+						return path.join(__dirname, 'deps/dep.js');
+					}
+				},
+				moduleDest(file) {
+					if (file === '../deps/dep.js') {
+						return 'dep.js';
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/chunking-form/samples/module-dest/_expected/amd/dep.js
+++ b/test/chunking-form/samples/module-dest/_expected/amd/dep.js
@@ -1,0 +1,9 @@
+define(['exports'], function (exports) { 'use strict';
+
+  function fn () {
+    console.log('dep fn');
+  }
+
+  exports.fn = fn;
+
+});

--- a/test/chunking-form/samples/module-dest/_expected/amd/main.js
+++ b/test/chunking-form/samples/module-dest/_expected/amd/main.js
@@ -1,0 +1,11 @@
+define(['dep'], function (___deps_dep_js) { 'use strict';
+
+  class Main {
+    constructor () {
+      ___deps_dep_js.fn();
+    }
+  }
+
+  return Main;
+
+});

--- a/test/chunking-form/samples/module-dest/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/module-dest/_expected/cjs/dep.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function fn () {
+  console.log('dep fn');
+}
+
+exports.fn = fn;

--- a/test/chunking-form/samples/module-dest/_expected/cjs/main.js
+++ b/test/chunking-form/samples/module-dest/_expected/cjs/main.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var ___deps_dep_js = require('dep');
+
+class Main {
+  constructor () {
+    ___deps_dep_js.fn();
+  }
+}
+
+module.exports = Main;

--- a/test/chunking-form/samples/module-dest/_expected/es/dep.js
+++ b/test/chunking-form/samples/module-dest/_expected/es/dep.js
@@ -1,0 +1,5 @@
+function fn () {
+  console.log('dep fn');
+}
+
+export { fn };

--- a/test/chunking-form/samples/module-dest/_expected/es/main.js
+++ b/test/chunking-form/samples/module-dest/_expected/es/main.js
@@ -1,0 +1,9 @@
+import { fn } from 'dep';
+
+class Main {
+  constructor () {
+    fn();
+  }
+}
+
+export default Main;

--- a/test/chunking-form/samples/module-dest/_expected/system/dep.js
+++ b/test/chunking-form/samples/module-dest/_expected/system/dep.js
@@ -1,0 +1,13 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      exports('fn', fn);
+      function fn () {
+        console.log('dep fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/module-dest/_expected/system/main.js
+++ b/test/chunking-form/samples/module-dest/_expected/system/main.js
@@ -1,0 +1,18 @@
+System.register(['dep'], function (exports, module) {
+  'use strict';
+  var fn;
+  return {
+    setters: [function (module) {
+      fn = module.fn;
+    }],
+    execute: function () {
+
+      class Main {
+        constructor () {
+          fn();
+        }
+      } exports('default', Main);
+
+    }
+  };
+});

--- a/test/chunking-form/samples/module-dest/deps/dep.js
+++ b/test/chunking-form/samples/module-dest/deps/dep.js
@@ -1,0 +1,3 @@
+export function fn () {
+  console.log('dep fn');
+}

--- a/test/chunking-form/samples/module-dest/lib/main.js
+++ b/test/chunking-form/samples/module-dest/lib/main.js
@@ -1,0 +1,7 @@
+import { fn } from 'dep';
+
+export default class Main {
+  constructor () {
+    fn();
+  }
+}

--- a/test/cli/samples/config-deprecations/rollup.config.js
+++ b/test/cli/samples/config-deprecations/rollup.config.js
@@ -30,7 +30,7 @@ module.exports = {
 				warnings[1],
 				{
 					code: 'UNKNOWN_OPTION',
-					message: 'Unknown input option: abc. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
+					message: 'Unknown input option: abc. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, inputRelativeDir, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
 				}
 			);
 		} else {

--- a/test/cli/samples/warn-unknown-options/rollup.config.js
+++ b/test/cli/samples/warn-unknown-options/rollup.config.js
@@ -17,6 +17,6 @@ module.exports = commands => ({
 		warnings++;
 		assert.equal(warning.code, 'UNKNOWN_OPTION');
 		assert.equal(warning.message,
-			'Unknown CLI flag: unknownOption. Allowed options: acorn, acornInjectPlugins, amd, banner, c, cache, config, context, dir, e, entry, environment, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, exports, extend, external, f, file, footer, format, freeze, g, globals, h, i, indent, input, interop, intro, l, legacy, m, moduleContext, n, name, namespaceToStringTag, noConflict, o, onwarn, outro, paths, perf, plugins, preferConst, preserveSymlinks, silent, sourcemap, sourcemapFile, strict, treeshake, v, w, watch');
+			'Unknown CLI flag: unknownOption. Allowed options: acorn, acornInjectPlugins, amd, banner, c, cache, config, context, dir, e, entry, environment, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, exports, extend, external, f, file, footer, format, freeze, g, globals, h, i, indent, input, inputRelativeDir, interop, intro, l, legacy, m, moduleContext, n, name, namespaceToStringTag, noConflict, o, onwarn, outro, paths, perf, plugins, preferConst, preserveSymlinks, silent, sourcemap, sourcemapFile, strict, treeshake, v, w, watch');
 	}
 });

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -68,7 +68,7 @@ describe('sanity checks', () => {
 					{
 						code: 'UNKNOWN_OPTION',
 						message:
-							'Unknown input option: plUgins. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
+							'Unknown input option: plUgins. Allowed options: acorn, acornInjectPlugins, cache, context, entry, experimentalCodeSplitting, experimentalDynamicImport, experimentalPreserveModules, external, input, inputRelativeDir, moduleContext, onwarn, perf, plugins, preferConst, preserveSymlinks, treeshake, watch'
 					}
 				]);
 			});


### PR DESCRIPTION
Now that you can keep the folder layout of your project with `experimentalPreserveModules`, I believe some additional configuration is necessary. When using the node-resolve plugin, you can leave your project root with the `opts.basedir ` property. When the common ancestor is found to determine the new folder layout, it can get pretty gnarly.

Given `process.cwd() = '.'`.

Source:

```
- path
  - to
    - node_modules
      - dep
        - index.js
- path
  - to
    - project
      - index.js
```

Desired:

```
- node_modules
  - dep
    - index.js
- index.js
```

with exposing the existing option `inputRelativeDir = 'path/to/project` and a `moduleDest` hook that lets you override the node_modules location.