### PR TITLE
fix: Using -w flag fails when config.input is an object

### DIFF
--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -11,11 +11,11 @@ import loadConfigFile from './loadConfigFile';
 import relativeId from '../../../src/utils/relativeId';
 import { handleError, stderr } from '../logging';
 import { printTimings } from './timings';
-import { RollupError, RollupWatchOptions, Bundle, BundleSet } from '../../../src/rollup/types';
+import { RollupError, RollupWatchOptions, Bundle, BundleSet, InputOption } from '../../../src/rollup/types';
 interface WatchEvent {
 	code?: string;
 	error?: RollupError | Error;
-	input?: string | string[];
+	input?: InputOption;
 	output?: string[];
 	duration?: number;
 	result?: Bundle | BundleSet;
@@ -98,14 +98,17 @@ export default function watch(
 					break;
 
 				case 'BUNDLE_START':
-					if (!silent)
+					if (!silent) {
+						let input = event.input;
+						if ( typeof input !== 'string' ) {
+							input = Array.isArray(input) ? input.join(', ') : Object.values(input).join(', ')
+						}
 						stderr(
 							chalk.cyan(
-								`bundles ${chalk.bold(
-									typeof event.input === 'string' ? event.input : event.input.join(', ')
-								)} → ${chalk.bold(event.output.map(relativeId).join(', '))}...`
+								`bundles ${chalk.bold(input)} → ${chalk.bold(event.output.map(relativeId).join(', '))}...`
 							)
 						);
+					}
 					break;
 
 				case 'BUNDLE_END':

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -128,9 +128,10 @@ export interface TreeshakingOptions {
 
 export type ExternalOption = string[] | IsExternalHook;
 export type GlobalsOption = { [name: string]: string } | ((name: string) => string);
+export type InputOption = string | string[] | { [entryAlias: string]: string };
 
 export interface InputOptions {
-	input: string | string[] | { [entryAlias: string]: string };
+	input: InputOption;
 	manualChunks?: { [chunkAlias: string]: string[] };
 	external?: ExternalOption;
 	plugins?: Plugin[];


### PR DESCRIPTION
The watcher defines it's own type for the `input` option which predictably went out of sync with the "official" `InputOptions.input` type - which led to this passing unnoticed:

When using `experimentalCodeSplitting` and setting `input` to be an object, then the watcher threw an error.
