### PR TITLE
perf(load): memoize default load hook

### DIFF
--- a/browser/fs.ts
+++ b/browser/fs.ts
@@ -5,4 +5,5 @@ export const readdirSync = nope('readdirSync');
 export const readFileSync = nope('readFileSync');
 export const realpathSync = nope('realpathSync');
 export const writeFile = nope('writeFile');
+export const readFile = nope('writeFile');
 export const stat = nope('stat');

--- a/browser/fs.ts
+++ b/browser/fs.ts
@@ -5,3 +5,4 @@ export const readdirSync = nope('readdirSync');
 export const readFileSync = nope('readFileSync');
 export const realpathSync = nope('realpathSync');
 export const writeFile = nope('writeFile');
+export const stat = nope('stat');

--- a/src/utils/default-plugin.ts
+++ b/src/utils/default-plugin.ts
@@ -11,8 +11,9 @@ interface LoadMemoization {
 	};
 }
 
+const loadMemoization: LoadMemoization = Object.create(null);
+
 export function getRollupDefaultPlugin(options: InputOptions): Plugin {
-	const loadMemoization: LoadMemoization = Object.create(null);
 	return {
 		name: 'Rollup Core',
 		resolveId: createResolveId(options),


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [X] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [X] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR applies over the top of https://github.com/rollup/rollup/pull/2382, and memoizes the `load` call. Any time `load(id)` is called, `load` will first stat that file, and check its in-memory representation of the file. If the file has the same `mtimeMs` and `size` then the in-memory representation is returned, otherwise the file is read from disk.

This will mean any time `load(id)` is called twice (with the same `id`, in the same process) then the return result should be much faster and this should result in a nice speed bump in the build process.

This kind of follows on from https://github.com/rollup/rollup/pull/2366 but is a much smaller slice of that.