### PR TITLE
Handle undefined expressions in treeshaking

### DIFF
--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -15,7 +15,7 @@ import {
 import * as NodeType from './NodeType';
 import { Node, NodeBase } from './shared/Node';
 
-export type LiteralValue = string | boolean | null | number | RegExp;
+export type LiteralValue = string | boolean | null | number | RegExp | undefined;
 
 export function isLiteral(node: Node): node is Literal {
 	return node.type === NodeType.Literal;

--- a/src/ast/scopes/ModuleScope.ts
+++ b/src/ast/scopes/ModuleScope.ts
@@ -22,12 +22,8 @@ export default class ModuleScope extends Scope {
 		super(parent);
 		this.context = context;
 		this.isModuleScope = true;
-		this.variables.this = new LocalVariable(
-			'this',
-			null,
-			UNDEFINED_EXPRESSION,
-			context.reassignmentTracker
-		);
+		this.variables.this = new LocalVariable('this', null, UNDEFINED_EXPRESSION, context.reassignmentTracker);
+		this.variables.undefined = new LocalVariable('undefined', null, UNDEFINED_EXPRESSION, context.reassignmentTracker);
 	}
 
 	deshadow(names: Set<string>, children = this.children) {

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -54,7 +54,7 @@ export const UNKNOWN_EXPRESSION: ExpressionEntity = {
 };
 export const UNDEFINED_EXPRESSION: ExpressionEntity = {
 	included: true,
-	getLiteralValueAtPath: () => UNKNOWN_VALUE,
+	getLiteralValueAtPath: () => undefined,
 	getReturnExpressionWhenCalledAtPath: () => UNKNOWN_EXPRESSION,
 	hasEffectsWhenAccessedAtPath: path => path.length > 0,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,

--- a/test/form/samples/undefined-var/_config.js
+++ b/test/form/samples/undefined-var/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'treeshakes undefined variable literals'
+};

--- a/test/form/samples/undefined-var/_expected.js
+++ b/test/form/samples/undefined-var/_expected.js
@@ -1,8 +1,8 @@
 var z;
-if ((console.log('b'), true))
-	 console.log('yes');
-if ((console.log('b'), false))
-	;
-if (z ? (console.log('a'), false) : (console.log('b'), false))
+console.log('no');
+console.log('no');
+if (z)
 	console.log('yes');
+if (!z)
+	console.log('no');
 z = 1;

--- a/test/form/samples/undefined-var/_expected.js
+++ b/test/form/samples/undefined-var/_expected.js
@@ -1,0 +1,8 @@
+var z;
+if ((console.log('b'), true))
+	 console.log('yes');
+if ((console.log('b'), false))
+	;
+if (z ? (console.log('a'), false) : (console.log('b'), false))
+	console.log('yes');
+z = 1;

--- a/test/form/samples/undefined-var/main.js
+++ b/test/form/samples/undefined-var/main.js
@@ -1,10 +1,16 @@
 var x;
 var y = undefined;
 var z;
-if (x ? (console.log('a'), false) : (console.log('b'), true))
-	 console.log('yes');
-if (y ? (console.log('a'), false) : (console.log('b'), false))
-	console.log('no');
-if (z ? (console.log('a'), false) : (console.log('b'), false))
+if (x)
 	console.log('yes');
+if (!x)
+	console.log('no');
+if (y)
+	console.log('yes');
+if (!y)
+	console.log('no');
+if (z)
+	console.log('yes');
+if (!z)
+	console.log('no');
 z = 1;

--- a/test/form/samples/undefined-var/main.js
+++ b/test/form/samples/undefined-var/main.js
@@ -1,0 +1,10 @@
+var x;
+var y = undefined;
+var z;
+if (x ? (console.log('a'), false) : (console.log('b'), true))
+	 console.log('yes');
+if (y ? (console.log('a'), false) : (console.log('b'), false))
+	console.log('no');
+if (z ? (console.log('a'), false) : (console.log('b'), false))
+	console.log('yes');
+z = 1;


### PR DESCRIPTION
Resolves #2223

This extends the `UNDEFINED_EXPRESSION` to return a `undefined` literal value which can be treeshaken.