### PR TITLE
Fix plugin regressions

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -270,9 +270,10 @@ export default function rollup(
 
 							// render chunk import statements and finalizer wrappers given known names
 							return Promise.all(
-								chunks.map(chunk =>
-									chunk.render(outputOptions, addons).then(rendered => {
-										const outputChunk = <OutputChunk>outputBundle[chunk.id];
+								chunks.map(chunk => {
+									const chunkId = chunk.id;
+									return chunk.render(outputOptions, addons).then(rendered => {
+										const outputChunk = <OutputChunk>outputBundle[chunkId];
 										outputChunk.code = rendered.code;
 										outputChunk.map = rendered.map;
 
@@ -287,8 +288,8 @@ export default function rollup(
 													)
 												)
 										);
-									})
-								)
+									});
+								})
 							).then(() => {});
 						})
 						.then(() => {

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -280,7 +280,11 @@ export default function rollup(
 											graph.plugins
 												.filter(plugin => plugin.ongenerate)
 												.map(plugin =>
-													plugin.ongenerate.call(graph.pluginContext, outputOptions, outputChunk)
+													plugin.ongenerate.call(
+														graph.pluginContext,
+														Object.assign({ bundle: outputChunk }, outputOptions),
+														outputChunk
+													)
 												)
 										);
 									})

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -231,60 +231,6 @@ function getInputOptions(
 		inputOptions.entry = inputOptions.input;
 	}
 
-	if (!inputOptions.experimentalCodeSplitting) {
-		inputOptions.inlineDynamicImports = true;
-		if (inputOptions.manualChunks)
-			error({
-				code: 'INVALID_OPTION',
-				message: '"manualChunks" option is only supported for experimentalCodeSplitting.'
-			});
-		if (inputOptions.optimizeChunks)
-			error({
-				code: 'INVALID_OPTION',
-				message: '"optimizeChunks" option is only supported for experimentalCodeSplitting.'
-			});
-		if (inputOptions.input instanceof Array || typeof inputOptions.input === 'object')
-			error({
-				code: 'INVALID_OPTION',
-				message: 'Multiple inputs are only supported for experimentalCodeSplitting.'
-			});
-	}
-
-	if (inputOptions.inlineDynamicImports) {
-		if (inputOptions.manualChunks)
-			error({
-				code: 'INVALID_OPTION',
-				message: '"manualChunks" option is not supported for inlineDynamicImports.'
-			});
-
-		if (inputOptions.optimizeChunks)
-			error({
-				code: 'INVALID_OPTION',
-				message: '"optimizeChunks" option is not supported for inlineDynamicImports.'
-			});
-		if (inputOptions.input instanceof Array || typeof inputOptions.input === 'object')
-			error({
-				code: 'INVALID_OPTION',
-				message: 'Multiple inputs are not supported for inlineDynamicImports.'
-			});
-	} else if (inputOptions.experimentalPreserveModules) {
-		if (inputOptions.inlineDynamicImports)
-			error({
-				code: 'INVALID_OPTION',
-				message: `experimentalPreserveModules does not support the inlineDynamicImports option.`
-			});
-		if (inputOptions.manualChunks)
-			error({
-				code: 'INVALID_OPTION',
-				message: 'experimentalPreserveModules does not support the manualChunks option.'
-			});
-		if (inputOptions.optimizeChunks)
-			error({
-				code: 'INVALID_OPTION',
-				message: 'experimentalPreserveModules does not support the optimizeChunks option.'
-			});
-	}
-
 	return inputOptions;
 }
 


### PR DESCRIPTION
1. I seem to have messed up the signature of this function in the process by mistake - this returns it to its usual form as expected (resolves #2245)
2. I've also included a closure fix for the chunk.id handling, which must be read synchronously (resolves #2243)
3. I've fixed the multiple input validation to happen after the options hook call (resolves #2247)