### PR TITLE
Handle external reassignments

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -275,10 +275,10 @@ export default class Graph {
 			// Phase 3 – marking. We include all statements that should be included
 			timeStart('mark included statements', 2);
 
-			entryModule.markExports();
+			entryModule.markPublicExports();
 
 			for (const dynamicImportModule of dynamicImports) {
-				if (entryModule !== dynamicImportModule) dynamicImportModule.markExports();
+				if (entryModule !== dynamicImportModule) dynamicImportModule.markPublicExports();
 				// all dynamic import modules inlined for single-file build
 				dynamicImportModule.getOrCreateNamespace().include();
 			}
@@ -419,7 +419,7 @@ export default class Graph {
 				// Phase 3 – marking. We include all statements that should be included
 				timeStart('mark included statements', 2);
 
-				for (const entryModule of entryModules) entryModule.markExports();
+				for (const entryModule of entryModules) entryModule.markPublicExports();
 
 				// only include statements that should appear in the bundle
 				this.includeMarked(orderedModules);

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -35,6 +35,8 @@ import { isLiteral } from './ast/nodes/Literal';
 import Chunk from './Chunk';
 import { RenderOptions } from './utils/renderHelpers';
 import { getOriginalLocation } from './utils/getOriginalLocation';
+import { NEW_EXECUTION_PATH } from './ast/ExecutionPathOptions';
+import { UNKNOWN_PATH } from './ast/values';
 
 export interface CommentDescription {
 	block: boolean;
@@ -431,11 +433,12 @@ export default class Module {
 		return makeLegal(ext ? base.slice(0, -ext.length) : base);
 	}
 
-	markExports() {
+	markPublicExports() {
 		for (const exportName of this.getExports()) {
 			const variable = this.traceExport(exportName);
 
 			variable.exportName = exportName;
+			variable.reassignPath(UNKNOWN_PATH, NEW_EXECUTION_PATH);
 			variable.include();
 
 			if (variable.isNamespace) {
@@ -452,6 +455,7 @@ export default class Module {
 				variable.reexported = (<ExternalVariable>variable).module.reexported = true;
 			} else {
 				variable.include();
+				variable.reassignPath(UNKNOWN_PATH, NEW_EXECUTION_PATH);
 			}
 		}
 	}

--- a/test/function/samples/externally-reassigned-default-exports/_config.js
+++ b/test/function/samples/externally-reassigned-default-exports/_config.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+
+module.exports = {
+	description: 'calls to externally reassigned methods of default exports must be retained',
+	exports(exports) {
+		let triggered = false;
+		exports.reassigned = function() {
+			triggered = true;
+		};
+		exports.test();
+		assert.ok(triggered);
+	}
+};

--- a/test/function/samples/externally-reassigned-default-exports/main.js
+++ b/test/function/samples/externally-reassigned-default-exports/main.js
@@ -1,0 +1,8 @@
+const obj = {
+	reassigned() {},
+	test() {
+		obj.reassigned();
+	}
+};
+
+export default obj;

--- a/test/function/samples/externally-reassigned-globals/_config.js
+++ b/test/function/samples/externally-reassigned-globals/_config.js
@@ -1,0 +1,22 @@
+var assert = require('assert');
+
+module.exports = {
+	description: 'calls to externally reassigned global methods must be retained',
+	exports(exports) {
+		let triggered1 = false,
+			triggered2 = false;
+		global.obj1.reassigned = function() {
+			triggered1 = true;
+		};
+		global.obj2.reassigned = function() {
+			triggered2 = true;
+		};
+
+		exports.test();
+		delete global.obj1;
+		delete global.obj2;
+
+		assert.ok(triggered1);
+		assert.ok(triggered2);
+	}
+};

--- a/test/function/samples/externally-reassigned-globals/main.js
+++ b/test/function/samples/externally-reassigned-globals/main.js
@@ -1,0 +1,14 @@
+const obj1 = {
+	reassigned() {}
+};
+
+global.obj1 = obj1;
+
+global.obj2 = {
+	reassigned() {}
+};
+
+export function test() {
+	obj1.reassigned();
+	global.obj2.reassigned();
+}

--- a/test/function/samples/externally-reassigned-named-exports/_config.js
+++ b/test/function/samples/externally-reassigned-named-exports/_config.js
@@ -1,0 +1,18 @@
+var assert = require('assert');
+
+module.exports = {
+	description: 'calls to externally reassigned methods of named exports must be retained',
+	exports(exports) {
+		let triggered1 = false,
+			triggered2 = false;
+		exports.obj1.reassigned = function() {
+			triggered1 = true;
+		};
+		exports.obj2.reassigned = function() {
+			triggered2 = true;
+		};
+		exports.test();
+		assert.ok(triggered1);
+		assert.ok(triggered2);
+	}
+};

--- a/test/function/samples/externally-reassigned-named-exports/main.js
+++ b/test/function/samples/externally-reassigned-named-exports/main.js
@@ -1,0 +1,13 @@
+export const obj1 = {
+	reassigned() {}
+};
+
+const obj2 = {
+	reassigned() {}
+};
+export { obj2 };
+
+export function test() {
+	obj1.reassigned();
+	obj2.reassigned();
+}

--- a/test/function/samples/externally-reassigned-named-reexports/_config.js
+++ b/test/function/samples/externally-reassigned-named-reexports/_config.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+
+module.exports = {
+	description: 'calls to externally reassigned methods of named reexports must be retained',
+	exports(exports) {
+		let triggered = false;
+		exports.obj.reassigned = function() {
+			triggered = true;
+		};
+		exports.test();
+		assert.ok(triggered);
+	}
+};

--- a/test/function/samples/externally-reassigned-named-reexports/foo.js
+++ b/test/function/samples/externally-reassigned-named-reexports/foo.js
@@ -1,0 +1,3 @@
+export const obj = {
+	reassigned() {}
+};

--- a/test/function/samples/externally-reassigned-named-reexports/main.js
+++ b/test/function/samples/externally-reassigned-named-reexports/main.js
@@ -1,0 +1,7 @@
+export { obj } from './foo.js';
+
+import { obj } from './foo.js';
+
+export function test() {
+	obj.reassigned();
+}

--- a/test/function/samples/externally-reassigned-star-reexports/_config.js
+++ b/test/function/samples/externally-reassigned-star-reexports/_config.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+
+module.exports = {
+	description: 'calls to externally reassigned methods of namespace reexports must be retained',
+	exports(exports) {
+		let triggered = false;
+		exports.obj.reassigned = function() {
+			triggered = true;
+		};
+		exports.test();
+		assert.ok(triggered);
+	}
+};

--- a/test/function/samples/externally-reassigned-star-reexports/foo.js
+++ b/test/function/samples/externally-reassigned-star-reexports/foo.js
@@ -1,0 +1,3 @@
+export const obj = {
+	reassigned() {}
+};

--- a/test/function/samples/externally-reassigned-star-reexports/main.js
+++ b/test/function/samples/externally-reassigned-star-reexports/main.js
@@ -1,0 +1,7 @@
+export * from './foo.js';
+
+import { obj } from './foo.js';
+
+export function test() {
+	obj.reassigned();
+}


### PR DESCRIPTION
Resolves #2237

As it turns out, there was nothing to do for objects attached to globals as the global variable handling has always been very conservative here. Added a regression test nonetheless.

External exports are now properly marked as reassigned.
