### PR TITLE
Add circularity prevention to value detection

### DIFF
--- a/src/ast/ExecutionPathOptions.ts
+++ b/src/ast/ExecutionPathOptions.ts
@@ -17,6 +17,7 @@ export enum OptionTypes {
 	IGNORE_RETURN_AWAIT_YIELD,
 	NODES_CALLED_AT_PATH_WITH_OPTIONS,
 	REPLACED_VARIABLE_INITS,
+	RETRIEVED_VALUE_NODES,
 	RETURN_EXPRESSIONS_ACCESSED_AT_PATH,
 	RETURN_EXPRESSIONS_ASSIGNED_AT_PATH,
 	RETURN_EXPRESSIONS_CALLED_AT_PATH
@@ -95,6 +96,10 @@ export class ExecutionPathOptions {
 		);
 	}
 
+	addRetrievedNodeValueAtPath(path: ObjectPath, node: ExpressionEntity) {
+		return this.setIn([OptionTypes.RETRIEVED_VALUE_NODES, node, ...path, RESULT_KEY], true);
+	}
+
 	getArgumentsVariables(): ExpressionEntity[] {
 		return <ExpressionEntity[]>(this.get(OptionTypes.ARGUMENTS_VARIABLES) || []);
 	}
@@ -134,6 +139,10 @@ export class ExecutionPathOptions {
 				otherCallOptions.equals(callOptions)
 			)
 		);
+	}
+
+	hasNodeValueBeenRetrievedAtPath(path: ObjectPath, node: ExpressionEntity): boolean {
+		return this.optionValues.getIn([OptionTypes.RETRIEVED_VALUE_NODES, node, ...path, RESULT_KEY]);
 	}
 
 	hasReturnExpressionBeenAccessedAtPath(

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -37,12 +37,12 @@ export default class BinaryExpression extends NodeBase {
 	right: ExpressionNode;
 	operator: keyof typeof binaryOperators;
 
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown {
 		if (path.length > 0) return UNKNOWN_VALUE;
-		const leftValue = this.left.getLiteralValueAtPath(EMPTY_PATH);
+		const leftValue = this.left.getLiteralValueAtPath(EMPTY_PATH, options);
 		if (leftValue === UNKNOWN_VALUE) return UNKNOWN_VALUE;
 
-		const rightValue = this.right.getLiteralValueAtPath(EMPTY_PATH);
+		const rightValue = this.right.getLiteralValueAtPath(EMPTY_PATH, options);
 		if (rightValue === UNKNOWN_VALUE) return UNKNOWN_VALUE;
 
 		const operatorFn = binaryOperators[this.operator];

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -72,9 +72,9 @@ export default class Identifier extends NodeBase {
 		}
 	}
 
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown {
 		if (this.variable !== null) {
-			return this.variable.getLiteralValueAtPath(path);
+			return this.variable.getLiteralValueAtPath(path, options);
 		}
 		return UNKNOWN_VALUE;
 	}

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -35,14 +35,14 @@ export default class Literal<T = LiteralValue> extends NodeBase {
 		return <any>this.value;
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, _options: ExecutionPathOptions) {
+	hasEffectsWhenAccessedAtPath(path: ObjectPath) {
 		if (this.value === null) {
 			return path.length > 0;
 		}
 		return path.length > 1;
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, _options: ExecutionPathOptions) {
+	hasEffectsWhenAssignedAtPath(path: ObjectPath) {
 		return path.length > 0;
 	}
 

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -106,7 +106,7 @@ export default class MemberExpression extends NodeBase {
 			this.variable.forEachReturnExpressionWhenCalledAtPath(path, callOptions, callback, options);
 		} else {
 			this.object.forEachReturnExpressionWhenCalledAtPath(
-				[this.propertyKey || this.getComputedKey(), ...path],
+				[this.propertyKey || this.getComputedKey(options), ...path],
 				callOptions,
 				callback,
 				options
@@ -114,11 +114,14 @@ export default class MemberExpression extends NodeBase {
 		}
 	}
 
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown {
 		if (this.variable !== null) {
-			return this.variable.getLiteralValueAtPath(path);
+			return this.variable.getLiteralValueAtPath(path, options);
 		}
-		return this.object.getLiteralValueAtPath([this.propertyKey || this.getComputedKey(), ...path]);
+		return this.object.getLiteralValueAtPath(
+			[this.propertyKey || this.getComputedKey(options), ...path],
+			options
+		);
 	}
 
 	hasEffects(options: ExecutionPathOptions): boolean {
@@ -127,7 +130,7 @@ export default class MemberExpression extends NodeBase {
 			this.object.hasEffects(options) ||
 			(this.arePropertyReadSideEffectsChecked &&
 				this.object.hasEffectsWhenAccessedAtPath(
-					[this.propertyKey || this.getComputedKey()],
+					[this.propertyKey || this.getComputedKey(options)],
 					options
 				))
 		);
@@ -141,7 +144,7 @@ export default class MemberExpression extends NodeBase {
 			return this.variable.hasEffectsWhenAccessedAtPath(path, options);
 		}
 		return this.object.hasEffectsWhenAccessedAtPath(
-			[this.propertyKey || this.getComputedKey(), ...path],
+			[this.propertyKey || this.getComputedKey(options), ...path],
 			options
 		);
 	}
@@ -151,7 +154,7 @@ export default class MemberExpression extends NodeBase {
 			return this.variable.hasEffectsWhenAssignedAtPath(path, options);
 		}
 		return this.object.hasEffectsWhenAssignedAtPath(
-			[this.propertyKey || this.getComputedKey(), ...path],
+			[this.propertyKey || this.getComputedKey(options), ...path],
 			options
 		);
 	}
@@ -165,7 +168,7 @@ export default class MemberExpression extends NodeBase {
 			return this.variable.hasEffectsWhenCalledAtPath(path, callOptions, options);
 		}
 		return this.object.hasEffectsWhenCalledAtPath(
-			[this.propertyKey || this.getComputedKey(), ...path],
+			[this.propertyKey || this.getComputedKey(options), ...path],
 			callOptions,
 			options
 		);
@@ -198,7 +201,10 @@ export default class MemberExpression extends NodeBase {
 		if (this.variable) {
 			this.variable.reassignPath(path, options);
 		} else {
-			this.object.reassignPath([this.propertyKey || this.getComputedKey(), ...path], options);
+			this.object.reassignPath(
+				[this.propertyKey || this.getComputedKey(options), ...path],
+				options
+			);
 		}
 	}
 
@@ -247,7 +253,7 @@ export default class MemberExpression extends NodeBase {
 			);
 		}
 		return this.object.someReturnExpressionWhenCalledAtPath(
-			[this.propertyKey || this.getComputedKey(), ...path],
+			[this.propertyKey || this.getComputedKey(options), ...path],
 			callOptions,
 			predicateFunction,
 			options
@@ -269,8 +275,8 @@ export default class MemberExpression extends NodeBase {
 		}
 	}
 
-	private getComputedKey() {
-		const value = this.property.getLiteralValueAtPath(EMPTY_PATH);
+	private getComputedKey(options: ExecutionPathOptions) {
+		const value = this.property.getLiteralValueAtPath(EMPTY_PATH, options);
 		return value === UNKNOWN_VALUE ? UNKNOWN_KEY : String(value);
 	}
 

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -49,11 +49,11 @@ export default class Property extends NodeBase {
 		}
 	}
 
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown {
 		if (this.kind === 'get') {
 			return UNKNOWN_VALUE;
 		}
-		return this.value.getLiteralValueAtPath(path);
+		return this.value.getLiteralValueAtPath(path, options);
 	}
 
 	hasEffects(options: ExecutionPathOptions): boolean {

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -31,8 +31,8 @@ export default class SequenceExpression extends NodeBase {
 		);
 	}
 
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
-		return this.expressions[this.expressions.length - 1].getLiteralValueAtPath(path);
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown {
+		return this.expressions[this.expressions.length - 1].getLiteralValueAtPath(path, options);
 	}
 
 	hasEffects(options: ExecutionPathOptions): boolean {

--- a/src/ast/nodes/UnaryExpression.ts
+++ b/src/ast/nodes/UnaryExpression.ts
@@ -29,9 +29,9 @@ export default class UnaryExpression extends NodeBase {
 		}
 	}
 
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown {
 		if (path.length > 0) return UNKNOWN_VALUE;
-		const argumentValue = this.argument.getLiteralValueAtPath(EMPTY_PATH);
+		const argumentValue = this.argument.getLiteralValueAtPath(EMPTY_PATH, options);
 		if (argumentValue === UNKNOWN_VALUE) return UNKNOWN_VALUE;
 
 		return unaryOperators[this.operator](<LiteralValue>argumentValue);

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -24,7 +24,7 @@ export interface ExpressionEntity extends WritableEntity {
 	 * for inlining or comparing values.
 	 * Otherwise it should return UNKNOWN_VALUE.
 	 */
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown;
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown;
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions): boolean;
 	hasEffectsWhenCalledAtPath(
 		path: ObjectPath,

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -139,7 +139,7 @@ export class NodeBase implements ExpressionNode {
 		_options: ExecutionPathOptions
 	) {}
 
-	getLiteralValueAtPath(_path: ObjectPath): LiteralValueOrUnknown {
+	getLiteralValueAtPath(_path: ObjectPath, _options: ExecutionPathOptions): LiteralValueOrUnknown {
 		return UNKNOWN_VALUE;
 	}
 

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -57,11 +57,19 @@ export default class LocalVariable extends Variable {
 		}
 	}
 
-	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
-		if (!this.init || this.reassignments.isPathReassigned(path)) {
+	getLiteralValueAtPath(path: ObjectPath, options: ExecutionPathOptions): LiteralValueOrUnknown {
+		if (
+			!this.init ||
+			path.length > MAX_PATH_DEPTH ||
+			this.reassignments.isPathReassigned(path) ||
+			options.hasNodeValueBeenRetrievedAtPath(path, this.init)
+		) {
 			return UNKNOWN_VALUE;
 		}
-		return this.init.getLiteralValueAtPath(path);
+		return this.init.getLiteralValueAtPath(
+			path,
+			options.addRetrievedNodeValueAtPath(path, this.init)
+		);
 	}
 
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions) {

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -54,7 +54,7 @@ export default class Variable implements ExpressionEntity {
 		return this.safeName || this.name;
 	}
 
-	getLiteralValueAtPath(_path: ObjectPath): LiteralValueOrUnknown {
+	getLiteralValueAtPath(_path: ObjectPath, _options: ExecutionPathOptions): LiteralValueOrUnknown {
 		return UNKNOWN_VALUE;
 	}
 

--- a/test/form/samples/recursive-values/_config.js
+++ b/test/form/samples/recursive-values/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'do not fail for pathological recursive algorithms and circular structures'
+};

--- a/test/form/samples/recursive-values/_expected.js
+++ b/test/form/samples/recursive-values/_expected.js
@@ -1,0 +1,7 @@
+var x = x || true;
+
+x && console.log(1);
+
+var y = {y};
+
+y.y && console.log(2);

--- a/test/form/samples/recursive-values/main.js
+++ b/test/form/samples/recursive-values/main.js
@@ -1,0 +1,7 @@
+var x = x || true;
+
+x && console.log(1);
+
+var y = {y};
+
+y.y && console.log(2);


### PR DESCRIPTION
This adds logic to handle circular structures when retrieving literal values similar to how this is done in other situations.

Resolves #2192 (hopefully).
