### PR TITLE
Remove duplicated rollup version output

### DIFF
--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -91,8 +91,6 @@ export default function watch(
 	}
 
 	function start(configs: RollupWatchOptions[]) {
-		screen.reset(chalk.underline(`rollup v${rollup.VERSION}`));
-
 		const screenWriter = processConfigsErr || screen.reset;
 
 		watcher = rollup.watch(configs);


### PR DESCRIPTION
<!--
Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code. In many cases features are absent for a reason.
* This message body should clearly illustrate what problems it solves. If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI. (Remember to `npm run lint`!)
-->

Related https://github.com/rollup/rollup/issues/2314

Hey, when trying to fix related issue I removed the first version output to remove duplication. There is a `START` event which does the same so the output is duplicated.

Is there any case where `START` event doesn't fire or fires not first so you actually need the first version output? If there is, I will fix this another way.