### PR TITLE
Resolve #2191: Add spaces after return and yield if necessary

### DIFF
--- a/src/ast/nodes/ReturnStatement.ts
+++ b/src/ast/nodes/ReturnStatement.ts
@@ -2,17 +2,30 @@ import { UNKNOWN_EXPRESSION } from '../values';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import * as NodeType from './NodeType';
 import { ExpressionNode, StatementBase } from './shared/Node';
+import { RenderOptions } from '../../utils/renderHelpers';
+import MagicString from 'magic-string';
 
 export default class ReturnStatement extends StatementBase {
 	type: NodeType.tReturnStatement;
 	argument: ExpressionNode | null;
 
 	hasEffects(options: ExecutionPathOptions) {
-		return super.hasEffects(options) || !options.ignoreReturnAwaitYield();
+		return (
+			!options.ignoreReturnAwaitYield() || (this.argument && this.argument.hasEffects(options))
+		);
 	}
 
 	initialise() {
 		this.included = false;
 		this.scope.addReturnExpression(this.argument || UNKNOWN_EXPRESSION);
+	}
+
+	render(code: MagicString, options: RenderOptions) {
+		if (this.argument) {
+			this.argument.render(code, options);
+			if (this.argument.start === this.start + 6 /* 'return'.length */) {
+				code.prependLeft(this.start + 6, ' ');
+			}
+		}
 	}
 }

--- a/src/ast/nodes/YieldExpression.ts
+++ b/src/ast/nodes/YieldExpression.ts
@@ -1,6 +1,8 @@
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import * as NodeType from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
+import { RenderOptions } from '../../utils/renderHelpers';
+import MagicString from 'magic-string';
 
 export default class YieldExpression extends NodeBase {
 	type: NodeType.tYieldExpression;
@@ -8,6 +10,17 @@ export default class YieldExpression extends NodeBase {
 	delegate: boolean;
 
 	hasEffects(options: ExecutionPathOptions) {
-		return super.hasEffects(options) || !options.ignoreReturnAwaitYield();
+		return (
+			!options.ignoreReturnAwaitYield() || (this.argument && this.argument.hasEffects(options))
+		);
+	}
+
+	render(code: MagicString, options: RenderOptions) {
+		if (this.argument) {
+			this.argument.render(code, options);
+			if (this.argument.start === this.start + 5 /* 'yield'.length */) {
+				code.prependLeft(this.start + 5, ' ');
+			}
+		}
 	}
 }

--- a/test/form/samples/return-statement/missing-space/_config.js
+++ b/test/form/samples/return-statement/missing-space/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Inserts space when simplifying return statement without space'
+};

--- a/test/form/samples/return-statement/missing-space/_expected.js
+++ b/test/form/samples/return-statement/missing-space/_expected.js
@@ -1,0 +1,5 @@
+function test() {
+	return null;
+}
+
+console.log(test());

--- a/test/form/samples/return-statement/missing-space/main.js
+++ b/test/form/samples/return-statement/missing-space/main.js
@@ -1,0 +1,5 @@
+function test() {
+	return!1||null;
+}
+
+console.log(test());

--- a/test/form/samples/yield-expression/missing-space/_config.js
+++ b/test/form/samples/yield-expression/missing-space/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Inserts space when simplifying yield expression without space'
+};

--- a/test/form/samples/yield-expression/missing-space/_expected.js
+++ b/test/form/samples/yield-expression/missing-space/_expected.js
@@ -1,0 +1,7 @@
+function* test() {
+	yield null;
+}
+
+for (const x of test()) {
+	console.log(x);
+}

--- a/test/form/samples/yield-expression/missing-space/main.js
+++ b/test/form/samples/yield-expression/missing-space/main.js
@@ -1,0 +1,7 @@
+function* test() {
+	yield!1||null;
+}
+
+for (const x of test()) {
+	console.log(x);
+}


### PR DESCRIPTION
After some deliberation, this is the lowest impact fix I could come up with to resolve #2191. Basically as far as I am aware, this issue can only arise for `return` statements and `yield` expressions when there is no space between the keyword and the subsequent expression and the nested expression changes due to some simplification.

E.g. `return!1||true` -> `return true`.

For `await` expressions this is not an issue as operator precedence is different here (`await!1||true` is equivalent to `(await !1) || true`)

The solution is to insert a space if the argument of the `return` statement starts directly after the last letter of `return`, similarly for `yield`.