### PR TITLE
Fix type definition of Plugin

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -81,7 +81,7 @@ export type ResolveIdHook = (
 	this: PluginContext,
 	id: string,
 	parent: string
-) => Promise<string | boolean | void> | string | boolean | void;
+) => Promise<string | boolean | void | null> | string | boolean | void | null;
 
 export type IsExternal = (
 	id: string,
@@ -92,7 +92,7 @@ export type IsExternal = (
 export type LoadHook = (
 	this: PluginContext,
 	id: string
-) => Promise<SourceDescription | string | void> | SourceDescription | string | void;
+) => Promise<SourceDescription | string | void | null> | SourceDescription | string | void | null;
 
 export type TransformHook = (
 	this: PluginContext,
@@ -107,7 +107,8 @@ export type TransformChunkHook = (
 ) =>
 	| Promise<{ code: string; map: RawSourceMap } | void>
 	| { code: string; map: RawSourceMap }
-	| void;
+	| void
+	| null;
 
 export type TransformChunkHookBound = (
 	this: PluginContext,
@@ -129,7 +130,7 @@ export type AddonHook = string | ((this: PluginContext) => string | Promise<stri
 
 export interface Plugin {
 	name: string;
-	options?: (options: InputOptions) => InputOptions | void;
+	options?: (options: InputOptions) => InputOptions | void | null;
 	load?: LoadHook;
 	resolveId?: ResolveIdHook;
 	transform?: TransformHook;


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

Fix type definitions of properties of `Plugin` according to the [wiki](https://github.com/rollup/rollup/wiki/Plugins#creating-plugins), which says `options`, `resolveId`, `load`, and `transformChunk` can return `null`.
It is likely that some other properties such as `resolveDynamicImport` can also return `null`, though I only fixed the properties which are explicitly described to possibly return `null`.