### PR TITLE
Support static inline colouring for dynamic import

### DIFF
--- a/src/utils/entryHashing.ts
+++ b/src/utils/entryHashing.ts
@@ -29,6 +29,13 @@ export function randomUint8Array(len: number) {
 	return buffer;
 }
 
+export function Uint8ArrayEqual(bufferA: Uint8Array, bufferB: Uint8Array) {
+	for (let i = 0; i < bufferA.length; i++) {
+		if (bufferA[i] !== bufferB[i]) return false;
+	}
+	return true;
+}
+
 export function randomHexString(len: number) {
 	return Uint8ArrayToHexString(randomUint8Array(Math.floor(len / 2)));
 }

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_config.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'Dynamic import inlining for static colouring',
+	options: {
+		input: ['main.js']
+	}
+};

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/amd/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/amd/main.js
@@ -1,0 +1,13 @@
+define(['require'], function (require) { 'use strict';
+
+	var foo = "FOO";
+
+	var foo$1 = /*#__PURE__*/Object.freeze({
+		default: foo
+	});
+
+	var main = () => foo;
+
+	return main;
+
+});

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/amd/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/amd/main.js
@@ -6,7 +6,7 @@ define(['require'], function (require) { 'use strict';
 		default: foo
 	});
 
-	var main = () => foo;
+	var main = Promise.resolve().then(function () { return foo$1; });
 
 	return main;
 

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/cjs/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/cjs/main.js
@@ -6,6 +6,6 @@ var foo$1 = /*#__PURE__*/Object.freeze({
 	default: foo
 });
 
-var main = () => foo;
+var main = Promise.resolve().then(function () { return foo$1; });
 
 module.exports = main;

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/cjs/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/cjs/main.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var foo = "FOO";
+
+var foo$1 = /*#__PURE__*/Object.freeze({
+	default: foo
+});
+
+var main = () => foo;
+
+module.exports = main;

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/es/main.js
@@ -1,0 +1,9 @@
+var foo = "FOO";
+
+var foo$1 = /*#__PURE__*/Object.freeze({
+	default: foo
+});
+
+var main = () => foo;
+
+export default main;

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/es/main.js
@@ -4,6 +4,6 @@ var foo$1 = /*#__PURE__*/Object.freeze({
 	default: foo
 });
 
-var main = () => foo;
+var main = Promise.resolve().then(function () { return foo$1; });
 
 export default main;

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/system/main.js
@@ -9,7 +9,7 @@ System.register([], function (exports, module) {
 				default: foo
 			});
 
-			var main = exports('default', () => foo);
+			var main = exports('default', Promise.resolve().then(function () { return foo$1; }));
 
 		}
 	};

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/system/main.js
@@ -1,0 +1,16 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var foo = "FOO";
+
+			var foo$1 = /*#__PURE__*/Object.freeze({
+				default: foo
+			});
+
+			var main = exports('default', () => foo);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/foo.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/foo.js
@@ -1,0 +1,1 @@
+export default "FOO";

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/main.js
@@ -1,5 +1,3 @@
 import foo from "./foo.js";
 
-const unused = () => import("./foo.js");
-
-export default () => foo;
+export default import("./foo.js");

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/main.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/main.js
@@ -1,0 +1,5 @@
+import foo from "./foo.js";
+
+const unused = () => import("./foo.js");
+
+export default () => foo;

--- a/test/form/samples/dynamic-import-inlining/_expected.js
+++ b/test/form/samples/dynamic-import-inlining/_expected.js
@@ -5,6 +5,6 @@ var foo$1 = /*#__PURE__*/Object.freeze({
 });
 
 const bar = 2;
-Promise.resolve().then(function () { return foo; });
+Promise.resolve().then(function () { return foo$1; });
 
 export { bar };


### PR DESCRIPTION
This solves the issue described by @eight04 in https://github.com/rollup/rollup/issues/2284#issuecomment-398801336.

If a the time of checking a dynamic import, its already in the same static graph as the parent, then we don't treat it as a dynamic import at that point.

Only if later on we discover that the dynamic import is imported uniquely from a colouring where it is not already in that colouring's static graph do we properly raise it to the status of entry point.