### PR TITLE
Track inclusion of entities returned by literal methods

### DIFF
--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -2,9 +2,11 @@ import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import {
 	arrayMembers,
+	getMemberReturnExpressionWhenCalled,
 	hasMemberEffectWhenCalled,
 	ObjectPath,
-	someMemberReturnExpressionWhenCalled
+	someMemberReturnExpressionWhenCalled,
+	UNKNOWN_EXPRESSION
 } from '../values';
 import * as NodeType from './NodeType';
 import { SomeReturnExpressionCallback } from './shared/Expression';
@@ -14,6 +16,11 @@ import SpreadElement from './SpreadElement';
 export default class ArrayExpression extends NodeBase {
 	type: NodeType.tArrayExpression;
 	elements: (ExpressionNode | SpreadElement | null)[];
+
+	getReturnExpressionWhenCalledAtPath(path: ObjectPath) {
+		if (path.length !== 1) return UNKNOWN_EXPRESSION;
+		return getMemberReturnExpressionWhenCalled(arrayMembers, path[0]);
+	}
 
 	hasEffectsWhenAccessedAtPath(path: ObjectPath) {
 		return path.length > 1;

--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -5,11 +5,9 @@ import {
 	getMemberReturnExpressionWhenCalled,
 	hasMemberEffectWhenCalled,
 	ObjectPath,
-	someMemberReturnExpressionWhenCalled,
 	UNKNOWN_EXPRESSION
 } from '../values';
 import * as NodeType from './NodeType';
-import { SomeReturnExpressionCallback } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import SpreadElement from './SpreadElement';
 
@@ -33,24 +31,6 @@ export default class ArrayExpression extends NodeBase {
 	): boolean {
 		if (path.length === 1) {
 			return hasMemberEffectWhenCalled(arrayMembers, path[0], this.included, callOptions, options);
-		}
-		return true;
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		if (path.length === 1) {
-			return someMemberReturnExpressionWhenCalled(
-				arrayMembers,
-				path[0],
-				callOptions,
-				predicateFunction,
-				options
-			);
 		}
 		return true;
 	}

--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -2,7 +2,7 @@ import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import ReturnValueScope from '../scopes/ReturnValueScope';
 import Scope from '../scopes/Scope';
-import { ObjectPath } from '../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import BlockStatement from './BlockStatement';
 import * as NodeType from './NodeType';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
@@ -17,11 +17,6 @@ export default class ArrowFunctionExpression extends NodeBase {
 	scope: ReturnValueScope;
 	preventChildBlockScope: true;
 
-	bind() {
-		super.bind();
-		this.scope.bind();
-	}
-
 	createScope(parentScope: Scope) {
 		this.scope = new ReturnValueScope(parentScope);
 	}
@@ -32,6 +27,10 @@ export default class ArrowFunctionExpression extends NodeBase {
 		callback: ForEachReturnExpressionCallback
 	) {
 		path.length === 0 && this.scope.forEachReturnExpressionWhenCalled(callOptions, callback);
+	}
+
+	getReturnExpressionWhenCalledAtPath(path: ObjectPath) {
+		return path.length === 0 ? this.scope.getReturnExpression() : UNKNOWN_EXPRESSION;
 	}
 
 	hasEffects(_options: ExecutionPathOptions) {

--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -5,7 +5,6 @@ import Scope from '../scopes/Scope';
 import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import BlockStatement from './BlockStatement';
 import * as NodeType from './NodeType';
-import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { ExpressionNode, GenericEsTreeNode, NodeBase } from './shared/Node';
 import { PatternNode } from './shared/Pattern';
 
@@ -19,14 +18,6 @@ export default class ArrowFunctionExpression extends NodeBase {
 
 	createScope(parentScope: Scope) {
 		this.scope = new ReturnValueScope(parentScope);
-	}
-
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback
-	) {
-		path.length === 0 && this.scope.forEachReturnExpressionWhenCalled(callOptions, callback);
 	}
 
 	getReturnExpressionWhenCalledAtPath(path: ObjectPath) {
@@ -80,18 +71,6 @@ export default class ArrowFunctionExpression extends NodeBase {
 			);
 		}
 		super.parseNode(esTreeNode);
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		return (
-			path.length > 0 ||
-			this.scope.someReturnExpressionWhenCalled(callOptions, predicateFunction, options)
-		);
 	}
 }
 

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -1,10 +1,18 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EntityPathTracker } from '../utils/EntityPathTracker';
-import { ObjectPath, UNKNOWN_PATH } from '../values';
+import {
+	EMPTY_IMMUTABLE_TRACKER,
+	ImmutableEntityPathTracker
+} from '../utils/ImmutableEntityPathTracker';
+import { EMPTY_PATH, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_PATH } from '../values';
 import Identifier from './Identifier';
 import * as NodeType from './NodeType';
-import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
+import {
+	ExpressionEntity,
+	ForEachReturnExpressionCallback,
+	SomeReturnExpressionCallback
+} from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import SpreadElement from './SpreadElement';
 
@@ -14,6 +22,7 @@ export default class CallExpression extends NodeBase {
 	arguments: (ExpressionNode | SpreadElement)[];
 
 	private callOptions: CallOptions;
+	private returnExpression: ExpressionEntity | null;
 
 	bind() {
 		super.bind();
@@ -41,6 +50,12 @@ export default class CallExpression extends NodeBase {
 				);
 			}
 		}
+		if (this.returnExpression === null) {
+			this.returnExpression = this.callee.getReturnExpressionWhenCalledAtPath(
+				EMPTY_PATH,
+				EMPTY_IMMUTABLE_TRACKER
+			);
+		}
 		for (const argument of this.arguments) {
 			// This will make sure all properties of parameters behave as "unknown"
 			argument.reassignPath(UNKNOWN_PATH);
@@ -53,12 +68,36 @@ export default class CallExpression extends NodeBase {
 		callback: ForEachReturnExpressionCallback,
 		recursionTracker: EntityPathTracker
 	) {
-		this.callee.forEachReturnExpressionWhenCalledAtPath(
-			[],
-			this.callOptions,
-			node =>
-				node.forEachReturnExpressionWhenCalledAtPath(path, callOptions, callback, recursionTracker),
+		if (this.returnExpression === null) {
+			this.returnExpression = this.callee.getReturnExpressionWhenCalledAtPath(
+				EMPTY_PATH,
+				EMPTY_IMMUTABLE_TRACKER
+			);
+		}
+		this.returnExpression.forEachReturnExpressionWhenCalledAtPath(
+			path,
+			callOptions,
+			callback,
 			recursionTracker
+		);
+	}
+
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		recursionTracker: ImmutableEntityPathTracker
+	) {
+		if (this.returnExpression === null) {
+			this.returnExpression = this.callee.getReturnExpressionWhenCalledAtPath(
+				EMPTY_PATH,
+				recursionTracker
+			);
+		}
+		if (recursionTracker.isTracked(this.returnExpression, path)) {
+			return UNKNOWN_EXPRESSION;
+		}
+		return this.returnExpression.getReturnExpressionWhenCalledAtPath(
+			path,
+			recursionTracker.track(this.returnExpression, path)
 		);
 	}
 
@@ -66,10 +105,13 @@ export default class CallExpression extends NodeBase {
 		for (const argument of this.arguments) {
 			if (argument.hasEffects(options)) return true;
 		}
-		return this.callee.hasEffectsWhenCalledAtPath(
-			[],
-			this.callOptions,
-			options.getHasEffectsWhenCalledOptions()
+		return (
+			this.callee.hasEffects(options) ||
+			this.callee.hasEffectsWhenCalledAtPath(
+				[],
+				this.callOptions,
+				options.getHasEffectsWhenCalledOptions()
+			)
 		);
 	}
 
@@ -77,32 +119,21 @@ export default class CallExpression extends NodeBase {
 		return (
 			path.length > 0 &&
 			!options.hasReturnExpressionBeenAccessedAtPath(path, this) &&
-			this.callee.someReturnExpressionWhenCalledAtPath(
-				[],
-				this.callOptions,
-				(innerOptions, node) =>
-					node.hasEffectsWhenAccessedAtPath(
-						path,
-						innerOptions.addAccessedReturnExpressionAtPath(path, this)
-					),
-				options
+			this.returnExpression.hasEffectsWhenAccessedAtPath(
+				path,
+				options.addAccessedReturnExpressionAtPath(path, this)
 			)
 		);
 	}
 
 	hasEffectsWhenAssignedAtPath(path: ObjectPath, options: ExecutionPathOptions): boolean {
 		return (
-			!options.hasReturnExpressionBeenAssignedAtPath(path, this) &&
-			this.callee.someReturnExpressionWhenCalledAtPath(
-				[],
-				this.callOptions,
-				(innerOptions, node) =>
-					node.hasEffectsWhenAssignedAtPath(
-						path,
-						innerOptions.addAssignedReturnExpressionAtPath(path, this)
-					),
-				options
-			)
+			path.length === 0 ||
+			(!options.hasReturnExpressionBeenAssignedAtPath(path, this) &&
+				this.returnExpression.hasEffectsWhenAssignedAtPath(
+					path,
+					options.addAssignedReturnExpressionAtPath(path, this)
+				))
 		);
 	}
 
@@ -111,24 +142,17 @@ export default class CallExpression extends NodeBase {
 		callOptions: CallOptions,
 		options: ExecutionPathOptions
 	): boolean {
+		if (options.hasReturnExpressionBeenCalledAtPath(path, this)) return false;
+		const innerOptions = options.addCalledReturnExpressionAtPath(path, this);
 		return (
-			!options.hasReturnExpressionBeenCalledAtPath(path, this) &&
-			this.callee.someReturnExpressionWhenCalledAtPath(
-				[],
-				this.callOptions,
-				(innerOptions, node) =>
-					node.hasEffectsWhenCalledAtPath(
-						path,
-						callOptions,
-						innerOptions.addCalledReturnExpressionAtPath(path, this)
-					),
-				options
-			)
+			this.hasEffects(innerOptions) ||
+			this.returnExpression.hasEffectsWhenCalledAtPath(path, callOptions, innerOptions)
 		);
 	}
 
 	initialise() {
 		this.included = false;
+		this.returnExpression = null;
 		this.callOptions = CallOptions.create({
 			withNew: false,
 			args: this.arguments,
@@ -138,12 +162,13 @@ export default class CallExpression extends NodeBase {
 
 	reassignPath(path: ObjectPath) {
 		if (path.length > 0 && !this.context.reassignmentTracker.track(this, path)) {
-			this.callee.forEachReturnExpressionWhenCalledAtPath(
-				[],
-				this.callOptions,
-				node => node.reassignPath(path),
-				new EntityPathTracker()
-			);
+			if (this.returnExpression === null) {
+				this.returnExpression = this.callee.getReturnExpressionWhenCalledAtPath(
+					EMPTY_PATH,
+					EMPTY_IMMUTABLE_TRACKER
+				);
+			}
+			this.returnExpression.reassignPath(path);
 		}
 	}
 
@@ -153,16 +178,10 @@ export default class CallExpression extends NodeBase {
 		predicateFunction: SomeReturnExpressionCallback,
 		options: ExecutionPathOptions
 	): boolean {
-		return this.callee.someReturnExpressionWhenCalledAtPath(
-			[],
-			this.callOptions,
-			(innerOptions, node) =>
-				node.someReturnExpressionWhenCalledAtPath(
-					path,
-					callOptions,
-					predicateFunction,
-					innerOptions
-				),
+		return this.returnExpression.someReturnExpressionWhenCalledAtPath(
+			path,
+			callOptions,
+			predicateFunction,
 			options
 		);
 	}

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -125,6 +125,13 @@ export default class CallExpression extends NodeBase {
 		);
 	}
 
+	include() {
+		super.include();
+		if (!this.returnExpression.included) {
+			this.returnExpression.include();
+		}
+	}
+
 	initialise() {
 		this.included = false;
 		this.returnExpression = null;

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -83,7 +83,7 @@ export default class CallExpression extends NodeBase {
 		return (
 			this.callee.hasEffects(options) ||
 			this.callee.hasEffectsWhenCalledAtPath(
-				[],
+				EMPTY_PATH,
 				this.callOptions,
 				options.getHasEffectsWhenCalledOptions()
 			)

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -1,6 +1,5 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
 import {
 	EMPTY_IMMUTABLE_TRACKER,
 	ImmutableEntityPathTracker
@@ -8,11 +7,7 @@ import {
 import { EMPTY_PATH, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_PATH } from '../values';
 import Identifier from './Identifier';
 import * as NodeType from './NodeType';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from './shared/Expression';
+import { ExpressionEntity } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import SpreadElement from './SpreadElement';
 
@@ -60,26 +55,6 @@ export default class CallExpression extends NodeBase {
 			// This will make sure all properties of parameters behave as "unknown"
 			argument.reassignPath(UNKNOWN_PATH);
 		}
-	}
-
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		if (this.returnExpression === null) {
-			this.returnExpression = this.callee.getReturnExpressionWhenCalledAtPath(
-				EMPTY_PATH,
-				EMPTY_IMMUTABLE_TRACKER
-			);
-		}
-		this.returnExpression.forEachReturnExpressionWhenCalledAtPath(
-			path,
-			callOptions,
-			callback,
-			recursionTracker
-		);
 	}
 
 	getReturnExpressionWhenCalledAtPath(
@@ -170,19 +145,5 @@ export default class CallExpression extends NodeBase {
 			}
 			this.returnExpression.reassignPath(path);
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		return this.returnExpression.someReturnExpressionWhenCalledAtPath(
-			path,
-			callOptions,
-			predicateFunction,
-			options
-		);
 	}
 }

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -8,10 +8,20 @@ import {
 	EMPTY_IMMUTABLE_TRACKER,
 	ImmutableEntityPathTracker
 } from '../utils/ImmutableEntityPathTracker';
-import { EMPTY_PATH, LiteralValueOrUnknown, ObjectPath, UNKNOWN_VALUE } from '../values';
+import {
+	EMPTY_PATH,
+	LiteralValueOrUnknown,
+	ObjectPath,
+	UNKNOWN_EXPRESSION,
+	UNKNOWN_VALUE
+} from '../values';
 import CallExpression from './CallExpression';
 import * as NodeType from './NodeType';
-import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
+import {
+	ExpressionEntity,
+	ForEachReturnExpressionCallback,
+	SomeReturnExpressionCallback
+} from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 
 export default class ConditionalExpression extends NodeBase {
@@ -60,6 +70,19 @@ export default class ConditionalExpression extends NodeBase {
 		return testValue
 			? this.consequent.getLiteralValueAtPath(path, recursionTracker)
 			: this.alternate.getLiteralValueAtPath(path, recursionTracker);
+	}
+
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		calledPathTracker: ImmutableEntityPathTracker
+	): ExpressionEntity {
+		const testValue = this.hasUnknownTestValue
+			? UNKNOWN_VALUE
+			: this.getTestValue(EMPTY_IMMUTABLE_TRACKER);
+		if (testValue === UNKNOWN_VALUE) return UNKNOWN_EXPRESSION;
+		return testValue
+			? this.consequent.getReturnExpressionWhenCalledAtPath(path, calledPathTracker)
+			: this.alternate.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
 	}
 
 	hasEffects(options: ExecutionPathOptions): boolean {

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -99,6 +99,16 @@ export default class Identifier extends NodeBase {
 		return UNKNOWN_VALUE;
 	}
 
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		calledPathTracker: ImmutableEntityPathTracker
+	) {
+		if (this.variable !== null) {
+			return this.variable.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+		}
+		return UNKNOWN_EXPRESSION;
+	}
+
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions): boolean {
 		return this.variable && this.variable.hasEffectsWhenAccessedAtPath(path, options);
 	}

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -5,18 +5,13 @@ import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import FunctionScope from '../scopes/FunctionScope';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
 import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker';
 import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../values';
 import Variable from '../variables/Variable';
 import AssignmentExpression from './AssignmentExpression';
 import * as NodeType from './NodeType';
 import Property from './Property';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from './shared/Expression';
+import { ExpressionEntity } from './shared/Expression';
 import { Node, NodeBase } from './shared/Node';
 import UpdateExpression from './UpdateExpression';
 
@@ -72,23 +67,6 @@ export default class Identifier extends NodeBase {
 		}
 	}
 
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		if (!this.bound) this.bind();
-		if (this.variable !== null) {
-			this.variable.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		}
-	}
-
 	getLiteralValueAtPath(
 		path: ObjectPath,
 		recursionTracker: ImmutableEntityPathTracker
@@ -101,10 +79,10 @@ export default class Identifier extends NodeBase {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		calledPathTracker: ImmutableEntityPathTracker
+		recursionTracker: ImmutableEntityPathTracker
 	) {
 		if (this.variable !== null) {
-			return this.variable.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+			return this.variable.getReturnExpressionWhenCalledAtPath(path, recursionTracker);
 		}
 		return UNKNOWN_EXPRESSION;
 	}
@@ -187,23 +165,6 @@ export default class Identifier extends NodeBase {
 				this.renderSystemBindingUpdate(code, name);
 			}
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	) {
-		if (this.variable) {
-			return this.variable.someReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				predicateFunction,
-				options
-			);
-		}
-		return predicateFunction(options, UNKNOWN_EXPRESSION);
 	}
 
 	private disallowImportReassignment() {

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -4,11 +4,13 @@ import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import {
 	getLiteralMembersForValue,
+	getMemberReturnExpressionWhenCalled,
 	hasMemberEffectWhenCalled,
 	LiteralValueOrUnknown,
 	MemberDescription,
 	ObjectPath,
 	someMemberReturnExpressionWhenCalled,
+	UNKNOWN_EXPRESSION,
 	UNKNOWN_VALUE
 } from '../values';
 import * as NodeType from './NodeType';
@@ -33,6 +35,11 @@ export default class Literal<T = LiteralValue> extends NodeBase {
 		}
 		// not sure why we need this type cast here
 		return <any>this.value;
+	}
+
+	getReturnExpressionWhenCalledAtPath(path: ObjectPath) {
+		if (path.length !== 1) return UNKNOWN_EXPRESSION;
+		return getMemberReturnExpressionWhenCalled(this.members, path[0]);
 	}
 
 	hasEffectsWhenAccessedAtPath(path: ObjectPath) {

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -9,12 +9,10 @@ import {
 	LiteralValueOrUnknown,
 	MemberDescription,
 	ObjectPath,
-	someMemberReturnExpressionWhenCalled,
 	UNKNOWN_EXPRESSION,
 	UNKNOWN_VALUE
 } from '../values';
 import * as NodeType from './NodeType';
-import { SomeReturnExpressionCallback } from './shared/Expression';
 import { Node, NodeBase } from './shared/Node';
 
 export type LiteralValue = string | boolean | null | number | RegExp;
@@ -73,23 +71,5 @@ export default class Literal<T = LiteralValue> extends NodeBase {
 		if (typeof this.value === 'string') {
 			(<[number, number][]>code.indentExclusionRanges).push([this.start + 1, this.end - 1]);
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		if (path.length === 1) {
-			return someMemberReturnExpressionWhenCalled(
-				this.members,
-				path[0],
-				callOptions,
-				predicateFunction,
-				options
-			);
-		}
-		return true;
 	}
 }

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -8,10 +8,20 @@ import {
 	EMPTY_IMMUTABLE_TRACKER,
 	ImmutableEntityPathTracker
 } from '../utils/ImmutableEntityPathTracker';
-import { EMPTY_PATH, LiteralValueOrUnknown, ObjectPath, UNKNOWN_VALUE } from '../values';
+import {
+	EMPTY_PATH,
+	LiteralValueOrUnknown,
+	ObjectPath,
+	UNKNOWN_EXPRESSION,
+	UNKNOWN_VALUE
+} from '../values';
 import CallExpression from './CallExpression';
 import * as NodeType from './NodeType';
-import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
+import {
+	ExpressionEntity,
+	ForEachReturnExpressionCallback,
+	SomeReturnExpressionCallback
+} from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 
 export type LogicalOperator = '||' | '&&';
@@ -74,6 +84,19 @@ export default class LogicalExpression extends NodeBase {
 		if (leftValue === UNKNOWN_VALUE) return UNKNOWN_VALUE;
 		if (this.isOrExpression ? leftValue : !leftValue) return leftValue;
 		return this.right.getLiteralValueAtPath(path, recursionTracker);
+	}
+
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		calledPathTracker: ImmutableEntityPathTracker
+	): ExpressionEntity {
+		const leftValue = this.hasUnknownLeftValue
+			? UNKNOWN_VALUE
+			: this.getLeftValue(EMPTY_IMMUTABLE_TRACKER);
+		if (leftValue === UNKNOWN_VALUE) return UNKNOWN_EXPRESSION;
+		if (this.isOrExpression ? leftValue : !leftValue)
+			return this.left.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+		return this.right.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
 	}
 
 	hasEffects(options: ExecutionPathOptions): boolean {

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -3,7 +3,6 @@ import { BLANK } from '../../utils/blank';
 import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
 import {
 	EMPTY_IMMUTABLE_TRACKER,
 	ImmutableEntityPathTracker
@@ -17,11 +16,7 @@ import {
 } from '../values';
 import CallExpression from './CallExpression';
 import * as NodeType from './NodeType';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from './shared/Expression';
+import { ExpressionEntity } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 
 export type LogicalOperator = '||' | '&&';
@@ -34,45 +29,6 @@ export default class LogicalExpression extends NodeBase {
 
 	private hasUnknownLeftValue: boolean;
 	private isOrExpression: boolean;
-
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		const leftValue = this.hasUnknownLeftValue
-			? UNKNOWN_VALUE
-			: this.getLeftValue(EMPTY_IMMUTABLE_TRACKER);
-		if (leftValue === UNKNOWN_VALUE) {
-			this.left.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-			this.right.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		} else if (this.isOrExpression ? leftValue : !leftValue) {
-			this.left.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		} else {
-			this.right.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		}
-	}
 
 	getLiteralValueAtPath(
 		path: ObjectPath,
@@ -88,15 +44,15 @@ export default class LogicalExpression extends NodeBase {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		calledPathTracker: ImmutableEntityPathTracker
+		recursionTracker: ImmutableEntityPathTracker
 	): ExpressionEntity {
 		const leftValue = this.hasUnknownLeftValue
 			? UNKNOWN_VALUE
 			: this.getLeftValue(EMPTY_IMMUTABLE_TRACKER);
 		if (leftValue === UNKNOWN_VALUE) return UNKNOWN_EXPRESSION;
 		if (this.isOrExpression ? leftValue : !leftValue)
-			return this.left.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
-		return this.right.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+			return this.left.getReturnExpressionWhenCalledAtPath(path, recursionTracker);
+		return this.right.getReturnExpressionWhenCalledAtPath(path, recursionTracker);
 	}
 
 	hasEffects(options: ExecutionPathOptions): boolean {
@@ -224,48 +180,6 @@ export default class LogicalExpression extends NodeBase {
 		} else {
 			super.render(code, options);
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		const leftValue = this.hasUnknownLeftValue
-			? UNKNOWN_VALUE
-			: this.getLeftValue(EMPTY_IMMUTABLE_TRACKER);
-		if (leftValue === UNKNOWN_VALUE) {
-			return (
-				this.left.someReturnExpressionWhenCalledAtPath(
-					path,
-					callOptions,
-					predicateFunction,
-					options
-				) ||
-				this.right.someReturnExpressionWhenCalledAtPath(
-					path,
-					callOptions,
-					predicateFunction,
-					options
-				)
-			);
-		}
-		return (this.isOrExpression
-		? leftValue
-		: !leftValue)
-			? this.left.someReturnExpressionWhenCalledAtPath(
-					path,
-					callOptions,
-					predicateFunction,
-					options
-			  )
-			: this.right.someReturnExpressionWhenCalledAtPath(
-					path,
-					callOptions,
-					predicateFunction,
-					options
-			  );
 	}
 
 	private getLeftValue(recursionTracker: ImmutableEntityPathTracker) {

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -73,7 +73,6 @@ export default class MemberExpression extends NodeBase {
 
 	propertyKey: ObjectPathKey;
 	variable: Variable = null;
-	private arePropertyReadSideEffectsChecked: boolean;
 	private bound: boolean;
 	private replacement: string | null;
 
@@ -136,11 +135,24 @@ export default class MemberExpression extends NodeBase {
 		);
 	}
 
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		calledPathTracker: ImmutableEntityPathTracker
+	) {
+		if (this.variable !== null) {
+			return this.variable.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+		}
+		return this.object.getReturnExpressionWhenCalledAtPath(
+			[this.propertyKey || this.getComputedKey(EMPTY_IMMUTABLE_TRACKER), ...path],
+			calledPathTracker
+		);
+	}
+
 	hasEffects(options: ExecutionPathOptions): boolean {
 		return (
 			this.property.hasEffects(options) ||
 			this.object.hasEffects(options) ||
-			(this.arePropertyReadSideEffectsChecked &&
+			(this.context.propertyReadSideEffects &&
 				this.object.hasEffectsWhenAccessedAtPath(
 					[this.propertyKey || this.getComputedKey(EMPTY_IMMUTABLE_TRACKER)],
 					options
@@ -202,7 +214,6 @@ export default class MemberExpression extends NodeBase {
 		this.included = false;
 		this.propertyKey = getPropertyKey(this);
 		this.variable = null;
-		this.arePropertyReadSideEffectsChecked = this.context.propertyReadSideEffects;
 		this.bound = false;
 		this.replacement = null;
 	}

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -4,7 +4,6 @@ import relativeId from '../../utils/relativeId';
 import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
 import {
 	EMPTY_IMMUTABLE_TRACKER,
 	ImmutableEntityPathTracker
@@ -23,7 +22,6 @@ import Variable from '../variables/Variable';
 import Identifier from './Identifier';
 import Literal from './Literal';
 import * as NodeType from './NodeType';
-import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './shared/Expression';
 import { ExpressionNode, Node, NodeBase } from './shared/Node';
 
 function getPropertyKey(memberExpression: MemberExpression): string | null {
@@ -98,30 +96,6 @@ export default class MemberExpression extends NodeBase {
 		}
 	}
 
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		if (!this.bound) this.bind();
-		if (this.variable !== null) {
-			this.variable.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		} else {
-			this.object.forEachReturnExpressionWhenCalledAtPath(
-				[this.propertyKey || this.getComputedKey(EMPTY_IMMUTABLE_TRACKER), ...path],
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		}
-	}
-
 	getLiteralValueAtPath(
 		path: ObjectPath,
 		recursionTracker: ImmutableEntityPathTracker
@@ -137,14 +111,14 @@ export default class MemberExpression extends NodeBase {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		calledPathTracker: ImmutableEntityPathTracker
+		recursionTracker: ImmutableEntityPathTracker
 	) {
 		if (this.variable !== null) {
-			return this.variable.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+			return this.variable.getReturnExpressionWhenCalledAtPath(path, recursionTracker);
 		}
 		return this.object.getReturnExpressionWhenCalledAtPath(
 			[this.propertyKey || this.getComputedKey(EMPTY_IMMUTABLE_TRACKER), ...path],
-			calledPathTracker
+			recursionTracker
 		);
 	}
 
@@ -251,28 +225,6 @@ export default class MemberExpression extends NodeBase {
 			}
 			super.render(code, options);
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		if (this.variable) {
-			return this.variable.someReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				predicateFunction,
-				options
-			);
-		}
-		return this.object.someReturnExpressionWhenCalledAtPath(
-			[this.propertyKey || this.getComputedKey(EMPTY_IMMUTABLE_TRACKER), ...path],
-			callOptions,
-			predicateFunction,
-			options
-		);
 	}
 
 	private disallowNamespaceReassignment() {

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -1,6 +1,6 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { ObjectPath, UNKNOWN_PATH } from '../values';
+import { EMPTY_PATH, ObjectPath, UNKNOWN_PATH } from '../values';
 import * as NodeType from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
 
@@ -24,7 +24,7 @@ export default class NewExpression extends NodeBase {
 			if (argument.hasEffects(options)) return true;
 		}
 		return this.callee.hasEffectsWhenCalledAtPath(
-			[],
+			EMPTY_PATH,
 			this.callOptions,
 			options.getHasEffectsWhenCalledOptions()
 		);

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -3,7 +3,6 @@ import { BLANK } from '../../utils/blank';
 import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
 import {
 	EMPTY_IMMUTABLE_TRACKER,
 	ImmutableEntityPathTracker
@@ -16,7 +15,6 @@ import {
 	objectMembers,
 	ObjectPath,
 	ObjectPathKey,
-	someMemberReturnExpressionWhenCalled,
 	UNKNOWN_EXPRESSION,
 	UNKNOWN_KEY,
 	UNKNOWN_PATH,
@@ -26,11 +24,7 @@ import Identifier from './Identifier';
 import Literal from './Literal';
 import * as NodeType from './NodeType';
 import Property from './Property';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from './shared/Expression';
+import { ExpressionEntity } from './shared/Expression';
 import { Node, NodeBase } from './shared/Node';
 
 const PROPERTY_KINDS_READ = ['init', 'get'];
@@ -46,29 +40,6 @@ export default class ObjectExpression extends NodeBase {
 
 	private reassignedPaths: { [key: string]: true };
 	private hasUnknownReassignedProperty: boolean;
-
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		if (path.length === 0) return;
-
-		const { properties } = this.getPossiblePropertiesWithName(
-			path[0],
-			PROPERTY_KINDS_READ,
-			EMPTY_IMMUTABLE_TRACKER
-		);
-		for (const property of properties) {
-			property.forEachReturnExpressionWhenCalledAtPath(
-				path.slice(1),
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		}
-	}
 
 	getLiteralValueAtPath(
 		path: ObjectPath,
@@ -93,7 +64,7 @@ export default class ObjectExpression extends NodeBase {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		calledPathTracker: ImmutableEntityPathTracker
+		recursionTracker: ImmutableEntityPathTracker
 	): ExpressionEntity {
 		const key = path[0];
 		if (
@@ -116,7 +87,7 @@ export default class ObjectExpression extends NodeBase {
 		)
 			return getMemberReturnExpressionWhenCalled(objectMembers, key);
 		if (!hasCertainHit || properties.length > 1) return UNKNOWN_EXPRESSION;
-		return properties[0].getReturnExpressionWhenCalledAtPath(path.slice(1), calledPathTracker);
+		return properties[0].getReturnExpressionWhenCalledAtPath(path.slice(1), recursionTracker);
 	}
 
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions) {
@@ -241,50 +212,6 @@ export default class ObjectExpression extends NodeBase {
 			code.appendRight(this.start, '(');
 			code.prependLeft(this.end, ')');
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		const key = path[0];
-		if (
-			path.length === 0 ||
-			this.hasUnknownReassignedProperty ||
-			(typeof key === 'string' && this.reassignedPaths[key])
-		)
-			return true;
-
-		const { properties, hasCertainHit } = this.getPossiblePropertiesWithName(
-			key,
-			PROPERTY_KINDS_READ,
-			EMPTY_IMMUTABLE_TRACKER
-		);
-		if (!(hasCertainHit || (path.length === 1 && typeof key === 'string' && objectMembers[key])))
-			return true;
-		const subPath = path.slice(1);
-		for (const property of properties) {
-			if (
-				property.someReturnExpressionWhenCalledAtPath(
-					subPath,
-					callOptions,
-					predicateFunction,
-					options
-				)
-			)
-				return true;
-		}
-		if (path.length === 1 && typeof key === 'string' && objectMembers[key])
-			return someMemberReturnExpressionWhenCalled(
-				objectMembers,
-				key,
-				callOptions,
-				predicateFunction,
-				options
-			);
-		return false;
 	}
 
 	private getPossiblePropertiesWithName(

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -80,7 +80,7 @@ export default class Property extends NodeBase {
 		if (this.kind === 'get') {
 			return (
 				this.value.hasEffectsWhenCalledAtPath(
-					[],
+					EMPTY_PATH,
 					this.accessorCallOptions,
 					options.getHasEffectsWhenCalledOptions()
 				) ||
@@ -98,7 +98,7 @@ export default class Property extends NodeBase {
 			return (
 				path.length > 0 ||
 				this.value.hasEffectsWhenCalledAtPath(
-					[],
+					EMPTY_PATH,
 					this.accessorCallOptions,
 					options.getHasEffectsWhenCalledOptions()
 				)

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -2,18 +2,13 @@ import MagicString from 'magic-string';
 import { RenderOptions } from '../../utils/renderHelpers';
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
 import {
 	EMPTY_IMMUTABLE_TRACKER,
 	ImmutableEntityPathTracker
 } from '../utils/ImmutableEntityPathTracker';
 import { EMPTY_PATH, LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import * as NodeType from './NodeType';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from './shared/Expression';
+import { ExpressionEntity } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 
 export default class Property extends NodeBase {
@@ -42,35 +37,6 @@ export default class Property extends NodeBase {
 		this.value.declare(kind, UNKNOWN_EXPRESSION);
 	}
 
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		if (this.kind === 'get') {
-			this.value.forEachReturnExpressionWhenCalledAtPath(
-				[],
-				this.accessorCallOptions,
-				node =>
-					node.forEachReturnExpressionWhenCalledAtPath(
-						path,
-						callOptions,
-						callback,
-						recursionTracker
-					),
-				recursionTracker
-			);
-		} else {
-			this.value.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		}
-	}
-
 	getLiteralValueAtPath(
 		path: ObjectPath,
 		recursionTracker: ImmutableEntityPathTracker
@@ -82,14 +48,14 @@ export default class Property extends NodeBase {
 					EMPTY_IMMUTABLE_TRACKER
 				);
 			}
-			return this.returnExpression.getLiteralValueAtPath(path, getValueTracker);
+			return this.returnExpression.getLiteralValueAtPath(path, recursionTracker);
 		}
 		return this.value.getLiteralValueAtPath(path, recursionTracker);
 	}
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		calledPathTracker: ImmutableEntityPathTracker
+		recursionTracker: ImmutableEntityPathTracker
 	): ExpressionEntity {
 		if (this.kind === 'set') {
 			return UNKNOWN_EXPRESSION;
@@ -101,9 +67,9 @@ export default class Property extends NodeBase {
 					EMPTY_IMMUTABLE_TRACKER
 				);
 			}
-			return this.returnExpression.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+			return this.returnExpression.getReturnExpressionWhenCalledAtPath(path, recursionTracker);
 		}
-		return this.value.getReturnExpressionWhenCalledAtPath(path, calledPathTracker);
+		return this.value.getReturnExpressionWhenCalledAtPath(path, recursionTracker);
 	}
 
 	hasEffects(options: ExecutionPathOptions): boolean {
@@ -182,27 +148,5 @@ export default class Property extends NodeBase {
 			this.key.render(code, options);
 		}
 		this.value.render(code, options);
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		if (this.kind === 'get') {
-			return this.returnExpression.someReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				predicateFunction,
-				options
-			);
-		}
-		return this.value.someReturnExpressionWhenCalledAtPath(
-			path,
-			callOptions,
-			predicateFunction,
-			options
-		);
 	}
 }

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -7,31 +7,15 @@ import {
 } from '../../utils/renderHelpers';
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
 import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker';
 import { LiteralValueOrUnknown, ObjectPath } from '../values';
 import CallExpression from './CallExpression';
 import * as NodeType from './NodeType';
-import { ForEachReturnExpressionCallback } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 
 export default class SequenceExpression extends NodeBase {
 	type: NodeType.tSequenceExpression;
 	expressions: ExpressionNode[];
-
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		this.expressions[this.expressions.length - 1].forEachReturnExpressionWhenCalledAtPath(
-			path,
-			callOptions,
-			callback,
-			recursionTracker
-		);
-	}
 
 	getLiteralValueAtPath(
 		path: ObjectPath,

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -1,5 +1,6 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
+import { EMPTY_PATH } from '../values';
 import Identifier from './Identifier';
 import * as NodeType from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
@@ -44,7 +45,7 @@ export default class TaggedTemplateExpression extends NodeBase {
 		return (
 			super.hasEffects(options) ||
 			this.tag.hasEffectsWhenCalledAtPath(
-				[],
+				EMPTY_PATH,
 				this.callOptions,
 				options.getHasEffectsWhenCalledOptions()
 			)

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -5,6 +5,8 @@ import { ImmutableEntityPathTracker } from '../../utils/ImmutableEntityPathTrack
 import { LiteralValueOrUnknown, ObjectPath } from '../../values';
 
 export interface ExpressionEntity extends WritableEntity {
+	included: boolean;
+
 	/**
 	 * If possible it returns a stringifyable literal value for this node that can be used
 	 * for inlining or comparing values.
@@ -24,4 +26,5 @@ export interface ExpressionEntity extends WritableEntity {
 		callOptions: CallOptions,
 		options: ExecutionPathOptions
 	): boolean;
+	include(): void;
 }

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -1,26 +1,10 @@
 import CallOptions from '../../CallOptions';
 import { WritableEntity } from '../../Entity';
 import { ExecutionPathOptions } from '../../ExecutionPathOptions';
-import { EntityPathTracker } from '../../utils/EntityPathTracker';
 import { ImmutableEntityPathTracker } from '../../utils/ImmutableEntityPathTracker';
 import { LiteralValueOrUnknown, ObjectPath } from '../../values';
 
-export type SomeReturnExpressionCallback = (
-	options: ExecutionPathOptions,
-	node: ExpressionEntity
-) => boolean;
-export type ForEachReturnExpressionCallback = (node: ExpressionEntity) => void;
-
 export interface ExpressionEntity extends WritableEntity {
-	/**
-	 * Executes the callback on each possible return expression when calling this node.
-	 */
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	): void;
 	/**
 	 * If possible it returns a stringifyable literal value for this node that can be used
 	 * for inlining or comparing values.
@@ -32,23 +16,12 @@ export interface ExpressionEntity extends WritableEntity {
 	): LiteralValueOrUnknown;
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		calledPathTracker: ImmutableEntityPathTracker
+		recursionTracker: ImmutableEntityPathTracker
 	): ExpressionEntity;
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions): boolean;
 	hasEffectsWhenCalledAtPath(
 		path: ObjectPath,
 		callOptions: CallOptions,
-		options: ExecutionPathOptions
-	): boolean;
-
-	/**
-	 * Should return true if some possible return expression when called at the given
-	 * path returns true.
-	 */
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
 		options: ExecutionPathOptions
 	): boolean;
 }

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -30,6 +30,10 @@ export interface ExpressionEntity extends WritableEntity {
 		path: ObjectPath,
 		recursionTracker: ImmutableEntityPathTracker
 	): LiteralValueOrUnknown;
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		calledPathTracker: ImmutableEntityPathTracker
+	): ExpressionEntity;
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions): boolean;
 	hasEffectsWhenCalledAtPath(
 		path: ObjectPath,

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -3,7 +3,7 @@ import { ExecutionPathOptions } from '../../ExecutionPathOptions';
 import BlockScope from '../../scopes/FunctionScope';
 import FunctionScope from '../../scopes/FunctionScope';
 import Scope from '../../scopes/Scope';
-import { ObjectPath } from '../../values';
+import { ObjectPath, UNKNOWN_EXPRESSION } from '../../values';
 import BlockStatement from '../BlockStatement';
 import Identifier from '../Identifier';
 import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './Expression';
@@ -20,11 +20,6 @@ export default class FunctionNode extends NodeBase {
 
 	private isPrototypeReassigned: boolean;
 
-	bind() {
-		super.bind();
-		this.scope.bind();
-	}
-
 	createScope(parentScope: FunctionScope) {
 		this.scope = new FunctionScope(parentScope, this.context.reassignmentTracker);
 	}
@@ -35,6 +30,10 @@ export default class FunctionNode extends NodeBase {
 		callback: ForEachReturnExpressionCallback
 	) {
 		path.length === 0 && this.scope.forEachReturnExpressionWhenCalled(callOptions, callback);
+	}
+
+	getReturnExpressionWhenCalledAtPath(path: ObjectPath) {
+		return path.length === 0 ? this.scope.getReturnExpression() : UNKNOWN_EXPRESSION;
 	}
 
 	hasEffects(options: ExecutionPathOptions) {

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -6,7 +6,6 @@ import Scope from '../../scopes/Scope';
 import { ObjectPath, UNKNOWN_EXPRESSION } from '../../values';
 import BlockStatement from '../BlockStatement';
 import Identifier from '../Identifier';
-import { ForEachReturnExpressionCallback, SomeReturnExpressionCallback } from './Expression';
 import { GenericEsTreeNode, NodeBase } from './Node';
 import { PatternNode } from './Pattern';
 
@@ -22,14 +21,6 @@ export default class FunctionNode extends NodeBase {
 
 	createScope(parentScope: FunctionScope) {
 		this.scope = new FunctionScope(parentScope, this.context.reassignmentTracker);
-	}
-
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback
-	) {
-		path.length === 0 && this.scope.forEachReturnExpressionWhenCalled(callOptions, callback);
 	}
 
 	getReturnExpressionWhenCalledAtPath(path: ObjectPath) {
@@ -99,18 +90,6 @@ export default class FunctionNode extends NodeBase {
 		if (path.length === 1 && path[0] === 'prototype') {
 			this.isPrototypeReassigned = true;
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		return (
-			path.length > 0 ||
-			this.scope.someReturnExpressionWhenCalled(callOptions, predicateFunction, options)
-		);
 	}
 }
 

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -7,15 +7,10 @@ import { Entity } from '../../Entity';
 import { ExecutionPathOptions } from '../../ExecutionPathOptions';
 import { getAndCreateKeys, keys } from '../../keys';
 import Scope from '../../scopes/Scope';
-import { EntityPathTracker } from '../../utils/EntityPathTracker';
 import { ImmutableEntityPathTracker } from '../../utils/ImmutableEntityPathTracker';
 import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../../values';
 import Variable from '../../variables/Variable';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from './Expression';
+import { ExpressionEntity } from './Expression';
 
 export interface GenericEsTreeNode {
 	type: string;
@@ -136,13 +131,6 @@ export class NodeBase implements ExpressionNode {
 
 	declare(_kind: string, _init: ExpressionEntity | null) {}
 
-	forEachReturnExpressionWhenCalledAtPath(
-		_path: ObjectPath,
-		_callOptions: CallOptions,
-		_callback: ForEachReturnExpressionCallback,
-		_recursionTracker: EntityPathTracker
-	) {}
-
 	getLiteralValueAtPath(
 		_path: ObjectPath,
 		_recursionTracker: ImmutableEntityPathTracker
@@ -152,7 +140,7 @@ export class NodeBase implements ExpressionNode {
 
 	getReturnExpressionWhenCalledAtPath(
 		_path: ObjectPath,
-		_calledPathTracker: ImmutableEntityPathTracker
+		_recursionTracker: ImmutableEntityPathTracker
 	): ExpressionEntity {
 		return UNKNOWN_EXPRESSION;
 	}
@@ -269,15 +257,6 @@ export class NodeBase implements ExpressionNode {
 
 	shouldBeIncluded(): boolean {
 		return this.included || this.hasEffects(NEW_EXECUTION_PATH);
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		_path: ObjectPath,
-		_callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		return predicateFunction(options, UNKNOWN_EXPRESSION);
 	}
 
 	toString() {

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -150,6 +150,13 @@ export class NodeBase implements ExpressionNode {
 		return UNKNOWN_VALUE;
 	}
 
+	getReturnExpressionWhenCalledAtPath(
+		_path: ObjectPath,
+		_calledPathTracker: ImmutableEntityPathTracker
+	): ExpressionEntity {
+		return UNKNOWN_EXPRESSION;
+	}
+
 	hasEffects(options: ExecutionPathOptions): boolean {
 		for (const key of this.keys) {
 			const value = (<GenericEsTreeNode>this)[key];

--- a/src/ast/scopes/FunctionScope.ts
+++ b/src/ast/scopes/FunctionScope.ts
@@ -1,7 +1,7 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EntityPathTracker } from '../utils/EntityPathTracker';
-import { UNKNOWN_EXPRESSION, UNKNOWN_OBJECT_EXPRESSION } from '../values';
+import { UNKNOWN_EXPRESSION, UnknownObjectExpression } from '../values';
 import ArgumentsVariable from '../variables/ArgumentsVariable';
 import ExportDefaultVariable from '../variables/ExportDefaultVariable';
 import ExternalVariable from '../variables/ExternalVariable';
@@ -39,7 +39,7 @@ export default class FunctionScope extends ReturnValueScope {
 		return options
 			.replaceVariableInit(
 				this.variables.this,
-				withNew ? UNKNOWN_OBJECT_EXPRESSION : UNKNOWN_EXPRESSION
+				withNew ? new UnknownObjectExpression() : UNKNOWN_EXPRESSION
 			)
 			.setArgumentsVariables(
 				args.map((parameter, index) => super.getParameterVariables()[index] || parameter)

--- a/src/ast/scopes/ReturnValueScope.ts
+++ b/src/ast/scopes/ReturnValueScope.ts
@@ -11,31 +11,22 @@ import ParameterScope from './ParameterScope';
 export default class ReturnValueScope extends ParameterScope {
 	private returnExpressions: ExpressionEntity[] = [];
 	private returnExpression: ExpressionEntity | null = null;
-	private bound: boolean = false;
 
 	addReturnExpression(expression: ExpressionEntity) {
 		this.returnExpressions.push(expression);
-	}
-
-	bind() {
-		if (this.bound) return;
-		this.bound = true;
-		if (this.returnExpressions.length === 1) {
-			this.returnExpression = this.returnExpressions[0];
-		} else {
-			this.returnExpression = UNKNOWN_EXPRESSION;
-			for (const expression of this.returnExpressions) {
-				expression.reassignPath(UNKNOWN_PATH);
-			}
-		}
 	}
 
 	forEachReturnExpressionWhenCalled(
 		_callOptions: CallOptions,
 		callback: ForEachReturnExpressionCallback
 	) {
-		if (!this.bound) this.bind();
+		if (this.returnExpression === null) this.updateReturnExpression();
 		callback(this.returnExpression);
+	}
+
+	getReturnExpression(): ExpressionEntity {
+		if (this.returnExpression === null) this.updateReturnExpression();
+		return this.returnExpression;
 	}
 
 	someReturnExpressionWhenCalled(
@@ -44,5 +35,16 @@ export default class ReturnValueScope extends ParameterScope {
 		options: ExecutionPathOptions
 	): boolean {
 		return predicateFunction(options, this.returnExpression);
+	}
+
+	private updateReturnExpression() {
+		if (this.returnExpressions.length === 1) {
+			this.returnExpression = this.returnExpressions[0];
+		} else {
+			this.returnExpression = UNKNOWN_EXPRESSION;
+			for (const expression of this.returnExpressions) {
+				expression.reassignPath(UNKNOWN_PATH);
+			}
+		}
 	}
 }

--- a/src/ast/scopes/ReturnValueScope.ts
+++ b/src/ast/scopes/ReturnValueScope.ts
@@ -1,10 +1,4 @@
-import CallOptions from '../CallOptions';
-import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from '../nodes/shared/Expression';
+import { ExpressionEntity } from '../nodes/shared/Expression';
 import { UNKNOWN_EXPRESSION, UNKNOWN_PATH } from '../values';
 import ParameterScope from './ParameterScope';
 
@@ -16,25 +10,9 @@ export default class ReturnValueScope extends ParameterScope {
 		this.returnExpressions.push(expression);
 	}
 
-	forEachReturnExpressionWhenCalled(
-		_callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback
-	) {
-		if (this.returnExpression === null) this.updateReturnExpression();
-		callback(this.returnExpression);
-	}
-
 	getReturnExpression(): ExpressionEntity {
 		if (this.returnExpression === null) this.updateReturnExpression();
 		return this.returnExpression;
-	}
-
-	someReturnExpressionWhenCalled(
-		_callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		return predicateFunction(options, this.returnExpression);
 	}
 
 	private updateReturnExpression() {

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -53,13 +53,14 @@ export const UNKNOWN_EXPRESSION: ExpressionEntity = {
 	toString: () => '[[UNKNOWN]]'
 };
 export const UNDEFINED_EXPRESSION: ExpressionEntity = {
-	reassignPath: () => {},
-	forEachReturnExpressionWhenCalledAtPath: () => {},
+	included: true,
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getReturnExpressionWhenCalledAtPath: () => UNKNOWN_EXPRESSION,
 	hasEffectsWhenAccessedAtPath: path => path.length > 0,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,
 	hasEffectsWhenCalledAtPath: () => true,
-	someReturnExpressionWhenCalledAtPath: () => true,
+	include: () => {},
+	reassignPath: () => {},
 	toString: () => 'undefined'
 };
 const returnsUnknown: RawMemberDescription = {
@@ -442,7 +443,7 @@ export function hasMemberEffectWhenCalled(
 		if (
 			callOptions.args[argIndex] &&
 			callOptions.args[argIndex].hasEffectsWhenCalledAtPath(
-				[],
+				EMPTY_PATH,
 				CallOptions.create({
 					withNew: false,
 					args: [],

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -44,6 +44,7 @@ export const UNKNOWN_EXPRESSION: ExpressionEntity = {
 	reassignPath: () => {},
 	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getReturnExpressionWhenCalledAtPath: () => UNKNOWN_EXPRESSION,
 	hasEffectsWhenAccessedAtPath: path => path.length > 0,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,
 	hasEffectsWhenCalledAtPath: () => true,
@@ -74,6 +75,12 @@ export const UNKNOWN_ARRAY_EXPRESSION: ExpressionEntity = {
 	reassignPath: () => {},
 	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getReturnExpressionWhenCalledAtPath: path => {
+		if (path.length === 1) {
+			return getMemberReturnExpressionWhenCalled(arrayMembers, path[0]);
+		}
+		return UNKNOWN_EXPRESSION;
+	},
 	hasEffectsWhenAccessedAtPath: path => path.length > 1,
 	hasEffectsWhenAssignedAtPath: path => path.length > 1,
 	hasEffectsWhenCalledAtPath: (path, callOptions, options) => {
@@ -118,6 +125,12 @@ const UNKNOWN_LITERAL_BOOLEAN: ExpressionEntity = {
 	reassignPath: () => {},
 	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getReturnExpressionWhenCalledAtPath: path => {
+		if (path.length === 1) {
+			return getMemberReturnExpressionWhenCalled(literalBooleanMembers, path[0]);
+		}
+		return UNKNOWN_EXPRESSION;
+	},
 	hasEffectsWhenAccessedAtPath: path => path.length > 1,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,
 	hasEffectsWhenCalledAtPath: path => {
@@ -156,6 +169,12 @@ const UNKNOWN_LITERAL_NUMBER: ExpressionEntity = {
 	reassignPath: () => {},
 	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getReturnExpressionWhenCalledAtPath: path => {
+		if (path.length === 1) {
+			return getMemberReturnExpressionWhenCalled(literalNumberMembers, path[0]);
+		}
+		return UNKNOWN_EXPRESSION;
+	},
 	hasEffectsWhenAccessedAtPath: path => path.length > 1,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,
 	hasEffectsWhenCalledAtPath: path => {
@@ -197,6 +216,12 @@ const UNKNOWN_LITERAL_STRING: ExpressionEntity = {
 	reassignPath: () => {},
 	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getReturnExpressionWhenCalledAtPath: path => {
+		if (path.length === 1) {
+			return getMemberReturnExpressionWhenCalled(literalStringMembers, path[0]);
+		}
+		return UNKNOWN_EXPRESSION;
+	},
 	hasEffectsWhenAccessedAtPath: path => path.length > 1,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,
 	hasEffectsWhenCalledAtPath: path => {
@@ -232,6 +257,12 @@ export const UNKNOWN_OBJECT_EXPRESSION: ExpressionEntity = {
 	reassignPath: () => {},
 	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getReturnExpressionWhenCalledAtPath: path => {
+		if (path.length === 1) {
+			return getMemberReturnExpressionWhenCalled(objectMembers, path[0]);
+		}
+		return UNKNOWN_EXPRESSION;
+	},
 	hasEffectsWhenAccessedAtPath: path => path.length > 1,
 	hasEffectsWhenAssignedAtPath: path => path.length > 1,
 	hasEffectsWhenCalledAtPath: path => {
@@ -391,6 +422,15 @@ export function hasMemberEffectWhenCalled(
 			return true;
 	}
 	return false;
+}
+
+export function getMemberReturnExpressionWhenCalled(
+	members: MemberDescriptions,
+	memberName: ObjectPathKey
+): ExpressionEntity {
+	return typeof memberName !== 'string' || !members[memberName]
+		? UNKNOWN_EXPRESSION
+		: members[memberName].returns;
 }
 
 export function someMemberReturnExpressionWhenCalled(

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -1,7 +1,7 @@
 import CallOptions from './CallOptions';
 import { ExecutionPathOptions } from './ExecutionPathOptions';
 import { LiteralValue } from './nodes/Literal';
-import { ExpressionEntity, SomeReturnExpressionCallback } from './nodes/shared/Expression';
+import { ExpressionEntity } from './nodes/shared/Expression';
 
 export interface UnknownKey {
 	UNKNOWN_KEY: true;
@@ -42,13 +42,11 @@ export type LiteralValueOrUnknown = LiteralValue | UnknownValue;
 
 export const UNKNOWN_EXPRESSION: ExpressionEntity = {
 	reassignPath: () => {},
-	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
 	getReturnExpressionWhenCalledAtPath: () => UNKNOWN_EXPRESSION,
 	hasEffectsWhenAccessedAtPath: path => path.length > 0,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,
 	hasEffectsWhenCalledAtPath: () => true,
-	someReturnExpressionWhenCalledAtPath: () => true,
 	toString: () => '[[UNKNOWN]]'
 };
 export const UNDEFINED_EXPRESSION: ExpressionEntity = {
@@ -73,7 +71,6 @@ const callsArgReturnsUnknown: RawMemberDescription = {
 
 export const UNKNOWN_ARRAY_EXPRESSION: ExpressionEntity = {
 	reassignPath: () => {},
-	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
 	getReturnExpressionWhenCalledAtPath: path => {
 		if (path.length === 1) {
@@ -86,23 +83,6 @@ export const UNKNOWN_ARRAY_EXPRESSION: ExpressionEntity = {
 	hasEffectsWhenCalledAtPath: (path, callOptions, options) => {
 		if (path.length === 1) {
 			return hasMemberEffectWhenCalled(arrayMembers, path[0], false, callOptions, options);
-		}
-		return true;
-	},
-	someReturnExpressionWhenCalledAtPath: (
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	) => {
-		if (path.length === 1) {
-			return someMemberReturnExpressionWhenCalled(
-				arrayMembers,
-				path[0],
-				callOptions,
-				predicateFunction,
-				options
-			);
 		}
 		return true;
 	},
@@ -123,7 +103,6 @@ const callsArgMutatesSelfReturnsArray: RawMemberDescription = {
 
 const UNKNOWN_LITERAL_BOOLEAN: ExpressionEntity = {
 	reassignPath: () => {},
-	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
 	getReturnExpressionWhenCalledAtPath: path => {
 		if (path.length === 1) {
@@ -140,22 +119,6 @@ const UNKNOWN_LITERAL_BOOLEAN: ExpressionEntity = {
 		}
 		return true;
 	},
-	someReturnExpressionWhenCalledAtPath: (
-		path: ObjectPath,
-		_callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	) => {
-		if (path.length === 1) {
-			const subPath = path[0];
-			return (
-				typeof subPath !== 'string' ||
-				!literalBooleanMembers[subPath] ||
-				predicateFunction(options, literalBooleanMembers[subPath].returns)
-			);
-		}
-		return true;
-	},
 	toString: () => '[[UNKNOWN BOOLEAN]]'
 };
 const returnsBoolean: RawMemberDescription = {
@@ -167,7 +130,6 @@ const callsArgReturnsBoolean: RawMemberDescription = {
 
 const UNKNOWN_LITERAL_NUMBER: ExpressionEntity = {
 	reassignPath: () => {},
-	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
 	getReturnExpressionWhenCalledAtPath: path => {
 		if (path.length === 1) {
@@ -181,22 +143,6 @@ const UNKNOWN_LITERAL_NUMBER: ExpressionEntity = {
 		if (path.length === 1) {
 			const subPath = path[0];
 			return typeof subPath !== 'string' || !literalNumberMembers[subPath];
-		}
-		return true;
-	},
-	someReturnExpressionWhenCalledAtPath: (
-		path: ObjectPath,
-		_callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	) => {
-		if (path.length === 1) {
-			const subPath = path[0];
-			return (
-				typeof subPath !== 'string' ||
-				!literalNumberMembers[subPath] ||
-				predicateFunction(options, literalNumberMembers[subPath].returns)
-			);
 		}
 		return true;
 	},
@@ -214,7 +160,6 @@ const callsArgReturnsNumber: RawMemberDescription = {
 
 const UNKNOWN_LITERAL_STRING: ExpressionEntity = {
 	reassignPath: () => {},
-	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
 	getReturnExpressionWhenCalledAtPath: path => {
 		if (path.length === 1) {
@@ -231,22 +176,6 @@ const UNKNOWN_LITERAL_STRING: ExpressionEntity = {
 		}
 		return true;
 	},
-	someReturnExpressionWhenCalledAtPath: (
-		path: ObjectPath,
-		_callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	) => {
-		if (path.length === 1) {
-			const subPath = path[0];
-			return (
-				typeof subPath !== 'string' ||
-				!literalStringMembers[subPath] ||
-				predicateFunction(options, literalStringMembers[subPath].returns)
-			);
-		}
-		return true;
-	},
 	toString: () => '[[UNKNOWN STRING]]'
 };
 const returnsString: RawMemberDescription = {
@@ -255,7 +184,6 @@ const returnsString: RawMemberDescription = {
 
 export const UNKNOWN_OBJECT_EXPRESSION: ExpressionEntity = {
 	reassignPath: () => {},
-	forEachReturnExpressionWhenCalledAtPath: () => {},
 	getLiteralValueAtPath: () => UNKNOWN_VALUE,
 	getReturnExpressionWhenCalledAtPath: path => {
 		if (path.length === 1) {
@@ -269,22 +197,6 @@ export const UNKNOWN_OBJECT_EXPRESSION: ExpressionEntity = {
 		if (path.length === 1) {
 			const subPath = path[0];
 			return typeof subPath !== 'string' || !objectMembers[subPath];
-		}
-		return true;
-	},
-	someReturnExpressionWhenCalledAtPath: (
-		path: ObjectPath,
-		_callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	) => {
-		if (path.length === 1) {
-			const subPath = path[0];
-			return (
-				typeof subPath !== 'string' ||
-				!objectMembers[subPath] ||
-				predicateFunction(options, objectMembers[subPath].returns)
-			);
 		}
 		return true;
 	},
@@ -431,18 +343,4 @@ export function getMemberReturnExpressionWhenCalled(
 	return typeof memberName !== 'string' || !members[memberName]
 		? UNKNOWN_EXPRESSION
 		: members[memberName].returns;
-}
-
-export function someMemberReturnExpressionWhenCalled(
-	members: MemberDescriptions,
-	memberName: ObjectPathKey,
-	callOptions: CallOptions,
-	predicateFunction: SomeReturnExpressionCallback,
-	options: ExecutionPathOptions
-) {
-	return (
-		hasMemberEffectWhenCalled(members, memberName, false, callOptions, options) ||
-		// if calling has no effect, memberName is a string and members[memberName] exists
-		predicateFunction(options, members[<string>memberName].returns)
-	);
 }

--- a/src/ast/variables/ArgumentsVariable.ts
+++ b/src/ast/variables/ArgumentsVariable.ts
@@ -1,6 +1,5 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
-import { SomeReturnExpressionCallback } from '../nodes/shared/Expression';
 import { EntityPathTracker } from '../utils/EntityPathTracker';
 import { ObjectPath, UNKNOWN_EXPRESSION } from '../values';
 import LocalVariable from './LocalVariable';
@@ -61,22 +60,5 @@ export default class ArgumentsVariable extends LocalVariable {
 				this.parameters[firstArgNum].reassignPath(path.slice(1));
 			}
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		if (path.length === 0) {
-			return true;
-		}
-		return getParameterVariable(path, options).someReturnExpressionWhenCalledAtPath(
-			path.slice(1),
-			callOptions,
-			predicateFunction,
-			options
-		);
 	}
 }

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -11,7 +11,13 @@ import {
 import { Node } from '../nodes/shared/Node';
 import { EntityPathTracker } from '../utils/EntityPathTracker';
 import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker';
-import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_PATH, UNKNOWN_VALUE } from '../values';
+import {
+	LiteralValueOrUnknown,
+	ObjectPath,
+	UNKNOWN_EXPRESSION,
+	UNKNOWN_PATH,
+	UNKNOWN_VALUE
+} from '../values';
 import Variable from './Variable';
 
 // To avoid infinite recursions
@@ -72,6 +78,24 @@ export default class LocalVariable extends Variable {
 			return UNKNOWN_VALUE;
 		}
 		return this.init.getLiteralValueAtPath(path, recursionTracker.track(this.init, path));
+	}
+
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		calledPathTracker: ImmutableEntityPathTracker
+	): ExpressionEntity {
+		if (
+			this.isReassigned ||
+			!this.init ||
+			path.length > MAX_PATH_DEPTH ||
+			calledPathTracker.isTracked(this.init, path)
+		) {
+			return UNKNOWN_EXPRESSION;
+		}
+		return this.init.getReturnExpressionWhenCalledAtPath(
+			path,
+			calledPathTracker.track(this.init, path)
+		);
 	}
 
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, options: ExecutionPathOptions) {

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -3,11 +3,7 @@ import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import Identifier from '../nodes/Identifier';
 import * as NodeType from '../nodes/NodeType';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from '../nodes/shared/Expression';
+import { ExpressionEntity } from '../nodes/shared/Expression';
 import { Node } from '../nodes/shared/Node';
 import { EntityPathTracker } from '../utils/EntityPathTracker';
 import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker';
@@ -44,27 +40,6 @@ export default class LocalVariable extends Variable {
 		this.declarations.push(identifier);
 	}
 
-	forEachReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		callback: ForEachReturnExpressionCallback,
-		recursionTracker: EntityPathTracker
-	) {
-		if (
-			!this.isReassigned &&
-			this.init &&
-			path.length <= MAX_PATH_DEPTH &&
-			!recursionTracker.track(this.init, path)
-		) {
-			this.init.forEachReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				callback,
-				recursionTracker
-			);
-		}
-	}
-
 	getLiteralValueAtPath(
 		path: ObjectPath,
 		recursionTracker: ImmutableEntityPathTracker
@@ -82,19 +57,19 @@ export default class LocalVariable extends Variable {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		calledPathTracker: ImmutableEntityPathTracker
+		recursionTracker: ImmutableEntityPathTracker
 	): ExpressionEntity {
 		if (
 			this.isReassigned ||
 			!this.init ||
 			path.length > MAX_PATH_DEPTH ||
-			calledPathTracker.isTracked(this.init, path)
+			recursionTracker.isTracked(this.init, path)
 		) {
 			return UNKNOWN_EXPRESSION;
 		}
 		return this.init.getReturnExpressionWhenCalledAtPath(
 			path,
-			calledPathTracker.track(this.init, path)
+			recursionTracker.track(this.init, path)
 		);
 	}
 
@@ -174,25 +149,5 @@ export default class LocalVariable extends Variable {
 				this.init.reassignPath(path);
 			}
 		}
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		if (path.length > MAX_PATH_DEPTH) return true;
-		return (
-			this.isReassigned ||
-			(this.init &&
-				!options.hasNodeBeenCalledAtPathWithOptions(path, this.init, callOptions) &&
-				this.init.someReturnExpressionWhenCalledAtPath(
-					path,
-					callOptions,
-					predicateFunction,
-					options.addCalledNodeAtPathWithOptions(path, this.init, callOptions)
-				))
-		);
 	}
 }

--- a/src/ast/variables/ReplaceableInitializationVariable.ts
+++ b/src/ast/variables/ReplaceableInitializationVariable.ts
@@ -1,7 +1,7 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import Identifier from '../nodes/Identifier';
-import { ExpressionEntity, SomeReturnExpressionCallback } from '../nodes/shared/Expression';
+import { ExpressionEntity } from '../nodes/shared/Expression';
 import { EntityPathTracker } from '../utils/EntityPathTracker';
 import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../values';
 import LocalVariable from './LocalVariable';
@@ -37,22 +37,6 @@ export default class ReplaceableInitializationVariable extends LocalVariable {
 		return (
 			this._getInit(options).hasEffectsWhenCalledAtPath(path, callOptions, options) ||
 			super.hasEffectsWhenCalledAtPath(path, callOptions, options)
-		);
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		path: ObjectPath,
-		callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	): boolean {
-		return (
-			this._getInit(options).someReturnExpressionWhenCalledAtPath(
-				path,
-				callOptions,
-				predicateFunction,
-				options
-			) || super.someReturnExpressionWhenCalledAtPath(path, callOptions, predicateFunction, options)
 		);
 	}
 

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -1,12 +1,7 @@
 import CallOptions from '../CallOptions';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import Identifier from '../nodes/Identifier';
-import {
-	ExpressionEntity,
-	ForEachReturnExpressionCallback,
-	SomeReturnExpressionCallback
-} from '../nodes/shared/Expression';
-import { EntityPathTracker } from '../utils/EntityPathTracker';
+import { ExpressionEntity } from '../nodes/shared/Expression';
 import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker';
 import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../values';
 
@@ -36,13 +31,6 @@ export default class Variable implements ExpressionEntity {
 	 */
 	addReference(_identifier: Identifier) {}
 
-	forEachReturnExpressionWhenCalledAtPath(
-		_path: ObjectPath,
-		_callOptions: CallOptions,
-		_callback: ForEachReturnExpressionCallback,
-		_recursionTracker: EntityPathTracker
-	) {}
-
 	getName(reset?: boolean): string {
 		if (
 			reset &&
@@ -66,7 +54,7 @@ export default class Variable implements ExpressionEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		_path: ObjectPath,
-		_calledPathTracker: ImmutableEntityPathTracker
+		_recursionTracker: ImmutableEntityPathTracker
 	): ExpressionEntity {
 		return UNKNOWN_EXPRESSION;
 	}
@@ -101,15 +89,6 @@ export default class Variable implements ExpressionEntity {
 
 	setSafeName(name: string) {
 		this.safeName = name;
-	}
-
-	someReturnExpressionWhenCalledAtPath(
-		_path: ObjectPath,
-		_callOptions: CallOptions,
-		predicateFunction: SomeReturnExpressionCallback,
-		options: ExecutionPathOptions
-	) {
-		return predicateFunction(options, UNKNOWN_EXPRESSION);
 	}
 
 	toString() {

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -64,6 +64,13 @@ export default class Variable implements ExpressionEntity {
 		return UNKNOWN_VALUE;
 	}
 
+	getReturnExpressionWhenCalledAtPath(
+		_path: ObjectPath,
+		_calledPathTracker: ImmutableEntityPathTracker
+	): ExpressionEntity {
+		return UNKNOWN_EXPRESSION;
+	}
+
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, _options: ExecutionPathOptions) {
 		return path.length > 0;
 	}

--- a/test/form/samples/conditional-expression/main.js
+++ b/test/form/samples/conditional-expression/main.js
@@ -6,7 +6,6 @@ var unknownValue = bar();
 // unknown branch without side-effects
 var b = unknownValue ? 1 : 2;
 new (unknownValue ? function () {} : function () {this.x = 1;})();
-(unknownValue ? () => () => {} : () => () => {})()();
 
 // unknown branch with side-effect
 var c = unknownValue ? foo() : 2;

--- a/test/form/samples/recursive-return-value-assignments/_expected.js
+++ b/test/form/samples/recursive-return-value-assignments/_expected.js
@@ -1,1 +1,5 @@
+function foo() {
+	return foo()();
+}
 
+foo().x = 1;

--- a/test/function/samples/trace-inclusion-of-virtual-literals/_config.js
+++ b/test/function/samples/trace-inclusion-of-virtual-literals/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	solo: false,
+	description: 'tracks the "included" state of virtual literals with regard to mutating oparations'
+};

--- a/test/function/samples/trace-inclusion-of-virtual-literals/main.js
+++ b/test/function/samples/trace-inclusion-of-virtual-literals/main.js
@@ -1,0 +1,4 @@
+const foo = [].slice();
+foo.push(1);
+
+assert.equal(foo[0], 1);


### PR DESCRIPTION
This resolves #2253 by internally using instances that can track their own inclusion status for return values of literal methods. E.g. in this example:

```js
const virtual = [1, 2].slice();
virtual.push(3);
const otherVirtual = virtual.slice();
console.log(virtual);
```

the line `virtual.push(3)` will be included as `virtual` itself is included due to the `console.log` statement. The third line, on the other hand, is still removed as it is no side-effect.

To be able to do that, a larger refactoring was necessary. The main issue was that in order to track the inclusion status of an entity that is not represented by an AST node, another AST node needed to take up that responsibility. In this case, the respective `CallExpression` seemed the natural choice (each call to `Array.prototype.slice` creates an independent new object).

Thus I needed to change the fundamental logic that tracks side-effects around return expressions. Instead of e.g. the call expression "asking" a function declaration if calling its return value has a side-effect, the call expression initially asks the function declaration for its return expression, stores this value and then directly performs queries on this return expression.

The only (tested) situation where this performs less optimal than before is when we call an expression that can resolve to more than one possible callable entity. In this case, we just treat the return value as "unknown".