### PR TITLE
Add compatibility with umdjs and es6 module import

### DIFF
--- a/src/finalisers/umd.ts
+++ b/src/finalisers/umd.ts
@@ -115,7 +115,7 @@ export default function umd(
 	wrapperIntro += `${_}${cjsExport}factory(${cjsDeps.join(`,${_}`)})${_}:${n}`;
 	wrapperIntro += `${t}typeof ${define}${_}===${_}'function'${_}&&${_}${define}.amd${_}?${_}${define}(${amdParams}factory)${_}:${n}`;
 	wrapperIntro += `${t}${globalExport};${n}`;
-	wrapperIntro += `}(this,${_}(function${_}(${args})${_}{${useStrict}${n}`;
+	wrapperIntro += `}(typeof window!=='undefined'?window:this,${_}(function${_}(${args})${_}{${useStrict}${n}`;
 
 	// var foo__default = 'default' in foo ? foo['default'] : foo;
 	const interopBlock = getInteropBlock(dependencies, options, graph.varOrConst);


### PR DESCRIPTION
Add change similar to that merged into umdjs here: https://github.com/umdjs/umd/pull/125/commits/47e725735b854dfd93c1ca6fcebf1e018bd52606, to allow umd based modules to be imported as valid es6 modules when strict mode does not upgrade this to global window. This allows for importing a umd module with native browser import and keeps compatibility with https://github.com/umdjs/umd.
