### PR TITLE
always disable globbing

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -130,7 +130,8 @@ export class Task {
 		if (chokidarOptions) {
 			chokidarOptions = {
 				...(chokidarOptions === true ? {} : chokidarOptions),
-				ignoreInitial: true
+				ignoreInitial: true,
+				disableGlobbing: true
 			};
 		}
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevent issue numbers:

### Description

My situation is probably fairly unusual, but hopefully about to get a lot more common... If a module has `[brackets]` in the filename, chokidar interprets them as part of a globbing pattern, and Rollup doesn't rebuild the bundle if the file changes. 

Given that we're only ever passing fully resolved filenames to chokidar, it seems to me that the `disableGlobbing` option should always be used.

No tests just yet because I really need to get some sleep, but should be straightforward. 
