### PR TITLE
fix: no longer warns when no name was provided for global module

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -68,8 +68,17 @@ function getGlobalName(
 	graph: Graph,
 	hasExports: boolean
 ) {
-	if (typeof globals === 'function') return globals(module.id);
-	if (globals) return globals[module.id];
+	let globalName: string | undefined;
+	if (typeof globals === 'function') {
+		globalName = globals(module.id);
+	} else if (globals) {
+		globalName = globals[module.id];
+	}
+
+	if (globalName) {
+		return globalName;
+	}
+
 	if (hasExports) {
 		graph.warn({
 			code: 'MISSING_GLOBAL_NAME',

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -543,4 +543,36 @@ describe('misc', () => {
 				);
 			});
 	});
+
+	it('warns when globals option is specified and a global module name is guessed in a UMD bundle (#2358)', () => {
+		const warnings = [];
+
+		return rollup
+			.rollup({
+				input: 'input',
+				plugins: [
+					loader({
+						input: `import * as _ from 'lodash'`
+					})
+				],
+				onwarn: warning => warnings.push(warning)
+			})
+			.then(bundle =>
+				bundle.generate({
+					format: 'umd',
+					globals: [],
+					name: 'myBundle'
+				})
+			)
+			.then(() => {
+				const relevantWarnings = warnings.filter(
+					warning => warning.code === 'MISSING_GLOBAL_NAME'
+				);
+				assert.equal(relevantWarnings.length, 1);
+				assert.equal(
+					relevantWarnings[0].message,
+					`No name was provided for external module 'lodash' in output.globals – guessing 'lodash'`
+				);
+			});
+	});
 });


### PR DESCRIPTION
When the dictionary lookup or function look up return undefined or null, a warning should be emitted and the module name should be guessed.

If the user, doesn't receive a warning that the global name was not found, they won't be able to fix a possible issue. If the global name is incorrect or later set to null.

Closes: #2358

Some more context
https://github.com/dherges/ng-packagr/pull/1026#issuecomment-408605437