### PR TITLE
Asset invalidation and cache handling

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -10,7 +10,6 @@ import ExternalModule from './ExternalModule';
 import Module, { defaultAcornOptions } from './Module';
 import {
 	Asset,
-	EmitAsset,
 	InputOptions,
 	IsExternal,
 	LoadHook,
@@ -27,7 +26,7 @@ import {
 	WarningHandler,
 	Watcher
 } from './rollup/types';
-import { createAssetPluginHooks, finaliseAsset } from './utils/assetHooks';
+import { createAssetPluginHooks, EmitAsset, finaliseAsset } from './utils/assetHooks';
 import { load, makeOnwarn, resolveId } from './utils/defaults';
 import ensureArray from './utils/ensureArray';
 import { randomUint8Array, Uint8ArrayToHexString, Uint8ArrayXor } from './utils/entryHashing';
@@ -675,7 +674,7 @@ Try defining "${chunkName}" first in the manualChunks definitions of the Rollup 
 					// re-emit transform assets
 					if (cachedModule.transformAssets) {
 						for (const asset of cachedModule.transformAssets) {
-							this.pluginContext.emitAsset(asset.name, asset.source, asset.dependencies);
+							this.pluginContext.emitAsset(asset.name);
 						}
 					}
 					return cachedModule;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -30,6 +30,7 @@ import Chunk from './Chunk';
 import ExternalModule from './ExternalModule';
 import Graph from './Graph';
 import { Asset, IdMap, ModuleJSON, RawSourceMap, RollupError, RollupWarning } from './rollup/types';
+import { handleMissingExport } from './utils/defaults';
 import error from './utils/error';
 import getCodeFrame from './utils/getCodeFrame';
 import { getOriginalLocation } from './utils/getOriginalLocation';
@@ -39,7 +40,6 @@ import relativeId from './utils/relativeId';
 import { RenderOptions } from './utils/renderHelpers';
 import { SOURCEMAPPING_URL_RE } from './utils/sourceMappingURL';
 import { timeEnd, timeStart } from './utils/timers';
-import { handleMissingExport } from './utils/defaults';
 
 export interface CommentDescription {
 	block: boolean;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -29,8 +29,7 @@ import Variable from './ast/variables/Variable';
 import Chunk from './Chunk';
 import ExternalModule from './ExternalModule';
 import Graph from './Graph';
-import { IdMap, ModuleJSON, RawSourceMap, RollupError, RollupWarning } from './rollup/types';
-import { handleMissingExport } from './utils/defaults';
+import { Asset, IdMap, ModuleJSON, RawSourceMap, RollupError, RollupWarning } from './rollup/types';
 import error from './utils/error';
 import getCodeFrame from './utils/getCodeFrame';
 import { getOriginalLocation } from './utils/getOriginalLocation';
@@ -169,6 +168,7 @@ export default class Module {
 		alias: string;
 		resolution: Module | ExternalModule | string | void;
 	}[];
+	transformAssets: Asset[];
 
 	execIndex: number;
 	isEntryPoint: boolean;
@@ -646,6 +646,7 @@ export default class Module {
 			id: this.id,
 			dependencies: this.dependencies.map(module => module.id),
 			transformDependencies: this.transformDependencies,
+			transformAssets: this.transformAssets,
 			code: this.code,
 			originalCode: this.originalCode,
 			originalSourcemap: this.originalSourcemap,

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -39,6 +39,7 @@ import relativeId from './utils/relativeId';
 import { RenderOptions } from './utils/renderHelpers';
 import { SOURCEMAPPING_URL_RE } from './utils/sourceMappingURL';
 import { timeEnd, timeStart } from './utils/timers';
+import { handleMissingExport } from './utils/defaults';
 
 export interface CommentDescription {
 	block: boolean;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -83,6 +83,11 @@ export interface PluginContext {
 	parse: (input: string, options: any) => ESTree.Program;
 	emitAsset(name: string, source?: string | Buffer): string;
 	emitAsset(name: string, dependencies: string[], source?: string | Buffer): string;
+	emitAsset(
+		name: string,
+		dependenciesOrSource: string[] | string,
+		source?: string | Buffer
+	): string;
 	setAssetSource: (assetId: string, source: string | Buffer) => void;
 	getAssetFileName: (assetId: string) => string;
 	warn(warning: RollupWarning | string, pos?: { line: number; column: number }): void;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -52,7 +52,11 @@ export interface SourceMap {
 export interface SourceDescription {
 	code: string;
 	map?: string | RawSourceMap;
+}
+
+export interface TransformSourceDescription extends SourceDescription {
 	ast?: ESTree.Program;
+	dependencies?: string[];
 }
 
 export interface ModuleJSON {
@@ -115,7 +119,11 @@ export type TransformHook = (
 	this: PluginContext,
 	code: string,
 	id: string
-) => Promise<SourceDescription | string | void> | SourceDescription | string | void;
+) =>
+	| Promise<TransformSourceDescription | string | void>
+	| TransformSourceDescription
+	| string
+	| void;
 
 export type TransformChunkHook = (
 	code: string,

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -68,9 +68,6 @@ export interface ModuleJSON {
 	resolvedIds: IdMap;
 }
 
-export function emitAsset(name: string, source?: string | Buffer): string;
-export function emitAsset(name: string, dependencies: string[], source?: string | Buffer): string;
-
 export interface Asset {
 	name: string;
 	source: string | Buffer;
@@ -84,7 +81,8 @@ export interface PluginContext {
 	resolveId: ResolveIdHook;
 	isExternal: IsExternal;
 	parse: (input: string, options: any) => ESTree.Program;
-	emitAsset: EmitAsset;
+	emitAsset(name: string, source?: string | Buffer): string;
+	emitAsset(name: string, dependencies: string[], source?: string | Buffer): string;
 	setAssetSource: (assetId: string, source: string | Buffer) => void;
 	getAssetFileName: (assetId: string) => string;
 	warn(warning: RollupWarning | string, pos?: { line: number; column: number }): void;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -68,7 +68,8 @@ export interface ModuleJSON {
 	resolvedIds: IdMap;
 }
 
-export type EmitAsset = (name: string, source?: string | Buffer, dependencies?: string[]) => string;
+export function emitAsset(name: string, source?: string | Buffer): string;
+export function emitAsset(name: string, dependencies: string[], source?: string | Buffer): string;
 
 export interface Asset {
 	name: string;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -59,6 +59,7 @@ export interface ModuleJSON {
 	id: string;
 	dependencies: string[];
 	transformDependencies: string[];
+	transformAssets: Asset[] | void;
 	code: string;
 	originalCode: string;
 	originalSourcemap: RawSourceMap | void;
@@ -67,12 +68,22 @@ export interface ModuleJSON {
 	resolvedIds: IdMap;
 }
 
+export type EmitAsset = (name: string, source?: string | Buffer, dependencies?: string[]) => string;
+
+export interface Asset {
+	name: string;
+	source: string | Buffer;
+	fileName: string;
+	transform: boolean;
+	dependencies: string[];
+}
+
 export interface PluginContext {
 	watcher: Watcher;
 	resolveId: ResolveIdHook;
 	isExternal: IsExternal;
 	parse: (input: string, options: any) => ESTree.Program;
-	emitAsset: (name: string, source?: string | Buffer) => string;
+	emitAsset: EmitAsset;
 	setAssetSource: (assetId: string, source: string | Buffer) => void;
 	getAssetFileName: (assetId: string) => string;
 	warn(warning: RollupWarning | string, pos?: { line: number; column: number }): void;
@@ -325,6 +336,7 @@ export interface OutputChunk {
 
 export interface RollupCache {
 	modules: ModuleJSON[];
+	assetDependencies: string[];
 }
 
 export interface RollupSingleFileBuild {

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -25,17 +25,17 @@ export interface RollupError {
 	pluginCode?: string;
 }
 
-export type RawSourceMap =
-	| { mappings: '' }
-	| {
-			version: string;
-			sources: string[];
-			names: string[];
-			sourceRoot?: string;
-			sourcesContent?: string[];
-			mappings: string;
-			file: string;
-	  };
+export interface ExistingRawSourceMap {
+	version: string;
+	sources: string[];
+	names: string[];
+	sourceRoot?: string;
+	sourcesContent?: string[];
+	mappings: string;
+	file: string;
+}
+
+export type RawSourceMap = { mappings: '' } | ExistingRawSourceMap;
 
 export interface SourceMap {
 	version: string;
@@ -87,11 +87,6 @@ export interface PluginContext {
 	parse: (input: string, options: any) => ESTree.Program;
 	emitAsset(name: string, source?: string | Buffer): string;
 	emitAsset(name: string, dependencies: string[], source?: string | Buffer): string;
-	emitAsset(
-		name: string,
-		dependenciesOrSource: string[] | string,
-		source?: string | Buffer
-	): string;
 	setAssetSource: (assetId: string, source: string | Buffer) => void;
 	getAssetFileName: (assetId: string) => string;
 	warn(warning: RollupWarning | string, pos?: { line: number; column: number }): void;

--- a/src/utils/assetHooks.ts
+++ b/src/utils/assetHooks.ts
@@ -5,9 +5,11 @@ import { extname, normalize, resolve } from './path';
 import { isPlainName } from './relativeId';
 import { makeUnique, renderNamePattern } from './renderNamePattern';
 
-export type EmitAsset =
-	| ((name: string, source?: string | Buffer) => string)
-	| ((name: string, dependencies?: string[], source?: string | Buffer) => string);
+export type EmitAsset = (
+	name: string,
+	dependencies?: string[] | string | Buffer,
+	source?: string | Buffer
+) => string;
 
 export function getAssetFileName(
 	asset: Asset,
@@ -89,7 +91,7 @@ export function createAssetPluginHooks(
 	}
 
 	return {
-		emitAsset: <EmitAsset>emitAsset,
+		emitAsset,
 		createTransformEmitAsset() {
 			const assets: Asset[] = [];
 			return {

--- a/src/utils/assetHooks.ts
+++ b/src/utils/assetHooks.ts
@@ -1,16 +1,9 @@
 import sha256 from 'hash.js/lib/hash/sha/256';
-import { OutputBundle } from '../rollup/types';
-import { randomHexString } from './entryHashing';
+import { Asset, OutputBundle } from '../rollup/types';
 import error from './error';
-import { extname } from './path';
+import { extname, normalize, resolve } from './path';
 import { isPlainName } from './relativeId';
 import { makeUnique, renderNamePattern } from './renderNamePattern';
-
-export interface Asset {
-	name: string;
-	source: string | Buffer;
-	fileName: string;
-}
 
 export function getAssetFileName(
 	asset: Asset,
@@ -51,18 +44,54 @@ export function createAssetPluginHooks(
 	outputBundle?: OutputBundle,
 	assetFileNames?: string
 ) {
+	function emitAsset(name: string, source?: string | Buffer, dependencies?: string[]) {
+		if (typeof name !== 'string' || !isPlainName(name))
+			error({
+				code: 'INVALID_ASSET_NAME',
+				message: `Plugin error creating asset, name is not a plain (non relative or absolute URL) string name.`
+			});
+
+		if (Array.isArray(source) && dependencies === undefined) {
+			dependencies = source;
+			source = undefined;
+		}
+
+		if (dependencies) dependencies = dependencies.map(depId => normalize(resolve(depId)));
+
+		let assetId: string;
+		do {
+			const assetHash = sha256();
+			if (assetId) {
+				// if there is a collision, chain until there isn't
+				assetHash.update(assetId);
+			} else {
+				assetHash.update(name);
+				if (dependencies) for (const depId of dependencies) assetHash.update(depId);
+			}
+			assetId = assetHash.digest('hex').substr(0, 8);
+		} while (assetsById.has(assetId));
+
+		const asset: Asset = { name, source, fileName: undefined, dependencies, transform: false };
+		if (outputBundle && source !== undefined) finaliseAsset(asset, outputBundle, assetFileNames);
+		assetsById.set(assetId, asset);
+		return assetId;
+	}
+
 	return {
-		emitAsset(name: string, source?: string | Buffer) {
-			if (typeof name !== 'string' || !isPlainName(name))
-				error({
-					code: 'INVALID_ASSET_NAME',
-					message: `Plugin error creating asset, name is not a plain (non relative or absolute URL) string name.`
-				});
-			const assetId = randomHexString(8);
-			const asset: Asset = { name, source, fileName: undefined };
-			if (outputBundle && source !== undefined) finaliseAsset(asset, outputBundle, assetFileNames);
-			assetsById.set(assetId, asset);
-			return assetId;
+		emitAsset,
+		createTransformEmitAsset() {
+			const assets: Asset[] = [];
+			return {
+				assets,
+				emitAsset: (name: string, source?: string | Buffer, dependencies?: string[]) => {
+					const assetId = emitAsset(name, source, dependencies);
+					const asset = assetsById.get(assetId);
+					// distinguish transform assets
+					asset.transform = true;
+					assets.push(asset);
+					return assetId;
+				}
+			};
 		},
 		setAssetSource: (assetId: string, source: string | Buffer) => {
 			const asset = assetsById.get(assetId);

--- a/src/utils/assetHooks.ts
+++ b/src/utils/assetHooks.ts
@@ -50,25 +50,28 @@ export function createAssetPluginHooks(
 	outputBundle?: OutputBundle,
 	assetFileNames?: string
 ) {
-	function emitAsset(name: string, dependencies?: string[], source?: string | Buffer) {
+	function emitAsset(
+		name: string,
+		dependenciesOrSource?: string[] | string,
+		source?: string | Buffer
+	) {
 		if (typeof name !== 'string' || !isPlainName(name))
 			error({
 				code: 'INVALID_ASSET_NAME',
 				message: `Plugin error creating asset, name is not a plain (non relative or absolute URL) string name.`
 			});
 
-		if (source === undefined && !Array.isArray(dependencies)) {
-			source = dependencies;
-			dependencies = undefined;
-		}
+		let dependencies: string[];
 
-		if (dependencies) {
+		if (Array.isArray(dependenciesOrSource)) {
 			if (outputBundle)
 				error({
 					code: 'ASSETS_FINALISED',
 					message: `Plugin error creating asset, asset dependencies are not supported during generation, only during the build.`
 				});
-			dependencies = dependencies.map(depId => normalize(resolve(depId)));
+			dependencies = dependenciesOrSource.map(depId => normalize(resolve(depId)));
+		} else if (source === undefined) {
+			source = dependenciesOrSource;
 		}
 
 		let assetId: string;

--- a/src/utils/assetHooks.ts
+++ b/src/utils/assetHooks.ts
@@ -52,7 +52,7 @@ export function createAssetPluginHooks(
 ) {
 	function emitAsset(
 		name: string,
-		dependenciesOrSource?: string[] | string,
+		dependenciesOrSource?: string[] | string | Buffer,
 		source?: string | Buffer
 	) {
 		if (typeof name !== 'string' || !isPlainName(name))

--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -1,7 +1,7 @@
 import { DecodedSourceMap, SourceMap } from 'magic-string';
 import Chunk from '../Chunk';
 import Module from '../Module';
-import { RawSourceMap } from '../rollup/types';
+import { ExistingRawSourceMap, RawSourceMap } from '../rollup/types';
 import error from './error';
 import { basename, dirname, relative, resolve } from './path';
 
@@ -146,25 +146,26 @@ export default function collapseSourcemaps(
 		let sourcemapChain = module.sourcemapChain;
 
 		let source: Source;
-		if (!module.originalSourcemap) {
+		const originalSourcemap = <ExistingRawSourceMap>module.originalSourcemap;
+		if (!originalSourcemap) {
 			source = new Source(module.id, module.originalCode);
 		} else {
-			const sources = module.originalSourcemap.sources;
-			const sourcesContent = module.originalSourcemap.sourcesContent || [];
+			const sources = originalSourcemap.sources;
+			const sourcesContent = originalSourcemap.sourcesContent || [];
 
 			if (sources == null || (sources.length <= 1 && sources[0] == null)) {
 				source = new Source(module.id, sourcesContent[0]);
-				sourcemapChain = [module.originalSourcemap].concat(sourcemapChain);
+				sourcemapChain = [<RawSourceMap>originalSourcemap].concat(sourcemapChain);
 			} else {
 				// TODO indiscriminately treating IDs and sources as normal paths is probably bad.
 				const directory = dirname(module.id) || '.';
-				const sourceRoot = module.originalSourcemap.sourceRoot || '.';
+				const sourceRoot = originalSourcemap.sourceRoot || '.';
 
 				const baseSources = sources.map((source, i) => {
 					return new Source(resolve(directory, sourceRoot, source), sourcesContent[i]);
 				});
 
-				source = <any>new Link(<any>module.originalSourcemap, baseSources);
+				source = <any>new Link(<any>originalSourcemap, baseSources);
 			}
 		}
 

--- a/src/utils/getOriginalLocation.ts
+++ b/src/utils/getOriginalLocation.ts
@@ -1,4 +1,4 @@
-import { RawSourceMap } from '../rollup/types';
+import { ExistingRawSourceMap, RawSourceMap } from '../rollup/types';
 
 export function getOriginalLocation(
 	sourcemapChain: RawSourceMap[],
@@ -7,7 +7,7 @@ export function getOriginalLocation(
 	const filteredSourcemapChain = sourcemapChain.filter(sourcemap => sourcemap.mappings);
 
 	while (filteredSourcemapChain.length > 0) {
-		const sourcemap = filteredSourcemapChain.pop();
+		const sourcemap = <ExistingRawSourceMap>filteredSourcemapChain.pop();
 		const line: any = sourcemap.mappings[location.line - 1];
 		let locationFound = false;
 

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -6,7 +6,6 @@ import Graph from '../Graph';
 import Module from '../Module';
 import {
 	Asset,
-	EmitAsset,
 	Plugin,
 	PluginContext,
 	RawSourceMap,
@@ -14,6 +13,7 @@ import {
 	RollupWarning,
 	SourceDescription
 } from '../rollup/types';
+import { EmitAsset } from './assetHooks';
 import error from './error';
 import getCodeFrame from './getCodeFrame';
 import { dirname, resolve } from './path';

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -134,17 +134,20 @@ export default function transform(
 						createTransformEmitAsset
 					));
 
-					// assets emitted by transform are transformDependencies
-					if (assets.length) module.transformAssets = assets;
-					for (const asset of assets) {
-						for (const depId of asset.dependencies) {
-							if (!transformDependencies) transformDependencies = [];
-							if (transformDependencies.indexOf(depId) === -1) transformDependencies.push(depId);
-						}
-					}
 					return plugin.transform.call(context, previous, id);
 				})
 				.then(result => {
+					// assets emitted by transform are transformDependencies
+					if (assets.length) module.transformAssets = assets;
+					for (const asset of assets) {
+						if (asset.dependencies) {
+							for (const depId of asset.dependencies) {
+								if (!transformDependencies) transformDependencies = [];
+								if (transformDependencies.indexOf(depId) === -1) transformDependencies.push(depId);
+							}
+						}
+					}
+
 					if (result == null) return previous;
 
 					if (typeof result === 'string') {

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -11,7 +11,7 @@ import {
 	RawSourceMap,
 	RollupError,
 	RollupWarning,
-	SourceDescription
+	TransformSourceDescription
 } from '../rollup/types';
 import { EmitAsset } from './assetHooks';
 import error from './error';
@@ -94,7 +94,7 @@ function createPluginTransformContext(
 
 export default function transform(
 	graph: Graph,
-	source: SourceDescription,
+	source: TransformSourceDescription,
 	module: Module,
 	plugins: Plugin[],
 	createTransformEmitAsset: () => { assets: Asset[]; emitAsset: EmitAsset }

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -96,6 +96,7 @@ export class Task {
 	private inputOptions: InputOptions;
 	cache: {
 		modules: ModuleJSON[];
+		assetDependencies: string[];
 	};
 	private chokidarOptions: WatchOptions;
 	private chokidarOptionsHash: string;
@@ -212,6 +213,10 @@ export class Task {
 						});
 					}
 				});
+				this.cache.assetDependencies.forEach(assetDep => {
+					watched.add(assetDep);
+					this.watchFile(assetDep);
+				});
 				this.watched.forEach(id => {
 					if (!watched.has(id)) deleteTask(id, this, this.chokidarOptionsHash);
 				});
@@ -245,6 +250,11 @@ export class Task {
 									this.watchFile(depId, true);
 								});
 							}
+						});
+					}
+					if (this.cache.assetDependencies) {
+						this.cache.assetDependencies.forEach(assetDep => {
+							this.watchFile(assetDep);
 						});
 					}
 				}

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -479,7 +479,7 @@ describe('rollup.watch', () => {
 				});
 		});
 
-		it('watches and rebuilds asset dependencies', () => {
+		it('watches and rebuilds asset dependencies, caching transform call correctly', () => {
 			let v = 1;
 			return sander
 				.copydir('test/watch/samples/transform-dependencies')
@@ -505,60 +505,6 @@ describe('rollup.watch', () => {
 								}
 							},
 							transform (code) {
-								// transform call is cached
-								return { code: `export default "${v++}"`};
-							}
-						}],
-						watch: { chokidar }
-					});
-
-					return sequence(watcher, [
-						'START',
-						'BUNDLE_START',
-						'BUNDLE_END',
-						'END',
-						() => {
-							assert.equal(run('../_tmp/output/bundle.js'), 1);
-							sander.unlinkSync('test/_tmp/input/asdf');
-						},
-						'START',
-						'BUNDLE_START',
-						'BUNDLE_END',
-						'END',
-						() => {
-							assert.equal(run('../_tmp/output/bundle.js'), 1);
-						}
-					]);
-				});
-		});
-
-		it('watches and rebuilds asset dependencies', () => {
-			let v = 1;
-			return sander
-				.copydir('test/watch/samples/transform-dependencies')
-				.to('test/_tmp/input')
-				.then(() => {
-					const watcher = rollup.watch({
-						input: 'test/_tmp/input/main.js',
-						output: {
-							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
-						},
-						experimentalCodeSplitting: true,
-						plugins: [{
-							buildStart () {
-								try {
-									const file = 'test/_tmp/input/asdf';
-									const text = sander.readFileSync(file).toString();
-									this.emitAsset('test', [file], text);
-								}
-								catch (err) {
-									if (err.code !== 'ENOENT')
-										throw err;
-								}
-							},
-							transform (code) {
-								// transform call is cached
 								return { code: `export default "${v++}"`};
 							}
 						}],

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const sander = require('sander');
 const rollup = require('../../dist/rollup');
+const path = require('path');
 
 const cwd = process.cwd();
 
@@ -448,14 +449,127 @@ describe('rollup.watch', () => {
 							file: 'test/_tmp/output/bundle.js',
 							format: 'cjs'
 						},
-						plugins: [
-							{
-								transform(code) {
-									const dependencies = ['./'];
-									return { code: `export default ${v++}`, dependencies };
+						experimentalCodeSplitting: true,
+						plugins: [{
+							buildStart () {
+								try {
+									const file = 'test/_tmp/input/asdf';
+									const text = sander.readFileSync(file).toString();
+									this.emitAsset('test', [file], text);
 								}
+								catch (err) {
+									if (err.code !== 'ENOENT')
+										throw err;
+								}
+							},
+							transform (code) {
+								// transform call is cached
+								return { code: `export default "${v++}"`};
 							}
-						],
+						}],
+						watch: { chokidar }
+					});
+
+					return sequence(watcher, [
+						'START',
+						'BUNDLE_START',
+						'BUNDLE_END',
+						'END',
+						() => {
+							assert.equal(run('../_tmp/output/bundle.js'), 1);
+							sander.unlinkSync('test/_tmp/input/asdf');
+						},
+						'START',
+						'BUNDLE_START',
+						'BUNDLE_END',
+						'END',
+						() => {
+							assert.equal(run('../_tmp/output/bundle.js'), 1);
+						}
+					]);
+				});
+		});
+
+		it('watches and rebuilds asset dependencies', () => {
+			let v = 1;
+			return sander
+				.copydir('test/watch/samples/transform-dependencies')
+				.to('test/_tmp/input')
+				.then(() => {
+					const watcher = rollup.watch({
+						input: 'test/_tmp/input/main.js',
+						output: {
+							file: 'test/_tmp/output/bundle.js',
+							format: 'cjs'
+						},
+						experimentalCodeSplitting: true,
+						plugins: [{
+							buildStart () {
+								try {
+									const file = 'test/_tmp/input/asdf';
+									const text = sander.readFileSync(file).toString();
+									this.emitAsset('test', [file], text);
+								}
+								catch (err) {
+									if (err.code !== 'ENOENT')
+										throw err;
+								}
+							},
+							transform (code) {
+								// transform call is cached
+								return { code: `export default "${v++}"`};
+							}
+						}],
+						watch: { chokidar }
+					});
+
+					return sequence(watcher, [
+						'START',
+						'BUNDLE_START',
+						'BUNDLE_END',
+						'END',
+						() => {
+							assert.equal(run('../_tmp/output/bundle.js'), 1);
+							sander.unlinkSync('test/_tmp/input/asdf');
+						},
+						'START',
+						'BUNDLE_START',
+						'BUNDLE_END',
+						'END',
+						() => {
+							assert.equal(run('../_tmp/output/bundle.js'), 1);
+						}
+					]);
+				});
+		});
+
+		it('watches and rebuilds asset transform dependencies', () => {
+			let v = 1;
+			return sander
+				.copydir('test/watch/samples/transform-dependencies')
+				.to('test/_tmp/input')
+				.then(() => {
+					const watcher = rollup.watch({
+						input: 'test/_tmp/input/main.js',
+						output: {
+							file: 'test/_tmp/output/bundle.js',
+							format: 'cjs'
+						},
+						plugins: [{
+							transform (code, id) {
+								const file = 'test/_tmp/input/asdf';
+								try {
+									const text = sander.readFileSync(file).toString();
+									this.emitAsset('test', [file], text);
+								}
+								catch (err) {
+									if (err.code !== 'ENOENT')
+										throw err;
+									this.emitAsset('test', 'test');
+								}
+								return { code: `export default ${v++}` };
+							}
+						}],
 						watch: { chokidar }
 					});
 
@@ -715,7 +829,6 @@ describe('rollup.watch', () => {
 						() => {
 							assert.deepEqual(run('../_tmp/output/bundle1.js'), 42);
 							assert.deepEqual(run('../_tmp/output/bundle2.js'), 44);
-							watcher.close();
 						}
 					]);
 				});

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const sander = require('sander');
 const rollup = require('../../dist/rollup');
-const path = require('path');
 
 const cwd = process.cwd();
 


### PR DESCRIPTION
There are some fine details about ensuring caching expectations around `emitAsset` ensuring things work out with cached builds and watched builds.

Managing all the wiring here gets a bit complex, but the overall expectations seem in line with precedent and the API in a way that is at least consistent.

Putting this up now for review, ~~but tests are still pending~~. Based against the transform dependencies PR - https://github.com/rollup/rollup/pull/2259.

#### Reproducible AssetIds

Firstly, we need `emitAsset` to generate a reliably predictable `assetId` to ensure build consistency. In order to ensure this, the assetId is taken as the hash of the asset name, with collision handling.

#### transformAssets

Most plugin hooks will run each build, so we get re-emission of assets fine, except for the transform hook so this then needs special handling:

* `transformAssets` are stored on the module instance
* If using the cached transform hook, the assets are then re-emitted from this list, otherwise they are ignored

#### Asset dependencies

Assets themselves can have dependencies that should cause build invalidation through the file watcher, this is handled by adding another argument to `emitAsset` containing a list of dependencies.

Dependencies of transformAssets then themselves become transformDependencies, invalidating that transform as well.