### PR TITLE
Improve line-break detection to handle "/*" inside "//" comments,

### DIFF
--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -26,38 +26,43 @@ export function findFirstOccurrenceOutsideComment(
 	searchString: string,
 	start: number = 0
 ) {
-	let commentStart, searchPos;
+	let searchPos, charCodeAfterSlash;
+	searchPos = code.indexOf(searchString, start);
 	while (true) {
-		commentStart = code.indexOf('/', start);
-		searchPos = code.indexOf(searchString, start);
-		if (commentStart === -1) break;
-		if (searchPos >= commentStart) {
-			searchPos = -1;
-		} else if (searchPos !== -1) break;
-		start = commentStart + 1;
-		if (code.charCodeAt(start) === 42 /*"*"*/) {
-			start = code.indexOf('*/', start) + 2;
-		} else if (code.charCodeAt(start) === 47 /*"/"*/) {
+		start = code.indexOf('/', start);
+		if (start === -1 || start > searchPos) return searchPos;
+		charCodeAfterSlash = code.charCodeAt(++start);
+		++start;
+		if (charCodeAfterSlash === 47 /*"/"*/) {
 			start = code.indexOf('\n', start) + 1;
+			if (start === 0) return -1;
+			if (start > searchPos) {
+				searchPos = code.indexOf(searchString, start);
+			}
+		} else if (charCodeAfterSlash === 42 /*"*"*/) {
+			start = code.indexOf('*/', start) + 2;
+			if (start > searchPos) {
+				searchPos = code.indexOf(searchString, start);
+			}
 		}
 	}
-	return searchPos;
 }
 
 function findFirstLineBreakOutsideComment(code: string, start: number = 0) {
-	let commentStart, lineBreakPos, nextChar;
+	let lineBreakPos, charCodeAfterSlash;
+	lineBreakPos = code.indexOf('\n', start);
 	while (true) {
-		lineBreakPos = code.indexOf('\n', start);
-		do {
-			commentStart = code.indexOf('/', start);
-			if (commentStart === -1 || commentStart > lineBreakPos) return lineBreakPos;
-			nextChar = code[commentStart + 1];
-			if (nextChar === '/') return lineBreakPos;
-			if (nextChar === '*') break;
-			start = commentStart + 2;
-		} while (true);
-		start = code.indexOf('*/', commentStart) + 2;
-		if (start === -1) return -1;
+		start = code.indexOf('/', start);
+		if (start === -1 || start > lineBreakPos) return lineBreakPos;
+		charCodeAfterSlash = code.charCodeAt(++start);
+		if (charCodeAfterSlash === 47 /*"/"*/) return lineBreakPos;
+		++start;
+		if (charCodeAfterSlash === 42 /*"*"*/) {
+			start = code.indexOf('*/', start) + 2;
+			if (start > lineBreakPos) {
+				lineBreakPos = code.indexOf('\n', start);
+			}
+		}
 	}
 }
 

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -45,17 +45,20 @@ export function findFirstOccurrenceOutsideComment(
 }
 
 function findFirstLineBreakOutsideComment(code: string, start: number = 0) {
-	let commentStart, lineBreakPos;
+	let commentStart, lineBreakPos, nextChar;
 	while (true) {
-		commentStart = code.indexOf('/*', start);
 		lineBreakPos = code.indexOf('\n', start);
-		if (commentStart === -1) break;
-		if (lineBreakPos >= commentStart) {
-			lineBreakPos = -1;
-		} else if (lineBreakPos !== -1) break;
+		do {
+			commentStart = code.indexOf('/', start);
+			if (commentStart === -1 || commentStart > lineBreakPos) return lineBreakPos;
+			nextChar = code[commentStart + 1];
+			if (nextChar === '/') return lineBreakPos;
+			if (nextChar === '*') break;
+			start = commentStart + 2;
+		} while (true);
 		start = code.indexOf('*/', commentStart) + 2;
+		if (start === -1) return -1;
 	}
-	return lineBreakPos;
 }
 
 export function renderStatementList(

--- a/test/form/samples/comment-start-inside-comment/_config.js
+++ b/test/form/samples/comment-start-inside-comment/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'properly remove coments above import statements'
+};

--- a/test/form/samples/comment-start-inside-comment/_expected/amd.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/amd.js
@@ -1,0 +1,9 @@
+define(function () { 'use strict';
+
+	var foo = () => 'foo';
+
+	// /*
+
+	console.log(foo(), bar());
+
+});

--- a/test/form/samples/comment-start-inside-comment/_expected/amd.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/amd.js
@@ -3,7 +3,6 @@ define(function () { 'use strict';
 	var foo = () => 'foo';
 
 	// /*
-
-	console.log(foo(), bar());
+	console.log(foo());
 
 });

--- a/test/form/samples/comment-start-inside-comment/_expected/cjs.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/cjs.js
@@ -3,5 +3,4 @@
 var foo = () => 'foo';
 
 // /*
-
-console.log(foo(), bar());
+console.log(foo());

--- a/test/form/samples/comment-start-inside-comment/_expected/cjs.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var foo = () => 'foo';
+
+// /*
+
+console.log(foo(), bar());

--- a/test/form/samples/comment-start-inside-comment/_expected/es.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/es.js
@@ -1,5 +1,4 @@
 var foo = () => 'foo';
 
 // /*
-
-console.log(foo(), bar());
+console.log(foo());

--- a/test/form/samples/comment-start-inside-comment/_expected/es.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/es.js
@@ -1,0 +1,5 @@
+var foo = () => 'foo';
+
+// /*
+
+console.log(foo(), bar());

--- a/test/form/samples/comment-start-inside-comment/_expected/iife.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/iife.js
@@ -1,0 +1,10 @@
+(function () {
+	'use strict';
+
+	var foo = () => 'foo';
+
+	// /*
+
+	console.log(foo(), bar());
+
+}());

--- a/test/form/samples/comment-start-inside-comment/_expected/iife.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/iife.js
@@ -4,7 +4,6 @@
 	var foo = () => 'foo';
 
 	// /*
-
-	console.log(foo(), bar());
+	console.log(foo());
 
 }());

--- a/test/form/samples/comment-start-inside-comment/_expected/system.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/system.js
@@ -6,8 +6,7 @@ System.register([], function (exports, module) {
 			var foo = () => 'foo';
 
 			// /*
-
-			console.log(foo(), bar());
+			console.log(foo());
 
 		}
 	};

--- a/test/form/samples/comment-start-inside-comment/_expected/system.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/system.js
@@ -1,0 +1,14 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var foo = () => 'foo';
+
+			// /*
+
+			console.log(foo(), bar());
+
+		}
+	};
+});

--- a/test/form/samples/comment-start-inside-comment/_expected/umd.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/umd.js
@@ -1,0 +1,13 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+	var foo = () => 'foo';
+
+	// /*
+
+	console.log(foo(), bar());
+
+})));

--- a/test/form/samples/comment-start-inside-comment/_expected/umd.js
+++ b/test/form/samples/comment-start-inside-comment/_expected/umd.js
@@ -7,7 +7,6 @@
 	var foo = () => 'foo';
 
 	// /*
-
-	console.log(foo(), bar());
+	console.log(foo());
 
 })));

--- a/test/form/samples/comment-start-inside-comment/foo.js
+++ b/test/form/samples/comment-start-inside-comment/foo.js
@@ -1,0 +1,1 @@
+export default () => 'foo';

--- a/test/form/samples/comment-start-inside-comment/main.js
+++ b/test/form/samples/comment-start-inside-comment/main.js
@@ -1,0 +1,4 @@
+// /*
+import foo from './foo.js'; //
+
+console.log(foo(), bar());

--- a/test/form/samples/comment-start-inside-comment/main.js
+++ b/test/form/samples/comment-start-inside-comment/main.js
@@ -1,4 +1,6 @@
 // /*
-import foo from './foo.js'; //
+import foo from './foo.js';
 
-console.log(foo(), bar());
+const bar = 'unused'; /*/ this comment is not closed yet
+*/
+console.log(foo());


### PR DESCRIPTION
Resolves #2127

Previously, line-break detection outside comments was faulty in that since line comments cannot contain line-breaks, it would only scan the code for block comments. This approach failed if a block comment start `/*` was nested inside a line comment.

The new logic now scans for all types of comments and ignores any markup inside both types of comments.