### PR TITLE
Tree shake logical expressions

### DIFF
--- a/bin/src/run/loadConfigFile.ts
+++ b/bin/src/run/loadConfigFile.ts
@@ -4,7 +4,8 @@ import * as rollup from 'rollup';
 import batchWarnings from './batchWarnings';
 import relativeId from '../../../src/utils/relativeId';
 import { handleError, stderr } from '../logging';
-import { InputOptions, OutputChunk } from '../../../src/rollup/index';
+import { InputOptions } from '../../../src/rollup/index';
+import { Bundle } from '../../../src/rollup';
 
 interface NodeModuleWithCompile extends NodeModule {
 	_compile(code: string, filename: string): any;
@@ -25,7 +26,7 @@ export default function loadConfigFile(
 			},
 			onwarn: warnings.add
 		})
-		.then((bundle: OutputChunk) => {
+		.then((bundle: Bundle) => {
 			if (!silent && warnings.count > 0) {
 				stderr(chalk.bold(`loaded ${relativeId(configFile)} with warnings`));
 				warnings.flush();

--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -13,13 +13,15 @@ import { handleError, stderr } from '../logging';
 import { RollupError } from '../../../src/utils/error';
 import { RollupWatchOptions } from '../../../src/watch/index';
 import { printTimings } from './timings';
+import { Bundle, BundleSet } from '../../../src/rollup';
 
 interface WatchEvent {
-	code: string;
-	error: RollupError | Error;
-	input: string | string[];
-	output: string[];
-	duration: number;
+	code?: string;
+	error?: RollupError | Error;
+	input?: string | string[];
+	output?: string[];
+	duration?: number;
+	result?: Bundle | BundleSet;
 }
 
 interface Watcher {

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -1,7 +1,6 @@
 import CallOptions from '../CallOptions';
 import ExecutionPathOptions from '../ExecutionPathOptions';
 import SpreadElement from './SpreadElement';
-import { isGlobalVariable } from '../variables/GlobalVariable';
 import { isIdentifier } from './Identifier';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { isNamespaceVariable } from '../variables/NamespaceVariable';
@@ -45,7 +44,7 @@ export default class CallExpression extends NodeBase {
 				);
 			}
 
-			if (this.callee.name === 'eval' && isGlobalVariable(variable)) {
+			if (this.callee.name === 'eval') {
 				this.module.warn(
 					{
 						code: 'EVAL',

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -6,8 +6,12 @@ import { isIdentifier } from './Identifier';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { isNamespaceVariable } from '../variables/NamespaceVariable';
 import { NodeType } from './NodeType';
-import { ExpressionNode, NodeBase } from './shared/Node';
+import { ExpressionNode, Node, NodeBase } from './shared/Node';
 import { ObjectPath } from '../values';
+
+export function isCallExpression(node: Node | { type?: string }): node is CallExpression {
+	return node.type === NodeType.CallExpression;
+}
 
 export default class CallExpression extends NodeBase {
 	type: NodeType.CallExpression;

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -5,12 +5,8 @@ import { isIdentifier } from './Identifier';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { isNamespaceVariable } from '../variables/NamespaceVariable';
 import { NodeType } from './NodeType';
-import { ExpressionNode, Node, NodeBase } from './shared/Node';
+import { ExpressionNode, NodeBase } from './shared/Node';
 import { ObjectPath } from '../values';
-
-export function isCallExpression(node: Node | { type?: string }): node is CallExpression {
-	return node.type === NodeType.CallExpression;
-}
 
 export default class CallExpression extends NodeBase {
 	type: NodeType.CallExpression;

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -82,7 +82,7 @@ export default class ConditionalExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ hasBecomeCallee }: NodeRenderOptions = BLANK
+		{ hasBecomeCallee, hasBecomeStatement }: NodeRenderOptions = BLANK
 	) {
 		if (!this.module.graph.treeshake || this.test.included) {
 			super.render(code, options);
@@ -91,6 +91,7 @@ export default class ConditionalExpression extends NodeBase {
 			code.remove(this.start, branchToRetain.start);
 			code.remove(branchToRetain.end, this.end);
 			branchToRetain.render(code, options, {
+				hasBecomeStatement,
 				hasBecomeCallee:
 					hasBecomeCallee || (isCallExpression(this.parent) && this.parent.callee === this),
 				hasDifferentParent: true

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -4,9 +4,10 @@ import CallOptions from '../CallOptions';
 import MagicString from 'magic-string';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
-import { ExpressionNode, Node, NodeBase } from './shared/Node';
-import { getFieldOfParent, NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
+import { ExpressionNode, NodeBase } from './shared/Node';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { BLANK } from '../../utils/blank';
+import CallExpression from './CallExpression';
 
 export default class ConditionalExpression extends NodeBase {
 	type: NodeType.ConditionalExpression;
@@ -82,7 +83,7 @@ export default class ConditionalExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ renderedParent, fieldOfRenderedParent }: NodeRenderOptions = BLANK
+		{ renderedParentType, isCalleeOfRenderedParent }: NodeRenderOptions = BLANK
 	) {
 		if (!this.module.graph.treeshake || this.test.included) {
 			super.render(code, options);
@@ -91,8 +92,10 @@ export default class ConditionalExpression extends NodeBase {
 			code.remove(this.start, branchToRetain.start);
 			code.remove(branchToRetain.end, this.end);
 			branchToRetain.render(code, options, {
-				renderedParent: renderedParent || <Node>this.parent,
-				fieldOfRenderedParent: renderedParent ? fieldOfRenderedParent : getFieldOfParent(this)
+				renderedParentType: renderedParentType || this.parent.type,
+				isCalleeOfRenderedParent: renderedParentType
+					? isCalleeOfRenderedParent
+					: (<CallExpression>this.parent).callee === this
 			});
 		}
 	}

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -11,6 +11,7 @@ import {
 	RenderOptions
 } from '../../utils/renderHelpers';
 import { BLANK } from '../../utils/blank';
+import Program from './Program';
 
 const WHITESPACE = /\s/;
 
@@ -100,7 +101,10 @@ export default class ExportDefaultDeclaration extends NodeBase {
 			this.renderVariableDeclaration(code, declarationStart, options);
 		} else {
 			code.remove(this.start, declarationStart);
-			this.declaration.render(code, options, { hasBecomeStatement: true });
+			this.declaration.render(code, options, {
+				renderedParent: <Program>this.parent,
+				fieldOfRenderedParent: 'body'
+			});
 			if (code.original[this.end - 1] !== ';') {
 				code.appendLeft(this.end, ';');
 			}

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -10,7 +10,6 @@ import {
 	NodeRenderOptions,
 	RenderOptions
 } from '../../utils/renderHelpers';
-import { isObjectExpression } from './ObjectExpression';
 import { BLANK } from '../../utils/blank';
 
 const WHITESPACE = /\s/;
@@ -32,8 +31,6 @@ function getIdInsertPosition(code: string, declarationKeyword: string, start = 0
 	}
 	return declarationEnd + generatorStarPos + 1;
 }
-
-const needsToBeWrapped = isObjectExpression;
 
 export default class ExportDefaultDeclaration extends NodeBase {
 	type: NodeType.ExportDefaultDeclaration;
@@ -102,7 +99,12 @@ export default class ExportDefaultDeclaration extends NodeBase {
 		} else if (this.variable.included) {
 			this.renderVariableDeclaration(code, declarationStart, options);
 		} else {
-			this.renderForSideEffectsOnly(code, declarationStart);
+			code.remove(this.start, declarationStart);
+			this.declaration.render(code, options, { hasBecomeStatement: true });
+			if (code.original[this.end - 1] !== ';') {
+				code.appendLeft(this.end, ';');
+			}
+			return;
 		}
 		super.render(code, options);
 	}
@@ -149,18 +151,6 @@ export default class ExportDefaultDeclaration extends NodeBase {
 		);
 		if (systemBinding) {
 			code.appendRight(code.original[this.end - 1] === ';' ? this.end - 1 : this.end, ')');
-		}
-	}
-
-	private renderForSideEffectsOnly(code: MagicString, declarationStart: number) {
-		code.remove(this.start, declarationStart);
-		if (needsToBeWrapped(this.declaration)) {
-			code.appendLeft(declarationStart, '(');
-			if (code.original[this.end - 1] === ';') {
-				code.prependRight(this.end - 1, ')');
-			} else {
-				code.prependRight(this.end, ');');
-			}
 		}
 	}
 }

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -11,7 +11,6 @@ import {
 	RenderOptions
 } from '../../utils/renderHelpers';
 import { BLANK } from '../../utils/blank';
-import Program from './Program';
 
 const WHITESPACE = /\s/;
 
@@ -102,8 +101,8 @@ export default class ExportDefaultDeclaration extends NodeBase {
 		} else {
 			code.remove(this.start, declarationStart);
 			this.declaration.render(code, options, {
-				renderedParent: <Program>this.parent,
-				fieldOfRenderedParent: 'body'
+				renderedParentType: NodeType.ExpressionStatement,
+				isCalleeOfRenderedParent: false
 			});
 			if (code.original[this.end - 1] !== ';') {
 				code.appendLeft(this.end, ';');

--- a/src/ast/nodes/ExpressionStatement.ts
+++ b/src/ast/nodes/ExpressionStatement.ts
@@ -2,12 +2,17 @@ import MagicString from 'magic-string';
 import Scope from '../scopes/Scope';
 import { StatementBase } from './shared/Node';
 import { RenderOptions } from '../../utils/renderHelpers';
+import { NodeType } from './NodeType';
 
 export default class ExpressionStatement extends StatementBase {
 	directive?: string;
 
 	initialiseNode(_parentScope: Scope) {
-		if (this.directive && this.directive !== 'use strict' && this.parent.type === 'Program') {
+		if (
+			this.directive &&
+			this.directive !== 'use strict' &&
+			this.parent.type === NodeType.Program
+		) {
 			this.module.warn(
 				// This is necessary, because either way (deleting or not) can lead to errors.
 				{
@@ -24,7 +29,8 @@ export default class ExpressionStatement extends StatementBase {
 	}
 
 	shouldBeIncluded() {
-		if (this.directive && this.directive !== 'use strict') return this.parent.type !== 'Program';
+		if (this.directive && this.directive !== 'use strict')
+			return this.parent.type !== NodeType.Program;
 
 		return super.shouldBeIncluded();
 	}

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -162,7 +162,7 @@ export default class Identifier extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ hasBecomeCallee }: NodeRenderOptions = BLANK
+		{ renderedParent, fieldOfRenderedParent }: NodeRenderOptions = BLANK
 	) {
 		if (this.variable) {
 			const name = this.variable.getName();
@@ -176,7 +176,13 @@ export default class Identifier extends NodeBase {
 					code.prependRight(this.start, `${this.name}: `);
 				}
 			}
-			if (hasBecomeCallee && name === 'eval') {
+			// In strict mode, any variable named "eval" must be the actual "eval" function
+			if (
+				name === 'eval' &&
+				renderedParent &&
+				renderedParent.type === 'CallExpression' &&
+				fieldOfRenderedParent === 'callee'
+			) {
 				code.appendRight(this.start, '0, ');
 			}
 			if (options.systemBindings && this.variable.exportName) {

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -162,7 +162,7 @@ export default class Identifier extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ renderedParent, fieldOfRenderedParent }: NodeRenderOptions = BLANK
+		{ renderedParentType, isCalleeOfRenderedParent }: NodeRenderOptions = BLANK
 	) {
 		if (this.variable) {
 			const name = this.variable.getName();
@@ -179,9 +179,8 @@ export default class Identifier extends NodeBase {
 			// In strict mode, any variable named "eval" must be the actual "eval" function
 			if (
 				name === 'eval' &&
-				renderedParent &&
-				renderedParent.type === 'CallExpression' &&
-				fieldOfRenderedParent === 'callee'
+				renderedParentType === NodeType.CallExpression &&
+				isCalleeOfRenderedParent
 			) {
 				code.appendRight(this.start, '0, ');
 			}

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -7,10 +7,9 @@ import {
 	SomeReturnExpressionCallback
 } from './shared/Expression';
 import { NodeType } from './NodeType';
-import { ExpressionNode, NodeBase } from './shared/Node';
-import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
+import { ExpressionNode, Node, NodeBase } from './shared/Node';
+import { getFieldOfParent, NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import MagicString from 'magic-string';
-import { isCallExpression } from './CallExpression';
 import { BLANK } from '../../utils/blank';
 
 export type LogicalOperator = '||' | '&&';
@@ -98,7 +97,7 @@ export default class LogicalExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ hasBecomeCallee, hasBecomeStatement }: NodeRenderOptions = BLANK
+		{ renderedParent, fieldOfRenderedParent }: NodeRenderOptions = BLANK
 	) {
 		if (!this.module.graph.treeshake || (this.left.included && this.right.included)) {
 			super.render(code, options);
@@ -107,10 +106,8 @@ export default class LogicalExpression extends NodeBase {
 			code.remove(this.start, branchToRetain.start);
 			code.remove(branchToRetain.end, this.end);
 			branchToRetain.render(code, options, {
-				hasBecomeStatement,
-				hasBecomeCallee:
-					hasBecomeCallee || (isCallExpression(this.parent) && this.parent.callee === this),
-				hasDifferentParent: true
+				renderedParent: renderedParent || <Node>this.parent,
+				fieldOfRenderedParent: renderedParent ? fieldOfRenderedParent : getFieldOfParent(this)
 			});
 		}
 	}

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -98,7 +98,7 @@ export default class LogicalExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ hasBecomeCallee }: NodeRenderOptions = BLANK
+		{ hasBecomeCallee, hasBecomeStatement }: NodeRenderOptions = BLANK
 	) {
 		if (!this.module.graph.treeshake || (this.left.included && this.right.included)) {
 			super.render(code, options);
@@ -107,6 +107,7 @@ export default class LogicalExpression extends NodeBase {
 			code.remove(this.start, branchToRetain.start);
 			code.remove(branchToRetain.end, this.end);
 			branchToRetain.render(code, options, {
+				hasBecomeStatement,
 				hasBecomeCallee:
 					hasBecomeCallee || (isCallExpression(this.parent) && this.parent.callee === this),
 				hasDifferentParent: true

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -7,10 +7,11 @@ import {
 	SomeReturnExpressionCallback
 } from './shared/Expression';
 import { NodeType } from './NodeType';
-import { ExpressionNode, Node, NodeBase } from './shared/Node';
-import { getFieldOfParent, NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
+import { ExpressionNode, NodeBase } from './shared/Node';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import MagicString from 'magic-string';
 import { BLANK } from '../../utils/blank';
+import CallExpression from './CallExpression';
 
 export type LogicalOperator = '||' | '&&';
 
@@ -97,7 +98,7 @@ export default class LogicalExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ renderedParent, fieldOfRenderedParent }: NodeRenderOptions = BLANK
+		{ renderedParentType, isCalleeOfRenderedParent }: NodeRenderOptions = BLANK
 	) {
 		if (!this.module.graph.treeshake || (this.left.included && this.right.included)) {
 			super.render(code, options);
@@ -106,8 +107,10 @@ export default class LogicalExpression extends NodeBase {
 			code.remove(this.start, branchToRetain.start);
 			code.remove(branchToRetain.end, this.end);
 			branchToRetain.render(code, options, {
-				renderedParent: renderedParent || <Node>this.parent,
-				fieldOfRenderedParent: renderedParent ? fieldOfRenderedParent : getFieldOfParent(this)
+				renderedParentType: renderedParentType || this.parent.type,
+				isCalleeOfRenderedParent: renderedParentType
+					? isCalleeOfRenderedParent
+					: (<CallExpression>this.parent).callee === this
 			});
 		}
 	}

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -216,12 +216,10 @@ export default class MemberExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ renderedParent, fieldOfRenderedParent }: NodeRenderOptions = BLANK
+		{ renderedParentType, isCalleeOfRenderedParent }: NodeRenderOptions = BLANK
 	) {
 		const isCalleeOfDifferentParent =
-			renderedParent &&
-			renderedParent.type === 'CallExpression' &&
-			fieldOfRenderedParent === 'callee';
+			renderedParentType === NodeType.CallExpression && isCalleeOfRenderedParent;
 		if (this.variable || this.replacement) {
 			let replacement = this.variable ? this.variable.getName() : this.replacement;
 			if (isCalleeOfDifferentParent) replacement = '0, ' + replacement;

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -10,8 +10,9 @@ import { isNamespaceVariable } from '../variables/NamespaceVariable';
 import { isExternalVariable } from '../variables/ExternalVariable';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../utils/renderHelpers';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { isUnknownKey, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../values';
+import { BLANK } from '../../utils/blank';
 
 const validProp = /^[a-zA-Z_$][a-zA-Z_$0-9]*$/;
 
@@ -212,20 +213,24 @@ export default class MemberExpression extends NodeBase {
 		}
 	}
 
-	render(code: MagicString, options: RenderOptions) {
-		if (this.variable) {
-			code.overwrite(this.start, this.end, this.variable.getName(), {
+	render(
+		code: MagicString,
+		options: RenderOptions,
+		{ hasBecomeCallee }: NodeRenderOptions = BLANK
+	) {
+		if (this.variable || this.replacement) {
+			let replacement = this.variable ? this.variable.getName() : this.replacement;
+			if (hasBecomeCallee) replacement = '0, ' + replacement;
+			code.overwrite(this.start, this.end, replacement, {
 				storeName: true,
-				contentOnly: false
+				contentOnly: true
 			});
-		} else if (this.replacement) {
-			code.overwrite(this.start, this.end, this.replacement, {
-				storeName: true,
-				contentOnly: false
-			});
+		} else {
+			if (hasBecomeCallee) {
+				code.appendRight(this.start, '0, ');
+			}
+			super.render(code, options);
 		}
-
-		super.render(code, options);
 	}
 
 	someReturnExpressionWhenCalledAtPath(

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -216,17 +216,21 @@ export default class MemberExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ hasBecomeCallee }: NodeRenderOptions = BLANK
+		{ renderedParent, fieldOfRenderedParent }: NodeRenderOptions = BLANK
 	) {
+		const isCalleeOfDifferentParent =
+			renderedParent &&
+			renderedParent.type === 'CallExpression' &&
+			fieldOfRenderedParent === 'callee';
 		if (this.variable || this.replacement) {
 			let replacement = this.variable ? this.variable.getName() : this.replacement;
-			if (hasBecomeCallee) replacement = '0, ' + replacement;
+			if (isCalleeOfDifferentParent) replacement = '0, ' + replacement;
 			code.overwrite(this.start, this.end, replacement, {
 				storeName: true,
 				contentOnly: true
 			});
 		} else {
-			if (hasBecomeCallee) {
+			if (isCalleeOfDifferentParent) {
 				code.appendRight(this.start, '0, ');
 			}
 			super.render(code, options);

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -6,7 +6,7 @@ import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from '.
 import { isUnknownKey, objectMembers, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../values';
 import { Node, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
-import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
+import { childIsStatement, NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { BLANK } from '../../utils/blank';
 import MagicString from 'magic-string';
 
@@ -133,13 +133,9 @@ export default class ObjectExpression extends NodeBase {
 		);
 	}
 
-	render(
-		code: MagicString,
-		options: RenderOptions,
-		{ hasBecomeStatement }: NodeRenderOptions = BLANK
-	) {
+	render(code: MagicString, options: RenderOptions, { renderedParent }: NodeRenderOptions = BLANK) {
 		super.render(code, options);
-		if (hasBecomeStatement) {
+		if (renderedParent && childIsStatement(renderedParent)) {
 			code.appendRight(this.start, '(');
 			code.prependLeft(this.end, ')');
 		}

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -6,6 +6,9 @@ import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from '.
 import { isUnknownKey, objectMembers, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../values';
 import { Node, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
+import { BLANK } from '../../utils/blank';
+import MagicString from 'magic-string';
 
 const PROPERTY_KINDS_READ = ['init', 'get'];
 const PROPERTY_KINDS_WRITE = ['init', 'set'];
@@ -128,6 +131,18 @@ export default class ObjectExpression extends NodeBase {
 				property.hasEffectsWhenCalledAtPath(path.slice(1), callOptions, options)
 			)
 		);
+	}
+
+	render(
+		code: MagicString,
+		options: RenderOptions,
+		{ hasBecomeStatement }: NodeRenderOptions = BLANK
+	) {
+		super.render(code, options);
+		if (hasBecomeStatement) {
+			code.appendRight(this.start, '(');
+			code.prependLeft(this.end, ')');
+		}
 	}
 
 	someReturnExpressionWhenCalledAtPath(

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -6,7 +6,7 @@ import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from '.
 import { isUnknownKey, objectMembers, ObjectPath, ObjectPathKey, UNKNOWN_KEY } from '../values';
 import { Node, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
-import { childIsStatement, NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { BLANK } from '../../utils/blank';
 import MagicString from 'magic-string';
 
@@ -133,9 +133,13 @@ export default class ObjectExpression extends NodeBase {
 		);
 	}
 
-	render(code: MagicString, options: RenderOptions, { renderedParent }: NodeRenderOptions = BLANK) {
+	render(
+		code: MagicString,
+		options: RenderOptions,
+		{ renderedParentType }: NodeRenderOptions = BLANK
+	) {
 		super.render(code, options);
-		if (renderedParent && childIsStatement(renderedParent)) {
+		if (renderedParentType === NodeType.ExpressionStatement) {
 			code.appendRight(this.start, '(');
 			code.prependLeft(this.end, ')');
 		}

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -2,11 +2,34 @@ import ExecutionPathOptions from '../ExecutionPathOptions';
 import MagicString from 'magic-string';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { NodeType } from './NodeType';
-import { RenderOptions } from '../../utils/renderHelpers';
+import {
+	getCommaSeparatedNodesWithBoundaries,
+	NodeRenderOptions,
+	RenderOptions
+} from '../../utils/renderHelpers';
+import { BLANK } from '../../utils/blank';
+import { ObjectPath } from '../values';
+import CallOptions from '../CallOptions';
+import { ForEachReturnExpressionCallback } from './shared/Expression';
+import { isCallExpression } from './CallExpression';
 
 export default class SequenceExpression extends NodeBase {
 	type: NodeType.SequenceExpression;
 	expressions: ExpressionNode[];
+
+	forEachReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		callOptions: CallOptions,
+		callback: ForEachReturnExpressionCallback,
+		options: ExecutionPathOptions
+	) {
+		this.expressions[this.expressions.length - 1].forEachReturnExpressionWhenCalledAtPath(
+			path,
+			callOptions,
+			callback,
+			options
+		);
+	}
 
 	getValue(): any {
 		return this.expressions[this.expressions.length - 1].getValue();
@@ -16,54 +39,84 @@ export default class SequenceExpression extends NodeBase {
 		return this.expressions.some(expression => expression.hasEffects(options));
 	}
 
+	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions): boolean {
+		return (
+			path.length > 0 &&
+			this.expressions[this.expressions.length - 1].hasEffectsWhenAccessedAtPath(path, options)
+		);
+	}
+
+	hasEffectsWhenAssignedAtPath(path: ObjectPath, options: ExecutionPathOptions): boolean {
+		return (
+			path.length === 0 ||
+			this.expressions[this.expressions.length - 1].hasEffectsWhenAssignedAtPath(path, options)
+		);
+	}
+
+	hasEffectsWhenCalledAtPath(
+		path: ObjectPath,
+		callOptions: CallOptions,
+		options: ExecutionPathOptions
+	): boolean {
+		return this.expressions[this.expressions.length - 1].hasEffectsWhenCalledAtPath(
+			path,
+			callOptions,
+			options
+		);
+	}
+
 	includeInBundle() {
 		let addedNewNodes = !this.included;
 		this.included = true;
-		if (this.expressions[this.expressions.length - 1].includeInBundle()) {
-			addedNewNodes = true;
+		for (let i = 0; i < this.expressions.length - 1; i++) {
+			const node = this.expressions[i];
+			if (node.shouldBeIncluded() && node.includeInBundle()) addedNewNodes = true;
 		}
-		this.expressions.forEach(node => {
-			if (node.shouldBeIncluded()) {
-				if (node.includeInBundle()) {
-					addedNewNodes = true;
-				}
-			}
-		});
+		if (this.expressions[this.expressions.length - 1].includeInBundle()) addedNewNodes = true;
 		return addedNewNodes;
 	}
 
-	render(code: MagicString, options: RenderOptions) {
+	reassignPath(path: ObjectPath, options: ExecutionPathOptions) {
+		if (path.length > 0) this.expressions[this.expressions.length - 1].reassignPath(path, options);
+	}
+
+	render(
+		code: MagicString,
+		options: RenderOptions,
+		{ hasBecomeCallee, hasDifferentParent }: NodeRenderOptions = BLANK
+	) {
 		if (!this.module.graph.treeshake) {
 			super.render(code, options);
 		} else {
-			const last = this.expressions[this.expressions.length - 1];
-			last.render(code, options);
-
-			if (
-				this.parent.type === NodeType.CallExpression &&
-				last.type === NodeType.MemberExpression &&
-				this.expressions.length > 1
-			) {
-				this.expressions[0].included = true;
-			}
-
-			const included = this.expressions
-				.slice(0, this.expressions.length - 1)
-				.filter(expression => expression.included);
-			if (included.length === 0) {
-				code.remove(this.start, last.start);
-				code.remove(last.end, this.end);
-			} else {
-				let previousEnd = this.start;
-				for (const expression of included) {
-					expression.render(code, options);
-					code.remove(previousEnd, expression.start);
-					code.appendLeft(expression.end, ', ');
-					previousEnd = expression.end;
+			let firstStart = 0,
+				lastEnd,
+				includedNodes = 0;
+			for (const { node, start, end } of getCommaSeparatedNodesWithBoundaries(
+				this.expressions,
+				code,
+				this.start,
+				this.end
+			)) {
+				if (!node.included) {
+					code.remove(start, end);
+					continue;
 				}
-
-				code.remove(previousEnd, last.start);
-				code.remove(last.end, this.end);
+				includedNodes++;
+				if (firstStart === 0) firstStart = start;
+				lastEnd = end;
+				if (node === this.expressions[this.expressions.length - 1] && includedNodes === 1) {
+					node.render(code, options, {
+						hasBecomeCallee:
+							hasBecomeCallee || (isCallExpression(this.parent) && this.parent.callee === this),
+						hasDifferentParent: true
+					});
+				} else {
+					node.render(code, options);
+				}
+			}
+			if (includedNodes > 1 && hasDifferentParent) {
+				code.prependRight(firstStart, '(');
+				code.appendLeft(lastEnd, ')');
 			}
 		}
 	}

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -2,7 +2,6 @@ import CallOptions from '../CallOptions';
 import TemplateLiteral from './TemplateLiteral';
 import Identifier from './Identifier';
 import ExecutionPathOptions from '../ExecutionPathOptions';
-import { isGlobalVariable } from '../variables/GlobalVariable';
 import { isNamespaceVariable } from '../variables/NamespaceVariable';
 import { NodeType } from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
@@ -28,7 +27,7 @@ export default class TaggedTemplateExpression extends NodeBase {
 				);
 			}
 
-			if ((<Identifier>this.tag).name === 'eval' && isGlobalVariable(variable)) {
+			if ((<Identifier>this.tag).name === 'eval' && variable.isGlobal) {
 				this.module.warn(
 					{
 						code: 'EVAL',

--- a/src/ast/variables/GlobalVariable.ts
+++ b/src/ast/variables/GlobalVariable.ts
@@ -2,10 +2,6 @@ import Variable from './Variable';
 import pureFunctions from '../nodes/shared/pureFunctions';
 import { ObjectPath } from '../values';
 
-export function isGlobalVariable(variable: Variable): variable is GlobalVariable {
-	return variable.isGlobal;
-}
-
 export default class GlobalVariable extends Variable {
 	isExternal: true;
 	isGlobal: true;

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -92,7 +92,7 @@ export type GlobalsOption = { [name: string]: string } | ((name: string) => stri
 
 export interface InputOptions {
 	input: string | string[] | { [entryAlias: string]: string };
-	manualChunks: { [chunkAlias: string]: string[] };
+	manualChunks?: { [chunkAlias: string]: string[] };
 	external?: ExternalOption;
 	plugins?: Plugin[];
 

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -15,9 +15,28 @@ export interface NodeRenderOptions {
 	start?: number;
 	end?: number;
 	isNoStatement?: boolean;
-	hasBecomeCallee?: boolean;
-	hasBecomeStatement?: boolean;
-	hasDifferentParent?: boolean;
+	renderedParent?: Node;
+	fieldOfRenderedParent?: string | null;
+}
+
+export function getFieldOfParent(child: Node): string | null {
+	const parent = <Node>child.parent;
+	for (const key of parent.keys) {
+		const value = (<any>parent)[key];
+		if (value === child) return key;
+		if (Array.isArray(value)) {
+			for (const nestedValue of value) {
+				if (nestedValue === child) return key;
+			}
+		}
+	}
+	return null;
+}
+
+export function childIsStatement(parent: { type?: string }) {
+	return (
+		parent.type === 'Program' || parent.type === 'ExpressionStatement' // e.g. default exports rendered for side-effects only
+	);
 }
 
 export const NO_SEMICOLON: NodeRenderOptions = { isNoStatement: true };

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -15,6 +15,8 @@ export interface NodeRenderOptions {
 	start?: number;
 	end?: number;
 	isNoStatement?: boolean;
+	hasBecomeCallee?: boolean;
+	hasDifferentParent?: boolean;
 }
 
 export const NO_SEMICOLON: NodeRenderOptions = { isNoStatement: true };

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -16,6 +16,7 @@ export interface NodeRenderOptions {
 	end?: number;
 	isNoStatement?: boolean;
 	hasBecomeCallee?: boolean;
+	hasBecomeStatement?: boolean;
 	hasDifferentParent?: boolean;
 }
 

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -15,28 +15,8 @@ export interface NodeRenderOptions {
 	start?: number;
 	end?: number;
 	isNoStatement?: boolean;
-	renderedParent?: Node;
-	fieldOfRenderedParent?: string | null;
-}
-
-export function getFieldOfParent(child: Node): string | null {
-	const parent = <Node>child.parent;
-	for (const key of parent.keys) {
-		const value = (<any>parent)[key];
-		if (value === child) return key;
-		if (Array.isArray(value)) {
-			for (const nestedValue of value) {
-				if (nestedValue === child) return key;
-			}
-		}
-	}
-	return null;
-}
-
-export function childIsStatement(parent: { type?: string }) {
-	return (
-		parent.type === 'Program' || parent.type === 'ExpressionStatement' // e.g. default exports rendered for side-effects only
-	);
+	renderedParentType?: string; // also serves as a flag if the rendered parent is different from the actual parent
+	isCalleeOfRenderedParent?: boolean;
 }
 
 export const NO_SEMICOLON: NodeRenderOptions = { isNoStatement: true };

--- a/test/form/samples/conditional-put-parens-around-sequence/_expected/amd.js
+++ b/test/form/samples/conditional-put-parens-around-sequence/_expected/amd.js
@@ -1,10 +1,10 @@
 define(function () { 'use strict';
 
-	var a = (foo(), 3);
-	var b = (bar(), 6);
+	var a = (foo(), 3 );
+	var b = (bar(), 6 );
 	foo( a, b );
 
 	// verify works with no whitespace
-	bar((foo(), 2),(bar(), 8));
+	bar((foo(),2),(bar(),8));
 
 });

--- a/test/form/samples/conditional-put-parens-around-sequence/_expected/cjs.js
+++ b/test/form/samples/conditional-put-parens-around-sequence/_expected/cjs.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var a = (foo(), 3);
-var b = (bar(), 6);
+var a = (foo(), 3 );
+var b = (bar(), 6 );
 foo( a, b );
 
 // verify works with no whitespace
-bar((foo(), 2),(bar(), 8));
+bar((foo(),2),(bar(),8));

--- a/test/form/samples/conditional-put-parens-around-sequence/_expected/es.js
+++ b/test/form/samples/conditional-put-parens-around-sequence/_expected/es.js
@@ -1,6 +1,6 @@
-var a = (foo(), 3);
-var b = (bar(), 6);
+var a = (foo(), 3 );
+var b = (bar(), 6 );
 foo( a, b );
 
 // verify works with no whitespace
-bar((foo(), 2),(bar(), 8));
+bar((foo(),2),(bar(),8));

--- a/test/form/samples/conditional-put-parens-around-sequence/_expected/iife.js
+++ b/test/form/samples/conditional-put-parens-around-sequence/_expected/iife.js
@@ -1,11 +1,11 @@
 (function () {
 	'use strict';
 
-	var a = (foo(), 3);
-	var b = (bar(), 6);
+	var a = (foo(), 3 );
+	var b = (bar(), 6 );
 	foo( a, b );
 
 	// verify works with no whitespace
-	bar((foo(), 2),(bar(), 8));
+	bar((foo(),2),(bar(),8));
 
 }());

--- a/test/form/samples/conditional-put-parens-around-sequence/_expected/system.js
+++ b/test/form/samples/conditional-put-parens-around-sequence/_expected/system.js
@@ -3,12 +3,12 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var a = (foo(), 3);
-			var b = (bar(), 6);
+			var a = (foo(), 3 );
+			var b = (bar(), 6 );
 			foo( a, b );
 
 			// verify works with no whitespace
-			bar((foo(), 2),(bar(), 8));
+			bar((foo(),2),(bar(),8));
 
 		}
 	};

--- a/test/form/samples/conditional-put-parens-around-sequence/_expected/umd.js
+++ b/test/form/samples/conditional-put-parens-around-sequence/_expected/umd.js
@@ -4,11 +4,11 @@
 	(factory());
 }(this, (function () { 'use strict';
 
-	var a = (foo(), 3);
-	var b = (bar(), 6);
+	var a = (foo(), 3 );
+	var b = (bar(), 6 );
 	foo( a, b );
 
 	// verify works with no whitespace
-	bar((foo(), 2),(bar(), 8));
+	bar((foo(),2),(bar(),8));
 
 })));

--- a/test/form/samples/mutate-logical-expression/_expected/amd.js
+++ b/test/form/samples/mutate-logical-expression/_expected/amd.js
@@ -5,11 +5,11 @@ define(['exports'], function (exports) { 'use strict';
 	logicalAExp.bar = 1;
 
 	var bExp = {};
-	var logicalBExp = false || bExp;
+	var logicalBExp = bExp;
 	logicalBExp.bar = 1;
 
 	var cExp = {};
-	var logicalCExp = true && cExp;
+	var logicalCExp = cExp;
 	logicalCExp.bar = 1;
 
 	exports.aExp = aExp;

--- a/test/form/samples/mutate-logical-expression/_expected/cjs.js
+++ b/test/form/samples/mutate-logical-expression/_expected/cjs.js
@@ -7,11 +7,11 @@ var logicalAExp = aExp || {};
 logicalAExp.bar = 1;
 
 var bExp = {};
-var logicalBExp = false || bExp;
+var logicalBExp = bExp;
 logicalBExp.bar = 1;
 
 var cExp = {};
-var logicalCExp = true && cExp;
+var logicalCExp = cExp;
 logicalCExp.bar = 1;
 
 exports.aExp = aExp;

--- a/test/form/samples/mutate-logical-expression/_expected/es.js
+++ b/test/form/samples/mutate-logical-expression/_expected/es.js
@@ -3,11 +3,11 @@ var logicalAExp = aExp || {};
 logicalAExp.bar = 1;
 
 var bExp = {};
-var logicalBExp = false || bExp;
+var logicalBExp = bExp;
 logicalBExp.bar = 1;
 
 var cExp = {};
-var logicalCExp = true && cExp;
+var logicalCExp = cExp;
 logicalCExp.bar = 1;
 
 export { aExp, bExp, cExp };

--- a/test/form/samples/mutate-logical-expression/_expected/iife.js
+++ b/test/form/samples/mutate-logical-expression/_expected/iife.js
@@ -6,11 +6,11 @@ var bundle = (function (exports) {
 	logicalAExp.bar = 1;
 
 	var bExp = {};
-	var logicalBExp = false || bExp;
+	var logicalBExp = bExp;
 	logicalBExp.bar = 1;
 
 	var cExp = {};
-	var logicalCExp = true && cExp;
+	var logicalCExp = cExp;
 	logicalCExp.bar = 1;
 
 	exports.aExp = aExp;

--- a/test/form/samples/mutate-logical-expression/_expected/system.js
+++ b/test/form/samples/mutate-logical-expression/_expected/system.js
@@ -8,11 +8,11 @@ System.register([], function (exports, module) {
 			logicalAExp.bar = 1;
 
 			var bExp = exports('bExp', {});
-			var logicalBExp = false || bExp;
+			var logicalBExp = bExp;
 			logicalBExp.bar = 1;
 
 			var cExp = exports('cExp', {});
-			var logicalCExp = true && cExp;
+			var logicalCExp = cExp;
 			logicalCExp.bar = 1;
 
 		}

--- a/test/form/samples/mutate-logical-expression/_expected/umd.js
+++ b/test/form/samples/mutate-logical-expression/_expected/umd.js
@@ -9,11 +9,11 @@
 	logicalAExp.bar = 1;
 
 	var bExp = {};
-	var logicalBExp = false || bExp;
+	var logicalBExp = bExp;
 	logicalBExp.bar = 1;
 
 	var cExp = {};
-	var logicalCExp = true && cExp;
+	var logicalCExp = cExp;
 	logicalCExp.bar = 1;
 
 	exports.aExp = aExp;

--- a/test/form/samples/side-effects-logical-expressions/_expected/amd.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/amd.js
@@ -1,8 +1,8 @@
 define(function () { 'use strict';
 
 	// effect
-	false || console.log( 'effect' );
-	true && console.log( 'effect' );
+	console.log( 'effect' );
+	console.log( 'effect' );
 	console.log( 'effect' ) || {};
 	console.log( 'effect' ) && {};
 
@@ -14,23 +14,23 @@ define(function () { 'use strict';
 	};
 
 	// effect
-	(false || foo).effect;
-	(true && foo).effect;
+	(foo).effect;
+	(foo).effect;
 
 	// effect
-	(false || null).foo = 1;
-	(true && null).foo = 1;
+	(null).foo = 1;
+	(null).foo = 1;
 
 	// effect
-	(true || (() => {}))();
-	(false && (() => {}))();
-	(false || (() => console.log( 'effect' )))();
-	(true && (() => console.log( 'effect' )))();
+	(true)();
+	(false)();
+	(() => console.log( 'effect' ))();
+	(() => console.log( 'effect' ))();
 
 	// effect
-	(true || (() => () => {}))()();
-	(false && (() => () => {}))()();
-	(false || (() => () => console.log( 'effect' )))()();
-	(true && (() => () => console.log( 'effect' )))()();
+	(true)()();
+	(false)()();
+	(() => () => console.log( 'effect' ))()();
+	(() => () => console.log( 'effect' ))()();
 
 });

--- a/test/form/samples/side-effects-logical-expressions/_expected/cjs.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/cjs.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // effect
-false || console.log( 'effect' );
-true && console.log( 'effect' );
+console.log( 'effect' );
+console.log( 'effect' );
 console.log( 'effect' ) || {};
 console.log( 'effect' ) && {};
 
@@ -14,21 +14,21 @@ const foo = {
 };
 
 // effect
-(false || foo).effect;
-(true && foo).effect;
+(foo).effect;
+(foo).effect;
 
 // effect
-(false || null).foo = 1;
-(true && null).foo = 1;
+(null).foo = 1;
+(null).foo = 1;
 
 // effect
-(true || (() => {}))();
-(false && (() => {}))();
-(false || (() => console.log( 'effect' )))();
-(true && (() => console.log( 'effect' )))();
+(true)();
+(false)();
+(() => console.log( 'effect' ))();
+(() => console.log( 'effect' ))();
 
 // effect
-(true || (() => () => {}))()();
-(false && (() => () => {}))()();
-(false || (() => () => console.log( 'effect' )))()();
-(true && (() => () => console.log( 'effect' )))()();
+(true)()();
+(false)()();
+(() => () => console.log( 'effect' ))()();
+(() => () => console.log( 'effect' ))()();

--- a/test/form/samples/side-effects-logical-expressions/_expected/es.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/es.js
@@ -1,6 +1,6 @@
 // effect
-false || console.log( 'effect' );
-true && console.log( 'effect' );
+console.log( 'effect' );
+console.log( 'effect' );
 console.log( 'effect' ) || {};
 console.log( 'effect' ) && {};
 
@@ -12,21 +12,21 @@ const foo = {
 };
 
 // effect
-(false || foo).effect;
-(true && foo).effect;
+(foo).effect;
+(foo).effect;
 
 // effect
-(false || null).foo = 1;
-(true && null).foo = 1;
+(null).foo = 1;
+(null).foo = 1;
 
 // effect
-(true || (() => {}))();
-(false && (() => {}))();
-(false || (() => console.log( 'effect' )))();
-(true && (() => console.log( 'effect' )))();
+(true)();
+(false)();
+(() => console.log( 'effect' ))();
+(() => console.log( 'effect' ))();
 
 // effect
-(true || (() => () => {}))()();
-(false && (() => () => {}))()();
-(false || (() => () => console.log( 'effect' )))()();
-(true && (() => () => console.log( 'effect' )))()();
+(true)()();
+(false)()();
+(() => () => console.log( 'effect' ))()();
+(() => () => console.log( 'effect' ))()();

--- a/test/form/samples/side-effects-logical-expressions/_expected/iife.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/iife.js
@@ -2,8 +2,8 @@
 	'use strict';
 
 	// effect
-	false || console.log( 'effect' );
-	true && console.log( 'effect' );
+	console.log( 'effect' );
+	console.log( 'effect' );
 	console.log( 'effect' ) || {};
 	console.log( 'effect' ) && {};
 
@@ -15,23 +15,23 @@
 	};
 
 	// effect
-	(false || foo).effect;
-	(true && foo).effect;
+	(foo).effect;
+	(foo).effect;
 
 	// effect
-	(false || null).foo = 1;
-	(true && null).foo = 1;
+	(null).foo = 1;
+	(null).foo = 1;
 
 	// effect
-	(true || (() => {}))();
-	(false && (() => {}))();
-	(false || (() => console.log( 'effect' )))();
-	(true && (() => console.log( 'effect' )))();
+	(true)();
+	(false)();
+	(() => console.log( 'effect' ))();
+	(() => console.log( 'effect' ))();
 
 	// effect
-	(true || (() => () => {}))()();
-	(false && (() => () => {}))()();
-	(false || (() => () => console.log( 'effect' )))()();
-	(true && (() => () => console.log( 'effect' )))()();
+	(true)()();
+	(false)()();
+	(() => () => console.log( 'effect' ))()();
+	(() => () => console.log( 'effect' ))()();
 
 }());

--- a/test/form/samples/side-effects-logical-expressions/_expected/system.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/system.js
@@ -4,8 +4,8 @@ System.register([], function (exports, module) {
 		execute: function () {
 
 			// effect
-			false || console.log( 'effect' );
-			true && console.log( 'effect' );
+			console.log( 'effect' );
+			console.log( 'effect' );
 			console.log( 'effect' ) || {};
 			console.log( 'effect' ) && {};
 
@@ -17,24 +17,24 @@ System.register([], function (exports, module) {
 			};
 
 			// effect
-			(false || foo).effect;
-			(true && foo).effect;
+			(foo).effect;
+			(foo).effect;
 
 			// effect
-			(false || null).foo = 1;
-			(true && null).foo = 1;
+			(null).foo = 1;
+			(null).foo = 1;
 
 			// effect
-			(true || (() => {}))();
-			(false && (() => {}))();
-			(false || (() => console.log( 'effect' )))();
-			(true && (() => console.log( 'effect' )))();
+			(true)();
+			(false)();
+			(() => console.log( 'effect' ))();
+			(() => console.log( 'effect' ))();
 
 			// effect
-			(true || (() => () => {}))()();
-			(false && (() => () => {}))()();
-			(false || (() => () => console.log( 'effect' )))()();
-			(true && (() => () => console.log( 'effect' )))()();
+			(true)()();
+			(false)()();
+			(() => () => console.log( 'effect' ))()();
+			(() => () => console.log( 'effect' ))()();
 
 		}
 	};

--- a/test/form/samples/side-effects-logical-expressions/_expected/umd.js
+++ b/test/form/samples/side-effects-logical-expressions/_expected/umd.js
@@ -5,8 +5,8 @@
 }(this, (function () { 'use strict';
 
 	// effect
-	false || console.log( 'effect' );
-	true && console.log( 'effect' );
+	console.log( 'effect' );
+	console.log( 'effect' );
 	console.log( 'effect' ) || {};
 	console.log( 'effect' ) && {};
 
@@ -18,23 +18,23 @@
 	};
 
 	// effect
-	(false || foo).effect;
-	(true && foo).effect;
+	(foo).effect;
+	(foo).effect;
 
 	// effect
-	(false || null).foo = 1;
-	(true && null).foo = 1;
+	(null).foo = 1;
+	(null).foo = 1;
 
 	// effect
-	(true || (() => {}))();
-	(false && (() => {}))();
-	(false || (() => console.log( 'effect' )))();
-	(true && (() => console.log( 'effect' )))();
+	(true)();
+	(false)();
+	(() => console.log( 'effect' ))();
+	(() => console.log( 'effect' ))();
 
 	// effect
-	(true || (() => () => {}))()();
-	(false && (() => () => {}))()();
-	(false || (() => () => console.log( 'effect' )))()();
-	(true && (() => () => console.log( 'effect' )))()();
+	(true)()();
+	(false)()();
+	(() => () => console.log( 'effect' ))()();
+	(() => () => console.log( 'effect' ))()();
 
 })));

--- a/test/form/samples/tree-shake-default-exports/_expected/amd.js
+++ b/test/form/samples/tree-shake-default-exports/_expected/amd.js
@@ -43,7 +43,7 @@ define(function () { 'use strict';
 	/* header 7 */
 
 	/* leading retained */
-(	{
+	({
 		effect: console.log( 'side-effect' ) || 43
 	}); // trailing retained
 
@@ -52,7 +52,7 @@ define(function () { 'use strict';
 	/* header 8 */
 
 	/* leading retained */
-(	{
+	({
 		effect: console.log( 'side-effect' ) || 43
 	}); // trailing retained
 

--- a/test/form/samples/tree-shake-default-exports/_expected/iife.js
+++ b/test/form/samples/tree-shake-default-exports/_expected/iife.js
@@ -44,7 +44,7 @@
 	/* header 7 */
 
 	/* leading retained */
-(	{
+	({
 		effect: console.log( 'side-effect' ) || 43
 	}); // trailing retained
 
@@ -53,7 +53,7 @@
 	/* header 8 */
 
 	/* leading retained */
-(	{
+	({
 		effect: console.log( 'side-effect' ) || 43
 	}); // trailing retained
 

--- a/test/form/samples/tree-shake-default-exports/_expected/system.js
+++ b/test/form/samples/tree-shake-default-exports/_expected/system.js
@@ -46,7 +46,7 @@ System.register([], function (exports, module) {
 			/* header 7 */
 
 			/* leading retained */
-(			{
+			({
 				effect: console.log( 'side-effect' ) || 43
 			}); // trailing retained
 
@@ -55,7 +55,7 @@ System.register([], function (exports, module) {
 			/* header 8 */
 
 			/* leading retained */
-(			{
+			({
 				effect: console.log( 'side-effect' ) || 43
 			}); // trailing retained
 

--- a/test/form/samples/tree-shake-default-exports/_expected/umd.js
+++ b/test/form/samples/tree-shake-default-exports/_expected/umd.js
@@ -47,7 +47,7 @@
 	/* header 7 */
 
 	/* leading retained */
-(	{
+	({
 		effect: console.log( 'side-effect' ) || 43
 	}); // trailing retained
 
@@ -56,7 +56,7 @@
 	/* header 8 */
 
 	/* leading retained */
-(	{
+	({
 		effect: console.log( 'side-effect' ) || 43
 	}); // trailing retained
 

--- a/test/form/samples/tree-shake-logical-expressions/_config.js
+++ b/test/form/samples/tree-shake-logical-expressions/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'tree-shake unused parts of logical expressions'
+};

--- a/test/form/samples/tree-shake-logical-expressions/_expected/amd.js
+++ b/test/form/samples/tree-shake-logical-expressions/_expected/amd.js
@@ -1,0 +1,19 @@
+define(function () { 'use strict';
+
+	function getStringA() {
+		return 'A';
+	}
+
+	console.log(getStringA());
+
+	console.log(false);
+
+	console.log(true);
+
+	function getStringD() {
+		return 'D';
+	}
+
+	console.log(getStringD());
+
+});

--- a/test/form/samples/tree-shake-logical-expressions/_expected/cjs.js
+++ b/test/form/samples/tree-shake-logical-expressions/_expected/cjs.js
@@ -1,0 +1,17 @@
+'use strict';
+
+function getStringA() {
+	return 'A';
+}
+
+console.log(getStringA());
+
+console.log(false);
+
+console.log(true);
+
+function getStringD() {
+	return 'D';
+}
+
+console.log(getStringD());

--- a/test/form/samples/tree-shake-logical-expressions/_expected/es.js
+++ b/test/form/samples/tree-shake-logical-expressions/_expected/es.js
@@ -1,0 +1,15 @@
+function getStringA() {
+	return 'A';
+}
+
+console.log(getStringA());
+
+console.log(false);
+
+console.log(true);
+
+function getStringD() {
+	return 'D';
+}
+
+console.log(getStringD());

--- a/test/form/samples/tree-shake-logical-expressions/_expected/iife.js
+++ b/test/form/samples/tree-shake-logical-expressions/_expected/iife.js
@@ -1,0 +1,20 @@
+(function () {
+	'use strict';
+
+	function getStringA() {
+		return 'A';
+	}
+
+	console.log(getStringA());
+
+	console.log(false);
+
+	console.log(true);
+
+	function getStringD() {
+		return 'D';
+	}
+
+	console.log(getStringD());
+
+}());

--- a/test/form/samples/tree-shake-logical-expressions/_expected/system.js
+++ b/test/form/samples/tree-shake-logical-expressions/_expected/system.js
@@ -1,0 +1,24 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			function getStringA() {
+				return 'A';
+			}
+
+			console.log(getStringA());
+
+			console.log(false);
+
+			console.log(true);
+
+			function getStringD() {
+				return 'D';
+			}
+
+			console.log(getStringD());
+
+		}
+	};
+});

--- a/test/form/samples/tree-shake-logical-expressions/_expected/umd.js
+++ b/test/form/samples/tree-shake-logical-expressions/_expected/umd.js
@@ -1,0 +1,23 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	function getStringA() {
+		return 'A';
+	}
+
+	console.log(getStringA());
+
+	console.log(false);
+
+	console.log(true);
+
+	function getStringD() {
+		return 'D';
+	}
+
+	console.log(getStringD());
+
+})));

--- a/test/form/samples/tree-shake-logical-expressions/main.js
+++ b/test/form/samples/tree-shake-logical-expressions/main.js
@@ -1,0 +1,23 @@
+function getStringA() {
+	return 'A';
+}
+
+console.log(true && getStringA());
+
+function getStringB() {
+	return 'B';
+}
+
+console.log(false && getStringB());
+
+function getStringC() {
+	return 'C';
+}
+
+console.log(true || getStringC());
+
+function getStringD() {
+	return 'D';
+}
+
+console.log(false || getStringD());

--- a/test/form/samples/wrap-simplified-expressions/_config.js
+++ b/test/form/samples/wrap-simplified-expressions/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'wraps simplified expressions that have become callees if necessary'
+};

--- a/test/form/samples/wrap-simplified-expressions/_expected/amd.js
+++ b/test/form/samples/wrap-simplified-expressions/_expected/amd.js
@@ -1,0 +1,29 @@
+define(function () { 'use strict';
+
+	const wrapper = {
+		foo() {
+			console.log(this);
+		}
+	};
+
+	// Indirectly called member expressions set the callee's context to global "this"
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+
+	// Only callees of call expressions should be wrapped
+	console.log(wrapper.foo);
+
+	// Indirectly invoked eval is executed in the global scope
+	function testEval() {
+		console.log((0, eval)('this'));
+		console.log((0, eval)('this'));
+		console.log((0, eval)('this'));
+	}
+
+	testEval.call('test');
+
+});

--- a/test/form/samples/wrap-simplified-expressions/_expected/cjs.js
+++ b/test/form/samples/wrap-simplified-expressions/_expected/cjs.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const wrapper = {
+	foo() {
+		console.log(this);
+	}
+};
+
+// Indirectly called member expressions set the callee's context to global "this"
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+
+// Only callees of call expressions should be wrapped
+console.log(wrapper.foo);
+
+// Indirectly invoked eval is executed in the global scope
+function testEval() {
+	console.log((0, eval)('this'));
+	console.log((0, eval)('this'));
+	console.log((0, eval)('this'));
+}
+
+testEval.call('test');

--- a/test/form/samples/wrap-simplified-expressions/_expected/es.js
+++ b/test/form/samples/wrap-simplified-expressions/_expected/es.js
@@ -1,0 +1,25 @@
+const wrapper = {
+	foo() {
+		console.log(this);
+	}
+};
+
+// Indirectly called member expressions set the callee's context to global "this"
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+(0, wrapper.foo)();
+
+// Only callees of call expressions should be wrapped
+console.log(wrapper.foo);
+
+// Indirectly invoked eval is executed in the global scope
+function testEval() {
+	console.log((0, eval)('this'));
+	console.log((0, eval)('this'));
+	console.log((0, eval)('this'));
+}
+
+testEval.call('test');

--- a/test/form/samples/wrap-simplified-expressions/_expected/iife.js
+++ b/test/form/samples/wrap-simplified-expressions/_expected/iife.js
@@ -1,0 +1,30 @@
+(function () {
+	'use strict';
+
+	const wrapper = {
+		foo() {
+			console.log(this);
+		}
+	};
+
+	// Indirectly called member expressions set the callee's context to global "this"
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+
+	// Only callees of call expressions should be wrapped
+	console.log(wrapper.foo);
+
+	// Indirectly invoked eval is executed in the global scope
+	function testEval() {
+		console.log((0, eval)('this'));
+		console.log((0, eval)('this'));
+		console.log((0, eval)('this'));
+	}
+
+	testEval.call('test');
+
+}());

--- a/test/form/samples/wrap-simplified-expressions/_expected/system.js
+++ b/test/form/samples/wrap-simplified-expressions/_expected/system.js
@@ -1,0 +1,34 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const wrapper = {
+				foo() {
+					console.log(this);
+				}
+			};
+
+			// Indirectly called member expressions set the callee's context to global "this"
+			(0, wrapper.foo)();
+			(0, wrapper.foo)();
+			(0, wrapper.foo)();
+			(0, wrapper.foo)();
+			(0, wrapper.foo)();
+			(0, wrapper.foo)();
+
+			// Only callees of call expressions should be wrapped
+			console.log(wrapper.foo);
+
+			// Indirectly invoked eval is executed in the global scope
+			function testEval() {
+				console.log((0, eval)('this'));
+				console.log((0, eval)('this'));
+				console.log((0, eval)('this'));
+			}
+
+			testEval.call('test');
+
+		}
+	};
+});

--- a/test/form/samples/wrap-simplified-expressions/_expected/umd.js
+++ b/test/form/samples/wrap-simplified-expressions/_expected/umd.js
@@ -1,0 +1,33 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	const wrapper = {
+		foo() {
+			console.log(this);
+		}
+	};
+
+	// Indirectly called member expressions set the callee's context to global "this"
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+	(0, wrapper.foo)();
+
+	// Only callees of call expressions should be wrapped
+	console.log(wrapper.foo);
+
+	// Indirectly invoked eval is executed in the global scope
+	function testEval() {
+		console.log((0, eval)('this'));
+		console.log((0, eval)('this'));
+		console.log((0, eval)('this'));
+	}
+
+	testEval.call('test');
+
+})));

--- a/test/form/samples/wrap-simplified-expressions/main.js
+++ b/test/form/samples/wrap-simplified-expressions/main.js
@@ -1,0 +1,25 @@
+const wrapper = {
+	foo() {
+		console.log(this);
+	}
+};
+
+// Indirectly called member expressions set the callee's context to global "this"
+(true && wrapper.foo)();
+(true ? wrapper.foo : null)();
+(1, 2, wrapper.foo)();
+(true && (true && wrapper.foo))();
+(true && (true ? wrapper.foo : null))();
+(true && (1, 2, wrapper.foo))();
+
+// Only callees of call expressions should be wrapped
+console.log(true && wrapper.foo);
+
+// Indirectly invoked eval is executed in the global scope
+function testEval() {
+	console.log((true && eval)('this'));
+	console.log((true ? eval : null)('this'));
+	console.log((1, 2, eval)('this'));
+}
+
+testEval.call('test');

--- a/test/function/samples/side-effects-only-default-exports/_config.js
+++ b/test/function/samples/side-effects-only-default-exports/_config.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const mutated = {};
+
+module.exports = {
+	description: 'Wraps inlined default exports which are rendered for side-effects only',
+	options: {
+		external: ['external']
+	},
+	context: {
+		require: () => mutated
+	},
+	bundle() {
+		assert.ok(mutated.mutated);
+		assert.ok(mutated.veryMutated);
+		assert.ok(mutated.extremelyMutated);
+		assert.ok(mutated.utterlyMutated);
+	}
+};

--- a/test/function/samples/side-effects-only-default-exports/_expected/amd.js
+++ b/test/function/samples/side-effects-only-default-exports/_expected/amd.js
@@ -1,0 +1,10 @@
+define(function () { 'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+});

--- a/test/function/samples/side-effects-only-default-exports/_expected/cjs.js
+++ b/test/function/samples/side-effects-only-default-exports/_expected/cjs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var a = () => {
+    console.log('props');
+};
+
+a();
+a();

--- a/test/function/samples/side-effects-only-default-exports/_expected/es.js
+++ b/test/function/samples/side-effects-only-default-exports/_expected/es.js
@@ -1,0 +1,6 @@
+var a = () => {
+    console.log('props');
+};
+
+a();
+a();

--- a/test/function/samples/side-effects-only-default-exports/_expected/iife.js
+++ b/test/function/samples/side-effects-only-default-exports/_expected/iife.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+}());

--- a/test/function/samples/side-effects-only-default-exports/_expected/system.js
+++ b/test/function/samples/side-effects-only-default-exports/_expected/system.js
@@ -1,0 +1,15 @@
+System.register([], function (exports, module) {
+    'use strict';
+    return {
+        execute: function () {
+
+            var a = () => {
+                console.log('props');
+            };
+
+            a();
+            a();
+
+        }
+    };
+});

--- a/test/function/samples/side-effects-only-default-exports/_expected/umd.js
+++ b/test/function/samples/side-effects-only-default-exports/_expected/umd.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    (factory());
+}(this, (function () { 'use strict';
+
+    var a = () => {
+        console.log('props');
+    };
+
+    a();
+    a();
+
+})));

--- a/test/function/samples/side-effects-only-default-exports/bar.js
+++ b/test/function/samples/side-effects-only-default-exports/bar.js
@@ -1,0 +1,3 @@
+import x from 'external';
+
+export default (x.veryMutated = true, x.extremelyMutated = true);

--- a/test/function/samples/side-effects-only-default-exports/baz.js
+++ b/test/function/samples/side-effects-only-default-exports/baz.js
@@ -1,0 +1,6 @@
+import x from 'external';
+
+export default true ? {
+	a: x.totallyMutated = true,
+	makeSureThisIsAnObject: true
+} : null;

--- a/test/function/samples/side-effects-only-default-exports/foo.js
+++ b/test/function/samples/side-effects-only-default-exports/foo.js
@@ -1,0 +1,6 @@
+import x from 'external';
+
+export default {
+	a: x.mutated = true,
+	makeSureThisIsAnObject: true
+};

--- a/test/function/samples/side-effects-only-default-exports/main.js
+++ b/test/function/samples/side-effects-only-default-exports/main.js
@@ -1,0 +1,4 @@
+import foo from './foo.js';
+import bar from './bar.js';
+import baz from './baz.js';
+import quux from './quux.js';

--- a/test/function/samples/side-effects-only-default-exports/quux.js
+++ b/test/function/samples/side-effects-only-default-exports/quux.js
@@ -1,0 +1,6 @@
+import x from 'external';
+
+export default true && {
+	a: x.utterlyMutated = true,
+	makeSureThisIsAnObject: true
+};

--- a/test/function/samples/wraps-object-expressions-as-statements/_config.js
+++ b/test/function/samples/wraps-object-expressions-as-statements/_config.js
@@ -1,0 +1,5 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'wraps object expressions that have become statements'
+};

--- a/test/function/samples/wraps-object-expressions-as-statements/main.js
+++ b/test/function/samples/wraps-object-expressions-as-statements/main.js
@@ -1,0 +1,10 @@
+const foo = {};
+
+// new parent is expression statement
+true && {
+	a: foo.a = true,
+	b: foo.a = true
+};
+assert.ok(foo.a);
+
+export default foo;

--- a/test/function/samples/wraps-simplified-expressions/_config.js
+++ b/test/function/samples/wraps-simplified-expressions/_config.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'wraps simplified expressions that have become callees if necessary',
+	warnings: warnings => warnings.forEach(warning => assert.equal(warning.code, 'EVAL'))
+};

--- a/test/function/samples/wraps-simplified-expressions/main.js
+++ b/test/function/samples/wraps-simplified-expressions/main.js
@@ -1,0 +1,22 @@
+const wrapper = {
+	foo() {
+		assert.notEqual(this, wrapper)
+	}
+};
+
+// Indirectly called member expressions set the callee's context to global "this"
+(true && wrapper.foo)();
+(true ? wrapper.foo : null)();
+(1, 2, wrapper.foo)();
+(true && (true && wrapper.foo))();
+(true && (true ? wrapper.foo : null))();
+(true && (1, 2, wrapper.foo))();
+
+// Indirectly invoked eval is executed in the global scope
+function testEval() {
+	assert.notEqual((true && eval)('this'), 'test');
+	assert.notEqual((true ? eval : null)('this'), 'test');
+	assert.notEqual((1, 2, eval)('this'), 'test');
+}
+
+testEval.call('test');


### PR DESCRIPTION
This was inspired by, supersedes and closes #2007 and therefore resolves #2004.
Also resolves #2091.

Originally I wanted to collect some ideas on how to improve #2007 to get it merged before I started implementing larger refactorings to our tree-shaking logic. As it turned out, the changes necessary were a little more than I anticipated so I instead created a generic solution which should now be able to handle all combinations of the now three expressions that support tree-shaking:
* sequence expressions (`a, b`)
* logical expressions (`a || b`, `a && b`)
* conditional expressions (`a ? b : c`)

For now, tree-shaking will only occur for conditional and logical expressions if `a` is a literal or calculated from literals, not variables. This is usually the case when using something like https://github.com/rollup/rollup-plugin-replace to set compiler flags. However the new generic solution is designed to easily handle more generic situations as well provided the `getValue` functionality will be extended at some point (which I decided was out of scope for this PR). This PR is focused on functionality only and not speed, which will be the focus of an upcoming PR. Nevertheless, performance seems to be about on par with the previous version.

This enables tree-shaking things like
```javascript
// input
function x() {
  console.log('unused');
}

if (false && x()) console.log('ok');

// output: nothing
```

Also, sequence expressions have been refactored to resolve some lingering bugs that no-one has stumbled upon probably because most people are sensible enough not to use a lot of sequence expressions. In case one of the three expression types is simplified and the result is the callee of a call expression and the context would be changed by the simplification, the result is wrapped in a `(0, expression)` babel style. This works even in nested situations:

```javascript
// input
(true, true ? true && x.y : null)()

// output
(0, x.y)()
```

Also, handling of default exports that are rendered for side-effects only has been refined and synced with these changes.