### PR TITLE
Fix large variable count numbering

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -466,7 +466,7 @@ export default class Chunk {
 		function getSafeName(name: string): string {
 			let safeName = name;
 			while (used[safeName]) {
-				safeName = `${name}$${toBase64(used[name]++)}`;
+				safeName = `${name}$${toBase64(used[name]++, true)}`;
 			}
 			used[safeName] = 1;
 			return safeName;

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,10 +1,11 @@
-const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_';
+const chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$';
 
-export function toBase64(num: number) {
+export function toBase64(num: number, base63 = false) {
 	let outStr = '';
+	const base = base63 ? 63 : 64;
 	do {
-		const curDigit = num % 64;
-		num = Math.floor(num / 64);
+		const curDigit = num % base;
+		num = Math.floor(num / base);
 		outStr = chars[curDigit] + outStr;
 	} while (num !== 0);
 	return outStr;

--- a/test/form/samples/large-var-cnt-deduping/1.js
+++ b/test/form/samples/large-var-cnt-deduping/1.js
@@ -1,0 +1,3 @@
+var x = "a";
+
+export var result = `1 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/10.js
+++ b/test/form/samples/large-var-cnt-deduping/10.js
@@ -1,0 +1,3 @@
+var x = "j";
+
+export var result = `10 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/11.js
+++ b/test/form/samples/large-var-cnt-deduping/11.js
@@ -1,0 +1,3 @@
+var x = "k";
+
+export var result = `11 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/12.js
+++ b/test/form/samples/large-var-cnt-deduping/12.js
@@ -1,0 +1,3 @@
+var x = "l";
+
+export var result = `12 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/13.js
+++ b/test/form/samples/large-var-cnt-deduping/13.js
@@ -1,0 +1,3 @@
+var x = "m";
+
+export var result = `13 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/14.js
+++ b/test/form/samples/large-var-cnt-deduping/14.js
@@ -1,0 +1,3 @@
+var x = "n";
+
+export var result = `14 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/15.js
+++ b/test/form/samples/large-var-cnt-deduping/15.js
@@ -1,0 +1,3 @@
+var x = "o";
+
+export var result = `15 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/16.js
+++ b/test/form/samples/large-var-cnt-deduping/16.js
@@ -1,0 +1,3 @@
+var x = "p";
+
+export var result = `16 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/17.js
+++ b/test/form/samples/large-var-cnt-deduping/17.js
@@ -1,0 +1,3 @@
+var x = "q";
+
+export var result = `17 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/18.js
+++ b/test/form/samples/large-var-cnt-deduping/18.js
@@ -1,0 +1,3 @@
+var x = "r";
+
+export var result = `18 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/19.js
+++ b/test/form/samples/large-var-cnt-deduping/19.js
@@ -1,0 +1,3 @@
+var x = "s";
+
+export var result = `19 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/2.js
+++ b/test/form/samples/large-var-cnt-deduping/2.js
@@ -1,0 +1,3 @@
+var x = "b";
+
+export var result = `2 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/20.js
+++ b/test/form/samples/large-var-cnt-deduping/20.js
@@ -1,0 +1,3 @@
+var x = "t";
+
+export var result = `20 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/21.js
+++ b/test/form/samples/large-var-cnt-deduping/21.js
@@ -1,0 +1,3 @@
+var x = "u";
+
+export var result = `21 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/22.js
+++ b/test/form/samples/large-var-cnt-deduping/22.js
@@ -1,0 +1,3 @@
+var x = "v";
+
+export var result = `22 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/23.js
+++ b/test/form/samples/large-var-cnt-deduping/23.js
@@ -1,0 +1,3 @@
+var x = "w";
+
+export var result = `23 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/24.js
+++ b/test/form/samples/large-var-cnt-deduping/24.js
@@ -1,0 +1,3 @@
+var x = "x";
+
+export var result = `24 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/25.js
+++ b/test/form/samples/large-var-cnt-deduping/25.js
@@ -1,0 +1,3 @@
+var x = "y";
+
+export var result = `25 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/26.js
+++ b/test/form/samples/large-var-cnt-deduping/26.js
@@ -1,0 +1,3 @@
+var x = "z";
+
+export var result = `26 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/27.js
+++ b/test/form/samples/large-var-cnt-deduping/27.js
@@ -1,0 +1,3 @@
+var x = "A";
+
+export var result = `27 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/28.js
+++ b/test/form/samples/large-var-cnt-deduping/28.js
@@ -1,0 +1,3 @@
+var x = "B";
+
+export var result = `28 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/29.js
+++ b/test/form/samples/large-var-cnt-deduping/29.js
@@ -1,0 +1,3 @@
+var x = "C";
+
+export var result = `29 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/3.js
+++ b/test/form/samples/large-var-cnt-deduping/3.js
@@ -1,0 +1,3 @@
+var x = "c";
+
+export var result = `3 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/30.js
+++ b/test/form/samples/large-var-cnt-deduping/30.js
@@ -1,0 +1,3 @@
+var x = "D";
+
+export var result = `30 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/31.js
+++ b/test/form/samples/large-var-cnt-deduping/31.js
@@ -1,0 +1,3 @@
+var x = "E";
+
+export var result = `31 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/32.js
+++ b/test/form/samples/large-var-cnt-deduping/32.js
@@ -1,0 +1,3 @@
+var x = "F";
+
+export var result = `32 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/33.js
+++ b/test/form/samples/large-var-cnt-deduping/33.js
@@ -1,0 +1,3 @@
+var x = "G";
+
+export var result = `33 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/34.js
+++ b/test/form/samples/large-var-cnt-deduping/34.js
@@ -1,0 +1,3 @@
+var x = "H";
+
+export var result = `34 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/35.js
+++ b/test/form/samples/large-var-cnt-deduping/35.js
@@ -1,0 +1,3 @@
+var x = "I";
+
+export var result = `35 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/36.js
+++ b/test/form/samples/large-var-cnt-deduping/36.js
@@ -1,0 +1,3 @@
+var x = "J";
+
+export var result = `36 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/37.js
+++ b/test/form/samples/large-var-cnt-deduping/37.js
@@ -1,0 +1,3 @@
+var x = "K";
+
+export var result = `37 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/38.js
+++ b/test/form/samples/large-var-cnt-deduping/38.js
@@ -1,0 +1,3 @@
+var x = "L";
+
+export var result = `38 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/39.js
+++ b/test/form/samples/large-var-cnt-deduping/39.js
@@ -1,0 +1,3 @@
+var x = "M";
+
+export var result = `39 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/4.js
+++ b/test/form/samples/large-var-cnt-deduping/4.js
@@ -1,0 +1,3 @@
+var x = "d";
+
+export var result = `4 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/40.js
+++ b/test/form/samples/large-var-cnt-deduping/40.js
@@ -1,0 +1,3 @@
+var x = "N";
+
+export var result = `40 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/41.js
+++ b/test/form/samples/large-var-cnt-deduping/41.js
@@ -1,0 +1,3 @@
+var x = "O";
+
+export var result = `41 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/42.js
+++ b/test/form/samples/large-var-cnt-deduping/42.js
@@ -1,0 +1,3 @@
+var x = "P";
+
+export var result = `42 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/43.js
+++ b/test/form/samples/large-var-cnt-deduping/43.js
@@ -1,0 +1,3 @@
+var x = "Q";
+
+export var result = `43 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/44.js
+++ b/test/form/samples/large-var-cnt-deduping/44.js
@@ -1,0 +1,3 @@
+var x = "R";
+
+export var result = `44 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/45.js
+++ b/test/form/samples/large-var-cnt-deduping/45.js
@@ -1,0 +1,3 @@
+var x = "S";
+
+export var result = `45 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/46.js
+++ b/test/form/samples/large-var-cnt-deduping/46.js
@@ -1,0 +1,3 @@
+var x = "T";
+
+export var result = `46 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/47.js
+++ b/test/form/samples/large-var-cnt-deduping/47.js
@@ -1,0 +1,3 @@
+var x = "U";
+
+export var result = `47 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/48.js
+++ b/test/form/samples/large-var-cnt-deduping/48.js
@@ -1,0 +1,3 @@
+var x = "V";
+
+export var result = `48 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/49.js
+++ b/test/form/samples/large-var-cnt-deduping/49.js
@@ -1,0 +1,3 @@
+var x = "W";
+
+export var result = `49 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/5.js
+++ b/test/form/samples/large-var-cnt-deduping/5.js
@@ -1,0 +1,3 @@
+var x = "e";
+
+export var result = `5 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/50.js
+++ b/test/form/samples/large-var-cnt-deduping/50.js
@@ -1,0 +1,3 @@
+var x = "X";
+
+export var result = `50 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/51.js
+++ b/test/form/samples/large-var-cnt-deduping/51.js
@@ -1,0 +1,3 @@
+var x = "Y";
+
+export var result = `51 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/52.js
+++ b/test/form/samples/large-var-cnt-deduping/52.js
@@ -1,0 +1,3 @@
+var x = "Z";
+
+export var result = `52 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/53.js
+++ b/test/form/samples/large-var-cnt-deduping/53.js
@@ -1,0 +1,3 @@
+var x = "1";
+
+export var result = `53 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/54.js
+++ b/test/form/samples/large-var-cnt-deduping/54.js
@@ -1,0 +1,3 @@
+var x = "2";
+
+export var result = `54 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/55.js
+++ b/test/form/samples/large-var-cnt-deduping/55.js
@@ -1,0 +1,3 @@
+var x = "3";
+
+export var result = `55 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/56.js
+++ b/test/form/samples/large-var-cnt-deduping/56.js
@@ -1,0 +1,3 @@
+var x = "4";
+
+export var result = `56 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/57.js
+++ b/test/form/samples/large-var-cnt-deduping/57.js
@@ -1,0 +1,3 @@
+var x = "5";
+
+export var result = `57 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/58.js
+++ b/test/form/samples/large-var-cnt-deduping/58.js
@@ -1,0 +1,3 @@
+var x = "6";
+
+export var result = `58 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/59.js
+++ b/test/form/samples/large-var-cnt-deduping/59.js
@@ -1,0 +1,3 @@
+var x = "7";
+
+export var result = `59 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/6.js
+++ b/test/form/samples/large-var-cnt-deduping/6.js
@@ -1,0 +1,3 @@
+var x = "f";
+
+export var result = `6 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/60.js
+++ b/test/form/samples/large-var-cnt-deduping/60.js
@@ -1,0 +1,3 @@
+var x = "8";
+
+export var result = `60 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/61.js
+++ b/test/form/samples/large-var-cnt-deduping/61.js
@@ -1,0 +1,3 @@
+var x = "9";
+
+export var result = `61 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/62.js
+++ b/test/form/samples/large-var-cnt-deduping/62.js
@@ -1,0 +1,3 @@
+var x = "0";
+
+export var result = `62 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/63.js
+++ b/test/form/samples/large-var-cnt-deduping/63.js
@@ -1,0 +1,3 @@
+var x = "_";
+
+export var result = `63 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/64.js
+++ b/test/form/samples/large-var-cnt-deduping/64.js
@@ -1,0 +1,3 @@
+var x = "0";
+
+export var result = `64 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/7.js
+++ b/test/form/samples/large-var-cnt-deduping/7.js
@@ -1,0 +1,3 @@
+var x = "g";
+
+export var result = `7 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/8.js
+++ b/test/form/samples/large-var-cnt-deduping/8.js
@@ -1,0 +1,3 @@
+var x = "h";
+
+export var result = `8 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/9.js
+++ b/test/form/samples/large-var-cnt-deduping/9.js
@@ -1,0 +1,3 @@
+var x = "i";
+
+export var result = `9 = ${x}`;

--- a/test/form/samples/large-var-cnt-deduping/_config.js
+++ b/test/form/samples/large-var-cnt-deduping/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'large variable count deduping'
+};

--- a/test/form/samples/large-var-cnt-deduping/_expected.js
+++ b/test/form/samples/large-var-cnt-deduping/_expected.js
@@ -1,0 +1,325 @@
+var x = "a";
+
+var result = `1 = ${x}`;
+
+var x$1 = "b";
+
+var result$1 = `2 = ${x$1}`;
+
+var x$2 = "c";
+
+var result$2 = `3 = ${x$2}`;
+
+var x$3 = "d";
+
+var result$3 = `4 = ${x$3}`;
+
+var x$4 = "e";
+
+var result$4 = `5 = ${x$4}`;
+
+var x$5 = "f";
+
+var result$5 = `6 = ${x$5}`;
+
+var x$6 = "g";
+
+var result$6 = `7 = ${x$6}`;
+
+var x$7 = "h";
+
+var result$7 = `8 = ${x$7}`;
+
+var x$8 = "i";
+
+var result$8 = `9 = ${x$8}`;
+
+var x$9 = "j";
+
+var result$9 = `10 = ${x$9}`;
+
+var x$a = "k";
+
+var result$a = `11 = ${x$a}`;
+
+var x$b = "l";
+
+var result$b = `12 = ${x$b}`;
+
+var x$c = "m";
+
+var result$c = `13 = ${x$c}`;
+
+var x$d = "n";
+
+var result$d = `14 = ${x$d}`;
+
+var x$e = "o";
+
+var result$e = `15 = ${x$e}`;
+
+var x$f = "p";
+
+var result$f = `16 = ${x$f}`;
+
+var x$g = "q";
+
+var result$g = `17 = ${x$g}`;
+
+var x$h = "r";
+
+var result$h = `18 = ${x$h}`;
+
+var x$i = "s";
+
+var result$i = `19 = ${x$i}`;
+
+var x$j = "t";
+
+var result$j = `20 = ${x$j}`;
+
+var x$k = "u";
+
+var result$k = `21 = ${x$k}`;
+
+var x$l = "v";
+
+var result$l = `22 = ${x$l}`;
+
+var x$m = "w";
+
+var result$m = `23 = ${x$m}`;
+
+var x$n = "x";
+
+var result$n = `24 = ${x$n}`;
+
+var x$o = "y";
+
+var result$o = `25 = ${x$o}`;
+
+var x$p = "z";
+
+var result$p = `26 = ${x$p}`;
+
+var x$q = "A";
+
+var result$q = `27 = ${x$q}`;
+
+var x$r = "B";
+
+var result$r = `28 = ${x$r}`;
+
+var x$s = "C";
+
+var result$s = `29 = ${x$s}`;
+
+var x$t = "D";
+
+var result$t = `30 = ${x$t}`;
+
+var x$u = "E";
+
+var result$u = `31 = ${x$u}`;
+
+var x$v = "F";
+
+var result$v = `32 = ${x$v}`;
+
+var x$w = "G";
+
+var result$w = `33 = ${x$w}`;
+
+var x$x = "H";
+
+var result$x = `34 = ${x$x}`;
+
+var x$y = "I";
+
+var result$y = `35 = ${x$y}`;
+
+var x$z = "J";
+
+var result$z = `36 = ${x$z}`;
+
+var x$A = "K";
+
+var result$A = `37 = ${x$A}`;
+
+var x$B = "L";
+
+var result$B = `38 = ${x$B}`;
+
+var x$C = "M";
+
+var result$C = `39 = ${x$C}`;
+
+var x$D = "N";
+
+var result$D = `40 = ${x$D}`;
+
+var x$E = "O";
+
+var result$E = `41 = ${x$E}`;
+
+var x$F = "P";
+
+var result$F = `42 = ${x$F}`;
+
+var x$G = "Q";
+
+var result$G = `43 = ${x$G}`;
+
+var x$H = "R";
+
+var result$H = `44 = ${x$H}`;
+
+var x$I = "S";
+
+var result$I = `45 = ${x$I}`;
+
+var x$J = "T";
+
+var result$J = `46 = ${x$J}`;
+
+var x$K = "U";
+
+var result$K = `47 = ${x$K}`;
+
+var x$L = "V";
+
+var result$L = `48 = ${x$L}`;
+
+var x$M = "W";
+
+var result$M = `49 = ${x$M}`;
+
+var x$N = "X";
+
+var result$N = `50 = ${x$N}`;
+
+var x$O = "Y";
+
+var result$O = `51 = ${x$O}`;
+
+var x$P = "Z";
+
+var result$P = `52 = ${x$P}`;
+
+var x$Q = "1";
+
+var result$Q = `53 = ${x$Q}`;
+
+var x$R = "2";
+
+var result$R = `54 = ${x$R}`;
+
+var x$S = "3";
+
+var result$S = `55 = ${x$S}`;
+
+var x$T = "4";
+
+var result$T = `56 = ${x$T}`;
+
+var x$U = "5";
+
+var result$U = `57 = ${x$U}`;
+
+var x$V = "6";
+
+var result$V = `58 = ${x$V}`;
+
+var x$W = "7";
+
+var result$W = `59 = ${x$W}`;
+
+var x$X = "8";
+
+var result$X = `60 = ${x$X}`;
+
+var x$Y = "9";
+
+var result$Y = `61 = ${x$Y}`;
+
+var x$Z = "0";
+
+var result$Z = `62 = ${x$Z}`;
+
+var x$_ = "_";
+
+var result$_ = `63 = ${x$_}`;
+
+var x$10 = "0";
+
+var result$10 = `64 = ${x$10}`;
+
+var results = [result,
+result$1,
+result$2,
+result$3,
+result$4,
+result$5,
+result$6,
+result$7,
+result$8,
+result$9,
+result$a,
+result$b,
+result$c,
+result$d,
+result$e,
+result$f,
+result$g,
+result$h,
+result$i,
+result$j,
+result$k,
+result$l,
+result$m,
+result$n,
+result$o,
+result$p,
+result$q,
+result$r,
+result$s,
+result$t,
+result$u,
+result$v,
+result$w,
+result$x,
+result$y,
+result$z,
+result$A,
+result$B,
+result$C,
+result$D,
+result$E,
+result$F,
+result$G,
+result$H,
+result$I,
+result$J,
+result$K,
+result$L,
+result$M,
+result$N,
+result$O,
+result$P,
+result$Q,
+result$R,
+result$S,
+result$T,
+result$U,
+result$V,
+result$W,
+result$X,
+result$Y,
+result$Z,
+result$_,
+result$10
+];
+
+results.forEach( ( result$$1 ) => {
+    console.log( result$$1 );
+} );

--- a/test/form/samples/large-var-cnt-deduping/main.js
+++ b/test/form/samples/large-var-cnt-deduping/main.js
@@ -1,0 +1,135 @@
+
+import { result as result1 } from "./1.js";
+import { result as result2 } from "./2.js";
+import { result as result3 } from "./3.js";
+import { result as result4 } from "./4.js";
+import { result as result5 } from "./5.js";
+import { result as result6 } from "./6.js";
+import { result as result7 } from "./7.js";
+import { result as result8 } from "./8.js";
+import { result as result9 } from "./9.js";
+import { result as result10 } from "./10.js";
+import { result as result11 } from "./11.js";
+import { result as result12 } from "./12.js";
+import { result as result13 } from "./13.js";
+import { result as result14 } from "./14.js";
+import { result as result15 } from "./15.js";
+import { result as result16 } from "./16.js";
+import { result as result17 } from "./17.js";
+import { result as result18 } from "./18.js";
+import { result as result19 } from "./19.js";
+import { result as result20 } from "./20.js";
+import { result as result21 } from "./21.js";
+import { result as result22 } from "./22.js";
+import { result as result23 } from "./23.js";
+import { result as result24 } from "./24.js";
+import { result as result25 } from "./25.js";
+import { result as result26 } from "./26.js";
+import { result as result27 } from "./27.js";
+import { result as result28 } from "./28.js";
+import { result as result29 } from "./29.js";
+import { result as result30 } from "./30.js";
+import { result as result31 } from "./31.js";
+import { result as result32 } from "./32.js";
+import { result as result33 } from "./33.js";
+import { result as result34 } from "./34.js";
+import { result as result35 } from "./35.js";
+import { result as result36 } from "./36.js";
+import { result as result37 } from "./37.js";
+import { result as result38 } from "./38.js";
+import { result as result39 } from "./39.js";
+import { result as result40 } from "./40.js";
+import { result as result41 } from "./41.js";
+import { result as result42 } from "./42.js";
+import { result as result43 } from "./43.js";
+import { result as result44 } from "./44.js";
+import { result as result45 } from "./45.js";
+import { result as result46 } from "./46.js";
+import { result as result47 } from "./47.js";
+import { result as result48 } from "./48.js";
+import { result as result49 } from "./49.js";
+import { result as result50 } from "./50.js";
+import { result as result51 } from "./51.js";
+import { result as result52 } from "./52.js";
+import { result as result53 } from "./53.js";
+import { result as result54 } from "./54.js";
+import { result as result55 } from "./55.js";
+import { result as result56 } from "./56.js";
+import { result as result57 } from "./57.js";
+import { result as result58 } from "./58.js";
+import { result as result59 } from "./59.js";
+import { result as result60 } from "./60.js";
+import { result as result61 } from "./61.js";
+import { result as result62 } from "./62.js";
+import { result as result63 } from "./63.js";
+import { result as result64 } from "./64.js";
+
+var results = [result1,
+result2,
+result3,
+result4,
+result5,
+result6,
+result7,
+result8,
+result9,
+result10,
+result11,
+result12,
+result13,
+result14,
+result15,
+result16,
+result17,
+result18,
+result19,
+result20,
+result21,
+result22,
+result23,
+result24,
+result25,
+result26,
+result27,
+result28,
+result29,
+result30,
+result31,
+result32,
+result33,
+result34,
+result35,
+result36,
+result37,
+result38,
+result39,
+result40,
+result41,
+result42,
+result43,
+result44,
+result45,
+result46,
+result47,
+result48,
+result49,
+result50,
+result51,
+result52,
+result53,
+result54,
+result55,
+result56,
+result57,
+result58,
+result59,
+result60,
+result61,
+result62,
+result63,
+result64
+];
+
+results.forEach( ( result ) => {
+    console.log( result );
+} );


### PR DESCRIPTION
Because of the special treatment of `$$` in variable deshadowing, we need to avoid outputting this as a trailer in safe import binding deshadowing. This limits the base output to 63 to avoid the use of `$` possibly creating a `$$` output.

Fixes #2241.