### PR TITLE
Allow [format] pattern for ID generation

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1009,6 +1009,8 @@ export default class Chunk {
 		const outName = makeUnique(
 			renderNamePattern(pattern, patternName, type => {
 				switch (type) {
+					case 'format':
+						return options.format === 'es' ? 'esm' : options.format;
 					case 'hash':
 						return this.computeFullHash(addons, options);
 					case 'name':

--- a/test/chunking-form/samples/filenames-patterns/_config.js
+++ b/test/chunking-form/samples/filenames-patterns/_config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	description: 'filenames custom pattern',
+	options: {
+		input: ['main1.js', 'main2.js'],
+		output: {
+			entryFileNames: 'entry-[name]-[hash]-[format].js',
+			chunkFileNames: 'chunk-[name]-[hash]-[format].js',
+		},
+	},
+};

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/chunk-main2-bff49b9a-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/chunk-main2-bff49b9a-amd.js
@@ -1,0 +1,14 @@
+define(['exports'], function (exports) { 'use strict';
+
+  var dep = { x: 42 };
+
+  function log (x) {
+    if (dep) {
+      console.log(x);
+    }
+  }
+
+  exports.dep = dep;
+  exports.log = log;
+
+});

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main1-bad4fd49-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main1-bad4fd49-amd.js
@@ -1,0 +1,5 @@
+define(['./chunk-main2-bff49b9a-amd.js'], function (main2) { 'use strict';
+
+	main2.log(main2.dep);
+
+});

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main2-cc8b7fec-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main2-cc8b7fec-amd.js
@@ -1,0 +1,7 @@
+define(['./chunk-main2-bff49b9a-amd.js'], function (main2) { 'use strict';
+
+
+
+	return main2.log;
+
+});

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/chunk-main2-4b102ef6-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/chunk-main2-4b102ef6-cjs.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var dep = { x: 42 };
+
+function log (x) {
+  if (dep) {
+    console.log(x);
+  }
+}
+
+exports.dep = dep;
+exports.log = log;

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main1-0af20c04-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main1-0af20c04-cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var main2 = require('./chunk-main2-4b102ef6-cjs.js');
+
+main2.log(main2.dep);

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main2-f433c6bb-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main2-f433c6bb-cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var main2 = require('./chunk-main2-4b102ef6-cjs.js');
+
+
+
+module.exports = main2.log;

--- a/test/chunking-form/samples/filenames-patterns/_expected/es/chunk-main2-e628225d-esm.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/es/chunk-main2-e628225d-esm.js
@@ -1,0 +1,9 @@
+var dep = { x: 42 };
+
+function log (x) {
+  if (dep) {
+    console.log(x);
+  }
+}
+
+export { dep as a, log as b };

--- a/test/chunking-form/samples/filenames-patterns/_expected/es/entry-main1-1a6a749d-esm.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/es/entry-main1-1a6a749d-esm.js
@@ -1,0 +1,3 @@
+import { a as dep, b as log } from './chunk-main2-e628225d-esm.js';
+
+log(dep);

--- a/test/chunking-form/samples/filenames-patterns/_expected/es/entry-main2-137367cc-esm.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/es/entry-main2-137367cc-esm.js
@@ -1,0 +1,1 @@
+export { b as default } from './chunk-main2-e628225d-esm.js';

--- a/test/chunking-form/samples/filenames-patterns/_expected/system/chunk-main2-4b538eea-system.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/system/chunk-main2-4b538eea-system.js
@@ -1,0 +1,18 @@
+System.register([], function (exports, module) {
+  'use strict';
+  return {
+    execute: function () {
+
+      exports('b', log);
+
+      var dep = exports('a', { x: 42 });
+
+      function log (x) {
+        if (dep) {
+          console.log(x);
+        }
+      }
+
+    }
+  };
+});

--- a/test/chunking-form/samples/filenames-patterns/_expected/system/entry-main1-d020ac3e-system.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/system/entry-main1-d020ac3e-system.js
@@ -1,0 +1,15 @@
+System.register(['./chunk-main2-4b538eea-system.js'], function (exports, module) {
+	'use strict';
+	var dep, log;
+	return {
+		setters: [function (module) {
+			dep = module.a;
+			log = module.b;
+		}],
+		execute: function () {
+
+			log(dep);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/filenames-patterns/_expected/system/entry-main2-e24445f6-system.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/system/entry-main2-e24445f6-system.js
@@ -1,0 +1,13 @@
+System.register(['./chunk-main2-4b538eea-system.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('default', module.b);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/filenames-patterns/dep.js
+++ b/test/chunking-form/samples/filenames-patterns/dep.js
@@ -1,0 +1,1 @@
+export default { x: 42 }

--- a/test/chunking-form/samples/filenames-patterns/main1.js
+++ b/test/chunking-form/samples/filenames-patterns/main1.js
@@ -1,0 +1,4 @@
+import dep from './dep.js';
+import log from './main2.js';
+
+log(dep);

--- a/test/chunking-form/samples/filenames-patterns/main2.js
+++ b/test/chunking-form/samples/filenames-patterns/main2.js
@@ -1,0 +1,7 @@
+import dep from './dep.js';
+
+export default function log (x) {
+  if (dep) {
+    console.log(x);
+  }
+}


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

Well, there is possible (but HIGHLY unlikely) breakage. If somebody has uses `[format]` in their filenames.

### Please Describe Your Changes

They are super simple, I've just added support for `[format]` in file names patterns.