### PR TITLE
DO NOT MERGE Add unit tests to demonstrate for-in bug

### DIFF
--- a/test/function/samples/for-in-null/_config.js
+++ b/test/function/samples/for-in-null/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles using the in operator in a scope where the iterator is a known null (#2342)'
+};

--- a/test/function/samples/for-in-null/main.js
+++ b/test/function/samples/for-in-null/main.js
@@ -1,0 +1,18 @@
+function getSelection(node) {
+	if ('selectionStart' in node && ReactInputSelection.hasSelectionCapabilities(node)) {
+		return {
+			start: node.selectionStart,
+			end: node.selectionEnd
+		};
+	} else if (window.getSelection) {
+		const selection = window.getSelection();
+		return {
+			anchorNode: selection.anchorNode,
+			anchorOffset: selection.anchorOffset,
+			focusNode: selection.focusNode,
+			focusOffset: selection.focusOffset
+		};
+	}
+}
+
+getSelection(null);


### PR DESCRIPTION
... when the iterator target is a null variable

This is just to demo the issue in #2342 

This fails with
```
  1) rollup
       function
         for-in-null: handles using the in operator in a scope where the iterator is a known null (#2342):
     TypeError: Cannot use 'in' operator to search for 'selectionStart' in null
      at getSelection (eval at bundle.generate.then.catch.then (test/function/index.js:86:20), <anonymous>:6:23)
      at Object.eval (eval at bundle.generate.then.catch.then (test/function/index.js:86:20), <anonymous>:22:1)
      at bundle.generate.then.catch.then (test/function/index.js:87:12)
      at <anonymous>
```