### PR TITLE
Chunk export mode fix for #2176

### DIFF
--- a/src/finalisers/amd.ts
+++ b/src/finalisers/amd.ts
@@ -10,7 +10,8 @@ export default function amd(
 	magicString: MagicStringBundle,
 	{
 		graph,
-		exportMode,
+		namedExportsMode,
+		hasExports,
 		indentString,
 		intro,
 		outro,
@@ -27,7 +28,7 @@ export default function amd(
 	const deps = dependencies.map(m => `'${m.id}'`);
 	const args = dependencies.map(m => m.name);
 
-	if (exportMode === 'named') {
+	if (namedExportsMode && hasExports) {
 		args.unshift(`exports`);
 		deps.unshift(`'exports'`);
 	}
@@ -57,9 +58,9 @@ export default function amd(
 
 	if (intro) magicString.prepend(intro);
 
-	const exportBlock = getExportBlock(exports, dependencies, exportMode, options.interop);
+	const exportBlock = getExportBlock(exports, dependencies, namedExportsMode, options.interop);
 	if (exportBlock) magicString.append('\n\n' + exportBlock);
-	if (exportMode === 'named' && options.legacy !== true && isEntryModuleFacade)
+	if (namedExportsMode && hasExports && options.legacy !== true && isEntryModuleFacade)
 		magicString.append(`\n\n${esModuleExport}`);
 	if (outro) magicString.append(outro);
 

--- a/src/finalisers/cjs.ts
+++ b/src/finalisers/cjs.ts
@@ -6,12 +6,21 @@ import { FinaliserOptions } from './index';
 
 export default function cjs(
 	magicString: MagicStringBundle,
-	{ graph, isEntryModuleFacade, exportMode, intro, outro, dependencies, exports }: FinaliserOptions,
+	{
+		graph,
+		isEntryModuleFacade,
+		namedExportsMode,
+		hasExports,
+		intro,
+		outro,
+		dependencies,
+		exports
+	}: FinaliserOptions,
 	options: OutputOptions
 ) {
 	intro =
 		(options.strict === false ? intro : `'use strict';\n\n${intro}`) +
-		(exportMode === 'named' && options.legacy !== true && isEntryModuleFacade
+		(namedExportsMode && hasExports && options.legacy !== true && isEntryModuleFacade
 			? `${esModuleExport}\n\n`
 			: '');
 
@@ -21,26 +30,41 @@ export default function cjs(
 	const interop = options.interop !== false;
 
 	const importBlock = dependencies
-		.map(({ id, isChunk, name, reexports, imports, exportsNames, exportsDefault }) => {
-			if (!reexports && !imports) {
-				return `require('${id}');`;
+		.map(
+			({
+				id,
+				namedExportsMode,
+				isChunk,
+				name,
+				reexports,
+				imports,
+				exportsNames,
+				exportsDefault
+			}) => {
+				if (!reexports && !imports) {
+					return `require('${id}');`;
+				}
+
+				if (!namedExportsMode) {
+					return `${varOrConst} ${name} = { default: require('${id}') };`;
+				}
+
+				if (!interop || isChunk || !exportsDefault) {
+					return `${varOrConst} ${name} = require('${id}');`;
+				}
+
+				needsInterop = true;
+
+				if (exportsNames) {
+					return (
+						`${varOrConst} ${name} = require('${id}');` +
+						`\n${varOrConst} ${name}__default = _interopDefault(${name});`
+					);
+				}
+
+				return `${varOrConst} ${name} = _interopDefault(require('${id}'));`;
 			}
-
-			if (!interop || isChunk || !exportsDefault) {
-				return `${varOrConst} ${name} = require('${id}');`;
-			}
-
-			needsInterop = true;
-
-			if (exportsNames) {
-				return (
-					`${varOrConst} ${name} = require('${id}');` +
-					`\n${varOrConst} ${name}__default = _interopDefault(${name});`
-				);
-			}
-
-			return `${varOrConst} ${name} = _interopDefault(require('${id}'));`;
-		})
+		)
 		.join('\n');
 
 	if (needsInterop) {
@@ -54,7 +78,7 @@ export default function cjs(
 	const exportBlock = getExportBlock(
 		exports,
 		dependencies,
-		exportMode,
+		namedExportsMode,
 		options.interop,
 		'module.exports ='
 	);

--- a/src/finalisers/cjs.ts
+++ b/src/finalisers/cjs.ts
@@ -45,11 +45,7 @@ export default function cjs(
 					return `require('${id}');`;
 				}
 
-				if (!namedExportsMode) {
-					return `${varOrConst} ${name} = { default: require('${id}') };`;
-				}
-
-				if (!interop || isChunk || !exportsDefault) {
+				if (!interop || isChunk || !exportsDefault || !namedExportsMode) {
 					return `${varOrConst} ${name} = require('${id}');`;
 				}
 

--- a/src/finalisers/index.ts
+++ b/src/finalisers/index.ts
@@ -10,8 +10,9 @@ import { OutputOptions } from '../rollup/types';
 import Graph from '../Graph';
 
 export interface FinaliserOptions {
-	exportMode: string;
 	indentString: string;
+	namedExportsMode: boolean;
+	hasExports: boolean;
 	intro: string;
 	outro: string;
 	dynamicImport: boolean;

--- a/src/finalisers/shared/getExportBlock.ts
+++ b/src/finalisers/shared/getExportBlock.ts
@@ -22,7 +22,7 @@ export default function getExportBlock(
 				if (!dep.reexports) return false;
 				return dep.reexports.some(expt => {
 					if (expt.reexported === 'default') {
-						local = `${dep.name}.${expt.imported}`;
+						local = dep.namedExportsMode ? `${dep.name}.${expt.imported}` : dep.name;
 						return true;
 					}
 					return false;

--- a/src/finalisers/shared/getExportBlock.ts
+++ b/src/finalisers/shared/getExportBlock.ts
@@ -3,11 +3,11 @@ import { ChunkExports, ChunkDependencies } from '../../Chunk';
 export default function getExportBlock(
 	exports: ChunkExports,
 	dependencies: ChunkDependencies,
-	exportMode: string,
+	namedExportsMode: boolean,
 	interop: boolean,
 	mechanism = 'return'
 ) {
-	if (exportMode === 'default') {
+	if (!namedExportsMode) {
 		let local;
 		exports.some(expt => {
 			if (expt.exported === 'default') {
@@ -36,7 +36,7 @@ export default function getExportBlock(
 
 	// star exports must always output first for precedence
 	dependencies.forEach(({ name, reexports }) => {
-		if (reexports && exportMode !== 'default') {
+		if (reexports && namedExportsMode) {
 			reexports.forEach(specifier => {
 				if (specifier.reexported === '*') {
 					exportBlock += `${
@@ -48,7 +48,7 @@ export default function getExportBlock(
 	});
 
 	dependencies.forEach(({ name, imports, reexports, isChunk }) => {
-		if (reexports && exportMode !== 'default') {
+		if (reexports && namedExportsMode) {
 			reexports.forEach(specifier => {
 				if (specifier.imported === 'default' && !isChunk) {
 					const exportsNamesOrNamespace =

--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -7,7 +7,9 @@ export default function getInteropBlock(
 	varOrConst: string
 ) {
 	return dependencies
-		.map(({ name, exportsNames, exportsDefault }) => {
+		.map(({ name, exportsNames, exportsDefault, namedExportsMode }) => {
+			if (!namedExportsMode) return `${name} = { default: ${name} };`;
+
 			if (!exportsDefault || options.interop === false) return null;
 
 			if (exportsNames)

--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -8,7 +8,7 @@ export default function getInteropBlock(
 ) {
 	return dependencies
 		.map(({ name, exportsNames, exportsDefault, namedExportsMode }) => {
-			if (!namedExportsMode) return `${name} = { default: ${name} };`;
+			if (!namedExportsMode) return;
 
 			if (!exportsDefault || options.interop === false) return null;
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -21,6 +21,7 @@ import {
 	Plugin,
 	ModuleJSON
 } from './types';
+import getExportMode from '../utils/getExportMode';
 
 export const VERSION = '<@VERSION@>';
 
@@ -169,6 +170,7 @@ export default function rollup(
 						.then(addons => {
 							chunk.generateInternalExports(outputOptions);
 							const inputBase = dirname(resolve(inputOptions.input));
+							chunk.exportMode = getExportMode(chunk, outputOptions);
 							chunk.preRender(outputOptions, inputBase);
 							chunk.id = basename(inputOptions.input);
 							return chunk.render(outputOptions, addons);
@@ -336,10 +338,11 @@ export default function rollup(
 							return (
 								Promise.resolve()
 									.then(() => {
-										if (!inputOptions.experimentalPreserveModules) {
-											for (let chunk of chunks) {
+										for (let chunk of chunks) {
+											if (!inputOptions.experimentalPreserveModules)
 												chunk.generateInternalExports(outputOptions);
-											}
+											if (chunk.isEntryModuleFacade)
+												chunk.exportMode = getExportMode(chunk, outputOptions);
 										}
 										for (let chunk of chunks) {
 											chunk.preRender(outputOptions, inputBase);

--- a/test/chunking-form/samples/chunking-reexport/_expected/amd/chunk-849a022f.js
+++ b/test/chunking-form/samples/chunking-reexport/_expected/amd/chunk-849a022f.js
@@ -1,4 +1,4 @@
-define(['exports', 'external'], function (exports, external) { 'use strict';
+define(['external'], function (external) { 'use strict';
 
 	console.log('dep');
 

--- a/test/chunking-form/samples/entry-chunk-export-mode/_config.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'entry chunk export mode checks',
+	options: {
+		input: ['main1.js', 'main2.js']
+	}
+};

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main1.js
@@ -1,7 +1,5 @@
 define(['./main2.js'], function (main2) { 'use strict';
 
-	main2 = { default: main2 };
-
-	main2.default();
+	main2();
 
 });

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main1.js
@@ -1,5 +1,7 @@
 define(['./main2.js'], function (main2) { 'use strict';
 
-	main2();
+	main2 = { default: main2 };
+
+	main2.default();
 
 });

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main1.js
@@ -1,0 +1,5 @@
+define(['./main2.js'], function (main2) { 'use strict';
+
+	main2();
+
+});

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main2.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/amd/main2.js
@@ -1,0 +1,9 @@
+define(function () { 'use strict';
+
+  function fn () {
+    console.log('main fn');
+  }
+
+  return fn;
+
+});

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main1.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var main2 = require('./main2.js');
+var main2 = { default: require('./main2.js') };
 
-main2();
+main2.default();

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main1.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var main2 = { default: require('./main2.js') };
+var main2 = require('./main2.js');
 
-main2.default();
+main2();

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var main2 = require('./main2.js');
+
+main2();

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/cjs/main2.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function fn () {
+  console.log('main fn');
+}
+
+module.exports = fn;

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/es/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/es/main1.js
@@ -1,0 +1,3 @@
+import fn from './main2.js';
+
+fn();

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/es/main2.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/es/main2.js
@@ -1,0 +1,5 @@
+function fn () {
+  console.log('main fn');
+}
+
+export default fn;

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/system/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/system/main1.js
@@ -1,0 +1,14 @@
+System.register(['./main2.js'], function (exports, module) {
+	'use strict';
+	var fn;
+	return {
+		setters: [function (module) {
+			fn = module.default;
+		}],
+		execute: function () {
+
+			fn();
+
+		}
+	};
+});

--- a/test/chunking-form/samples/entry-chunk-export-mode/_expected/system/main2.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/_expected/system/main2.js
@@ -1,0 +1,13 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      exports('default', fn);
+      function fn () {
+        console.log('main fn');
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/entry-chunk-export-mode/main1.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/main1.js
@@ -1,0 +1,4 @@
+import fn from './main2.js';
+
+
+fn();

--- a/test/chunking-form/samples/entry-chunk-export-mode/main2.js
+++ b/test/chunking-form/samples/entry-chunk-export-mode/main2.js
@@ -1,0 +1,3 @@
+export default function fn () {
+  console.log('main fn');
+}

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/head.js
@@ -1,9 +1,7 @@
 define(['./first.js'], function (first) { 'use strict';
 
-	first = { default: first };
 
 
-
-	return first.default;
+	return first;
 
 });

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/head.js
@@ -1,5 +1,7 @@
 define(['./first.js'], function (first) { 'use strict';
 
+	first = { default: first };
+
 
 
 	return first.default;

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
@@ -1,8 +1,6 @@
 define(['./first.js'], function (first) { 'use strict';
 
-	first = { default: first };
-
-	console.log(first.default);
-	console.log(first.default);
+	console.log(first);
+	console.log(first);
 
 });

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main1.js
@@ -1,5 +1,7 @@
 define(['./first.js'], function (first) { 'use strict';
 
+	first = { default: first };
+
 	console.log(first.default);
 	console.log(first.default);
 

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main2.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main2.js
@@ -1,5 +1,7 @@
 define(['./first.js'], function (first) { 'use strict';
 
+	first = { default: first };
+
 
 
 });

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main2.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/amd/main2.js
@@ -1,7 +1,5 @@
 define(['./first.js'], function (first) { 'use strict';
 
-	first = { default: first };
-
 
 
 });

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/head.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var first = require('./first.js');
+var first = { default: require('./first.js') };
 
 
 

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/head.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/head.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var first = { default: require('./first.js') };
+var first = require('./first.js');
 
 
 
-module.exports = first.default;
+module.exports = first;

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var first = require('./first.js');
+var first = { default: require('./first.js') };
 
 console.log(first.default);
 console.log(first.default);

--- a/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/import-variable-duplicates/_expected/cjs/main1.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var first = { default: require('./first.js') };
+var first = require('./first.js');
 
-console.log(first.default);
-console.log(first.default);
+console.log(first);
+console.log(first);


### PR DESCRIPTION
This fixes #2176.

I've refactored the exportMode a little into `namedExportsMode` and `hasExports` booleans for the finalizers.

The `namedExportsMode` could equally be considered the exact converse of a `defaultExportMode`.

We then effectively treat the default export mode as an extra interop case where we know the interop path already so don't need to do a check here.