### PR TITLE
Use primitive string type in TransformHook

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -103,7 +103,7 @@ export type LoadHook = (
 export type TransformHook = (
 	this: PluginContext,
 	code: string,
-	id: String
+	id: string
 ) => Promise<SourceDescription | string | void> | SourceDescription | string | void;
 
 export type TransformChunkHook = (


### PR DESCRIPTION
I beleive it's a typo and it causes issue:
```
Argument of type 'String' is not assignable to parameter of type 'string'. 'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible.
```
