### PR TITLE
imports of the same external can be independently renamed

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -645,7 +645,7 @@ export default class Chunk {
 			let id: string;
 			let globalName: string;
 			if (dep instanceof ExternalModule) {
-				id = dep.renderPath || dep.setRenderPath(options, inputBase);
+				id = dep.setRenderPath(options, inputBase);
 				if (options.format === 'umd' || options.format === 'iife') {
 					globalName = getGlobalName(
 						dep,

--- a/test/chunking-form/samples/external-independently-renamed/_config.js
+++ b/test/chunking-form/samples/external-independently-renamed/_config.js
@@ -1,0 +1,19 @@
+'use strict';
+
+let i = 0;
+
+module.exports = {
+	description: 'imports of the same external can be independently renamed',
+	options: {
+		input: ['main1.js', 'lib/main2.js'],
+		external(id) {
+			return id.endsWith('placeholder');
+		},
+		output: {
+			paths() {
+				return i++ === 0 ? './internal' : '../internal';
+			}
+		},
+		experimentalPreserveModules: true
+	}
+};

--- a/test/chunking-form/samples/external-independently-renamed/_expected/amd/lib/main2.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/amd/lib/main2.js
@@ -1,0 +1,9 @@
+define(['exports', '../internal'], function (exports, placeholder) { 'use strict';
+
+
+
+	Object.keys(placeholder).forEach(function (key) { exports[key] = placeholder[key]; });
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/external-independently-renamed/_expected/amd/main1.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/amd/main1.js
@@ -1,0 +1,9 @@
+define(['exports', '../internal'], function (exports, placeholder) { 'use strict';
+
+
+
+	Object.keys(placeholder).forEach(function (key) { exports[key] = placeholder[key]; });
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/external-independently-renamed/_expected/cjs/lib/main2.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/cjs/lib/main2.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var placeholder = require('../internal');
+
+
+
+Object.keys(placeholder).forEach(function (key) { exports[key] = placeholder[key]; });

--- a/test/chunking-form/samples/external-independently-renamed/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/cjs/main1.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var placeholder = require('../internal');
+
+
+
+Object.keys(placeholder).forEach(function (key) { exports[key] = placeholder[key]; });

--- a/test/chunking-form/samples/external-independently-renamed/_expected/es/lib/main2.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/es/lib/main2.js
@@ -1,0 +1,1 @@
+export * from '../internal';

--- a/test/chunking-form/samples/external-independently-renamed/_expected/es/main1.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/es/main1.js
@@ -1,0 +1,1 @@
+export * from './internal';

--- a/test/chunking-form/samples/external-independently-renamed/_expected/system/lib/main2.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/system/lib/main2.js
@@ -1,0 +1,18 @@
+System.register(['../internal'], function (exports, module) {
+	'use strict';
+	var _starExcludes = { default: 1 };
+	return {
+		setters: [function (module) {
+			var _setter = {};
+			for (var _$p in module) {
+				if (!_starExcludes[_$p]) _setter[_$p] = module[_$p];
+			}
+			exports(_setter);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/external-independently-renamed/_expected/system/main1.js
+++ b/test/chunking-form/samples/external-independently-renamed/_expected/system/main1.js
@@ -1,0 +1,18 @@
+System.register(['../internal'], function (exports, module) {
+	'use strict';
+	var _starExcludes = { default: 1 };
+	return {
+		setters: [function (module) {
+			var _setter = {};
+			for (var _$p in module) {
+				if (!_starExcludes[_$p]) _setter[_$p] = module[_$p];
+			}
+			exports(_setter);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/external-independently-renamed/lib/main2.js
+++ b/test/chunking-form/samples/external-independently-renamed/lib/main2.js
@@ -1,0 +1,1 @@
+export * from '../placeholder';

--- a/test/chunking-form/samples/external-independently-renamed/main1.js
+++ b/test/chunking-form/samples/external-independently-renamed/main1.js
@@ -1,0 +1,1 @@
+export * from './placeholder';


### PR DESCRIPTION
This will be more apparent once #2277 lands, but I thought I would submit on it's own to start the review.

When preserving modules, a use case you might have is a second build step after rollup that "fills in" remaining modules. The first resolved `paths` call is cached, and doesn't allow you to change it based on relative location. I will add inline comments to further clarify.