### PR TITLE
Correctly deconflict pattern defaults

### DIFF
--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -1,3 +1,6 @@
+import MagicString from 'magic-string';
+import { BLANK } from '../../utils/blank';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EMPTY_PATH, ObjectPath, UNKNOWN_PATH } from '../values';
 import * as NodeType from './NodeType';
@@ -26,5 +29,14 @@ export default class AssignmentPattern extends NodeBase implements PatternNode {
 
 	deoptimizePath(path: ObjectPath) {
 		path.length === 0 && this.left.deoptimizePath(path);
+	}
+
+	render(
+		code: MagicString,
+		options: RenderOptions,
+		{ isShorthandProperty }: NodeRenderOptions = BLANK
+	) {
+		this.left.render(code, options, { isShorthandProperty });
+		this.right.render(code, options);
 	}
 }

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -10,9 +10,7 @@ import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker'
 import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../values';
 import LocalVariable from '../variables/LocalVariable';
 import Variable from '../variables/Variable';
-import AssignmentPattern from './AssignmentPattern';
 import * as NodeType from './NodeType';
-import Property from './Property';
 import { ExpressionEntity } from './shared/Expression';
 import { Node, NodeBase } from './shared/Node';
 
@@ -146,7 +144,7 @@ export default class Identifier extends NodeBase {
 	render(
 		code: MagicString,
 		_options: RenderOptions,
-		{ renderedParentType, isCalleeOfRenderedParent }: NodeRenderOptions = BLANK
+		{ renderedParentType, isCalleeOfRenderedParent, isShorthandProperty }: NodeRenderOptions = BLANK
 	) {
 		if (this.variable) {
 			const name = this.variable.getName();
@@ -156,11 +154,7 @@ export default class Identifier extends NodeBase {
 					storeName: true,
 					contentOnly: true
 				});
-				let relevantParent = this.parent;
-				if (relevantParent.type === NodeType.AssignmentPattern) {
-					relevantParent = (<AssignmentPattern>relevantParent).parent;
-				}
-				if (relevantParent.type === NodeType.Property && (<Property>relevantParent).shorthand) {
+				if (isShorthandProperty) {
 					code.prependRight(this.start, `${this.name}: `);
 				}
 			}

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -155,7 +155,7 @@ export default class Property extends NodeBase implements DeoptimizableEntity {
 		if (!this.shorthand) {
 			this.key.render(code, options);
 		}
-		this.value.render(code, options);
+		this.value.render(code, options, { isShorthandProperty: this.shorthand });
 	}
 
 	private updateReturnExpression() {

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -16,6 +16,7 @@ export interface NodeRenderOptions {
 	isNoStatement?: boolean;
 	renderedParentType?: string; // also serves as a flag if the rendered parent is different from the actual parent
 	isCalleeOfRenderedParent?: boolean;
+	isShorthandProperty?: boolean;
 }
 
 export const NO_SEMICOLON: NodeRenderOptions = { isNoStatement: true };

--- a/test/form/samples/renamed-pattern-defaults/_config.js
+++ b/test/form/samples/renamed-pattern-defaults/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles deconflicting of variables used as defaults in patterns (#2445)'
+};

--- a/test/form/samples/renamed-pattern-defaults/_expected.js
+++ b/test/form/samples/renamed-pattern-defaults/_expected.js
@@ -1,0 +1,7 @@
+const EMPTY = null;
+const {foo = EMPTY} = {};
+console.log(foo);
+
+const EMPTY$1 = null;
+const {foo: foo$1 = EMPTY$1} = {};
+console.log(foo$1);

--- a/test/form/samples/renamed-pattern-defaults/dep.js
+++ b/test/form/samples/renamed-pattern-defaults/dep.js
@@ -1,0 +1,3 @@
+const EMPTY = null;
+const {foo = EMPTY} = {};
+console.log(foo);

--- a/test/form/samples/renamed-pattern-defaults/main.js
+++ b/test/form/samples/renamed-pattern-defaults/main.js
@@ -1,0 +1,5 @@
+import './dep.js';
+
+const EMPTY = null;
+const {foo = EMPTY} = {};
+console.log(foo);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2445
Resolves #2453 

### Description

In case of pattern properties, the previous deconflicting logic for identifiers contained a piece of special logic to detect if the identifier is a property in a shorthand pattern which faultily also triggered for identifiers in pattern defaults and caused #2445.

I replaced this with the IMO "proper" fix, which is adding a property to the node render options so that the parent can tell the child whether it is the name of a shorthand property. "Proper" because I expect these kinds of things to be much more stable in case we do syntax simplifications if the parent passes information to the child instead of the child querying the parent.