### PR TITLE
feat(types): add plugin implemenation type

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,8 +117,13 @@
     "README.md"
   ],
   "lint-staged": {
-    "*.ts": [
+    "{src,bin,browser,typings}/**/*.ts": [
       "tslint --project . --fix",
+      "prettier --write",
+      "git add"
+    ],
+    "test/**/*.ts": [
+      "tslint --project test/typescript --fix",
       "prettier --write",
       "git add"
     ]

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -158,7 +158,7 @@ export type AddonHook = string | ((this: PluginContext) => string | Promise<stri
  * const myPlugin: PluginImpl<Options> = (options = {}) => { ... }
  * ```
  */
-export type PluginImpl<O extends object> = (options?: O) => Plugin;
+export type PluginImpl<O extends object = object> = (options?: O) => Plugin;
 
 export interface Plugin {
 	name: string;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -148,6 +148,18 @@ export type ResolveDynamicImportHook = (
 
 export type AddonHook = string | ((this: PluginContext) => string | Promise<string>);
 
+/**
+ * use this type for plugin annotation
+ * @example
+ * ```ts
+ * interface Options {
+ * ...
+ * }
+ * const myPlugin: PluginImpl<Options> = (options = {}) => { ... }
+ * ```
+ */
+export type PluginImpl<O extends object> = (options?: O) => Plugin;
+
 export interface Plugin {
 	name: string;
 	options?: (options: InputOptions) => InputOptions | void | null;

--- a/test/typescript/index.ts
+++ b/test/typescript/index.ts
@@ -1,11 +1,14 @@
-// Plugin API
-// interface Options {
-// 	extensions?: string | string[];
-// }
-// const plugin: rollup.PluginImpl<Options> = (options = {}) => {
-// 	const extensions = options.extensions || ['.js'];
-// 	return { name: 'my-plugin' };
-// };
+import * as rollup from './dist/rollup';
 
-// plugin();
-// plugin({ extensions: ['.js', 'json'] });
+// Plugin API
+interface Options {
+	extensions?: string | string[];
+}
+const plugin: rollup.PluginImpl<Options> = (options = {}) => {
+	// tslint:disable-next-line:no-unused-variable
+	const extensions = options.extensions || ['.js'];
+	return { name: 'my-plugin' };
+};
+
+plugin();
+plugin({ extensions: ['.js', 'json'] });

--- a/test/typescript/index.ts
+++ b/test/typescript/index.ts
@@ -1,1 +1,11 @@
-import * as rollup from './dist/rollup';
+// Plugin API
+// interface Options {
+// 	extensions?: string | string[];
+// }
+// const plugin: rollup.PluginImpl<Options> = (options = {}) => {
+// 	const extensions = options.extensions || ['.js'];
+// 	return { name: 'my-plugin' };
+// };
+
+// plugin();
+// plugin({ extensions: ['.js', 'json'] });


### PR DESCRIPTION
If plugin author want's to use TypeScript, he is missing official type for plugin implementation type. 

This PR addresses lack of proper type for implementation.
