### PR TITLE
Pass codeSplitting generated filenames to onwrite hooks

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -597,13 +597,17 @@ export default function rollup(
 										code += `//# ${SOURCEMAPPING_URL}=${url}\n`;
 									}
 
-									promises.push(writeFile(dir + '/' + chunkName, code));
+									const file = dir + '/' + chunkName;
+									promises.push(writeFile(file, code));
 									return Promise.all(promises).then(() => {
 										return mapSequence(
 											graph.plugins.filter(plugin => plugin.onwrite),
 											(plugin: Plugin) =>
 												Promise.resolve(
-													plugin.onwrite(Object.assign({ bundle: chunk }, outputOptions), chunk)
+													plugin.onwrite(
+														Object.assign({ bundle: chunk }, outputOptions, { file }),
+														chunk
+													)
 												)
 										);
 									});


### PR DESCRIPTION
In case of codeSplitting there is no way to know what file got generated when it gets called and it's useful for `onwrite` hook