### PR TITLE
Don't test entry points for external

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -147,7 +147,7 @@ export default class Graph {
 		this.resolveId = first(
 			[
 				((id: string, parentId: string) =>
-					this.isExternal(id, parentId, false) ? false : null) as ResolveIdHook
+					parentId != null && this.isExternal(id, parentId, false) ? false : null) as ResolveIdHook
 			]
 				.concat(
 					this.plugins

--- a/test/function/samples/external-function-always-true/_config.js
+++ b/test/function/samples/external-function-always-true/_config.js
@@ -1,10 +1,12 @@
 module.exports = {
-	description: 'prints useful error if external returns true for entry (#1264)',
+	description: 'skip entry point when testing for external',
 	options: {
 		external: id => true
 	},
-	error: {
-		code: 'UNRESOLVED_ENTRY',
-		message: 'Entry module cannot be external'
+	context: {
+		require: id => {
+			if (id === 'external') return 42;
+			return require(id);
+		}
 	}
 };


### PR DESCRIPTION
Ref https://github.com/rollup/rollup/issues/1343

I just found that external is almost the same as `resolveId`. Currently
for the stuff like ignoring all `module` paths we should consider entry
point which may look similar and do not start with '.' or '/'. This is
annoying since external entry points are not allowed.

In this diff I suggest to not test entry points for external at all and
skip this check in user configs.