### PR TITLE
fix: version in watch mode + silent option, should not be displayed

### DIFF
--- a/bin/src/index.ts
+++ b/bin/src/index.ts
@@ -11,7 +11,7 @@ const command = minimist(process.argv.slice(2), {
 if (command.help || (process.argv.length <= 2 && process.stdin.isTTY)) {
 	console.log(`\n${help.replace('__VERSION__', version)}\n`); // eslint-disable-line no-console
 } else if (command.version) {
-	console.log(`rollup version ${version}`); // eslint-disable-line no-console
+	console.log(`rollup v${version}`); // eslint-disable-line no-console
 } else {
 	try {
 		require('source-map-support').install();

--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -109,7 +109,9 @@ export default function watch(
 					break;
 
 				case 'START':
-					screenWriter(tc.underline(`rollup v${rollup.VERSION}`));
+					if (!silent) {
+						screenWriter(tc.underline(`rollup v${rollup.VERSION}`));
+					}
 					break;
 
 				case 'BUNDLE_START':


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

This PR fixes #2324. Note that the version output in the CLI was updated to match the output in watch. I went with the `rollup v0.0.0` notation rather than the full `rollup version 0.0.0` notation, as it's personally seen as cleaner and seems to be a standard by consensus in the biz. eg:

```console
→ node --version
v10.1.0
```
