### PR TITLE
Support optional catch binding (stage 4 / ES2019)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup",
-  "version": "0.65.1",
+  "version": "0.65.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -101,7 +101,7 @@ export interface AstContext {
 
 export const defaultAcornOptions: AcornOptions = {
 	// TODO TypeScript waiting for acorn types to be updated
-	ecmaVersion: <any>2018,
+	ecmaVersion: <any>2019,
 	sourceType: 'module',
 	preserveParens: false
 };

--- a/src/ast/nodes/CatchClause.ts
+++ b/src/ast/nodes/CatchClause.ts
@@ -8,7 +8,7 @@ import { PatternNode } from './shared/Pattern';
 
 export default class CatchClause extends NodeBase {
 	type: NodeType.tCatchClause;
-	param: PatternNode;
+	param: PatternNode | null;
 	body: BlockStatement;
 
 	scope: CatchScope;
@@ -20,14 +20,15 @@ export default class CatchClause extends NodeBase {
 
 	initialise() {
 		this.included = false;
-		this.param.declare('parameter', UNKNOWN_EXPRESSION);
+
+		if (this.param) {
+			this.param.declare('parameter', UNKNOWN_EXPRESSION);
+		}
 	}
 
 	parseNode(esTreeNode: GenericEsTreeNode) {
-		this.body = <BlockStatement>new this.context.nodeConstructors.BlockStatement(
-			esTreeNode.body,
-			this,
-			this.scope
+		this.body = <BlockStatement>(
+			new this.context.nodeConstructors.BlockStatement(esTreeNode.body, this, this.scope)
 		);
 		super.parseNode(esTreeNode);
 	}

--- a/test/function/samples/optional-catch-binding/_config.js
+++ b/test/function/samples/optional-catch-binding/_config.js
@@ -3,11 +3,6 @@ const assert = require('assert');
 module.exports = {
 	description: 'allows optional catch binding with appropriate acorn settings',
 	minNodeVersion: 10,
-	options: {
-		acorn: {
-			ecmaVersion: 2019
-		}
-	},
 	exports(exports) {
 		assert.equal(exports.foo, true);
 	}

--- a/test/function/samples/optional-catch-binding/_config.js
+++ b/test/function/samples/optional-catch-binding/_config.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'allows optional catch binding with appropriate acorn settings',
+	minNodeVersion: 10,
+	options: {
+		acorn: {
+			ecmaVersion: 2019
+		}
+	},
+	exports(exports) {
+		assert.equal(exports.foo, true);
+	}
+};

--- a/test/function/samples/optional-catch-binding/main.js
+++ b/test/function/samples/optional-catch-binding/main.js
@@ -1,0 +1,7 @@
+export let foo;
+
+try {
+  foo();
+} catch {
+  foo = true;
+}

--- a/test/function/samples/optional-catch-binding/main.js
+++ b/test/function/samples/optional-catch-binding/main.js
@@ -1,7 +1,7 @@
 export let foo;
 
 try {
-  foo();
+	foo();
 } catch {
-  foo = true;
+	foo = true;
 }


### PR DESCRIPTION
As described in issue #2454, acorn supports optional catch bindings but Rollup unconditionally expected the parameter to exist.

This may be a terrible pull request — I’m not very familiar with TypeScript and I haven’t contributed before, so I may not have approached this correctly.

However build/test seems to be working correctly.