### PR TITLE
Correct error in #2101

### DIFF
--- a/bin/src/run/build.ts
+++ b/bin/src/run/build.ts
@@ -24,6 +24,7 @@ export default function build(
 	const useStdout =
 		outputOptions.length === 1 &&
 		!outputOptions[0].file &&
+		!outputOptions[0].dir &&
 		inputOptions.input instanceof Array === false &&
 		typeof inputOptions.input !== 'object';
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -215,7 +215,7 @@ export default function rollup(
 						if (!outputOptions || (!outputOptions.file && !outputOptions.dest)) {
 							error({
 								code: 'MISSING_OPTION',
-								message: 'You must specify output.file'
+								message: 'You must specify output.file when doing a single-file input build'
 							});
 						}
 


### PR DESCRIPTION
The issue is that when providing `input: 'file.js', output: { dir: 'dist' }`, Rollup thinks it is doing a single-file build, but the CLI was providing the error: "You must specify an --output (-o) option when creating a file with a sourcemap" which is completely useless.

With this change, the error now provided in this case is "You must specify output.file when doing a single-file input build".

We could perhaps clarify this even more as well.

To clarify the code-splitting logic here:

1. The experimental code splitting flag is treated as an experimental feature flag - that is, it doesn't imply a code splitting workflow on its own as the idea is that this flag will just be removed entirely one day.
2. We thus use the fact that the `input` is an array or object to indicate that this is a code-splitting workflow.
3. We can't easily check the `output.dir` option as the primary indicator that it is a code-splitting workflow because output options only known at generate time, while the type of build has to be determined from the input options already.

Happy to reconsider the logic here... perhaps a `codeSplitting: true / false` would make this clearer to users which build they are doing.