### PR TITLE
Simplify namespace interop

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -36,7 +36,6 @@ export interface ModuleDeclarationDependency {
 	// these used as interop signifiers
 	exportsDefault: boolean;
 	exportsNames: boolean;
-	exportsNamespace: boolean;
 	reexports?: ReexportSpecifier[];
 	imports?: ImportSpecifier[];
 }
@@ -629,15 +628,13 @@ export default class Chunk {
 			}
 
 			let reexports = reexportDeclarations.get(dep);
-			let exportsNames: boolean, exportsNamespace: boolean, exportsDefault: boolean;
+			let exportsNames: boolean, exportsDefault: boolean;
 			if (dep instanceof ExternalModule) {
-				exportsNames = dep.exportsNames;
-				exportsNamespace = dep.exportsNamespace;
+				exportsNames = dep.exportsNames || dep.exportsNamespace;
 				exportsDefault = 'default' in dep.declarations;
 			} else {
 				exportsNames = true;
 				// we don't want any interop patterns to trigger
-				exportsNamespace = false;
 				exportsDefault = false;
 			}
 
@@ -650,7 +647,7 @@ export default class Chunk {
 						<ExternalModule>dep,
 						options.globals,
 						this.graph,
-						exportsNames || exportsNamespace || exportsDefault
+						exportsNames || exportsDefault
 					);
 				}
 			}
@@ -663,7 +660,6 @@ export default class Chunk {
 				name: dep.name,
 				isChunk: !(<ExternalModule>dep).isExternal,
 				exportsNames,
-				exportsNamespace,
 				exportsDefault,
 				reexports,
 				imports
@@ -907,9 +903,6 @@ export default class Chunk {
 			}
 			if (!into.exportsNames && from.exportsNames) {
 				into.exportsNames = true;
-			}
-			if (!into.exportsNamespace && from.exportsNamespace) {
-				into.exportsNamespace = true;
 			}
 			if (!into.exportsDefault && from.exportsDefault) {
 				into.exportsDefault = true;

--- a/src/finalisers/cjs.ts
+++ b/src/finalisers/cjs.ts
@@ -21,41 +21,17 @@ export default function cjs(
 	const interop = options.interop !== false;
 
 	const importBlock = dependencies
-		.map(({ id, isChunk, name, reexports, imports }) => {
+		.map(({ id, isChunk, name, reexports, imports, exportsNames, exportsDefault }) => {
 			if (!reexports && !imports) {
 				return `require('${id}');`;
 			}
 
-			if (!interop || isChunk) {
+			if (!interop || isChunk || !exportsDefault) {
 				return `${varOrConst} ${name} = require('${id}');`;
-			}
-
-			const usesDefault =
-				(imports && imports.some(specifier => specifier.imported === 'default')) ||
-				(reexports && reexports.some(specifier => specifier.imported === 'default'));
-			if (!usesDefault) {
-				return `${varOrConst} ${name} = require('${id}');`;
-			}
-
-			const exportsNamespace = imports && imports.some(specifier => specifier.imported === '*');
-			if (exportsNamespace) {
-				return (
-					`${varOrConst} ${name} = require('${id}');` +
-					`\n${varOrConst} ${name}__default = ${name}['default'];`
-				);
 			}
 
 			needsInterop = true;
 
-			const exportsNames =
-				(imports &&
-					imports.some(
-						specifier => specifier.imported !== 'default' && specifier.imported !== '*'
-					)) ||
-				(reexports &&
-					reexports.some(
-						specifier => specifier.imported !== 'default' && specifier.imported !== '*'
-					));
 			if (exportsNames) {
 				return (
 					`${varOrConst} ${name} = require('${id}');` +

--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -7,10 +7,8 @@ export default function getInteropBlock(
 	varOrConst: string
 ) {
 	return dependencies
-		.map(({ name, exportsNamespace, exportsNames, exportsDefault }) => {
+		.map(({ name, exportsNames, exportsDefault }) => {
 			if (!exportsDefault || options.interop === false) return null;
-
-			if (exportsNamespace) return `${varOrConst} ${name}__default = ${name}['default'];`;
 
 			if (exportsNames)
 				return `${varOrConst} ${name}__default = 'default' in ${name} ? ${name}['default'] : ${name};`;

--- a/src/finalisers/shared/trimEmptyImports.ts
+++ b/src/finalisers/shared/trimEmptyImports.ts
@@ -5,7 +5,7 @@ export default function trimEmptyImports(dependencies: ModuleDeclarationDependen
 
 	while (i--) {
 		const dependency = dependencies[i];
-		if (dependency.exportsDefault || dependency.exportsNames || dependency.exportsNamespace) {
+		if (dependency.exportsDefault || dependency.exportsNames) {
 			return dependencies.slice(0, i + 1);
 		}
 	}

--- a/test/form/samples/import-external-namespace-and-default/_expected/amd.js
+++ b/test/form/samples/import-external-namespace-and-default/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['foo'], function (foo) { 'use strict';
 
-	var foo__default = foo['default'];
+	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	console.log( foo.bar );
 

--- a/test/form/samples/import-external-namespace-and-default/_expected/iife.js
+++ b/test/form/samples/import-external-namespace-and-default/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	var foo__default = foo['default'];
+	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	console.log( foo.bar );
 

--- a/test/form/samples/import-external-namespace-and-default/_expected/umd.js
+++ b/test/form/samples/import-external-namespace-and-default/_expected/umd.js
@@ -4,7 +4,7 @@
 	(factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	var foo__default = foo['default'];
+	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	console.log( foo.bar );
 


### PR DESCRIPTION
This fixes #2081 allowing external modules imported as both default and namespaces can still have default interop applied to them in the default import case (matching the AMD, IIFE and UMD interop cases to CommonJS in the process).

This replaces #2080, while including a lot of simplification in the interop handling code.