### PR TITLE
Watcher fixes (#2294)

### DIFF
--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -168,10 +168,6 @@ export default function watch(
 	}
 
 	function close(err: Error) {
-		if (err) {
-			console.error(err);
-		}
-
 		removeOnExit();
 		process.removeListener('uncaughtException', close);
 		// removing a non-existent listener is a no-op
@@ -183,11 +179,17 @@ export default function watch(
 		if (configWatcher) configWatcher.close();
 
 		if (err) {
+			console.error(err);
 			process.exit(1);
 		}
 	}
 
-	start(initialConfigs);
+	try {
+		start(initialConfigs);
+	} catch (err) {
+		close(err);
+		return;
+	}
 
 	if (configFile && !configFile.startsWith('node:')) {
 		let restarting = false;

--- a/test/watch/samples/multiple/main1.js
+++ b/test/watch/samples/multiple/main1.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/watch/samples/multiple/main2.js
+++ b/test/watch/samples/multiple/main2.js
@@ -1,0 +1,1 @@
+export default 43;


### PR DESCRIPTION
This fixes up some error handling in the watcher to ensure that any errors on start are properly thrown and also that input options errors (missing file and dir in this case) throw their proper messages.

In addition the issue raised in https://github.com/rollup/rollup/issues/2294#issuecomment-399275223 is also resolved which was a regression in the transform dependencies PR.

The `outputFiles` logic isn't there yet, I think it will need reworking, but that is a bigger job I'd like to work on on the 1.0 branch since it simplifies the logic of working out the output files.