### PR TITLE
Add renderStart and renderError hooks

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -183,7 +183,7 @@ export default function rollup(
 						return chunks;
 					}),
 				err =>
-					graph.pluginDriver.hookParallel('buildEnd', err).then(() => {
+					graph.pluginDriver.hookParallel('buildEnd', [err]).then(() => {
 						throw err;
 					})
 			)
@@ -258,7 +258,9 @@ export default function rollup(
 						chunks.filter(chunk => chunk.entryModule).map(chunk => chunk.entryModule.id)
 					);
 
-					return createAddons(graph, outputOptions)
+					return graph.pluginDriver
+						.hookSeq('renderStart')
+						.then(() => createAddons(graph, outputOptions))
 						.then(addons => {
 							// pre-render all chunks
 							for (const chunk of chunks) {
@@ -329,6 +331,11 @@ export default function rollup(
 								})
 							).then(() => {});
 						})
+						.catch(error =>
+							graph.pluginDriver.hookParallel('renderError', [error]).then(() => {
+								throw error;
+							})
+						)
 						.then(() => {
 							// run generateBundle hook
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -259,7 +259,7 @@ export default function rollup(
 					);
 
 					return graph.pluginDriver
-						.hookSeq('renderStart')
+						.hookParallel('renderStart')
 						.then(() => createAddons(graph, outputOptions))
 						.then(addons => {
 							// pre-render all chunks


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

https://github.com/rollup/rollup/issues/2434

### Description

`renderStart` hook is called in the beginning of a generation
`renderError ` hook is called when anything in generation is thrown an error

This is useful to achieve processing chunks inside workers and be able to start worker before any chunk is generated and end after generation or error.

@guybedford I'm not sure about `hookSeq`/`hookParallel` choice. Need your review here.