### PR TITLE
use npm 5 in lower node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ env:
     - BUILD_TIMEOUT=10000
 install: npm install --ignore-scripts
 before_install:
-  - if [[ $TRAVIS_NODE_VERSION -lt 7 ]]; then npm install --global npm@4; fi
+  - if [[ $TRAVIS_NODE_VERSION -lt 7 ]]; then npm install --global npm@5; fi
 # script: npm run ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - IF %nodejs_version% LSS 7 npm -g install npm@4
+  - IF %nodejs_version% LSS 7 npm -g install npm@5
   - npm install --ignore-scripts
 
 build: off


### PR DESCRIPTION
master has regressed in lower node versions https://travis-ci.org/rollup/rollup/jobs/378107881

```
Error: 'crypto' is imported by node_modules/math-random/node.js, but could not be resolved – treating it as an external dependency
```

This is because the lower envs don't use npm 5 and version drift occurred.