### PR TITLE
Add caching for resolve load transform hooks

### DIFF
--- a/browser/fs.ts
+++ b/browser/fs.ts
@@ -5,3 +5,4 @@ export const readdirSync = nope('readdirSync');
 export const readFileSync = nope('readFileSync');
 export const realpathSync = nope('realpathSync');
 export const writeFile = nope('writeFile');
+export const stat = nope('stat');

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -27,6 +27,7 @@ import {
 	Watcher
 } from './rollup/types';
 import { createAssetPluginHooks, EmitAsset, finaliseAsset } from './utils/assetHooks';
+import { cacheLoadHook, cacheResolveIdHook } from './utils/cache';
 import { load, makeOnwarn, resolveId } from './utils/defaults';
 import ensureArray from './utils/ensureArray';
 import {
@@ -163,7 +164,9 @@ export default class Graph {
 
 		this.pluginContext.resolveId = this.resolveId;
 
-		const loaders = this.plugins.map(plugin => plugin.load).filter(Boolean);
+		const loaders = this.plugins
+			.filter(plugin => 'load' in plugin)
+			.map(plugin => cacheLoadHook(this.cachedHooks, plugin));
 		this.hasLoaders = loaders.length !== 0;
 
 		this.load = first([...loaders, load]);

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -162,6 +162,7 @@ export type PluginImpl<O extends object = object> = (options?: O) => Plugin;
 
 export interface Plugin {
 	name: string;
+	cacheKey?: string;
 	options?: (options: InputOptions) => InputOptions | void | null;
 	load?: LoadHook;
 	resolveId?: ResolveIdHook;
@@ -205,6 +206,10 @@ export type ExternalOption = string[] | IsExternal;
 export type GlobalsOption = { [name: string]: string } | ((name: string) => string);
 export type InputOption = string | string[] | { [entryAlias: string]: string };
 
+export interface HookCache {
+	[key: string]: TransformSourceDescription | SourceDescription | string | boolean | void | null;
+}
+
 export interface InputOptions {
 	input: InputOption;
 	manualChunks?: { [chunkAlias: string]: string[] };
@@ -214,6 +219,7 @@ export interface InputOptions {
 	onwarn?: WarningHandler;
 	cache?: {
 		modules: ModuleJSON[];
+		hooks: HookCache;
 	};
 
 	acorn?: {};
@@ -358,6 +364,7 @@ export interface OutputChunk {
 export interface RollupCache {
 	modules: ModuleJSON[];
 	assetDependencies: string[];
+	hooks: HookCache;
 }
 
 export interface RollupSingleFileBuild {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,12 @@
+import { HookCache, Plugin } from './rollup/types';
+
+export function cacheResolveIdHook(cache: HookCache, plugin: Plugin) {
+	return function cachedResolveId(id: string) {
+		const key = `resolve|${plugin.name || '(anonymous plugin)'}|${plugin.cacheKey}|${id}`;
+		return key in cache
+			? Promise.resolve(cache[key])
+			: Promise.resolve()
+					.then(() => plugin.resolveId.call(this, id))
+					.then(value => (cache[key] = value));
+	};
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -32,3 +32,14 @@ export function cacheLoadHook(cache: HookCache, plugin: Plugin) {
 			});
 	};
 }
+
+export function cacheTransformHook(cache: HookCache, plugin: Plugin) {
+	return function cachedTransform(code: string, id: string) {
+		const key = `transform|${plugin.name || '(anonymous plugin)'}|${plugin.cacheKey}|${id}|${code}`;
+		return key in cache
+			? Promise.resolve(cache[key])
+			: Promise.resolve()
+					.then(() => plugin.transform.call(this, code, id))
+					.then(value => (cache[key] = value));
+	};
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -32,3 +32,12 @@ export function writeFile(dest: string, data: string | Buffer) {
 		});
 	});
 }
+
+export function stat(path: string) {
+	return new Promise((fulfil, reject) => {
+		fs.stat(path, (err, stats) => {
+			if (err) return reject(err);
+			fulfil(stats);
+		});
+	});
+}

--- a/test/cache/index.js
+++ b/test/cache/index.js
@@ -1,0 +1,69 @@
+const assert = require('assert');
+const rollup = require('../../dist/rollup');
+
+describe('cache', () => {
+	let genPlugin;
+	let resolveIdCalls;
+	const expectedCode = `(function () {
+	'use strict';
+
+	console.log( 42 );
+
+}());
+`;
+	beforeEach(() => {
+		resolveIdCalls = [];
+		genPlugin = (modules, i = 1) => ({
+			name: 'test-plugin',
+			cacheKey: `v${i}`,
+			resolveId(id) {
+				resolveIdCalls.push(id);
+				return id in modules ? id : null;
+			},
+			load(id) {
+				return modules[id];
+			}
+		});
+	});
+
+	it('caches calls to resolve on repeat loads', () => {
+		const plugins = [genPlugin({ x: `console.log( 42 );` })];
+		let cache = {};
+		return rollup
+			.rollup({ input: 'x', plugins })
+			.then(bundle => {
+				cache = bundle.cache;
+				return bundle.generate({ format: 'iife' });
+			})
+			.then(({ code }) => {
+				return rollup.rollup({ input: 'x', plugins, cache });
+			})
+			.then(bundle => {
+				return bundle.generate({ format: 'iife' });
+			})
+			.then(({ code }) => {
+				assert.deepEqual(resolveIdCalls, ['x']);
+				assert.deepEqual(code, expectedCode);
+			});
+	});
+
+	it('will not call resolve if given correctly primed cache', () => {
+		const plugins = [genPlugin({ x: `console.log( 42 );` })];
+		return rollup
+			.rollup({
+				input: 'x',
+				plugins,
+				cache: {
+					hooks: { 'resolve|test-plugin|v1|x': 'x' }
+				}
+			})
+			.then(bundle => {
+				return bundle.generate({ format: 'iife' });
+			})
+			.then(({ code }) => {
+				assert.deepEqual(resolveIdCalls, []);
+				assert.deepEqual(code, expectedCode);
+			});
+	});
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -16,5 +16,6 @@ describe('rollup', function() {
 	require('./incremental/index.js');
 	require('./hooks/index.js');
 	require('./cli/index.js');
+	require('./cache/index.js');
 	require('./watch/index.js');
 });


### PR DESCRIPTION
Refs https://github.com/rollup/rollup/issues/2301

### What?

This adds an initial implementation for caching the `resolveId`, `load`, and `transform` hooks.

### Why?

Adding caching for these hooks should greatly speed up the time it takes rollup to compute a bundle. At GitHub, we've been using Rollup in production since January - building our bundles hundreds of times a day: we've seen significant impact in CI reduction by hacking in a caching layer into Rollup. With our caching layer we see build times taking about 5% the time compared to cold cache. This PR implements most of what we do with our build - with this PR and a primed cache we should see numbers around 10% that of uncached builds.

<details><summary>Some more info about how we get those numbers</summary>

In real world numbers: GitHub's JS code (on my machine) builds in about ~80s with no caching, by caching just the transform hooks we see that number go down to ~30s. Caching transform as well as load/resolve reduces that to ~6s. We also cache the entire rollup end-to-end (not featured in this PR) which gets us down to ~3s.


Testing with the GitHub JS code, we can say `resolveId` takes about ~15% of the time that rollup does its work, `load` takes another ~15%, and `transform` (specifically for us - Babel) takes ~60% of the time (the eagle-eyed here might see this gets us to 90% - the remaining 10% is small bits here and there - e.g. initialization, Rollup's finalizers, etc).

`resolveId` (specifically `rollup-plugin-node-resolve` for us, which I imagine is what most folks are also using) is a lot of tree-traversal/stat calls. Stat calls which are pretty cheap (on an SSD maybe a few milliseconds) - but it does _a lot of them_. For our bundles we see stat calls in the multiple thousands, and readFiles (for `package.json`) in the hundreds. So mostly I/O here.

`load` pretty much does what it says on the tin - it usually just implements `readFile`. So most of the time spent here is just regular I/O.

`transform` for us (and I imagine many other Rollup users) is predominantly Babel. Babel is surprisingly slow - there is very little I/O here, but instead Babel is very specifically CPU intensive and accounts for the lions share of computation.

Luckily each of these can have a pretty similar caching mechanism and so we can implement all 3 at once and chip away the 90% figure, getting build times to about 10% of what they are without cache.
</details>

### How?

A plugin that exposes these hooks and wants them to be cached must also expose a `cacheKey` property which can be a string of their choosing. Conventionally they should roll this key for each version of the plugin or its dependencies (e.g. rollup-plugin-babel might derive its `cacheKey` from the combined versions of all plugins it is given).

Each hook has its own caching key which is derived from multiple parts: the hook name, the plugin name and version, and the arguments given to it. `load` also adds the `mtime` & `size` of the file expected to be loaded...

<details><summary>Some more details about why `load` adds those extras here</summary>

The `load` cache key is designed kind of like a really low-rent Bloom filter - As discussed in #2301, if the file changes mtime or size it's very likely the call should skip the cache and call `load`. "Very likely" is good enough! If a file changes these attributes it's probably because the file itself has changed. `stat` is a super cheap way to check if a file has _likely_ changed, without doing expensive computation of reading a file and calculating hash digests. There _is_ a possibility of the file changing without the mtime or size changing (e.g. changing one character won't change the size, and then `touch -A` can be used to fix the mtime as if the file was never modified) - this is a fringe case but one we might want to look at.
</details>

### What next?

Without any plugins opting into this mechanism, this PR is effectively a no-op. This PR requires opt-in from both plugins (by exposing a `cacheKey`) and by users (by saving the cache somewhere). As plugins start exposing a `cacheKey` (which I'll have follow-up PRs for) we may start discovering bugs, certainly edge cases.

One big outstanding issue is the issue of `PluginContext`. The discussion has started over in https://github.com/rollup/rollup/issues/2301#issuecomment-407474437. We need to solve this before we really merge, I think.