### PR TITLE
Unify sample-based tests

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -77,7 +77,7 @@ function getGlobalName(
 			guess: module.name,
 			message: `No name was provided for external module '${
 				module.id
-			}' in options.globals – guessing '${module.name}'`
+			}' in output.globals – guessing '${module.name}'`
 		});
 		return module.name;
 	}

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -1,19 +1,18 @@
+import Chunk from '../Chunk';
 import { optimizeChunks } from '../chunk-optimization';
 import Graph from '../Graph';
 import { createAddons } from '../utils/addons';
+import { createAssetPluginHooks, finaliseAsset } from '../utils/assetHooks';
 import commondir from '../utils/commondir';
 import { Deprecation } from '../utils/deprecateOptions';
 import ensureArray from '../utils/ensureArray';
 import error from '../utils/error';
 import { writeFile } from '../utils/fs';
+import getExportMode from '../utils/getExportMode';
 import mergeOptions, { GenericConfigObject } from '../utils/mergeOptions';
 import { basename, dirname, resolve } from '../utils/path';
 import { SOURCEMAPPING_URL } from '../utils/sourceMappingURL';
 import { getTimings, initialiseTimers, timeEnd, timeStart } from '../utils/timers';
-
-import Chunk from '../Chunk';
-import { createAssetPluginHooks, finaliseAsset } from '../utils/assetHooks';
-import getExportMode from '../utils/getExportMode';
 import { Watcher } from '../watch';
 import {
 	InputOptions,
@@ -56,13 +55,13 @@ function checkOutputOptions(options: OutputOptions) {
 
 	if (!options.format) {
 		error({
-			message: `You must specify options.format, which can be one of 'amd', 'cjs', 'system', 'esm', 'iife' or 'umd'`,
+			message: `You must specify output.format, which can be one of 'amd', 'cjs', 'system', 'esm', 'iife' or 'umd'`,
 			url: `https://rollupjs.org/#format-f-output-format-`
 		});
 	}
 
 	if (options.moduleId) {
-		if (options.amd) throw new Error('Cannot have both options.amd and options.moduleId');
+		if (options.amd) throw new Error('Cannot have both output.amd and output.moduleId');
 	}
 }
 

--- a/src/utils/getExportMode.ts
+++ b/src/utils/getExportMode.ts
@@ -5,7 +5,7 @@ import error from './error';
 function badExports(option: string, keys: string[]) {
 	error({
 		code: 'INVALID_EXPORT_OPTION',
-		message: `'${option}' was specified for options.exports, but entry module has following exports: ${keys.join(
+		message: `'${option}' was specified for output.exports, but entry module has following exports: ${keys.join(
 			', '
 		)}`
 	});
@@ -46,7 +46,7 @@ export default function getExportMode(
 	if (!/(?:default|named|none)/.test(exportMode)) {
 		error({
 			code: 'INVALID_EXPORT_OPTION',
-			message: `options.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`
+			message: `output.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`
 		});
 	}
 

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -137,7 +137,7 @@ export class Task {
 
 		if (chokidarOptions && !chokidar) {
 			throw new Error(
-				`options.watch.chokidar was provided, but chokidar could not be found. Have you installed it?`
+				`watch.chokidar was provided, but chokidar could not be found. Have you installed it?`
 			);
 		}
 

--- a/test/form/index.js
+++ b/test/form/index.js
@@ -2,40 +2,11 @@ const path = require('path');
 const assert = require('assert');
 const sander = require('sander');
 const rollup = require('../../dist/rollup');
-const { extend, loadConfig, normaliseOutput, removeOldTest } = require('../utils.js');
+const { extend, normaliseOutput, runTestSuiteWithSamples } = require('../utils.js');
 
-const SAMPLES_DIR = path.resolve(__dirname, 'samples');
 const FORMATS = ['amd', 'cjs', 'system', 'es', 'iife', 'umd'];
 
-describe('form', () => {
-	sander
-		.readdirSync(SAMPLES_DIR)
-		.filter(name => name[0] !== '.')
-		.sort()
-		.forEach(fileName => runTestsInDir(SAMPLES_DIR + '/' + fileName));
-});
-
-function runTestsInDir(dir) {
-	const fileNames = sander.readdirSync(dir);
-
-	if (fileNames.indexOf('_config.js') >= 0) {
-		runTestCaseInDir(dir);
-	} else if (fileNames.indexOf('_actual') >= 0 || fileNames.indexOf('_actual.js') >= 0) {
-		removeOldTest(dir);
-	} else {
-		describe(path.basename(dir), () => {
-			fileNames
-				.filter(name => name[0] !== '.')
-				.sort()
-				.forEach(fileName => runTestsInDir(dir + '/' + fileName));
-		});
-	}
-}
-
-function runTestCaseInDir(dir) {
-	const config = loadConfig(dir + '/_config.js');
-	if (!config || (config.skipIfWindows && process.platform === 'win32')) return;
-
+runTestSuiteWithSamples('form', path.resolve(__dirname, 'samples'), (dir, config) => {
 	const isSingleFormatTest = sander.existsSync(dir + '/_expected.js');
 	const itOrDescribe = isSingleFormatTest ? it : describe;
 	(config.skip ? itOrDescribe.skip : config.solo ? itOrDescribe.only : itOrDescribe)(
@@ -90,7 +61,7 @@ function runTestCaseInDir(dir) {
 			);
 		}
 	);
-}
+});
 
 function generateAndTestBundle(bundle, outputOptions, expectedFile, { show }) {
 	return bundle.write(outputOptions).then(() => {

--- a/test/function/index.js
+++ b/test/function/index.js
@@ -20,7 +20,7 @@ runTestSuiteWithSamples('function', path.resolve(__dirname, 'samples'), (dir, co
 							input: dir + '/main.js',
 							onwarn: warning => warnings.push(warning)
 						},
-						config.options
+						config.options || {}
 					)
 				)
 				.then(bundle => {
@@ -34,9 +34,12 @@ runTestSuiteWithSamples('function', path.resolve(__dirname, 'samples'), (dir, co
 
 					return bundle
 						.generate(
-							extend({}, config.bundleOptions, {
-								format: 'cjs'
-							})
+							extend(
+								{
+									format: 'cjs'
+								},
+								(config.options || {}).output || {}
+							)
 						)
 						.then(code => {
 							if (config.generateError) {

--- a/test/function/index.js
+++ b/test/function/index.js
@@ -1,167 +1,148 @@
 const path = require('path');
 const assert = require('assert');
-const sander = require('sander');
 const buble = require('buble');
 const rollup = require('../../dist/rollup');
-const { compareError, compareWarnings, extend, loadConfig } = require('../utils.js');
+const { compareError, compareWarnings, extend, runTestSuiteWithSamples } = require('../utils.js');
 
-const samples = path.resolve(__dirname, 'samples');
+runTestSuiteWithSamples('function', path.resolve(__dirname, 'samples'), (dir, config) => {
+	(config.skip ? it.skip : config.solo ? it.only : it)(
+		path.basename(dir) + ': ' + config.description,
+		() => {
+			if (config.solo) console.group(path.basename(dir));
 
-describe('function', () => {
-	sander
-		.readdirSync(samples)
-		.sort()
-		.forEach(dir => {
-			if (dir[0] === '.') return; // .DS_Store...
+			process.chdir(dir);
+			const warnings = [];
 
-			const config = loadConfig(samples + '/' + dir + '/_config.js');
-			if (
-				!config ||
-				(config.minNodeVersion &&
-					config.minNodeVersion > Number(/^v(\d+)/.exec(process.version)[1]))
-			)
-				return;
-			(config.skip ? it.skip : config.solo ? it.only : it)(dir, () => {
-				process.chdir(samples + '/' + dir);
+			return rollup
+				.rollup(
+					extend(
+						{
+							input: dir + '/main.js',
+							onwarn: warning => warnings.push(warning)
+						},
+						config.options
+					)
+				)
+				.then(bundle => {
+					let unintendedError;
 
-				const warnings = [];
-				const captureWarning = msg => warnings.push(msg);
+					if (config.error) {
+						throw new Error('Expected an error while rolling up');
+					}
 
-				const options = extend(
-					{
-						input: samples + '/' + dir + '/main.js',
-						onwarn: captureWarning
-					},
-					config.options
-				);
+					let result;
 
-				if (config.solo) console.group(dir);
-
-				return rollup
-					.rollup(options)
-					.then(bundle => {
-						let unintendedError;
-
-						if (config.error) {
-							throw new Error('Expected an error while rolling up');
-						}
-
-						let result;
-
-						// try to generate output
-						return Promise.resolve()
-							.then(() => {
-								return bundle.generate(
-									extend({}, config.bundleOptions, {
-										format: 'cjs'
-									})
-								);
+					return bundle
+						.generate(
+							extend({}, config.bundleOptions, {
+								format: 'cjs'
 							})
-							.then(code => {
-								if (config.generateError) {
-									unintendedError = new Error('Expected an error while generating output');
+						)
+						.then(code => {
+							if (config.generateError) {
+								unintendedError = new Error('Expected an error while generating output');
+							}
+
+							result = code;
+						})
+						.catch(err => {
+							if (config.generateError) {
+								compareError(err, config.generateError);
+							} else {
+								throw err;
+							}
+						})
+						.then(() => {
+							if (unintendedError) throw unintendedError;
+							if (config.error || config.generateError) return;
+
+							let code = result.code;
+
+							if (config.buble) {
+								code = buble.transform(code, {
+									transforms: { modules: false }
+								}).code;
+							}
+
+							if (config.code) config.code(code);
+
+							const module = {
+								exports: {}
+							};
+
+							const context = extend(
+								{ require, module, assert, exports: module.exports },
+								config.context || {}
+							);
+
+							const contextKeys = Object.keys(context);
+							const contextValues = contextKeys.map(key => context[key]);
+
+							try {
+								const fn = new Function(contextKeys, code);
+								fn.apply({}, contextValues);
+
+								if (config.runtimeError) {
+									unintendedError = new Error('Expected an error while executing output');
 								}
-
-								result = code;
-							})
-							.catch(err => {
-								if (config.generateError) {
-									compareError(err, config.generateError);
+							} catch (err) {
+								if (config.runtimeError) {
+									config.runtimeError(err);
 								} else {
 									unintendedError = err;
 								}
-							})
-							.then(() => {
-								if (unintendedError) throw unintendedError;
-								if (config.error || config.generateError) return;
+							}
 
-								let code = result.code;
-
-								if (config.buble) {
-									code = buble.transform(code, {
-										transforms: { modules: false }
-									}).code;
-								}
-
-								if (config.code) config.code(code);
-
-								const module = {
-									exports: {}
-								};
-
-								const context = extend(
-									{ require, module, assert, exports: module.exports },
-									config.context || {}
-								);
-
-								const contextKeys = Object.keys(context);
-								const contextValues = contextKeys.map(key => context[key]);
-
-								try {
-									const fn = new Function(contextKeys, code);
-									fn.apply({}, contextValues);
-
-									if (config.runtimeError) {
-										unintendedError = new Error('Expected an error while executing output');
+							return Promise.resolve()
+								.then(() => {
+									if (config.exports && !unintendedError) {
+										return config.exports(module.exports);
 									}
-								} catch (err) {
+								})
+								.then(() => {
+									if (config.bundle && !unintendedError) {
+										return config.bundle(bundle);
+									}
+								})
+								.catch(err => {
 									if (config.runtimeError) {
 										config.runtimeError(err);
 									} else {
 										unintendedError = err;
 									}
-								}
+								})
+								.then(() => {
+									if (config.show || unintendedError) {
+										console.log(result.code + '\n\n\n');
+									}
 
-								return Promise.resolve()
-									.then(() => {
-										if (config.exports && !unintendedError) {
-											return config.exports(module.exports);
-										}
-									})
-									.then(() => {
-										if (config.bundle && !unintendedError) {
-											return config.bundle(bundle);
-										}
-									})
-									.catch(err => {
-										if (config.runtimeError) {
-											config.runtimeError(err);
+									if (config.warnings) {
+										if (Array.isArray(config.warnings)) {
+											compareWarnings(warnings, config.warnings);
 										} else {
-											unintendedError = err;
+											config.warnings(warnings);
 										}
-									})
-									.then(() => {
-										if (config.show || unintendedError) {
-											console.log(result.code + '\n\n\n');
-										}
+									} else if (warnings.length) {
+										throw new Error(
+											`Got unexpected warnings:\n${warnings
+												.map(warning => warning.message)
+												.join('\n')}`
+										);
+									}
 
-										if (config.warnings) {
-											if (Array.isArray(config.warnings)) {
-												compareWarnings(warnings, config.warnings);
-											} else {
-												config.warnings(warnings);
-											}
-										} else if (warnings.length) {
-											throw new Error(
-												`Got unexpected warnings:\n${warnings
-													.map(warning => warning.message)
-													.join('\n')}`
-											);
-										}
+									if (config.solo) console.groupEnd();
 
-										if (config.solo) console.groupEnd();
-
-										if (unintendedError) throw unintendedError;
-									});
-							});
-					})
-					.catch(err => {
-						if (config.error) {
-							compareError(err, config.error);
-						} else {
-							throw err;
-						}
-					});
-			});
-		});
+									if (unintendedError) throw unintendedError;
+								});
+						});
+				})
+				.catch(err => {
+					if (config.error) {
+						compareError(err, config.error);
+					} else {
+						throw err;
+					}
+				});
+		}
+	);
 });

--- a/test/function/samples/compact/_config.js
+++ b/test/function/samples/compact/_config.js
@@ -1,11 +1,11 @@
 module.exports = {
 	description: 'compact output with compact: true',
 	options: {
-		external: ['external']
-	},
-	bundleOptions: {
-		compact: true,
-		namespaceToStringTag: true
+		external: ['external'],
+		output: {
+			compact: true,
+			namespaceToStringTag: true
+		}
 	},
 	warnings: [
 		{
@@ -15,7 +15,7 @@ module.exports = {
 		}
 	],
 	context: {
-		require (x) {
+		require(x) {
 			return 42;
 		}
 	}

--- a/test/function/samples/export-type-mismatch-b/_config.js
+++ b/test/function/samples/export-type-mismatch-b/_config.js
@@ -2,11 +2,9 @@ var assert = require('assert');
 
 module.exports = {
 	description: 'export type must be auto, default, named or none',
-	bundleOptions: {
-		exports: 'blah'
-	},
+	options: { output: { exports: 'blah' } },
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
-		message: `options.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`
+		message: `output.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`
 	}
 };

--- a/test/function/samples/export-type-mismatch-c/_config.js
+++ b/test/function/samples/export-type-mismatch-c/_config.js
@@ -2,11 +2,9 @@ var assert = require('assert');
 
 module.exports = {
 	description: 'cannot have named exports if explicit export type is default',
-	bundleOptions: {
-		exports: 'none'
-	},
+	options: { output: { exports: 'none' } },
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
-		message: `'none' was specified for options.exports, but entry module has following exports: default`
+		message: `'none' was specified for output.exports, but entry module has following exports: default`
 	}
 };

--- a/test/function/samples/export-type-mismatch/_config.js
+++ b/test/function/samples/export-type-mismatch/_config.js
@@ -2,11 +2,9 @@ var assert = require('assert');
 
 module.exports = {
 	description: 'cannot have named exports if explicit export type is default',
-	bundleOptions: {
-		exports: 'default'
-	},
+	options: { output: { exports: 'default' } },
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
-		message: `'default' was specified for options.exports, but entry module has following exports: foo`
+		message: `'default' was specified for output.exports, but entry module has following exports: foo`
 	}
 };

--- a/test/function/samples/handles-stringified-sourcemaps/_config.js
+++ b/test/function/samples/handles-stringified-sourcemaps/_config.js
@@ -12,11 +12,8 @@ module.exports = {
 					};
 				}
 			}
-		]
-	},
-
-	// ensure source maps are generated
-	bundleOptions: {
-		sourcemap: true
+		],
+		// ensure source maps are generated
+		output: { sourcemap: true }
 	}
 };

--- a/test/function/samples/import-meta-url-compact/_config.js
+++ b/test/function/samples/import-meta-url-compact/_config.js
@@ -4,17 +4,15 @@ const URL = global.URL || require('url-parse');
 
 module.exports = {
 	description: 'import.meta.url support',
-	bundleOptions: {
-		compact: true
-	},
+	options: { output: { compact: true } },
 	context: {
 		__filename: path.resolve(__dirname, 'test.js'),
-		require: (name) => {
+		require: name => {
 			assert.equal(name, 'url');
 			return { URL: URL };
 		}
 	},
-	exports (exports) {
+	exports(exports) {
 		assert.equal(exports, new URL('file:' + path.resolve(__dirname, 'test.js')).href);
 	}
 };

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -128,7 +128,7 @@ describe('sanity checks', () => {
 			.then(bundle => {
 				assert.throws(() => {
 					bundle.generate({ file: 'x' });
-				}, /You must specify options\.format, which can be one of 'amd', 'cjs', 'system', 'esm', 'iife' or 'umd'/);
+				}, /You must specify output\.format, which can be one of 'amd', 'cjs', 'system', 'esm', 'iife' or 'umd'/);
 			});
 	});
 

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -1,77 +1,67 @@
 const path = require('path');
-const sander = require('sander');
 const rollup = require('../../dist/rollup');
-const { compareWarnings, extend, loadConfig } = require('../utils.js');
+const { compareWarnings, extend, runTestSuiteWithSamples } = require('../utils.js');
 
-const samples = path.resolve(__dirname, 'samples');
+const FORMATS = ['amd', 'cjs', 'system', 'es', 'iife', 'umd'];
 
-const FORMATS = ['amd', 'cjs', 'es', 'iife', 'umd'];
+runTestSuiteWithSamples('sourcemaps', path.resolve(__dirname, 'samples'), (dir, config) => {
+	(config.skip ? describe.skip : config.solo ? describe.only : describe)(
+		path.basename(dir) + ': ' + config.description,
+		() => {
+			(config.formats || FORMATS).forEach(format =>
+				it('generates ' + format, () => {
+					process.chdir(dir);
+					const warnings = [];
+					const inputOptions = extend(
+						{
+							input: dir + '/main.js',
+							onwarn: warning => warnings.push(warning)
+						},
+						config.options || {}
+					);
+					const outputOptions = extend(
+						{
+							file: dir + '/_actual/bundle.' + format + '.js',
+							format,
+							sourcemap: true
+						},
+						(config.options || {}).output || {}
+					);
 
-describe('sourcemaps', () => {
-	sander
-		.readdirSync(samples)
-		.sort()
-		.forEach(dir => {
-			if (dir[0] === '.') return; // .DS_Store...
-
-			const config = loadConfig(samples + '/' + dir + '/_config.js');
-			if (!config) return;
-
-			describe(dir, () => {
-				const input = path.resolve(samples, dir, 'main.js');
-				const output = path.resolve(samples, dir, '_actual/bundle');
-
-				let warnings;
-
-				const inputOptions = extend({}, config.options, {
-					input,
-					onwarn: warning => warnings.push(warning)
-				});
-
-				FORMATS.forEach(format => {
-					(config.skip ? it.skip : config.solo ? it.only : it)('generates ' + format, () => {
-						warnings = [];
-
-						const testBundle = bundle => {
-							const outputOptions = extend(
-								{},
-								{
-									format,
-									sourcemap: true,
-									file: `${output}.${format}.js`
-								},
-								inputOptions.output || {}
-							);
-
-							return bundle.write(outputOptions).then(() => {
-								if (config.warnings) {
-									compareWarnings(warnings, config.warnings);
-								} else if (warnings.length) {
-									throw new Error(`Unexpected warnings`);
-								}
-
-								return bundle.generate(outputOptions).then(({ code, map }) => {
-									if (config.test) {
-										return config.test(code, map, { format });
-									}
-								});
-							});
-						};
-
-						return rollup.rollup(inputOptions).then(bundle => {
-							return testBundle(bundle).then(() => {
-								// cache rebuild does not reemit warnings.
-								if (config.warnings) {
-									return;
-								}
-								// test cache noop rebuild
-								return rollup.rollup(extend({ cache: bundle }, inputOptions)).then(bundle => {
-									testBundle(bundle);
-								});
-							});
-						});
-					});
-				});
-			});
-		});
+					return rollup.rollup(inputOptions).then(bundle =>
+						generateAndTestBundle(bundle, outputOptions, config, format, warnings).then(() => {
+							// cache rebuild does not reemit warnings.
+							if (config.warnings) {
+								return;
+							}
+							// test cache noop rebuild
+							return rollup
+								.rollup(extend({ cache: bundle }, inputOptions))
+								.then(bundle =>
+									generateAndTestBundle(bundle, outputOptions, config, format, warnings)
+								);
+						})
+					);
+				})
+			);
+		}
+	);
 });
+
+function generateAndTestBundle(bundle, outputOptions, config, format, warnings) {
+	return bundle
+		.write(outputOptions)
+		.then(() => {
+			if (config.warnings) {
+				compareWarnings(warnings, config.warnings);
+			} else if (warnings.length) {
+				throw new Error(`Unexpected warnings`);
+			}
+			return bundle.generate(outputOptions);
+		})
+		.then(({ code, map }) => {
+			if (config.test) {
+				return config.test(code, map, { format });
+			}
+		});
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -7,7 +7,6 @@ exports.compareWarnings = compareWarnings;
 exports.deindent = deindent;
 exports.executeBundle = executeBundle;
 exports.extend = extend;
-exports.loadConfig = loadConfig;
 exports.loader = loader;
 exports.normaliseOutput = normaliseOutput;
 exports.runTestSuiteWithSamples = runTestSuiteWithSamples;
@@ -131,16 +130,27 @@ function normaliseOutput(code) {
 }
 
 function runTestSuiteWithSamples(suiteName, samplesDir, runTest, onTeardown) {
-	describe(suiteName, () => {
-		if (onTeardown) {
-			afterEach(onTeardown);
-		}
-		sander
-			.readdirSync(samplesDir)
-			.filter(name => name[0] !== '.')
-			.sort()
-			.forEach(fileName => runTestsInDir(samplesDir + '/' + fileName, runTest));
-	});
+	describe(suiteName, () => runSamples(samplesDir, runTest, onTeardown));
+}
+
+// You can run only or skip certain kinds of tests be appending .only or .skip
+runTestSuiteWithSamples.only = function(suiteName, samplesDir, runTest, onTeardown) {
+	describe.only(suiteName, () => runSamples(samplesDir, runTest, onTeardown));
+};
+
+runTestSuiteWithSamples.skip = function(suiteName) {
+	describe.skip(suiteName, () => {});
+};
+
+function runSamples(samplesDir, runTest, onTeardown) {
+	if (onTeardown) {
+		afterEach(onTeardown);
+	}
+	sander
+		.readdirSync(samplesDir)
+		.filter(name => name[0] !== '.')
+		.sort()
+		.forEach(fileName => runTestsInDir(samplesDir + '/' + fileName, runTest));
 }
 
 function runTestsInDir(dir, runTest) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -130,14 +130,17 @@ function normaliseOutput(code) {
 		.replace(/\r\n/g, '\n');
 }
 
-function runTestSuiteWithSamples(suiteName, samplesDir, runTest) {
-	describe(suiteName, () =>
+function runTestSuiteWithSamples(suiteName, samplesDir, runTest, onTeardown) {
+	describe(suiteName, () => {
+		if (onTeardown) {
+			afterEach(onTeardown);
+		}
 		sander
 			.readdirSync(samplesDir)
 			.filter(name => name[0] !== '.')
 			.sort()
-			.forEach(fileName => runTestsInDir(samplesDir + '/' + fileName, runTest))
-	);
+			.forEach(fileName => runTestsInDir(samplesDir + '/' + fileName, runTest));
+	});
 }
 
 function runTestsInDir(dir, runTest) {


### PR DESCRIPTION
This unifies the basic setup of chunking-form, cli, form, function and sourcemaps test. With these changes, all of these tests can now be grouped into sub-folders. They also share the two common options `minNodeVersion` and `skipIfWindows`.

Beyond that, the options in function tests have been changed to have nested output options, similar to the other tests.

Also, some warning/error strings have been changed to correctly refer to `output.<optionName>` instead of `options.<optionName>`.
