### PR TITLE
Always log err.stack, even if err.frame is present

### DIFF
--- a/bin/src/logging.ts
+++ b/bin/src/logging.ts
@@ -28,7 +28,9 @@ export function handleError(err: RollupError, recover = false) {
 
 	if (err.frame) {
 		stderr(tc.dim(err.frame));
-	} else if (err.stack) {
+	}
+
+	if (err.stack) {
 		stderr(tc.dim(err.stack));
 	}
 

--- a/test/cli/samples/custom-frame-log-stack/_config.js
+++ b/test/cli/samples/custom-frame-log-stack/_config.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'errors with code frames should also log error\'s stack',
+	command: 'rollup -c',
+	error: () => true,
+	stderr: stderr => {
+		assert.ok(/custom code frame/.test(stderr));
+		assert.ok(/ at /.test(stderr));
+		assert.ok(/\.[a-z]+:\d+:\d+\)?\n/i.test(stderr));
+	}
+};

--- a/test/cli/samples/custom-frame-log-stack/main.js
+++ b/test/cli/samples/custom-frame-log-stack/main.js
@@ -1,0 +1,1 @@
+console.log("everyday I'm throwing");

--- a/test/cli/samples/custom-frame-log-stack/rollup.config.js
+++ b/test/cli/samples/custom-frame-log-stack/rollup.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+	plugins: [
+		{
+			transform() {
+				const err = new Error('My error.');
+				err.frame = 'custom code frame';
+				this.error(err);
+			}
+		},
+	]
+};


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes
- [ ] no

Breaking Changes?
- [ ] yes 
- [x] no

List any relevent issue numbers:

### Description

Error stacks are IMHO way too important to just swallow them, if present they should always be logged.