### PR TITLE
use existing plugin error, rather than wrapping

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -17,14 +17,9 @@ export interface RollupError {
 }
 
 export default function error(props: Error | RollupError) {
-	// use the same constructor as props (if it's an error object)
-	// so that err.name is preserved etc
-	// (Object.keys below does not update these values because they
-	// are properties on the prototype chain)
-	// basically if props is a SyntaxError it will not be overriden as a generic Error
-	const constructor: ErrorConstructor =
-		props instanceof Error ? <ErrorConstructor>props.constructor : Error;
-	const err = new constructor(props.message);
+	if (props instanceof Error) throw props;
+
+	const err = new Error(props.message);
 
 	Object.keys(props).forEach(key => {
 		(<any>err)[key] = (<any>props)[key];

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -128,6 +128,34 @@ describe('sanity checks', () => {
 				}, /You must specify options\.format, which can be one of 'amd', 'cjs', 'system', 'es', 'iife' or 'umd'/);
 			});
 	});
+
+	it('reuses existing error object', () => {
+		let error;
+
+		class CustomError extends Error {
+			constructor(message, x) {
+				super(message);
+				this.prop = x.toUpperCase();
+			}
+		}
+
+		return rollup
+			.rollup({
+				input: 'x',
+				plugins: [
+					loader({ x: `console.log( 42 );` }),
+					{
+						transform(code) {
+							error = new CustomError('foo', 'bar')
+							this.error(error);
+						}
+					}
+				]
+			})
+			.catch(e => {
+				assert.equal(e, error);
+			});
+	});
 });
 
 describe('deprecations', () => {


### PR DESCRIPTION
For some reason — not entirely sure what I was thinking — plugin errors get recreated in the default error handler, instead of just being thrown. This is causing problems with funky custom errors that do (admittedly unadvisable) things like having multiple arguments to the constructor.

The proposed fix is to just throw the error, and only create a new one if a plugin does something like:

```js
this.error({
  message: 'something went wrong!'
});
```

Does this seem reasonable?