### PR TITLE
Emit watch changes as a plugin hook

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -77,6 +77,9 @@ export default class Graph {
 	watchFiles: Record<string, true> = Object.create(null);
 	cacheExpiry: number;
 
+	// track graph build status as each graph instance is used only once
+	finished = false;
+
 	// deprecated
 	treeshake: boolean;
 
@@ -133,6 +136,8 @@ export default class Graph {
 		};
 
 		this.pluginDriver = createPluginDriver(this, options, this.pluginCache, watcher);
+
+		if (watcher) watcher.on('change', id => this.pluginDriver.hookSeqSync('watchChange', [id]));
 
 		if (typeof options.external === 'function') {
 			this.isExternal = options.external;
@@ -480,6 +485,7 @@ export default class Graph {
 
 				timeEnd('generate chunks', 2);
 
+				this.finished = true;
 				return chunkList;
 			}
 		);

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -672,13 +672,8 @@ Try defining "${chunkName}" first in the manualChunks definitions of the Rollup 
 				) {
 					// re-emit transform assets
 					if (cachedModule.transformAssets) {
-						for (const asset of cachedModule.transformAssets) {
-							this.pluginDriver.emitAsset(
-								asset.name,
-								<string[]>(asset.dependencies ? asset.dependencies : asset.source),
-								asset.dependencies && asset.source
-							);
-						}
+						for (const asset of cachedModule.transformAssets)
+							this.pluginDriver.emitAsset(asset.name, asset.source);
 					}
 					return cachedModule;
 				}

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -342,7 +342,6 @@ export default function rollup(
 							const assets = new Map(graph.assetsById);
 							const generateAssetPluginHooks = createAssetPluginHooks(
 								assets,
-								graph.watchFiles,
 								outputBundle,
 								assetFileNames
 							);

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -79,8 +79,6 @@ export interface Asset {
 	name: string;
 	source: string | Buffer;
 	fileName: string;
-	transform: boolean;
-	dependencies: string[];
 }
 
 export interface PluginCache {
@@ -91,16 +89,14 @@ export interface PluginCache {
 }
 
 export interface PluginContext {
-	// deprecate:
+	// TODO deprecate:
 	watcher: Watcher;
 	addWatchFile: (id: string) => void;
 	cache: PluginCache;
 	resolveId: ResolveIdHook;
 	isExternal: IsExternal;
 	parse: (input: string, options: any) => ESTree.Program;
-	// deprecate asset dependencies
 	emitAsset(name: string, source?: string | Buffer): string;
-	emitAsset(name: string, dependencies: string[], source?: string | Buffer): string;
 	setAssetSource: (assetId: string, source: string | Buffer) => void;
 	getAssetFileName: (assetId: string) => string;
 	warn(warning: RollupWarning | string, pos?: { line: number; column: number }): void;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -91,12 +91,14 @@ export interface PluginCache {
 }
 
 export interface PluginContext {
+	// deprecate:
 	watcher: Watcher;
 	addWatchFile: (id: string) => void;
 	cache: PluginCache;
 	resolveId: ResolveIdHook;
 	isExternal: IsExternal;
 	parse: (input: string, options: any) => ESTree.Program;
+	// deprecate asset dependencies
 	emitAsset(name: string, source?: string | Buffer): string;
 	emitAsset(name: string, dependencies: string[], source?: string | Buffer): string;
 	setAssetSource: (assetId: string, source: string | Buffer) => void;
@@ -203,6 +205,7 @@ export interface Plugin {
 	footer?: AddonHook;
 	intro?: AddonHook;
 	outro?: AddonHook;
+	watchChange?: (id: string) => void;
 }
 
 export interface TreeshakingOptions {

--- a/src/utils/pluginDriver.ts
+++ b/src/utils/pluginDriver.ts
@@ -17,6 +17,7 @@ export interface PluginDriver {
 	emitAsset: EmitAsset;
 	getAssetFileName(assetId: string): string;
 	hookSeq(hook: string, args?: any[], context?: HookContext): Promise<void>;
+	hookSeqSync(hook: string, args?: any[], context?: HookContext): void;
 	hookFirst<T = any>(hook: string, args?: any[], hookContext?: HookContext): Promise<T>;
 	hookParallel(hook: string, args?: any[], hookContext?: HookContext): Promise<void>;
 	hookReduceArg0<R = any, T = any>(
@@ -85,6 +86,7 @@ export function createPluginDriver(
 		const context: PluginContext = {
 			watcher,
 			addWatchFile(id: string) {
+				if (graph.finished) this.error('addWatchFile can only be called during the build.');
 				graph.watchFiles[id] = true;
 			},
 			cache: cacheInstance,
@@ -116,6 +118,45 @@ export function createPluginDriver(
 		};
 		return context;
 	});
+
+	function runHookSync<T>(
+		hookName: string,
+		args: any[],
+		pidx: number,
+		permitValues = false,
+		hookContext?: HookContext
+	): Promise<T> {
+		const plugin = plugins[pidx];
+		let context = pluginContexts[pidx];
+		const hook = (<any>plugin)[hookName];
+		if (!hook) return;
+		if (hookContext) {
+			context = hookContext(context, plugin);
+			if (!context || context === pluginContexts[pidx])
+				throw new Error('Internal Rollup error: hookContext must return a new context object.');
+		}
+		try {
+			// permit values allows values to be returned instead of a functional hook
+			if (typeof hook !== 'function') {
+				if (permitValues) return hook;
+				error({
+					code: 'INVALID_PLUGIN_HOOK',
+					message: `Error running plugin hook ${hookName} for ${plugin.name ||
+						`Plugin at pos ${pidx + 1}`}, expected a function hook.`
+				});
+			}
+			return hook.apply(context, args);
+		} catch (err) {
+			if (typeof err === 'string') err = { message: err };
+			if (err.code !== 'PLUGIN_ERROR') {
+				if (err.code) err.pluginCode = err.code;
+				err.code = 'PLUGIN_ERROR';
+			}
+			err.plugin = plugin.name || `Plugin at pos ${pidx}`;
+			err.hook = hookName;
+			error(err);
+		}
+	}
 
 	function runHook<T>(
 		hookName: string,
@@ -172,6 +213,12 @@ export function createPluginDriver(
 				});
 			return promise;
 		},
+
+		// chains, ignores returns
+		hookSeqSync(name, args, hookContext) {
+			for (let i = 0; i < plugins.length; i++) runHookSync<void>(name, args, i, false, hookContext);
+		},
+
 		// chains, first non-null result stops and returns
 		hookFirst(name, args, hookContext) {
 			let promise: Promise<any> = Promise.resolve();

--- a/src/utils/pluginDriver.ts
+++ b/src/utils/pluginDriver.ts
@@ -46,10 +46,7 @@ export function createPluginDriver(
 	watcher?: Watcher
 ): PluginDriver {
 	const plugins = [...(options.plugins || []), getRollupDefaultPlugin(options)];
-	const { emitAsset, getAssetFileName, setAssetSource } = createAssetPluginHooks(
-		graph.assetsById,
-		graph.watchFiles
-	);
+	const { emitAsset, getAssetFileName, setAssetSource } = createAssetPluginHooks(graph.assetsById);
 	const existingPluginKeys: string[] = [];
 
 	let hasLoadersOrTransforms = false;

--- a/src/utils/transformChunk.ts
+++ b/src/utils/transformChunk.ts
@@ -12,7 +12,7 @@ export default function transformChunk(
 	sourcemapChain: RawSourceMap[],
 	options: OutputOptions
 ) {
-	const transformChunkAssetPluginHooks = createAssetPluginHooks(graph.assetsById, graph.watchFiles);
+	const transformChunkAssetPluginHooks = createAssetPluginHooks(graph.assetsById);
 
 	const transformChunkReducer = (code: string, result: any, plugin: Plugin): string => {
 		if (result == null) return code;

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -155,6 +155,7 @@ export class Task {
 	}
 
 	invalidate(id: string, isTransformDependency: boolean) {
+		this.watcher.emit('change', id);
 		this.invalidated = true;
 		if (isTransformDependency) {
 			this.cache.modules.forEach(module => {

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -528,68 +528,6 @@ module.exports = input;
 			});
 	});
 
-	it('throws when emitting assets too late', () => {
-		let calledHook = false;
-		return rollup
-			.rollup({
-				input: 'input',
-				experimentalCodeSplitting: true,
-				plugins: [
-					loader({ input: `alert('hello')` }),
-					{
-						generateBundle(code, id) {
-							try {
-								this.emitAsset('test.ext', [], 'hello world');
-							} catch (e) {
-								assert.equal(e.code, 'ASSETS_FINALISED');
-								calledHook = true;
-							}
-						}
-					}
-				]
-			})
-			.then(bundle => {
-				return bundle.generate({
-					format: 'es',
-					assetFileNames: '[name][extname]'
-				});
-			})
-			.then(() => {
-				assert.equal(calledHook, true);
-			});
-	});
-
-	it('throws when calling setAssetSource from transform', () => {
-		let calledHook = false;
-		return rollup
-			.rollup({
-				input: 'input',
-				experimentalCodeSplitting: true,
-				plugins: [
-					loader({ input: `alert('hello')` }),
-					{
-						generateBundle(code, id) {
-							try {
-								this.emitAsset('test.ext', [], 'hello world');
-							} catch (e) {
-								assert.equal(e.code, 'ASSETS_FINALISED');
-								calledHook = true;
-							}
-						}
-					}
-				]
-			})
-			.then(bundle => {
-				return bundle.generate({
-					format: 'es',
-					assetFileNames: '[name][extname]'
-				});
-			})
-			.then(() => {
-				assert.equal(calledHook, true);
-			});
-	});
-
 	it('supports transformChunk in place of transformBundle', () => {
 		let calledHook = false;
 		return rollup

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const sander = require('sander');
 const rollup = require('../../dist/rollup');
+const path = require('path');
 
 const cwd = process.cwd();
 

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -38,6 +38,8 @@ describe('rollup.watch', () => {
 								console.error(event.error);
 							}
 							watcher.close();
+							if (event.code === 'ERROR')
+								console.log(event.error);
 							reject(new Error(`Expected ${next} event, got ${event.code}`));
 						} else {
 							go(event);
@@ -572,59 +574,8 @@ describe('rollup.watch', () => {
 				});
 		});
 
-		it('watches and rebuilds asset dependencies, caching transform call correctly', () => {
-			let v = 1;
-			return sander
-				.copydir('test/watch/samples/transform-dependencies')
-				.to('test/_tmp/input')
-				.then(() => {
-					const watcher = rollup.watch({
-						input: 'test/_tmp/input/main.js',
-						output: {
-							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
-						},
-						experimentalCodeSplitting: true,
-						plugins: [
-							{
-								buildStart() {
-									try {
-										const file = 'test/_tmp/input/asdf';
-										const text = sander.readFileSync(file).toString();
-										this.emitAsset('test', [file], text);
-									} catch (err) {
-										if (err.code !== 'ENOENT') throw err;
-									}
-								},
-								transform(code) {
-									return { code: `export default "${v++}"` };
-								}
-							}
-						],
-						watch: { chokidar }
-					});
-
-					return sequence(watcher, [
-						'START',
-						'BUNDLE_START',
-						'BUNDLE_END',
-						'END',
-						() => {
-							assert.equal(run('../_tmp/output/bundle.js'), 1);
-							sander.unlinkSync('test/_tmp/input/asdf');
-						},
-						'START',
-						'BUNDLE_START',
-						'BUNDLE_END',
-						'END',
-						() => {
-							assert.equal(run('../_tmp/output/bundle.js'), 1);
-						}
-					]);
-				});
-		});
-
-		it('watches and rebuilds asset dependencies, with transform cache opt-out for custom cache', () => {
+		it('watches and rebuilds transform dependencies, with transform cache opt-out for custom cache', () => {
+			const file = 'test/_tmp/input/asdf';
 			let v = 1;
 			return sander
 				.copydir('test/watch/samples/transform-dependencies')
@@ -641,16 +592,15 @@ describe('rollup.watch', () => {
 								name: 'x',
 								buildStart() {
 									try {
-										const file = 'test/_tmp/input/asdf';
 										const text = sander.readFileSync(file).toString();
-										this.emitAsset('test', [file], text);
+										this.emitAsset('test', text);
 									} catch (err) {
 										if (err.code !== 'ENOENT') throw err;
 									}
 								},
 								transform(code) {
 									this.cache.set('asdf', 'asdf');
-									return { code: `export default "${v++}"` };
+									return { code: `export default "${v++}"`, dependencies: [path.resolve(file)] };
 								}
 							}
 						],
@@ -695,12 +645,12 @@ describe('rollup.watch', () => {
 									const file = 'test/_tmp/input/asdf';
 									try {
 										const text = sander.readFileSync(file).toString();
-										this.emitAsset('test', [file], text);
+										this.emitAsset('test', text);
 									} catch (err) {
 										if (err.code !== 'ENOENT') throw err;
 										this.emitAsset('test', 'test');
 									}
-									return { code: `export default ${v++}` };
+									return { code: `export default ${v++}`, dependencies: v === 2 ? [path.resolve(file)] : [] };
 								}
 							}
 						],


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

### Please Describe Your Changes

Fixes https://github.com/rollup/rollup/issues/2383 adding a watch hook for change events.

The idea here as well is to then deprecate the `this.watcher` as we should now have all the info we need here.