### PR TITLE
missing export + preserve modules bug

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -353,7 +353,9 @@ export default class Chunk {
 		}
 
 		if (name === 'default') {
-			return;
+			// we found a missing default export, so
+			// let the module create it's own shim.
+			return { variable: module.traceExport(name), module };
 		}
 
 		// external star exports

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_config.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'missing export + preserve modules + export default specifier',
+	options: {
+		input: ['main.js'],
+		shimMissingExports: true,
+		experimentalPreserveModules: true
+	}
+};

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/amd/dep.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/amd/dep.js
@@ -1,0 +1,10 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var _missingExportShim = void 0;
+
+	sideEffect();
+
+	exports.default = _missingExportShim;
+	exports.y = _missingExportShim;
+
+});

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/amd/main.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/amd/main.js
@@ -1,0 +1,7 @@
+define(['./dep.js'], function (__chunk_2) { 'use strict';
+
+	var _missingExportShim = void 0;
+
+	return __chunk_2.default;
+
+});

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/cjs/dep.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var _missingExportShim = void 0;
+
+sideEffect();
+
+exports.default = _missingExportShim;
+exports.y = _missingExportShim;

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/cjs/main.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var __chunk_2 = require('./dep.js');
+
+var _missingExportShim = void 0;
+
+module.exports = __chunk_2.default;

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/es/dep.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/es/dep.js
@@ -1,0 +1,6 @@
+var _missingExportShim = void 0;
+
+sideEffect();
+
+export default _missingExportShim;
+export { _missingExportShim as y };

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/es/main.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/es/main.js
@@ -1,0 +1,3 @@
+export { default } from './dep.js';
+
+var _missingExportShim = void 0;

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/system/dep.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/system/dep.js
@@ -1,0 +1,17 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			exports({
+				default: _missingExportShim,
+				y: _missingExportShim
+			});
+
+			var _missingExportShim = void 0;
+
+			sideEffect();
+
+		}
+	};
+});

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/system/main.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/_expected/system/main.js
@@ -1,0 +1,13 @@
+System.register(['./dep.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('default', module.default);
+		}],
+		execute: function () {
+
+			var _missingExportShim = void 0;
+
+		}
+	};
+});

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/dep.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/dep.js
@@ -1,0 +1,3 @@
+export { default as y } from './dep2';
+
+sideEffect();

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/dep2.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/dep2.js
@@ -1,0 +1,3 @@
+export function x () {
+  sideEffect();
+}

--- a/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/main.js
+++ b/test/chunking-form/samples/missing-export-preserve-modules-export-default-specifier/main.js
@@ -1,0 +1,1 @@
+export { default } from './dep.js';


### PR DESCRIPTION
I tried to narrow it down to the minimal failure. I'm not sure why it is failing yet.

```
TypeError: Cannot read property 'variable' of undefined
      at Chunk.populateEntryExports (src/Chunk.ts:232:5)
      at /Users/kselden/code/rollup/src/Graph.ts:496:7
```