### PR TITLE
Fix #2230, default identifier renaming issue

### DIFF
--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -23,9 +23,11 @@ export default class ExportDefaultVariable extends LocalVariable {
 	}
 
 	addReference(identifier: Identifier) {
-		this.name = identifier.name;
-		if (this.original !== null) {
-			this.original.addReference(identifier);
+		if (!this.hasId) {
+			this.name = identifier.name;
+			if (this.original !== null) {
+				this.original.addReference(identifier);
+			}
 		}
 	}
 

--- a/test/form/samples/default-identifier-deshadowing/_config.js
+++ b/test/form/samples/default-identifier-deshadowing/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Handles export default identifier reassignment deshadowing'
+};

--- a/test/form/samples/default-identifier-deshadowing/_expected/amd.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/amd.js
@@ -1,0 +1,11 @@
+define(function () { 'use strict';
+
+  function a() {
+  	console.log('effect');
+    a = someGlobal;
+    return a();
+  }
+
+  a();
+
+});

--- a/test/form/samples/default-identifier-deshadowing/_expected/amd.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/amd.js
@@ -1,7 +1,6 @@
 define(function () { 'use strict';
 
   function a() {
-  	console.log('effect');
     a = someGlobal;
     return a();
   }

--- a/test/form/samples/default-identifier-deshadowing/_expected/cjs.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/cjs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function a() {
+	console.log('effect');
+  a = someGlobal;
+  return a();
+}
+
+a();

--- a/test/form/samples/default-identifier-deshadowing/_expected/cjs.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/cjs.js
@@ -1,7 +1,6 @@
 'use strict';
 
 function a() {
-	console.log('effect');
   a = someGlobal;
   return a();
 }

--- a/test/form/samples/default-identifier-deshadowing/_expected/es.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/es.js
@@ -1,5 +1,4 @@
 function a() {
-	console.log('effect');
   a = someGlobal;
   return a();
 }

--- a/test/form/samples/default-identifier-deshadowing/_expected/es.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/es.js
@@ -1,0 +1,7 @@
+function a() {
+	console.log('effect');
+  a = someGlobal;
+  return a();
+}
+
+a();

--- a/test/form/samples/default-identifier-deshadowing/_expected/iife.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/iife.js
@@ -1,0 +1,12 @@
+(function () {
+  'use strict';
+
+  function a() {
+  	console.log('effect');
+    a = someGlobal;
+    return a();
+  }
+
+  a();
+
+}());

--- a/test/form/samples/default-identifier-deshadowing/_expected/iife.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/iife.js
@@ -2,7 +2,6 @@
   'use strict';
 
   function a() {
-  	console.log('effect');
     a = someGlobal;
     return a();
   }

--- a/test/form/samples/default-identifier-deshadowing/_expected/system.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/system.js
@@ -4,7 +4,6 @@ System.register([], function (exports, module) {
     execute: function () {
 
       function a() {
-      	console.log('effect');
         a = someGlobal;
         return a();
       }

--- a/test/form/samples/default-identifier-deshadowing/_expected/system.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/system.js
@@ -1,0 +1,16 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      function a() {
+      	console.log('effect');
+        a = someGlobal;
+        return a();
+      }
+
+      a();
+
+    }
+  };
+});

--- a/test/form/samples/default-identifier-deshadowing/_expected/umd.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/umd.js
@@ -1,0 +1,15 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (factory());
+}(this, (function () { 'use strict';
+
+  function a() {
+  	console.log('effect');
+    a = someGlobal;
+    return a();
+  }
+
+  a();
+
+})));

--- a/test/form/samples/default-identifier-deshadowing/_expected/umd.js
+++ b/test/form/samples/default-identifier-deshadowing/_expected/umd.js
@@ -5,7 +5,6 @@
 }(this, (function () { 'use strict';
 
   function a() {
-  	console.log('effect');
     a = someGlobal;
     return a();
   }

--- a/test/form/samples/default-identifier-deshadowing/dep.js
+++ b/test/form/samples/default-identifier-deshadowing/dep.js
@@ -1,0 +1,5 @@
+export default function a() {
+	console.log('effect');
+  a = someGlobal;
+  return a();
+}

--- a/test/form/samples/default-identifier-deshadowing/dep.js
+++ b/test/form/samples/default-identifier-deshadowing/dep.js
@@ -1,5 +1,4 @@
 export default function a() {
-	console.log('effect');
   a = someGlobal;
   return a();
 }

--- a/test/form/samples/default-identifier-deshadowing/main.js
+++ b/test/form/samples/default-identifier-deshadowing/main.js
@@ -1,0 +1,2 @@
+import dep from './dep.js';
+dep();


### PR DESCRIPTION
This ensures that the name of the default variable is kept as its declaration name for function and class declarations, instead of using reference hints.