### PR TITLE
Ensure CLI warnings still show on errors, add an error for externalId collissions

### DIFF
--- a/bin/src/run/build.ts
+++ b/bin/src/run/build.ts
@@ -82,5 +82,8 @@ export default function build(
 				printTimings(bundle.getTimings());
 			}
 		})
-		.catch(handleError);
+		.catch((err: any) => {
+			if (warnings.count > 0) warnings.flush();
+			handleError(err);
+		});
 }

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -823,7 +823,7 @@ Try defining "${chunkName}" first in the manualChunks definitions of the Rollup 
 										'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
 								});
 							}
-							isExternal = !this.moduleById.has(module.id);
+							isExternal = true;
 						}
 
 						if (isExternal) {
@@ -836,6 +836,15 @@ Try defining "${chunkName}" first in the manualChunks definitions of the Rollup 
 							}
 
 							const externalModule = this.moduleById.get(externalId);
+
+							if (externalModule instanceof ExternalModule === false) {
+								error({
+									code: 'INVALID_EXTERNAL_ID',
+									message: `'${source}' is imported as an external by ${relativeId(
+										module.id
+									)}, but is already an existing non-external module id.`
+								});
+							}
 
 							// add external declarations so we can detect which are never used
 							for (const name in module.imports) {

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -823,7 +823,7 @@ Try defining "${chunkName}" first in the manualChunks definitions of the Rollup 
 										'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
 								});
 							}
-							isExternal = true;
+							isExternal = !this.moduleById.has(module.id);
 						}
 
 						if (isExternal) {

--- a/test/function/samples/external-conflict/_config.js
+++ b/test/function/samples/external-conflict/_config.js
@@ -1,0 +1,25 @@
+var path = require('path');
+var assert = require('assert');
+
+module.exports = {
+	description: 'external paths from custom resolver remain external (#633)',
+	options: {
+		external: (_id, parent) => parent === 'dep',
+		plugins: [
+			{
+				resolveId (id, parent) {
+					if (id === 'dep')
+						return id;
+				},
+				load (id) {
+					if (id === 'dep')
+						return `import 'dep'`;
+				}
+			}
+		]
+	},
+	error: {
+		code: "INVALID_EXTERNAL_ID",
+		message: "'dep' is imported as an external by dep, but is already an existing non-external module id."
+	}
+};

--- a/test/function/samples/external-conflict/main.js
+++ b/test/function/samples/external-conflict/main.js
@@ -1,0 +1,1 @@
+import 'dep';


### PR DESCRIPTION
This ensures the right diagnostic information is available for https://github.com/rollup/rollup/issues/2317, now outputting:

```
main.js → build.js...
(!) Unresolved dependencies
https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency
node_modules/vue/dist/vue.esm.js (imported by  commonjs-proxy:node_modules/vue/dist/vue.esm.js)
[!] Error: 'node_modules/vue/dist/vue.esm.js' is imported as an external by  commonjs-proxy:node_modules/vue/dist/vue.esm.js, but is already an existing non-external module id.
Error: 'node_modules/vue/dist/vue.esm.js' is imported as an external by  commonjs-proxy:node_modules/vue/dist/vue.esm.js, but is already an existing non-external module id.
```