### PR TITLE
Do not accumulate change listeners in watch mode

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -137,7 +137,13 @@ export default class Graph {
 
 		this.pluginDriver = createPluginDriver(this, options, this.pluginCache, watcher);
 
-		if (watcher) watcher.on('change', id => this.pluginDriver.hookSeqSync('watchChange', [id]));
+		if (watcher) {
+			const handleChange = (id: string) => this.pluginDriver.hookSeqSync('watchChange', [id]);
+			watcher.on('change', handleChange);
+			watcher.once('restart', () => {
+				watcher.removeListener('change', handleChange);
+			});
+		}
 
 		if (typeof options.external === 'function') {
 			const external = options.external;

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -24,6 +24,7 @@ export class Watcher extends EventEmitter {
 	private rerun: boolean = false;
 	private tasks: Task[];
 	private succeeded: boolean = false;
+	private invalidatedIds: Set<string> = new Set();
 
 	constructor(configs: RollupWatchOptions[] = []) {
 		super();
@@ -42,7 +43,10 @@ export class Watcher extends EventEmitter {
 		this.removeAllListeners();
 	}
 
-	invalidate() {
+	invalidate(id?: string) {
+		if (id) {
+			this.invalidatedIds.add(id);
+		}
 		if (this.running) {
 			this.rerun = true;
 			return;
@@ -52,6 +56,9 @@ export class Watcher extends EventEmitter {
 
 		this.buildTimeout = setTimeout(() => {
 			this.buildTimeout = undefined;
+			this.invalidatedIds.forEach(id => this.emit('change', id));
+			this.invalidatedIds.clear();
+			this.removeAllListeners('change');
 			this.run();
 		}, DELAY);
 	}
@@ -156,7 +163,6 @@ export class Task {
 	}
 
 	invalidate(id: string, isTransformDependency: boolean) {
-		this.watcher.emit('change', id);
 		this.invalidated = true;
 		if (isTransformDependency) {
 			this.cache.modules.forEach(module => {
@@ -166,7 +172,7 @@ export class Task {
 				module.originalCode = null;
 			});
 		}
-		this.watcher.invalidate();
+		this.watcher.invalidate(id);
 	}
 
 	run() {

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -58,7 +58,7 @@ export class Watcher extends EventEmitter {
 			this.buildTimeout = undefined;
 			this.invalidatedIds.forEach(id => this.emit('change', id));
 			this.invalidatedIds.clear();
-			this.removeAllListeners('change');
+			this.emit('restart');
 			this.run();
 		}, DELAY);
 	}

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -105,7 +105,7 @@ describe('rollup.watch', () => {
 				});
 		});
 
-		it('passes file events to the watchChange plugin hook', () => {
+		it('passes file events to the watchChange plugin hook once for each change', () => {
 			let watchChangeCnt = 0;
 			return sander
 				.copydir('test/watch/samples/basic')
@@ -144,7 +144,25 @@ describe('rollup.watch', () => {
 						'END',
 						() => {
 							assert.equal(run('../_tmp/output/bundle.js'), 43);
-							assert.ok(watchChangeCnt >= 1);
+							assert.equal(watchChangeCnt, 1);
+							sander.writeFileSync('test/_tmp/input/main.js', 'export default 43;');
+						},
+						'START',
+						'BUNDLE_START',
+						'BUNDLE_END',
+						'END',
+						() => {
+							assert.equal(run('../_tmp/output/bundle.js'), 43);
+							assert.equal(watchChangeCnt, 2);
+							sander.writeFileSync('test/_tmp/input/main.js', 'export default 43;');
+						},
+						'START',
+						'BUNDLE_START',
+						'BUNDLE_END',
+						'END',
+						() => {
+							assert.equal(run('../_tmp/output/bundle.js'), 43);
+							assert.equal(watchChangeCnt, 3);
 						}
 					]);
 				});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2440

### Description

In watch mode if a plugin has a watchChange hook, the hook would be re-attached to the watcher for each new run resulting in an ever increasing number of watchers.

This fixes this by removing all change listeners directly before each run.

Additionally, watchers are now only every triggered once per run. This is done by accumulating changed ids until a new run starts and then triggering the plugin hooks directly before the new run starts.