### PR TITLE
Properly rename destructured parameters

### DIFF
--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -11,6 +11,7 @@ import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } 
 import LocalVariable from '../variables/LocalVariable';
 import Variable from '../variables/Variable';
 import AssignmentExpression from './AssignmentExpression';
+import AssignmentPattern from './AssignmentPattern';
 import * as NodeType from './NodeType';
 import Property from './Property';
 import { ExpressionEntity } from './shared/Expression';
@@ -160,7 +161,11 @@ export default class Identifier extends NodeBase {
 					storeName: true,
 					contentOnly: true
 				});
-				if (this.parent.type === NodeType.Property && (<Property>this.parent).shorthand) {
+				let relevantParent = this.parent;
+				if (relevantParent.type === NodeType.AssignmentPattern) {
+					relevantParent = (<AssignmentPattern>relevantParent).parent;
+				}
+				if (relevantParent.type === NodeType.Property && (<Property>relevantParent).shorthand) {
 					code.prependRight(this.start, `${this.name}: `);
 				}
 			}

--- a/test/function/samples/consistently-renames-destructured-parameters/_config.js
+++ b/test/function/samples/consistently-renames-destructured-parameters/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'destructured parameters are properly renamed (#2418)'
+};

--- a/test/function/samples/consistently-renames-destructured-parameters/main.js
+++ b/test/function/samples/consistently-renames-destructured-parameters/main.js
@@ -1,0 +1,27 @@
+import { name } from './module_1.js';
+
+function withoutDefault({ name: name}) {
+	return name;
+}
+
+function withDefault({ name: name = 10} = {}) {
+	return name;
+}
+
+function shorthandWithoutDefault({ name}) {
+	return name;
+}
+
+function shorthandWithDefault({ name = 10 } = {}) {
+	return name;
+}
+
+assert.equal(name(), 'important to trigger renaming');
+
+assert.equal(withoutDefault({ name: 20 }), 20);
+assert.equal(withDefault({ name: 20 }), 20);
+assert.equal(withDefault(), 10);
+
+assert.equal(shorthandWithoutDefault({ name: 20 }), 20);
+assert.equal(shorthandWithDefault({ name: 20 }), 20);
+assert.equal(shorthandWithDefault(), 10);

--- a/test/function/samples/consistently-renames-destructured-parameters/module_1.js
+++ b/test/function/samples/consistently-renames-destructured-parameters/module_1.js
@@ -1,0 +1,3 @@
+export function name() {
+	return 'important to trigger renaming';
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevent issue numbers:
Resolves #2418

### Description
The issue was that in certain situations, cf. #2418, shorthanded properties in assignment patterns (all of this was necessary to trigger the bug) were renamed without keeping the original property name.

This one was tricky as to *why* this was broken between 0.57.1 and 0.58.0. The relevant change was the new logic to no longer switch AST prototypes but copy the AST into rollup.

The actual reason was that even though the pattern `{property = defaultVale}` produces the AST nodes `ObjectPattern > Property > AssignmentPattern > Identifier`, the old logic before 0.58.0 would mark the `Property` as the parent of the `Identifier`.

The changed logic starting with 0.58.0 unknowingly corrected this mistake by marking the `AssignmentPattern` as the parent of the `Identifier` which no longer triggered a check in the `Identifier` rendering logic.

I decided to stick with the correct parent-child relationships and changed the check in question.