### PR TITLE
Fix external renormalization regression (#2153)

### DIFF
--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -3,65 +3,50 @@ import ExternalVariable from './ast/variables/ExternalVariable';
 import Graph from './Graph';
 import Variable from './ast/variables/Variable';
 import { OutputOptions } from './rollup/types';
-import { isAbsolute, resolve, dirname, normalize, relative, isRelative } from './utils/path';
+import { isAbsolute, relative, normalize } from './utils/path';
 
 export default class ExternalModule {
 	private graph: Graph;
 	chunk: void;
 	declarations: { [name: string]: ExternalVariable };
-	exportsNames: boolean;
-	exportsNamespace: boolean;
+	exportsNames = false;
+	exportsNamespace: boolean = false;
 	id: string;
-	renderPath: string;
-	isExternal: true;
-	isEntryPoint: false;
+	renderPath: string = undefined;
+	renormalizeRenderPath = false;
+	isExternal = true;
+	isEntryPoint = false;
 	name: string;
-	mostCommonSuggestion: number;
+	mostCommonSuggestion: number = 0;
 	nameSuggestions: { [name: string]: number };
-	reexported: boolean;
-	used: boolean;
-	execIndex: number;
+	reexported: boolean = false;
+	used = false;
+	execIndex: number = undefined;
 
 	constructor({ graph, id }: { graph: Graph; id: string }) {
 		this.graph = graph;
 		this.id = id;
-		this.renderPath = undefined;
 
 		const parts = id.split(/[\\/]/);
 		this.name = makeLegal(parts.pop());
 
 		this.nameSuggestions = Object.create(null);
-		this.mostCommonSuggestion = 0;
-
-		this.isExternal = true;
-		this.used = false;
 		this.declarations = Object.create(null);
-
-		this.exportsNames = false;
 	}
 
-	setRenderPath(options: OutputOptions, inputPath: string) {
-		if (typeof options.paths === 'function') {
-			let outPath = options.paths(this.id);
-			if (outPath) {
-				this.renderPath = outPath;
-				return;
+	setRenderPath(options: OutputOptions, inputBase: string) {
+		if (options.paths)
+			this.renderPath =
+				typeof options.paths === 'function' ? options.paths(this.id) : options.paths[this.id];
+		if (!this.renderPath) {
+			if (!isAbsolute(this.id)) {
+				this.renderPath = this.id;
+			} else {
+				this.renderPath = normalize(relative(inputBase, this.id));
+				this.renormalizeRenderPath = true;
 			}
-		} else if (options.paths && options.paths.hasOwnProperty(this.id)) {
-			this.renderPath = options.paths[this.id];
-			return;
 		}
-
-		if (isAbsolute(this.id)) {
-			let outDir: string;
-			if (options.dir) outDir = resolve(options.dir);
-			else if (options.file) outDir = dirname(resolve(options.file));
-			else outDir = dirname(inputPath);
-			const relativeToEntry = normalize(relative(outDir, this.id));
-			this.renderPath = isRelative(relativeToEntry) ? relativeToEntry : `./${relativeToEntry}`;
-		} else {
-			this.renderPath = this.id;
-		}
+		return this.renderPath;
 	}
 
 	suggestName(name: string) {

--- a/src/chunk-optimization.ts
+++ b/src/chunk-optimization.ts
@@ -13,7 +13,8 @@ import { OutputOptions } from './rollup/types';
 export function optimizeChunks(
 	chunks: Chunk[],
 	options: OutputOptions,
-	CHUNK_GROUPING_SIZE: number
+	CHUNK_GROUPING_SIZE: number,
+	inputBase: string
 ): Chunk[] {
 	for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
 		const mainChunk = chunks[chunkIndex];
@@ -119,7 +120,7 @@ export function optimizeChunks(
 			if (optimizedChunkIndex <= chunkIndex) chunkIndex--;
 			chunks.splice(optimizedChunkIndex, 1);
 
-			lastChunk.merge(chunk, chunks, options);
+			lastChunk.merge(chunk, chunks, options, inputBase);
 
 			execGroup.splice(--execGroupIndex, 1);
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -1,5 +1,5 @@
 import { getTimings, initialiseTimers, timeEnd, timeStart } from '../utils/timers';
-import { basename, resolve, dirname, relative } from '../utils/path';
+import { basename, resolve, dirname } from '../utils/path';
 import { writeFile } from '../utils/fs';
 import { mapSequence } from '../utils/promise';
 import error from '../utils/error';
@@ -168,11 +168,9 @@ export default function rollup(
 						})
 						.then(addons => {
 							chunk.generateInternalExports(outputOptions);
-							chunk.preRender(outputOptions);
-							chunk.id =
-								typeof process !== 'undefined'
-									? relative(process.cwd(), inputOptions.input)
-									: inputOptions.input;
+							const inputBase = dirname(resolve(inputOptions.input));
+							chunk.preRender(outputOptions, inputBase);
+							chunk.id = basename(inputOptions.input);
 							return chunk.render(outputOptions, addons);
 						})
 						.then(rendered => {
@@ -326,9 +324,9 @@ export default function rollup(
 
 					const generated: { [chunkName: string]: OutputChunk } = {};
 
-					let preserveModulesBase: string;
-					if (inputOptions.experimentalPreserveModules)
-						preserveModulesBase = commondir(chunks.map(chunk => chunk.entryModule.id));
+					const inputBase = commondir(
+						chunks.filter(chunk => chunk.entryModule).map(chunk => chunk.entryModule.id)
+					);
 					let existingNames = Object.create(null);
 
 					const promise = createAddons(graph, outputOptions)
@@ -344,7 +342,7 @@ export default function rollup(
 											}
 										}
 										for (let chunk of chunks) {
-											chunk.preRender(outputOptions);
+											chunk.preRender(outputOptions, inputBase);
 										}
 										if (!optimized && inputOptions.optimizeChunks) {
 											if (inputOptions.experimentalPreserveModules) {
@@ -354,12 +352,17 @@ export default function rollup(
 														'experimentalPreserveModules does not support the optimizeChunks option.'
 												});
 											}
-											optimizeChunks(chunks, outputOptions, inputOptions.chunkGroupingSize);
+											optimizeChunks(
+												chunks,
+												outputOptions,
+												inputOptions.chunkGroupingSize,
+												inputBase
+											);
 											optimized = true;
 										}
 										for (let chunk of chunks) {
 											if (inputOptions.experimentalPreserveModules) {
-												chunk.generateNamePreserveModules(preserveModulesBase);
+												chunk.generateNamePreserveModules(inputBase);
 											} else {
 												let pattern;
 												if (chunk.isEntryModuleFacade) {

--- a/test/form/samples/relative-external-with-global/_expected/amd.js
+++ b/test/form/samples/relative-external-with-global/_expected/amd.js
@@ -1,4 +1,4 @@
-define(['../lib/throttle.js'], function (throttle) { 'use strict';
+define(['./lib/throttle.js'], function (throttle) { 'use strict';
 
 	throttle = throttle && throttle.hasOwnProperty('default') ? throttle['default'] : throttle;
 

--- a/test/form/samples/relative-external-with-global/_expected/cjs.js
+++ b/test/form/samples/relative-external-with-global/_expected/cjs.js
@@ -2,7 +2,7 @@
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var throttle = _interopDefault(require('../lib/throttle.js'));
+var throttle = _interopDefault(require('./lib/throttle.js'));
 
 const fn = throttle( () => {
 	console.log( '.' );

--- a/test/form/samples/relative-external-with-global/_expected/es.js
+++ b/test/form/samples/relative-external-with-global/_expected/es.js
@@ -1,4 +1,4 @@
-import throttle from '../lib/throttle.js';
+import throttle from './lib/throttle.js';
 
 const fn = throttle( () => {
 	console.log( '.' );

--- a/test/form/samples/relative-external-with-global/_expected/system.js
+++ b/test/form/samples/relative-external-with-global/_expected/system.js
@@ -1,4 +1,4 @@
-System.register(['../lib/throttle.js'], function (exports, module) {
+System.register(['./lib/throttle.js'], function (exports, module) {
 	'use strict';
 	var throttle;
 	return {

--- a/test/form/samples/relative-external-with-global/_expected/umd.js
+++ b/test/form/samples/relative-external-with-global/_expected/umd.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('../lib/throttle.js')) :
-	typeof define === 'function' && define.amd ? define(['../lib/throttle.js'], factory) :
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('./lib/throttle.js')) :
+	typeof define === 'function' && define.amd ? define(['./lib/throttle.js'], factory) :
 	(factory(global.Lib.throttle));
 }(this, (function (throttle) { 'use strict';
 

--- a/test/form/samples/url-external/_config.js
+++ b/test/form/samples/url-external/_config.js
@@ -1,0 +1,5 @@
+const { resolve } = require('path');
+
+module.exports = {
+	description: 'supports URL externals',
+};

--- a/test/form/samples/url-external/_expected/amd.js
+++ b/test/form/samples/url-external/_expected/amd.js
@@ -1,0 +1,7 @@
+define(['https://external.com/external.js'], function (external) { 'use strict';
+
+	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+
+	console.log(external);
+
+});

--- a/test/form/samples/url-external/_expected/cjs.js
+++ b/test/form/samples/url-external/_expected/cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var external = _interopDefault(require('https://external.com/external.js'));
+
+console.log(external);

--- a/test/form/samples/url-external/_expected/es.js
+++ b/test/form/samples/url-external/_expected/es.js
@@ -1,0 +1,3 @@
+import external from 'https://external.com/external.js';
+
+console.log(external);

--- a/test/form/samples/url-external/_expected/iife.js
+++ b/test/form/samples/url-external/_expected/iife.js
@@ -1,0 +1,8 @@
+(function (external) {
+	'use strict';
+
+	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+
+	console.log(external);
+
+}(external));

--- a/test/form/samples/url-external/_expected/system.js
+++ b/test/form/samples/url-external/_expected/system.js
@@ -1,0 +1,14 @@
+System.register(['https://external.com/external.js'], function (exports, module) {
+	'use strict';
+	var external;
+	return {
+		setters: [function (module) {
+			external = module.default;
+		}],
+		execute: function () {
+
+			console.log(external);
+
+		}
+	};
+});

--- a/test/form/samples/url-external/_expected/umd.js
+++ b/test/form/samples/url-external/_expected/umd.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('https://external.com/external.js')) :
+	typeof define === 'function' && define.amd ? define(['https://external.com/external.js'], factory) :
+	(factory(global.external));
+}(this, (function (external) { 'use strict';
+
+	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+
+	console.log(external);
+
+})));

--- a/test/form/samples/url-external/main.js
+++ b/test/form/samples/url-external/main.js
@@ -1,0 +1,3 @@
+import external from 'https://external.com/external.js';
+
+console.log(external);


### PR DESCRIPTION
In the shift to code-splitting, there was a regression in https://github.com/rollup/rollup/commit/f59e310fcedeef36f5a75506f1614e50dfeb51ee#diff-a1d1f47eb8dcd4b0026545f1e89b1b95.

The issue here has been making the conceptual model of single file builds adapt to the output model of a file structure in code splitting builds, while handling external naming in a way that can be reliably hashed as well as renormalized into the output folder.

In short the fix is to:
1. Adapt the `inputBase` we're already using for preserveModules to be an input into the preRender function
2. Marking which external modules should be "renormalized" (those that aren't absolute or set by options.paths)
3. Normalizing the external module id relative to the inputBase into a "virtual file space" for code splitting
4. Renormalizing the external module id on chunk write to be relative to the chunk itself, now that we know where it sits int he virtual file space of the build.