### PR TITLE
Init Module.exportAllModules as empty array

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -232,7 +232,7 @@ export default class Module {
 		this.reexports = Object.create(null);
 
 		this.exportAllSources = [];
-		this.exportAllModules = null;
+		this.exportAllModules = [];
 	}
 
 	setSource({


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] metadata

### Breaking Changes?

- [ ] yes
- [x] no

If yes, please describe the breakage.

### Please Describe Your Changes

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The initialization for `Module.exportAllModules` (`null`) contradicts the type definition at https://github.com/rollup/rollup/blob/4d491a496d3301a143182321612711e60bacd5b6/src/Module.ts#L196

This simply initializes `Module.exportAllModules` to an empty array, to avoid potential crashes when running `.forEach` when `exportAllModules` is `null`.
