### PR TITLE
Ensure correct handling for retraced namespace variables

### DIFF
--- a/test/chunking-form/samples/namespace-retracing/_config.js
+++ b/test/chunking-form/samples/namespace-retracing/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'internal reexported namespaces over chunk boundaries',
+	options: {
+		input: ['main-a.js', 'main-b.js']
+	}
+};

--- a/test/chunking-form/samples/namespace-retracing/_expected/amd/chunk-74c3c360.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/amd/chunk-74c3c360.js
@@ -1,0 +1,18 @@
+define(['exports'], function (exports) { 'use strict';
+
+	class Broken {
+	}
+
+	Broken.doSomething = function() { console.log('broken'); };
+
+	Broken.doSomething();
+
+	class Other {
+	}
+
+	Other.doSomething = function() { console.log('other'); };
+
+	exports.Other = Other;
+	exports.Broken = Broken;
+
+});

--- a/test/chunking-form/samples/namespace-retracing/_expected/amd/main-a.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/amd/main-a.js
@@ -1,0 +1,6 @@
+define(['./chunk-74c3c360.js'], function (__chunk_1) { 'use strict';
+
+	__chunk_1.Other.doSomething();
+	__chunk_1.Broken.doSomething();
+
+});

--- a/test/chunking-form/samples/namespace-retracing/_expected/amd/main-b.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/amd/main-b.js
@@ -1,0 +1,5 @@
+define(['./chunk-74c3c360.js'], function (__chunk_1) { 'use strict';
+
+	__chunk_1.Other.doSomething();
+
+});

--- a/test/chunking-form/samples/namespace-retracing/_expected/cjs/chunk-3848d4bd.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/cjs/chunk-3848d4bd.js
@@ -1,0 +1,16 @@
+'use strict';
+
+class Broken {
+}
+
+Broken.doSomething = function() { console.log('broken'); };
+
+Broken.doSomething();
+
+class Other {
+}
+
+Other.doSomething = function() { console.log('other'); };
+
+exports.Other = Other;
+exports.Broken = Broken;

--- a/test/chunking-form/samples/namespace-retracing/_expected/cjs/main-a.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/cjs/main-a.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var __chunk_1 = require('./chunk-3848d4bd.js');
+
+__chunk_1.Other.doSomething();
+__chunk_1.Broken.doSomething();

--- a/test/chunking-form/samples/namespace-retracing/_expected/cjs/main-b.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/cjs/main-b.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var __chunk_1 = require('./chunk-3848d4bd.js');
+
+__chunk_1.Other.doSomething();

--- a/test/chunking-form/samples/namespace-retracing/_expected/es/chunk-8b1ab447.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/es/chunk-8b1ab447.js
@@ -1,0 +1,13 @@
+class Broken {
+}
+
+Broken.doSomething = function() { console.log('broken'); };
+
+Broken.doSomething();
+
+class Other {
+}
+
+Other.doSomething = function() { console.log('other'); };
+
+export { Other as a, Broken as b };

--- a/test/chunking-form/samples/namespace-retracing/_expected/es/main-a.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/es/main-a.js
@@ -1,0 +1,4 @@
+import { a as Other, b as Broken } from './chunk-8b1ab447.js';
+
+Other.doSomething();
+Broken.doSomething();

--- a/test/chunking-form/samples/namespace-retracing/_expected/es/main-b.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/es/main-b.js
@@ -1,0 +1,3 @@
+import { a as Other } from './chunk-8b1ab447.js';
+
+Other.doSomething();

--- a/test/chunking-form/samples/namespace-retracing/_expected/system/chunk-4c4907dd.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/system/chunk-4c4907dd.js
@@ -1,0 +1,20 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			class Broken {
+			} exports('b', Broken);
+
+			Broken.doSomething = function() { console.log('broken'); };
+
+			Broken.doSomething();
+
+			class Other {
+			} exports('a', Other);
+
+			Other.doSomething = function() { console.log('other'); };
+
+		}
+	};
+});

--- a/test/chunking-form/samples/namespace-retracing/_expected/system/main-a.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/system/main-a.js
@@ -1,0 +1,16 @@
+System.register(['./chunk-4c4907dd.js'], function (exports, module) {
+	'use strict';
+	var Other, Broken;
+	return {
+		setters: [function (module) {
+			Other = module.a;
+			Broken = module.b;
+		}],
+		execute: function () {
+
+			Other.doSomething();
+			Broken.doSomething();
+
+		}
+	};
+});

--- a/test/chunking-form/samples/namespace-retracing/_expected/system/main-b.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/system/main-b.js
@@ -1,0 +1,14 @@
+System.register(['./chunk-4c4907dd.js'], function (exports, module) {
+	'use strict';
+	var Other;
+	return {
+		setters: [function (module) {
+			Other = module.a;
+		}],
+		execute: function () {
+
+			Other.doSomething();
+
+		}
+	};
+});

--- a/test/chunking-form/samples/namespace-retracing/broken.js
+++ b/test/chunking-form/samples/namespace-retracing/broken.js
@@ -1,0 +1,4 @@
+export class Broken {
+}
+
+Broken.doSomething = function() { console.log('broken'); }

--- a/test/chunking-form/samples/namespace-retracing/foo.js
+++ b/test/chunking-form/samples/namespace-retracing/foo.js
@@ -1,0 +1,1 @@
+export * from './broken';

--- a/test/chunking-form/samples/namespace-retracing/main-a.js
+++ b/test/chunking-form/samples/namespace-retracing/main-a.js
@@ -1,0 +1,5 @@
+import * as other from './other';
+import * as foo from './foo';
+
+other.Other.doSomething();
+foo.Broken.doSomething();

--- a/test/chunking-form/samples/namespace-retracing/main-b.js
+++ b/test/chunking-form/samples/namespace-retracing/main-b.js
@@ -1,0 +1,3 @@
+import * as other from './other';
+
+other.Other.doSomething();

--- a/test/chunking-form/samples/namespace-retracing/other.js
+++ b/test/chunking-form/samples/namespace-retracing/other.js
@@ -1,0 +1,8 @@
+import { Broken } from './broken';
+
+Broken.doSomething();
+
+export class Other {
+}
+
+Other.doSomething = function() { console.log('other'); }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevent issue numbers: https://github.com/rollup/rollup/issues/2413

### Description

Fix to ensure that the tracing done through namespaces gets all the same treatment as normal tracing, checking chunking boundaries and included status.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
