### PR TITLE
Fix RollupWatchOptions.output may be an array of OutputOptions

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -398,7 +398,7 @@ export interface WatcherOptions {
 }
 
 export interface RollupWatchOptions extends InputOptions {
-	output?: OutputOptions;
+	output?: OutputOptions | OutputOptions[];
 	watch?: WatcherOptions;
 }
 


### PR DESCRIPTION
#### Usage Example

Here's a reproduction of the issue: https://github.com/dherges/rollup-output-options-array

The javascript API allows to set `rollup.watch({ output: [{ .. }, { .. }])`, see
 https://github.com/dherges/rollup-output-options-array/blob/master/build.js

It's documented in the section "Configuration Files": https://rollupjs.org/guide/en#configuration-files 

#### What Does Not Work?

The typescript API does not reflect that int he types, a build will fail. See https://github.com/dherges/rollup-output-options-array/blob/master/build.ts

```bash
$ ts-node build.ts

/home/david/Projects/github/dherges/rollup-output-options-array/node_modules/ts-node/src/index.ts:250    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
build.ts(3,14): error TS2345: Argument of type '{ input: string; output: { format: string; file: string; }[]; }[]' is not
 assignable to parameter of type 'RollupWatchOptions[]'.
  Type '{ input: string; output: { format: string; file: string; }[]; }' is not assignable to type 'RollupWatchOptions'.
    Types of property 'output' are incompatible.
      Type '{ format: string; file: string; }[]' has no properties in common with type 'OutputOptions'.

    at createTSError (/home/david/Projects/github/dherges/rollup-output-options-array/node_modules/ts-node/src/index.ts:2
50:12)
    at getOutput (/home/david/Projects/github/dherges/rollup-output-options-array/node_modules/ts-node/src/index.ts:358:4
0)
    at Object.compile (/home/david/Projects/github/dherges/rollup-output-options-array/node_modules/ts-node/src/index.ts:546:11)
    at Module.m._compile (/home/david/Projects/github/dherges/rollup-output-options-array/node_modules/ts-node/src/index.
ts:430:43)    at Module._extensions..js (internal/modules/cjs/loader.js:665:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/home/david/Projects/github/dherges/rollup-output-options-array/node_modules/ts-node/src/index.ts:433:12)
    at Module.load (internal/modules/cjs/loader.js:566:32)    at tryModuleLoad (internal/modules/cjs/loader.js:506:12)
    at Function.Module._load (internal/modules/cjs/loader.js:498:3)    at Function.Module.runMain (internal/modules/cjs/loader.js:695:10)
error Command failed with exit code 1.
```

#### Expected Result

TypeScript API should reflect the JavaScript API

#### More Questions

Are `RollupFileOptions` and `RollupDirOptions` also affected?

https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts#L352-L362

