### PR TITLE
Fixed variable name when interop is false

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -525,7 +525,9 @@ export default class Chunk {
 				if (variable.name === '*') {
 					safeName = module.name;
 				} else if (variable.name === 'default') {
-					if (module.exportsNamespace || (!esm && module.exportsNames)) {
+					const interop = options.interop !== false;
+					
+					if (interop && (module.exportsNamespace || (!esm && module.exportsNames))) {
 						safeName = `${module.name}__default`;
 					} else {
 						safeName = module.name;


### PR DESCRIPTION
Fixed variable xxx__default is not defined when interop is false

Iutput Options:
```js
const inputOptions = {
  input: 'src/index.js',
  preferConst: true,
  external: ['url', 'node-fetch']
};
```

Output Options:
```js
const outputOptions = {
  format: 'cjs',
  strict: true,
  indent: true,
  legacy: true,
  interop: false, // interop is false
  file: 'index.js'
};
```
Source Code:
```js
import fetch, { Headers } from 'node-fetch';

export default fetch('https://httpbin.org/headers', {
  headers: new Headers({
    'X-Request-With': 'XMLHTTPRequst'
  })
});
```

Expect Output Code:
```js
'use strict';

const fetch = require('node-fetch');

const index = fetch('https://httpbin.org/headers', {
  headers: new fetch.Headers({
    'X-Request-With': 'XMLHTTPRequst'
  })
});

module.exports = index;
```

Actual Output Code:
```js
'use strict';

const fetch = require('node-fetch');

const index = fetch__default('https://httpbin.org/headers', {
  headers: new fetch.Headers({
    'X-Request-With': 'XMLHTTPRequst'
  })
});

module.exports = index;
```

It will throw `fetch__default is not defined!` error when exec ouput code.