### PR TITLE
Don't test ids started with null marker in external

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -135,7 +135,9 @@ export default class Graph {
 		this.pluginDriver = createPluginDriver(this, options, this.pluginCache, watcher);
 
 		if (typeof options.external === 'function') {
-			this.isExternal = options.external;
+			const external = options.external;
+			this.isExternal = (id, parentId, isResolved) =>
+				!id.startsWith('\0') && external(id, parentId, isResolved);
 		} else {
 			const external = options.external;
 			const ids = new Set(Array.isArray(external) ? external : external ? [external] : []);

--- a/test/function/samples/external-ignore-reserved-null-marker/_config.js
+++ b/test/function/samples/external-ignore-reserved-null-marker/_config.js
@@ -15,9 +15,13 @@ module.exports = {
 					}
 				},
 				load(id) {
+					if (id.slice(-7) === 'main.js') {
+						return 'import external from "\0external";assert.equal(external, 1);';
+					}
 					if (id === '\0external') {
 						return 'export default 1';
 					}
+					throw new Error('Unexpected id to be loaded: ' + id);
 				}
 			}
 		]

--- a/test/function/samples/external-ignore-reserved-null-marker/_config.js
+++ b/test/function/samples/external-ignore-reserved-null-marker/_config.js
@@ -1,0 +1,25 @@
+module.exports = {
+	description: 'external function ignores \\0 started ids',
+	options: {
+		external(id) {
+			if (id.startsWith('\0')) {
+				throw Error('\\0 started ids should not be tested as external');
+			}
+			return true;
+		},
+		plugins: [
+			{
+				resolveId(importee) {
+					if (importee === '\0external') {
+						return importee;
+					}
+				},
+				load(id) {
+					if (id === '\0external') {
+						return 'export default 1';
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/external-ignore-reserved-null-marker/main.js
+++ b/test/function/samples/external-ignore-reserved-null-marker/main.js
@@ -1,0 +1,3 @@
+import external from '\0external';
+
+assert.equal(external, 1);


### PR DESCRIPTION
Paths like `\0external` are reserved in rollup plugins and shouldn't be
considered as external.