### PR TITLE
Fix unreasonably slow bundle time on sourcemaps with long lines

### DIFF
--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -110,14 +110,23 @@ class Link {
 		const segments = this.mappings[line];
 		if (!segments) return null;
 
-		for (const segment of segments) {
-			if (segment[0] > column) return null;
+		// binary search through segments for the given column
+		let i = 0;
+		let j = segments.length - 1;
 
+		while (i <= j) {
+			const m = (i + j) >> 1;
+			const segment = segments[m];
 			if (segment[0] === column) {
 				const source = this.sources[segment[1]];
 				if (!source) return null;
 
 				return source.traceSegment(segment[2], segment[3], this.names[segment[4]] || name);
+			}
+			if (segment[0] > column) {
+				j = m - 1;
+			} else {
+				i = m + 1;
 			}
 		}
 


### PR DESCRIPTION
Fixes #1553. Fixes #1700.

For some builds like in the issues above, `traceSegment` in `collapseSourcemaps.ts` took unreasonably long time because some of the source maps contained very long lines (e.g. one example line had 50k segments), and linearly searching through them for every segment that needed tracing was too slow. This PR switches `traceSegment` to use simple binary search, fixing the issue.

Bundle times for the [repro case](https://github.com/houli/rollup-sourcemap-repro) in #1553:

- `sourceMap: false` (`master` rollup): 2.1s
- `sourceMap: true` (`master` rollup): 15.5s
- `sourceMap: true` (this branch): 2.4s

cc @lukastaegert 