### PR TITLE
Show errors for every build in multiconfig

### DIFF
--- a/bin/src/run/build.ts
+++ b/bin/src/run/build.ts
@@ -82,6 +82,10 @@ export default function build(
 			if (bundle && bundle.getTimings) {
 				printTimings(bundle.getTimings());
 			}
+			return true;
 		})
-		.catch(handleError);
+		.catch((error: any) => {
+			handleError(error, true);
+			return false;
+		});
 }

--- a/bin/src/run/index.ts
+++ b/bin/src/run/index.ts
@@ -97,7 +97,7 @@ export default function runRollup(command: any) {
 			.then(configs => execute(configFile, configs, command))
 			.catch(handleError);
 	} else {
-		return execute(configFile, <any>[{ input: null }], command);
+		execute(configFile, <any>[{ input: null }], command);
 	}
 }
 
@@ -126,6 +126,10 @@ function execute(configFile: string, configs: InputOptions[], command: any) {
 			if (optionError) inputOptions.onwarn({ code: 'UNKNOWN_OPTION', message: optionError });
 
 			return build(inputOptions, outputOptions, warnings, command.silent);
+		}).then(results => {
+			if (!results.every(Boolean)) {
+				process.exit(1);
+			}
 		});
 	}
 }

--- a/test/cli/samples/multiple-configs-parallel-errors/_config.js
+++ b/test/cli/samples/multiple-configs-parallel-errors/_config.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'fails for every build in multiple configuration',
+	command: 'rollup -c',
+	error: err => {
+		assert.ok(/Exception 1/.test(err.message));
+		assert.ok(/Exception 2/.test(err.message));
+	}
+};

--- a/test/cli/samples/multiple-configs-parallel-errors/main.js
+++ b/test/cli/samples/multiple-configs-parallel-errors/main.js
@@ -1,0 +1,1 @@
+export default 0;

--- a/test/cli/samples/multiple-configs-parallel-errors/rollup.config.js
+++ b/test/cli/samples/multiple-configs-parallel-errors/rollup.config.js
@@ -1,0 +1,30 @@
+export default [
+	{
+		input: 'main.js',
+		plugins: [
+			{
+				resolveId(id) {
+					throw new Error('Exception 1');
+				}
+			}
+		],
+		output: {
+			file: '_actual/bundle1.js',
+			format: 'cjs'
+		}
+	},
+	{
+		input: 'main.js',
+		plugins: [
+			{
+				resolveId(id) {
+					throw new Error('Exception 2');
+				}
+			}
+		],
+		output: {
+			file: '_actual/bundle2.js',
+			format: 'cjs'
+		}
+	}
+];


### PR DESCRIPTION
Currently if one build fails then the next one is swallowed.

I'm working on size-snapshot plugin which fails if size snapshot is
not matched. The problem is that with umd, esm and cjs configs we will
see only umd error which may confuse why there is not error for another
builds.

My solution is to lift `process.exit(1)`.