### PR TITLE
Fix performance timers

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint src browser bin test/test.js test/*/index.js test/utils test/**/_config.js",
     "precommit": "lint-staged",
     "postcommit": "git reset",
-    "perf": "node --expose-gc scripts/perf.js",
+    "perf": "npm run build && node --expose-gc scripts/perf.js",
     "perf:init": "node scripts/perf-init.js",
     "perf:debug": "node --inspect-brk scripts/perf-debug.js"
   },

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -754,11 +754,10 @@ export default class Chunk {
 
 	// prerender allows chunk hashes and names to be generated before finalizing
 	preRender(options: OutputOptions) {
-		let magicString = new MagicStringBundle({ separator: '\n\n' });
-		this.usedModules = [];
-
 		timeStart('render modules', 3);
 
+		let magicString = new MagicStringBundle({ separator: '\n\n' });
+		this.usedModules = [];
 		this.indentString = getIndentString(this.orderedModules, options);
 
 		const renderOptions: RenderOptions = {
@@ -823,6 +822,8 @@ export default class Chunk {
 			dependencies: this.getChunkDependencyDeclarations(options),
 			exports: this.getChunkExportDeclarations()
 		};
+
+		timeEnd('render modules', 3);
 	}
 
 	generateNamePreserveModules(preserveModulesRelativeDir: string) {
@@ -865,8 +866,6 @@ export default class Chunk {
 		}
 
 		this.id = outName;
-
-		timeEnd('render modules', 3);
 	}
 
 	render(options: OutputOptions, addons: Addons) {
@@ -915,13 +914,12 @@ export default class Chunk {
 			},
 			options
 		);
+		if (addons.banner) magicString.prepend(addons.banner + '\n');
+		if (addons.footer) magicString.append('\n' + addons.footer);
+		const prevCode = magicString.toString();
 
 		timeEnd('render format', 3);
 
-		if (addons.banner) magicString.prepend(addons.banner + '\n');
-		if (addons.footer) magicString.append('\n' + addons.footer);
-
-		const prevCode = magicString.toString();
 		let map: SourceMap = null;
 		const bundleSourcemapChain: RawSourceMap[] = [];
 


### PR DESCRIPTION
This will fix the performance timer for "render modules", which was broken ever since `preRender` was extracted from the rendering (was always ~0).

This also changes the `npm run perf` script to build the project first, which from my experience is usually what you want (otherwise you may end up with outdated timers without realizing it):