### PR TITLE
Revert and lock commonjs plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "require-relative": "^0.8.7",
     "rollup": "^0.58.1",
     "rollup-plugin-buble": "^0.19.2",
-    "rollup-plugin-commonjs": "^9.1.0",
+    "rollup-plugin-commonjs": "9.1.0",
     "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-replace": "^2.0.0",


### PR DESCRIPTION
Currently this is breaking builds due to a Node v6 incompatibility. I hope to post a fix to the plugin soon.