### PR TITLE
Add rendered length to module

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -782,6 +782,7 @@ export default class Chunk {
 			const namespace = module.getOrCreateNamespace();
 			if (namespace.needsNamespaceBlock || !source.isEmpty()) {
 				magicString.addSource(source);
+				module.incrementRenderedLength(source);
 				this.usedModules.push(module);
 
 				if (namespace.needsNamespaceBlock) {

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -153,6 +153,7 @@ export default class Module {
 	originalCode: string;
 	originalSourcemap: RawSourceMap | void;
 	reexports: { [name: string]: ReexportDescription };
+	renderedLength: number = 0;
 	resolvedIds: IdMap;
 	scope: ModuleScope;
 	sourcemapChain: RawSourceMap[];
@@ -631,6 +632,10 @@ export default class Module {
 		return magicString;
 	}
 
+	incrementRenderedLength(source: MagicString) {
+		this.renderedLength += source.toString().length;
+	}
+
 	toJSON(): ModuleJSON {
 		return {
 			id: this.id,
@@ -640,7 +645,8 @@ export default class Module {
 			originalSourcemap: this.originalSourcemap,
 			ast: this.esTreeAst,
 			sourcemapChain: this.sourcemapChain,
-			resolvedIds: this.resolvedIds
+			resolvedIds: this.resolvedIds,
+			renderedLength: this.renderedLength
 		};
 	}
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -212,7 +212,7 @@ export default function rollup(
 				const result: Bundle = {
 					imports,
 					exports,
-					modules: graph.getCache().modules,
+					modules,
 
 					cache: { modules },
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -73,7 +73,7 @@ const throwAsyncGenerateError = {
 export interface OutputChunk {
 	imports: string[];
 	exports: string[];
-	modules: string[];
+	modules: ModuleJSON[];
 	code: string;
 	map?: SourceMap;
 }
@@ -181,7 +181,7 @@ export default function rollup(
 							const output = {
 								imports,
 								exports,
-								modules: chunk.getModuleIds(),
+								modules: graph.getCache().modules,
 								code: rendered.code,
 								map: rendered.map
 							};
@@ -212,7 +212,7 @@ export default function rollup(
 				const result: Bundle = {
 					imports,
 					exports,
-					modules,
+					modules: graph.getCache().modules,
 
 					cache: { modules },
 
@@ -385,7 +385,7 @@ export default function rollup(
 													const output = {
 														imports: chunk.getImportIds(),
 														exports: chunk.getExportNames(),
-														modules: chunk.getModuleIds(),
+														modules: graph.getCache().modules,
 
 														code: rendered.code,
 														map: rendered.map

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -62,6 +62,7 @@ export interface ModuleJSON {
 	ast: ESTree.Program;
 	sourcemapChain: RawSourceMap[];
 	resolvedIds: IdMap;
+	renderedLength: number;
 }
 
 export type ResolveIdHook = (

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -289,9 +289,9 @@ describe('bundle.generate()', () => {
 				return bundle.generate({ format: 'es' });
 			})
 			.then(({ modules }) => {
-        modules.forEach((module) => {
-          assert.ok(module.renderedLength);
-        })
+				modules.forEach((module) => {
+					assert.ok(module.renderedLength);
+				});
 			});
 	});
 });

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -278,6 +278,24 @@ describe('deprecations', () => {
 	});
 });
 
+describe('bundle.generate()', () => {
+	it('includes renderedLength in each module', () => {
+		return rollup
+			.rollup({
+				input: 'x',
+				plugins: [loader({ x: `console.log( 42 );` })]
+			})
+			.then(bundle => {
+				return bundle.generate({ format: 'es' });
+			})
+			.then(({ modules }) => {
+        modules.forEach((module) => {
+          assert.ok(module.renderedLength);
+        })
+			});
+	});
+});
+
 describe('bundle.write()', () => {
 	it('fails without options or options.file', () => {
 		return rollup


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->
### Changes
This primarily makes two changes:

1. Adds `renderedLength` to `Module`
    - incremented whenever a module chunk is preRendered
    - exposed through `ModuleJSON`

2. More significantly, it is a **breaking API change** as `OutputChunk.modules` has been changed to `ModuleJSON[]` like the initial bundle
    - this allows exposing the renderedLength information where it matters (when it has a value)

### Motivation
Now for the why. There is allot of value in knowing what each component is contributing to the bundle size, particularly after tree-shaken and rendered. There are numerous tools and plugins to provide insight into this info as best they can but the metrics on a per module basis aren't available as far as I could find.

Specifically I'm needing it for to address [this issue](https://github.com/doesdev/rollup-analyzer/issues/3) in [rollup-analyzer](https://github.com/doesdev/rollup-analyzer).

### Considerations
I understand there's a good likelihood that this isn't a candidate for merging for a number of reasons. Likely there is a better way to do it for one. Secondly it's admittedly an intrusive change for what it provides, although I do think the insights will be very useful to the community.

If there is any variation on this theme that you could see getting merged I would be glad to implement with guidance.