### PR TITLE
Allow setAssetSource being called in generateBundle

### DIFF
--- a/src/utils/assetHooks.ts
+++ b/src/utils/assetHooks.ts
@@ -60,7 +60,7 @@ export function createAssetPluginHooks(
 				});
 			const assetId = randomHexString(8);
 			const asset: Asset = { name, source, fileName: undefined };
-			if (outputBundle) finaliseAsset(asset, outputBundle, assetFileNames);
+			if (outputBundle && source !== undefined) finaliseAsset(asset, outputBundle, assetFileNames);
 			assetsById.set(assetId, asset);
 			return assetId;
 		},
@@ -71,7 +71,7 @@ export function createAssetPluginHooks(
 					code: 'ASSET_NOT_FOUND',
 					message: `Plugin error - Unable to set asset source for unknown asset ${assetId}.`
 				});
-			if (asset.source)
+			if (asset.source !== undefined)
 				error({
 					code: 'ASSET_SOURCE_ALREADY_SET',
 					message: `Plugin error - Unable to set asset source for ${

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -383,6 +383,33 @@ module.exports = input;
 			});
 	});
 
+	it('allows setting asset source at generateBundle', () => {
+		let assetId;
+		return rollup
+			.rollup({
+				input: 'input',
+				experimentalCodeSplitting: true,
+				plugins: [
+					loader({ input: `alert('hello')` }),
+					{
+						transform () {
+							return '';
+						},
+						generateBundle () {
+							assetId = this.emitAsset('test.ext');
+							this.setAssetSource(assetId, 'hello world');
+						}
+					}
+				]
+			})
+			.then(bundle => {
+				return bundle.generate({ format: 'es' });
+			})
+			.then(({ output }) => {
+				assert.equal(output['assets/test-19916f7d.ext'], 'hello world');
+			});
+	});
+
 	it('throws when emitting assets too late', () => {
 		let calledHook = false;
 		return rollup


### PR DESCRIPTION
This allows `generateBundle` to still have calls to:

```js
const assetId = this.emitAsset('name');
this.setAssetsource(assetId, source);
```

whereas currently this throws due to expectations on assets already being finalised, while we should be extending this case to be supported in the extended finalisation of assets.