### PR TITLE
Move @types/acorn dependencies => devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.3.tgz",
       "integrity": "sha512-gou/kWQkGPMZjdCKNZGDpqxLm9+ErG/pFZKPX4tvCjr0Xf4FCYYX3nAsu7aDVKJV3KUe27+mvqqyWT/9VZoM/A==",
+      "dev": true,
       "requires": {
         "@types/estree": "0.0.38"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "homepage": "https://github.com/rollup/rollup",
   "dependencies": {
-    "@types/acorn": "^4.0.3",
     "acorn": "^5.5.3",
     "acorn-dynamic-import": "^3.0.0",
     "locate-character": "^2.0.5",
@@ -65,6 +64,7 @@
     "rollup-pluginutils": "^2.0.1"
   },
   "devDependencies": {
+    "@types/acorn": "^4.0.3",
     "@types/chokidar": "^1.7.5",
     "@types/minimist": "^1.2.0",
     "@types/node": "^9.6.0",


### PR DESCRIPTION
My project is written in TypeScript and targets ES3, and installing
Rollup causes my TypeScript compilation to error:

    node_modules/@types/acorn/index.d.ts(240,8): error TS2304: Cannot find name 'Symbol'.
    node_modules/@types/acorn/index.d.ts(240,28): error TS2304: Cannot find name 'Iterator'.

See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/24595

When I `rm -rf node_modules/@types`, rollup continues to run fine, so I
don't think this is really a runtime dependency of Rollup.

<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
