### PR TITLE
replace turbocolor with ansi-colors

### DIFF
--- a/bin/src/logging.ts
+++ b/bin/src/logging.ts
@@ -1,4 +1,4 @@
-import tc from 'turbocolor';
+import c from 'ansi-colors';
 import { RollupError } from '../../src/rollup/types';
 import relativeId from '../../src/utils/relativeId';
 
@@ -13,11 +13,11 @@ export function handleError(err: RollupError, recover = false) {
 			? `(${(<{ plugin?: string }>err).plugin} plugin) ${description}`
 			: description) || err;
 
-	stderr(tc.bold.red(`[!] ${tc.bold(message.toString())}`));
+	stderr(c.bold.red(`[!] ${c.bold(message.toString())}`));
 
 	// TODO should this be "err.url || (err.file && err.loc.file) || err.id"?
 	if (err.url) {
-		stderr(tc.cyan(err.url));
+		stderr(c.cyan(err.url));
 	}
 
 	if (err.loc) {
@@ -27,9 +27,9 @@ export function handleError(err: RollupError, recover = false) {
 	}
 
 	if (err.frame) {
-		stderr(tc.dim(err.frame));
+		stderr(c.dim(err.frame));
 	} else if (err.stack) {
-		stderr(tc.dim(err.stack));
+		stderr(c.dim(err.stack));
 	}
 
 	stderr('');

--- a/bin/src/run/batchWarnings.ts
+++ b/bin/src/run/batchWarnings.ts
@@ -1,4 +1,4 @@
-import tc from 'turbocolor';
+import c from 'ansi-colors';
 import { RollupWarning } from '../../../src/rollup/types';
 import relativeId from '../../../src/utils/relativeId';
 import { stderr } from '../logging';
@@ -55,7 +55,7 @@ export default function batchWarnings() {
 					handler.fn(warnings);
 				} else {
 					warnings.forEach(warning => {
-						stderr(`${tc.bold.yellow('(!)')} ${tc.bold.yellow(warning.message)}`);
+						stderr(`${c.bold.yellow('(!)')} ${c.bold.yellow(warning.message)}`);
 
 						if (warning.url) info(warning.url);
 
@@ -65,7 +65,7 @@ export default function batchWarnings() {
 								? `${relativeId(id)}: (${warning.loc.line}:${warning.loc.column})`
 								: relativeId(id);
 
-							stderr(tc.bold(relativeId(loc)));
+							stderr(c.bold(relativeId(loc)));
 						}
 
 						if (warning.frame) info(warning.frame);
@@ -91,7 +91,7 @@ const immediateHandlers: {
 		title(`Some options have been renamed`);
 		info(`https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32`);
 		warning.deprecations.forEach(option => {
-			stderr(`${tc.bold(option.old)} is now ${option.new}`);
+			stderr(`${c.bold(option.old)} is now ${option.new}`);
 		});
 	},
 
@@ -155,7 +155,7 @@ const deferredHandlers: {
 
 			Array.from(dependencies.keys()).forEach(dependency => {
 				const importers = dependencies.get(dependency);
-				stderr(`${tc.bold(dependency)} (imported by ${importers.join(', ')})`);
+				stderr(`${c.bold(dependency)} (imported by ${importers.join(', ')})`);
 			});
 		}
 	},
@@ -167,9 +167,9 @@ const deferredHandlers: {
 			info('https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module');
 
 			warnings.forEach(warning => {
-				stderr(tc.bold(warning.importer));
+				stderr(c.bold(warning.importer));
 				stderr(`${warning.missing} is not exported by ${warning.exporter}`);
-				stderr(tc.gray(warning.frame));
+				stderr(c.gray(warning.frame));
 			});
 		}
 	},
@@ -206,7 +206,7 @@ const deferredHandlers: {
 			title(`Conflicting re-exports`);
 			warnings.forEach(warning => {
 				stderr(
-					`${tc.bold(relativeId(warning.reexporter))} re-exports '${
+					`${c.bold(relativeId(warning.reexporter))} re-exports '${
 						warning.name
 					}' from both ${relativeId(warning.sources[0])} and ${relativeId(
 						warning.sources[1]
@@ -224,7 +224,7 @@ const deferredHandlers: {
 				`Use output.globals to specify browser global variable names corresponding to external modules`
 			);
 			warnings.forEach(warning => {
-				stderr(`${tc.bold(warning.source)} (guessing '${warning.guess}')`);
+				stderr(`${c.bold(warning.source)} (guessing '${warning.guess}')`);
 			});
 		}
 	},
@@ -271,7 +271,7 @@ const deferredHandlers: {
 							? `${relativeId(warning.id)}: (${warning.loc.line}:${warning.loc.column})`
 							: relativeId(warning.id);
 
-						stderr(tc.bold(relativeId(loc)));
+						stderr(c.bold(relativeId(loc)));
 						if (warning.frame) info(warning.frame);
 					});
 				});
@@ -281,11 +281,11 @@ const deferredHandlers: {
 };
 
 function title(str: string) {
-	stderr(`${tc.bold.yellow('(!)')} ${tc.bold.yellow(str)}`);
+	stderr(`${c.bold.yellow('(!)')} ${c.bold.yellow(str)}`);
 }
 
 function info(url: string) {
-	stderr(tc.gray(url));
+	stderr(c.gray(url));
 }
 
 function nest<T>(array: T[], prop: string) {
@@ -314,8 +314,8 @@ function showTruncatedWarnings(warnings: RollupWarning[]) {
 
 	const sliced = nestedByModule.length > 5 ? nestedByModule.slice(0, 3) : nestedByModule;
 	sliced.forEach(({ key: id, items }) => {
-		stderr(tc.bold(relativeId(id)));
-		stderr(tc.gray(items[0].frame));
+		stderr(c.bold(relativeId(id)));
+		stderr(c.gray(items[0].frame));
 
 		if (items.length > 1) {
 			stderr(`...and ${items.length - 1} other ${items.length > 2 ? 'occurrences' : 'occurrence'}`);

--- a/bin/src/run/build.ts
+++ b/bin/src/run/build.ts
@@ -1,6 +1,6 @@
+import c from 'ansi-colors';
 import ms from 'pretty-ms';
 import * as rollup from 'rollup';
-import tc from 'turbocolor';
 import {
 	InputOptions,
 	OutputOptions,
@@ -39,7 +39,7 @@ export default function build(
 				.map(name => (<Record<string, string>>inputOptions.input)[name])
 				.join(', ');
 		}
-		stderr(tc.cyan(`\n${tc.bold(inputFiles)} → ${tc.bold(files.join(', '))}...`));
+		stderr(c.cyan(`\n${c.bold(inputFiles)} → ${c.bold(files.join(', '))}...`));
 	}
 
 	return rollup
@@ -71,9 +71,7 @@ export default function build(
 		.then((bundle?: RollupSingleFileBuild | RollupBuild) => {
 			warnings.flush();
 			if (!silent)
-				stderr(
-					tc.green(`created ${tc.bold(files.join(', '))} in ${tc.bold(ms(Date.now() - start))}`)
-				);
+				stderr(c.green(`created ${c.bold(files.join(', '))} in ${c.bold(ms(Date.now() - start))}`));
 			if (bundle && bundle.getTimings) {
 				printTimings(bundle.getTimings());
 			}

--- a/bin/src/run/loadConfigFile.ts
+++ b/bin/src/run/loadConfigFile.ts
@@ -1,6 +1,6 @@
+import c from 'ansi-colors';
 import path from 'path';
 import rollup from 'rollup';
-import tc from 'turbocolor';
 import { InputOptions, RollupSingleFileBuild } from '../../../src/rollup/types';
 import relativeId from '../../../src/utils/relativeId';
 import { handleError, stderr } from '../logging';
@@ -27,7 +27,7 @@ export default function loadConfigFile(
 		})
 		.then((bundle: RollupSingleFileBuild) => {
 			if (!silent && warnings.count > 0) {
-				stderr(tc.bold(`loaded ${relativeId(configFile)} with warnings`));
+				stderr(c.bold(`loaded ${relativeId(configFile)} with warnings`));
 				warnings.flush();
 			}
 

--- a/bin/src/run/timings.ts
+++ b/bin/src/run/timings.ts
@@ -1,11 +1,11 @@
+import c from 'ansi-colors';
 import prettyBytes from 'pretty-bytes';
-import tc from 'turbocolor';
 import { SerializedTimings } from '../../../src/rollup/types';
 
 export function printTimings(timings: SerializedTimings) {
 	Object.keys(timings).forEach(label => {
 		const color =
-			label[0] === '#' ? (label[1] !== '#' ? tc.underline : tc.bold) : (text: string) => text;
+			label[0] === '#' ? (label[1] !== '#' ? c.underline : c.bold) : (text: string) => text;
 		const [time, memory, total] = timings[label];
 		const row = `${label}: ${time.toFixed(0)}ms, ${prettyBytes(memory)} / ${prettyBytes(total)}`;
 		console.info(color(row));

--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -1,9 +1,9 @@
+import c from 'ansi-colors';
 import dateTime from 'date-time';
 import fs from 'fs';
 import ms from 'pretty-ms';
 import * as rollup from 'rollup';
 import onExit from 'signal-exit';
-import tc from 'turbocolor';
 import {
 	InputOption,
 	RollupBuild,
@@ -110,7 +110,7 @@ export default function watch(
 
 				case 'START':
 					if (!silent) {
-						screenWriter(tc.underline(`rollup v${rollup.VERSION}`));
+						screenWriter(c.underline(`rollup v${rollup.VERSION}`));
 					}
 					break;
 
@@ -125,8 +125,8 @@ export default function watch(
 										.join(', ');
 						}
 						stderr(
-							tc.cyan(
-								`bundles ${tc.bold(input)} → ${tc.bold(event.output.map(relativeId).join(', '))}...`
+							c.cyan(
+								`bundles ${c.bold(input)} → ${c.bold(event.output.map(relativeId).join(', '))}...`
 							)
 						);
 					}
@@ -136,8 +136,8 @@ export default function watch(
 					warnings.flush();
 					if (!silent)
 						stderr(
-							tc.green(
-								`created ${tc.bold(event.output.map(relativeId).join(', '))} in ${tc.bold(
+							c.green(
+								`created ${c.bold(event.output.map(relativeId).join(', '))} in ${c.bold(
 									ms(event.duration)
 								)}`
 							)

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   "homepage": "https://github.com/rollup/rollup",
   "dependencies": {
     "@types/estree": "0.0.39",
-    "@types/node": "*"
+    "@types/node": "*",
+    "ansi-colors": "^3.0.0"
   },
   "devDependencies": {
     "@types/acorn": "^4.0.3",
@@ -109,7 +110,6 @@
     "source-map-support": "^0.5.6",
     "sourcemap-codec": "^1.4.1",
     "tslint": "^5.11.0",
-    "turbocolor": "^2.4.1",
     "typescript": "^3.0.1",
     "uglify-js": "^3.4.6",
     "url-parse": "^1.4.3"

--- a/scripts/perf.js
+++ b/scripts/perf.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const rollup = require('../dist/rollup.js');
-const tc = require('turbocolor');
+const c = require('ansi-colors');
 const { loadPerfConfig, targetDir } = require('./load-perf-config');
 
 const perfFile = path.resolve(targetDir, 'rollup.perf.json');
@@ -23,10 +23,10 @@ if (!(numberOfDiscardedResults >= 0) || !(numberOfDiscardedResults < numberOfRun
 	process.exit(1);
 }
 console.info(
-	tc.bold(
-		`Calculating the average of ${tc.cyan(
+	c.bold(
+		`Calculating the average of ${c.cyan(
 			numberOfRunsToAverage
-		)} runs discarding the ${tc.cyan(numberOfDiscardedResults)} largest results.\n`
+		)} runs discarding the ${c.cyan(numberOfDiscardedResults)} largest results.\n`
 	) + 'Run "npm run perf <number of runs> <number of discarded results>" to change that.'
 );
 
@@ -92,7 +92,7 @@ function printTimings(timings, existingTimings, filter = /.*/) {
 	const printedLabels = Object.keys(timings).filter(label => filter.test(label));
 	console.info('');
 	printedLabels.forEach(label => {
-		let color = tc;
+		let color = c;
 		if (label[0] === '#') {
 			color = color.bold;
 			if (label[1] !== '#') {
@@ -112,8 +112,8 @@ function getExistingTimings() {
 	try {
 		const timings = JSON.parse(fs.readFileSync(perfFile, 'utf8'));
 		console.info(
-			tc.bold(
-				`Comparing with ${tc.cyan(perfFile)}. Delete this file to create a new base line.`
+			c.bold(
+				`Comparing with ${c.cyan(perfFile)}. Delete this file to create a new base line.`
 			)
 		);
 		return timings;
@@ -126,11 +126,11 @@ function persistTimings(timings) {
 	try {
 		fs.writeFileSync(perfFile, JSON.stringify(timings, null, 2), 'utf8');
 		console.info(
-			tc.bold(`Saving performance information to new reference file ${tc.cyan(perfFile)}.`)
+			c.bold(`Saving performance information to new reference file ${c.cyan(perfFile)}.`)
 		);
 	} catch (e) {
 		console.error(
-			tc.bold(`Could not persist performance information in ${tc.cyan(perfFile)}.`)
+			c.bold(`Could not persist performance information in ${c.cyan(perfFile)}.`)
 		);
 		system.exit(1);
 	}
@@ -140,7 +140,7 @@ const MIN_ABSOLUTE_DEVIATION = 10;
 const RELATIVE_DEVIATION_FOR_COLORING = 5;
 
 function getFormattedTime(currentTime, persistedTime = currentTime) {
-	let color = tc,
+	let color = c,
 		formattedTime = `${currentTime.toFixed(0)}ms`;
 	const absoluteDeviation = Math.abs(currentTime - persistedTime);
 	if (absoluteDeviation > MIN_ABSOLUTE_DEVIATION) {

--- a/test/cli/samples/interop/_expected.js
+++ b/test/cli/samples/interop/_expected.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var tc = require('turbocolor');
+var c = require('ansi-colors');
 
-assert.ok( tc );
+assert.ok( c );

--- a/test/cli/samples/interop/main.js
+++ b/test/cli/samples/interop/main.js
@@ -1,3 +1,3 @@
-import tc from 'turbocolor';
+import c from 'ansi-colors';
 
-assert.ok( tc );
+assert.ok( c );


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The pull request replaces turbocolor with ansi-colors for the following primary reasons:

edit: Aug. 20, 2018 - I thought it would be worth mentioning that over the past couple of days I've spoken at length with Jorge, creator of turbocolor, and @doowb and I offered to team with him under an org or combined repository - even under the name turbocolor, since it would be better for the ecosystem. He declined and said he prefers not to collaborate with other developers. (I also offered the same to Luke Edwards, creator of Kleur, and he also turned it down). 

_(Note that I inadvertently caused a regression with nested colors in ansi-colors yesterday or the day before, but has been fixed)_.

- ansi-colors is more performant than turbocolor
- ansi-colors correctly renders chained styles. turbocolor has a rendering bug that _causes the wrong color to be rendered_ when chained colors are assigned to a variable - the is easily reproducible and demonstrated below.
- ansi-colors correctly renders background colors. turbocolor renders "bright background" colors _as (normal) background colors_, but inconsistently, as some are bright and some are not, which is confusing, unexpected and incorrect. 

## Performance

MacBook Pro, Intel Core i7, 2.3 GHz, 16 GB.

**Libraries tested**

- ansi-colors v3.0.0
- chalk v2.4.1
- turbocolor v2.4.5

### Load time

Time it takes to load the first time `require()` is called:

- ansi-colors - `0.794ms`
- chalk - `9.023ms`
- turbocolor - `4.895ms`


### Benchmarks

Note that turbocolor's rendering bug (see below) creates the illusion of appearing faster with stacked (chained)  colors:

```
# All Colors
  ansi-colors x 370,403 ops/sec ±2.29% (88 runs sampled))
  turbocolor x 365,739 ops/sec ±1.15% (88 runs sampled)
  chalk x 9,472 ops/sec ±2.28% (81 runs sampled))

# Nested colors
  ansi-colors x 206,363 ops/sec ±2.03% (93 runs sampled)
  turbocolor x 85,856 ops/sec ±0.24% (96 runs sampled)
  chalk x 4,029 ops/sec ±1.91% (82 runs sampled)

# Chained colors
  ansi-colors x 21,671 ops/sec ±0.71% (89 runs sampled)
  turbocolor x 53,270 ops/sec ±1.45% (87 runs sampled)
  chalk x 1,906 ops/sec ±2.11% (83 runs sampled)
```

### turbocolor rendering bug

turbocolor claims to be "faster than ansi-colors", but it's an unofficial fork of ansi-colors that only appears faster because the author removed code that was necessary for resetting chained colors.

To illustrate the bug, simply do the following with  `turbocolor` (as of v2.4.5):

```js
const turbocolor = require('turbocolor');
const red = turbocolor.bold.underline.red;
console.log(turbocolor.bold('I should be bold and white'));
// renders bold + underline + red

const blue = turbocolor.underline.blue;
console.log(turbocolor.underline('I should be underlined and white'));
// renders underline + blue
```

Which renders the following:

![image](https://user-images.githubusercontent.com/383994/44202955-7ee62100-a11b-11e8-8ee6-652dbde52911.png)

It's worth mentioning that the author of turbocolor had plenty of time to find and solve the rendering bug after I mentioned it in https://github.com/rollup/rollup/pull/2339 (technically it's a memory leak, despite being unlikely to manifest in a way that would classify it as such in a profiler). Both @doowb (author of ansi-colors) and I noticed the bug in turbocolor at first glance without having to run profiling tools to understand what was happening. 

**Other pitfalls**

Beyond the aforementioned rendering bug, turbocolor cannot be used a drop-in replacement for chalk:

- turbocolor fails half of the ansi-colors unit tests (chalk passes them all)
- turbocolor does not support bright or bright-background colors (chalk, ansi-colors, and just about every other styling library published on NPM support both)
- turbocolor swaps bright-background colors for background colors. (surprise! turbocolor gives users unexpected colors in the terminal!)
- ansi-colors is a drop-in replacement for chalk, turbocolor obviously is not 

