### PR TITLE
Swap chalk for turbocolor

### DIFF
--- a/bin/src/logging.ts
+++ b/bin/src/logging.ts
@@ -1,8 +1,6 @@
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import { RollupError } from '../../src/rollup/types';
 import relativeId from '../../src/utils/relativeId';
-
-if (!chalk.supportsColor) chalk.enabled = false;
 
 // log to stderr to keep `rollup main.js > bundle.js` from breaking
 export const stderr = console.error.bind(console); // eslint-disable-line no-console
@@ -15,11 +13,11 @@ export function handleError(err: RollupError, recover = false) {
 			? `(${(<{ plugin?: string }>err).plugin} plugin) ${description}`
 			: description) || err;
 
-	stderr(chalk.bold.red(`[!] ${chalk.bold(message.toString())}`));
+	stderr(tc.bold.red(`[!] ${tc.bold(message.toString())}`));
 
 	// TODO should this be "err.url || (err.file && err.loc.file) || err.id"?
 	if (err.url) {
-		stderr(chalk.cyan(err.url));
+		stderr(tc.cyan(err.url));
 	}
 
 	if (err.loc) {
@@ -29,9 +27,9 @@ export function handleError(err: RollupError, recover = false) {
 	}
 
 	if (err.frame) {
-		stderr(chalk.dim(err.frame));
+		stderr(tc.dim(err.frame));
 	} else if (err.stack) {
-		stderr(chalk.dim(err.stack));
+		stderr(tc.dim(err.stack));
 	}
 
 	stderr('');

--- a/bin/src/run/batchWarnings.ts
+++ b/bin/src/run/batchWarnings.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import { RollupWarning } from '../../../src/rollup/types';
 import relativeId from '../../../src/utils/relativeId';
 import { stderr } from '../logging';
@@ -55,7 +55,7 @@ export default function batchWarnings() {
 					handler.fn(warnings);
 				} else {
 					warnings.forEach(warning => {
-						stderr(`${chalk.bold.yellow('(!)')} ${chalk.bold.yellow(warning.message)}`);
+						stderr(`${tc.bold.yellow('(!)')} ${tc.bold.yellow(warning.message)}`);
 
 						if (warning.url) info(warning.url);
 
@@ -65,7 +65,7 @@ export default function batchWarnings() {
 								? `${relativeId(id)}: (${warning.loc.line}:${warning.loc.column})`
 								: relativeId(id);
 
-							stderr(chalk.bold(relativeId(loc)));
+							stderr(tc.bold(relativeId(loc)));
 						}
 
 						if (warning.frame) info(warning.frame);
@@ -91,7 +91,7 @@ const immediateHandlers: {
 		title(`Some options have been renamed`);
 		info(`https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32`);
 		warning.deprecations.forEach(option => {
-			stderr(`${chalk.bold(option.old)} is now ${option.new}`);
+			stderr(`${tc.bold(option.old)} is now ${option.new}`);
 		});
 	},
 
@@ -155,7 +155,7 @@ const deferredHandlers: {
 
 			Array.from(dependencies.keys()).forEach(dependency => {
 				const importers = dependencies.get(dependency);
-				stderr(`${chalk.bold(dependency)} (imported by ${importers.join(', ')})`);
+				stderr(`${tc.bold(dependency)} (imported by ${importers.join(', ')})`);
 			});
 		}
 	},
@@ -167,9 +167,9 @@ const deferredHandlers: {
 			info('https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module');
 
 			warnings.forEach(warning => {
-				stderr(chalk.bold(warning.importer));
+				stderr(tc.bold(warning.importer));
 				stderr(`${warning.missing} is not exported by ${warning.exporter}`);
-				stderr(chalk.grey(warning.frame));
+				stderr(tc.gray(warning.frame));
 			});
 		}
 	},
@@ -206,7 +206,7 @@ const deferredHandlers: {
 			title(`Conflicting re-exports`);
 			warnings.forEach(warning => {
 				stderr(
-					`${chalk.bold(relativeId(warning.reexporter))} re-exports '${
+					`${tc.bold(relativeId(warning.reexporter))} re-exports '${
 						warning.name
 					}' from both ${relativeId(warning.sources[0])} and ${relativeId(
 						warning.sources[1]
@@ -224,7 +224,7 @@ const deferredHandlers: {
 				`Use output.globals to specify browser global variable names corresponding to external modules`
 			);
 			warnings.forEach(warning => {
-				stderr(`${chalk.bold(warning.source)} (guessing '${warning.guess}')`);
+				stderr(`${tc.bold(warning.source)} (guessing '${warning.guess}')`);
 			});
 		}
 	},
@@ -271,7 +271,7 @@ const deferredHandlers: {
 							? `${relativeId(warning.id)}: (${warning.loc.line}:${warning.loc.column})`
 							: relativeId(warning.id);
 
-						stderr(chalk.bold(relativeId(loc)));
+						stderr(tc.bold(relativeId(loc)));
 						if (warning.frame) info(warning.frame);
 					});
 				});
@@ -281,11 +281,11 @@ const deferredHandlers: {
 };
 
 function title(str: string) {
-	stderr(`${chalk.bold.yellow('(!)')} ${chalk.bold.yellow(str)}`);
+	stderr(`${tc.bold.yellow('(!)')} ${tc.bold.yellow(str)}`);
 }
 
 function info(url: string) {
-	stderr(chalk.grey(url));
+	stderr(tc.gray(url));
 }
 
 function nest<T>(array: T[], prop: string) {
@@ -314,8 +314,8 @@ function showTruncatedWarnings(warnings: RollupWarning[]) {
 
 	const sliced = nestedByModule.length > 5 ? nestedByModule.slice(0, 3) : nestedByModule;
 	sliced.forEach(({ key: id, items }) => {
-		stderr(chalk.bold(relativeId(id)));
-		stderr(chalk.grey(items[0].frame));
+		stderr(tc.bold(relativeId(id)));
+		stderr(tc.gray(items[0].frame));
 
 		if (items.length > 1) {
 			stderr(`...and ${items.length - 1} other ${items.length > 2 ? 'occurrences' : 'occurrence'}`);

--- a/bin/src/run/build.ts
+++ b/bin/src/run/build.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import ms from 'pretty-ms';
 import * as rollup from 'rollup';
+import tc from 'turbocolor';
 import {
 	InputOptions,
 	OutputBundle,
@@ -42,7 +42,7 @@ export default function build(
 				.map(name => (<Record<string, string>>inputOptions.input)[name])
 				.join(', ');
 		}
-		stderr(chalk.cyan(`\n${chalk.bold(inputFiles)} → ${chalk.bold(files.join(', '))}...`));
+		stderr(tc.cyan(`\n${tc.bold(inputFiles)} → ${tc.bold(files.join(', '))}...`));
 	}
 
 	return rollup
@@ -76,9 +76,7 @@ export default function build(
 			warnings.flush();
 			if (!silent)
 				stderr(
-					chalk.green(
-						`created ${chalk.bold(files.join(', '))} in ${chalk.bold(ms(Date.now() - start))}`
-					)
+					tc.green(`created ${tc.bold(files.join(', '))} in ${tc.bold(ms(Date.now() - start))}`)
 				);
 			if (bundle && bundle.getTimings) {
 				printTimings(bundle.getTimings());

--- a/bin/src/run/loadConfigFile.ts
+++ b/bin/src/run/loadConfigFile.ts
@@ -1,6 +1,6 @@
-import chalk from 'chalk';
 import path from 'path';
 import rollup from 'rollup';
+import tc from 'turbocolor';
 import { InputOptions, RollupSingleFileBuild } from '../../../src/rollup/types';
 import relativeId from '../../../src/utils/relativeId';
 import { handleError, stderr } from '../logging';
@@ -27,7 +27,7 @@ export default function loadConfigFile(
 		})
 		.then((bundle: RollupSingleFileBuild) => {
 			if (!silent && warnings.count > 0) {
-				stderr(chalk.bold(`loaded ${relativeId(configFile)} with warnings`));
+				stderr(tc.bold(`loaded ${relativeId(configFile)} with warnings`));
 				warnings.flush();
 			}
 

--- a/bin/src/run/timings.ts
+++ b/bin/src/run/timings.ts
@@ -1,9 +1,9 @@
-import chalk from 'chalk';
+import tc from 'turbocolor';
 import { SerializedTimings } from '../../../src/rollup/types';
 
 export function printTimings(timings: SerializedTimings) {
 	Object.keys(timings).forEach(label => {
-		let color = chalk;
+		let color = tc;
 		if (label[0] === '#') {
 			color = color.bold;
 			if (label[1] !== '#') {

--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -1,9 +1,9 @@
-import chalk from 'chalk';
 import dateTime from 'date-time';
 import fs from 'fs';
 import ms from 'pretty-ms';
 import * as rollup from 'rollup';
 import onExit from 'signal-exit';
+import tc from 'turbocolor';
 import {
 	InputOption,
 	RollupBuild,
@@ -109,7 +109,7 @@ export default function watch(
 					break;
 
 				case 'START':
-					screenWriter(chalk.underline(`rollup v${rollup.VERSION}`));
+					screenWriter(tc.underline(`rollup v${rollup.VERSION}`));
 					break;
 
 				case 'BUNDLE_START':
@@ -123,10 +123,8 @@ export default function watch(
 										.join(', ');
 						}
 						stderr(
-							chalk.cyan(
-								`bundles ${chalk.bold(input)} → ${chalk.bold(
-									event.output.map(relativeId).join(', ')
-								)}...`
+							tc.cyan(
+								`bundles ${tc.bold(input)} → ${tc.bold(event.output.map(relativeId).join(', '))}...`
 							)
 						);
 					}
@@ -136,8 +134,8 @@ export default function watch(
 					warnings.flush();
 					if (!silent)
 						stderr(
-							chalk.green(
-								`created ${chalk.bold(event.output.map(relativeId).join(', '))} in ${chalk.bold(
+							tc.green(
+								`created ${tc.bold(event.output.map(relativeId).join(', '))} in ${tc.bold(
 									ms(event.duration)
 								)}`
 							)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5311,6 +5311,12 @@
         "tslib": "^1.8.1"
       }
     },
+    "turbocolor": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbocolor/-/turbocolor-2.4.0.tgz",
+      "integrity": "sha512-UlKGTmEVikCp+KON+99morx536pGjc7pqYZsekqUzU47HXZ17msaSu3R3sMbqBaYOZ9CAehdUyCTb27GBLOMiQ==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "acorn-import-meta": "^0.2.1",
     "ansi-escapes": "^3.1.0",
     "buble": "^0.19.3",
-    "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
     "console-group": "^0.3.1",
     "date-time": "^2.1.0",
@@ -104,6 +103,7 @@
     "source-map-support": "^0.5.6",
     "sourcemap-codec": "^1.4.1",
     "tslint": "^5.10.0",
+    "turbocolor": "2.4.0",
     "typescript": "^2.9.2",
     "uglify-js": "^3.4.1",
     "url-parse": "^1.4.0"

--- a/scripts/perf.js
+++ b/scripts/perf.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const rollup = require('../dist/rollup.js');
-const chalk = require('chalk');
+const tc = require('turbocolor');
 const { loadPerfConfig, targetDir } = require('./load-perf-config');
 
 const perfFile = path.resolve(targetDir, 'rollup.perf.json');
@@ -23,10 +23,10 @@ if (!(numberOfDiscardedResults >= 0) || !(numberOfDiscardedResults < numberOfRun
 	process.exit(1);
 }
 console.info(
-	chalk.bold(
-		`Calculating the average of ${chalk.cyan(
+	tc.bold(
+		`Calculating the average of ${tc.cyan(
 			numberOfRunsToAverage
-		)} runs discarding the ${chalk.cyan(numberOfDiscardedResults)} largest results.\n`
+		)} runs discarding the ${tc.cyan(numberOfDiscardedResults)} largest results.\n`
 	) + 'Run "npm run perf <number of runs> <number of discarded results>" to change that.'
 );
 
@@ -92,7 +92,7 @@ function printTimings(timings, existingTimings, filter = /.*/) {
 	const printedLabels = Object.keys(timings).filter(label => filter.test(label));
 	console.info('');
 	printedLabels.forEach(label => {
-		let color = chalk;
+		let color = tc;
 		if (label[0] === '#') {
 			color = color.bold;
 			if (label[1] !== '#') {
@@ -112,8 +112,8 @@ function getExistingTimings() {
 	try {
 		const timings = JSON.parse(fs.readFileSync(perfFile, 'utf8'));
 		console.info(
-			chalk.bold(
-				`Comparing with ${chalk.cyan(perfFile)}. Delete this file to create a new base line.`
+			tc.bold(
+				`Comparing with ${tc.cyan(perfFile)}. Delete this file to create a new base line.`
 			)
 		);
 		return timings;
@@ -126,11 +126,11 @@ function persistTimings(timings) {
 	try {
 		fs.writeFileSync(perfFile, JSON.stringify(timings, null, 2), 'utf8');
 		console.info(
-			chalk.bold(`Saving performance information to new reference file ${chalk.cyan(perfFile)}.`)
+			tc.bold(`Saving performance information to new reference file ${tc.cyan(perfFile)}.`)
 		);
 	} catch (e) {
 		console.error(
-			chalk.bold(`Could not persist performance information in ${chalk.cyan(perfFile)}.`)
+			tc.bold(`Could not persist performance information in ${tc.cyan(perfFile)}.`)
 		);
 		system.exit(1);
 	}
@@ -140,7 +140,7 @@ const MIN_ABSOLUTE_DEVIATION = 10;
 const RELATIVE_DEVIATION_FOR_COLORING = 5;
 
 function getFormattedTime(currentTime, persistedTime = currentTime) {
-	let color = chalk,
+	let color = tc,
 		formattedTime = `${currentTime.toFixed(0)}ms`;
 	const absoluteDeviation = Math.abs(currentTime - persistedTime);
 	if (absoluteDeviation > MIN_ABSOLUTE_DEVIATION) {

--- a/test/cli/samples/interop/_expected.js
+++ b/test/cli/samples/interop/_expected.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var chalk = require('chalk');
+var tc = require('turbocolor');
 
-assert.ok( chalk );
+assert.ok( tc );

--- a/test/cli/samples/interop/main.js
+++ b/test/cli/samples/interop/main.js
@@ -1,3 +1,3 @@
-import chalk from 'chalk';
+import tc from 'turbocolor';
 
-assert.ok( chalk );
+assert.ok( tc );


### PR DESCRIPTION
### Summary 

This PR swaps chalk for [turbocolor](https://github.com/jorgebucaran/turbocolor). It ought to give us a humble perf boost as turbocolor loads _>20x_ faster and applies styles _>18x_ [faster](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks) than chalk. Terminal color detection is also built-in, so I was able to simplify the code in one place. 

I let some comments in the diff to explain a few other things. 

Let me know if this looks good to you and if you'd like to take my contribution.

###### turbocolor ([1.1kB](https://bundlephobia.com/result?p=turbocolor@2.3.3)) / chalk ([20.2kB](https://bundlephobia.com/result?p=chalk@2.4.1))
<pre>
# Load Time
chalk: 15.190ms
<em>turbocolor: 0.777ms</em>

# All Colors
chalk × 8,729 ops/sec
<em>turbocolor × 158,383 ops/sec</em>

# Chained Colors
chalk × 1,838 ops/sec
<em>turbocolor × 39,830 ops/sec</em>

# Nested Colors
chalk × 4,049 ops/sec
<em>turbocolor × 59,833 ops/sec</em>
</pre>

Cheers! 👋 

@Rich-Harris @lukastaegert @TrySound 