### PR TITLE
Reassign for-in loop variable; resolves #2199

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rollup changelog
 
+## 0.59.2
+*2018-05-21*
+* Fix reassignment tracking in for-in loops ([#2205](https://github.com/rollup/rollup/pull/2205))
+
 ## 0.59.1
 *2018-05-16*
 * Fix infinite recursion when determining literal values of circular structures ([#2193](https://github.com/rollup/rollup/pull/2193))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Next-generation ES6 module bundler",
   "main": "dist/rollup.js",
   "module": "dist/rollup.es.js",

--- a/src/ast/nodes/ForInStatement.ts
+++ b/src/ast/nodes/ForInStatement.ts
@@ -1,7 +1,7 @@
 import BlockScope from '../scopes/BlockScope';
 import VariableDeclaration from './VariableDeclaration';
 import Scope from '../scopes/Scope';
-import { ExecutionPathOptions } from '../ExecutionPathOptions';
+import { ExecutionPathOptions, NEW_EXECUTION_PATH } from '../ExecutionPathOptions';
 import { PatternNode } from './shared/Pattern';
 import * as NodeType from './NodeType';
 import { ExpressionNode, Node, StatementBase, StatementNode } from './shared/Node';
@@ -18,6 +18,13 @@ export default class ForInStatement extends StatementBase {
 	left: VariableDeclaration | PatternNode;
 	right: ExpressionNode;
 	body: StatementNode;
+
+	bind() {
+		super.bind();
+		if (this.left.type !== NodeType.VariableDeclaration) {
+			this.left.reassignPath(EMPTY_PATH, NEW_EXECUTION_PATH);
+		}
+	}
 
 	createScope(parentScope: Scope) {
 		this.scope = new BlockScope({ parent: parentScope });

--- a/src/ast/nodes/ForOfStatement.ts
+++ b/src/ast/nodes/ForOfStatement.ts
@@ -21,7 +21,9 @@ export default class ForOfStatement extends StatementBase {
 
 	bind() {
 		super.bind();
-		this.left.reassignPath(EMPTY_PATH, NEW_EXECUTION_PATH);
+		if (this.left.type !== NodeType.VariableDeclaration) {
+			this.left.reassignPath(EMPTY_PATH, NEW_EXECUTION_PATH);
+		}
 	}
 
 	createScope(parentScope: Scope) {

--- a/test/function/samples/for-loops-as-assignments/_config.js
+++ b/test/function/samples/for-loops-as-assignments/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'make sure for loops are counted as variable assignments (#2199)'
+};

--- a/test/function/samples/for-loops-as-assignments/main.js
+++ b/test/function/samples/for-loops-as-assignments/main.js
@@ -1,0 +1,21 @@
+let x = false;
+let iteratedForIn = false;
+
+for (x in {key: true}) {
+	if (x === 'key') {
+		iteratedForIn = true;
+	}
+}
+
+assert.ok(iteratedForIn);
+
+let y = false;
+let iteratedForOf = false;
+
+for (y of ['key']) {
+	if (y === 'key') {
+		iteratedForOf = true;
+	}
+}
+
+assert.ok(iteratedForOf);


### PR DESCRIPTION
The issue was that in contrast to `for..of` loops, the logic for `for..in` loops did not mark non-declaration loop variables as "reassigned".

In the current situation if the the loop variable previously evaluated to a boolean, this value would not change and thus conditionals would be wrongly simplified.