### PR TITLE
Fixed faulty logic related to handling externals when resolver returns false

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -801,7 +801,9 @@ Try defining "${chunkName}" first in the manualChunks definitions of the Rollup 
 						const externalId =
 							<string>resolvedId ||
 							(isRelative(source) ? resolve(module.id, '..', source) : source);
-						let isExternal = this.isExternal.call(this.pluginContext, externalId, module.id, true);
+						let isExternal =
+							resolvedId === false ||
+							this.isExternal.call(this.pluginContext, externalId, module.id, true);
 
 						if (!resolvedId && !isExternal) {
 							if (isRelative(source)) {

--- a/test/function/samples/external-resolve-false/_config.js
+++ b/test/function/samples/external-resolve-false/_config.js
@@ -1,0 +1,23 @@
+var assert = require('assert');
+var path = require('path');
+
+module.exports = {
+	description: 'includes an external module with a false resolve return',
+	options: {
+		input: 'main.js',
+		plugins: [
+			{
+				resolveId: function(id) {
+					if (id === './external')
+						return false;
+				}
+			}
+		]
+	},
+	context: {
+		require: function(required) {
+			assert.equal(required, './external');
+			return 1;
+		}
+	}
+};

--- a/test/function/samples/external-resolve-false/main.js
+++ b/test/function/samples/external-resolve-false/main.js
@@ -1,0 +1,1 @@
+import './external';


### PR DESCRIPTION
Fix for https://github.com/rollup/rollup/issues/2350 - handle `resolvedId === false` like `isExternal === true`.