### PR TITLE
Do not fail for binary expressions involving "in" and "instanceof"

### DIFF
--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -29,8 +29,8 @@ const binaryOperators: {
 	'^': (left: any, right: any) => left ^ right,
 	'&': (left: any, right: any) => left & right,
 	'**': (left: any, right: any) => Math.pow(left, right),
-	in: (left, right: any) => left in right,
-	instanceof: (left, right: any) => left instanceof right
+	in: () => UNKNOWN_VALUE,
+	instanceof: () => UNKNOWN_VALUE
 };
 
 export default class BinaryExpression extends NodeBase {

--- a/test/form/samples/invalid-binary-expressions/_config.js
+++ b/test/form/samples/invalid-binary-expressions/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Does not fail when bundling code where the `in`-operator is used with invalid right sides'
+};

--- a/test/form/samples/invalid-binary-expressions/_expected.js
+++ b/test/form/samples/invalid-binary-expressions/_expected.js
@@ -1,0 +1,43 @@
+if ('x' in null) {
+	console.log('retained');
+}
+
+if ('x' in undefined) {
+	console.log('retained');
+}
+
+if ('x' in 1) {
+	console.log('retained');
+}
+
+if ('x' in true) {
+	console.log('retained');
+}
+
+if ('x' in 'y') {
+	console.log('retained');
+}
+
+if (null instanceof null) {
+	console.log('retained');
+}
+
+if (null instanceof undefined) {
+	console.log('retained');
+}
+
+if (null instanceof 1) {
+	console.log('retained');
+}
+
+if (null instanceof true) {
+	console.log('retained');
+}
+
+if (null instanceof 'y') {
+	console.log('retained');
+}
+
+if (null instanceof {}) {
+	console.log('retained');
+}

--- a/test/form/samples/invalid-binary-expressions/main.js
+++ b/test/form/samples/invalid-binary-expressions/main.js
@@ -1,0 +1,43 @@
+if ('x' in null) {
+	console.log('retained');
+}
+
+if ('x' in undefined) {
+	console.log('retained');
+}
+
+if ('x' in 1) {
+	console.log('retained');
+}
+
+if ('x' in true) {
+	console.log('retained');
+}
+
+if ('x' in 'y') {
+	console.log('retained');
+}
+
+if (null instanceof null) {
+	console.log('retained');
+}
+
+if (null instanceof undefined) {
+	console.log('retained');
+}
+
+if (null instanceof 1) {
+	console.log('retained');
+}
+
+if (null instanceof true) {
+	console.log('retained');
+}
+
+if (null instanceof 'y') {
+	console.log('retained');
+}
+
+if (null instanceof {}) {
+	console.log('retained');
+}


### PR DESCRIPTION
Resolves #2342 

Both the "in" and "instanceof" operator will throw a type error if the right side is a primitive value. Thus this PR changes the handling for these two to assume they always return an unknown value. 