### PR TITLE
Deconflict top-level class and function expressions with ids

### DIFF
--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -2,6 +2,7 @@ import ClassDeclaration from '../nodes/ClassDeclaration';
 import ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import FunctionDeclaration from '../nodes/FunctionDeclaration';
 import Identifier from '../nodes/Identifier';
+import * as NodeType from '../nodes/NodeType';
 import { EntityPathTracker } from '../utils/EntityPathTracker';
 import LocalVariable from './LocalVariable';
 import Variable from './Variable';
@@ -28,8 +29,10 @@ export default class ExportDefaultVariable extends LocalVariable {
 			exportDefaultDeclaration.declaration,
 			deoptimizationTracker
 		);
-		this.hasId = !!(<FunctionDeclaration | ClassDeclaration>exportDefaultDeclaration.declaration)
-			.id;
+		this.hasId =
+			(exportDefaultDeclaration.declaration.type === NodeType.FunctionDeclaration ||
+				exportDefaultDeclaration.declaration.type === NodeType.ClassDeclaration) &&
+			!!(<FunctionDeclaration | ClassDeclaration>exportDefaultDeclaration.declaration).id;
 	}
 
 	addReference(identifier: Identifier) {

--- a/test/function/samples/deconflict-default-exported-named-function/_config.js
+++ b/test/function/samples/deconflict-default-exported-named-function/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deconflict default exported named function and class expressions'
+};

--- a/test/function/samples/deconflict-default-exported-named-function/classDeclaration1.js
+++ b/test/function/samples/deconflict-default-exported-named-function/classDeclaration1.js
@@ -1,0 +1,5 @@
+export default class test {
+	constructor() {
+		this.name = 'classDeclaration1';
+	}
+}

--- a/test/function/samples/deconflict-default-exported-named-function/classDeclaration2.js
+++ b/test/function/samples/deconflict-default-exported-named-function/classDeclaration2.js
@@ -1,0 +1,5 @@
+export default class test {
+	constructor() {
+		this.name = 'classDeclaration2';
+	}
+}

--- a/test/function/samples/deconflict-default-exported-named-function/classExpression1.js
+++ b/test/function/samples/deconflict-default-exported-named-function/classExpression1.js
@@ -1,0 +1,5 @@
+export default (class test {
+	constructor() {
+		this.name = 'classExpression1';
+	}
+})

--- a/test/function/samples/deconflict-default-exported-named-function/classExpression2.js
+++ b/test/function/samples/deconflict-default-exported-named-function/classExpression2.js
@@ -1,0 +1,5 @@
+export default (class test {
+	constructor() {
+		this.name = 'classExpression2';
+	}
+})

--- a/test/function/samples/deconflict-default-exported-named-function/functionDeclaration1.js
+++ b/test/function/samples/deconflict-default-exported-named-function/functionDeclaration1.js
@@ -1,0 +1,3 @@
+export default function test() {
+	return 'functionDeclaration1';
+};

--- a/test/function/samples/deconflict-default-exported-named-function/functionDeclaration2.js
+++ b/test/function/samples/deconflict-default-exported-named-function/functionDeclaration2.js
@@ -1,0 +1,3 @@
+export default function test() {
+	return 'functionDeclaration2';
+};

--- a/test/function/samples/deconflict-default-exported-named-function/functionExpression1.js
+++ b/test/function/samples/deconflict-default-exported-named-function/functionExpression1.js
@@ -1,0 +1,3 @@
+export default (function test() {
+	return 'functionExpression1';
+});

--- a/test/function/samples/deconflict-default-exported-named-function/functionExpression2.js
+++ b/test/function/samples/deconflict-default-exported-named-function/functionExpression2.js
@@ -1,0 +1,3 @@
+export default (function test() {
+	return 'functionExpression2';
+});

--- a/test/function/samples/deconflict-default-exported-named-function/main.js
+++ b/test/function/samples/deconflict-default-exported-named-function/main.js
@@ -1,0 +1,19 @@
+import ClassDeclaration1 from './classDeclaration1';
+import ClassDeclaration2 from './classDeclaration2';
+import ClassExpression1 from './classExpression1';
+import ClassExpression2 from './classExpression2';
+import functionDeclaration1 from './functionDeclaration1';
+import functionDeclaration2 from './functionDeclaration2';
+import functionExpression1 from './functionExpression1';
+import functionExpression2 from './functionExpression2';
+import { test } from './named.js';
+
+assert.equal(test(), 'named');
+assert.equal(functionDeclaration1(), 'functionDeclaration1');
+assert.equal(functionDeclaration2(), 'functionDeclaration2');
+assert.equal(functionExpression1(), 'functionExpression1');
+assert.equal(functionExpression2(), 'functionExpression2');
+assert.equal((new ClassDeclaration1()).name, 'classDeclaration1');
+assert.equal((new ClassDeclaration2()).name, 'classDeclaration2');
+assert.equal((new ClassExpression1()).name, 'classExpression1');
+assert.equal((new ClassExpression2()).name, 'classExpression2');

--- a/test/function/samples/deconflict-default-exported-named-function/named.js
+++ b/test/function/samples/deconflict-default-exported-named-function/named.js
@@ -1,0 +1,3 @@
+export const test = function() {
+	return 'named';
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2322 

### Description
The deconflicting logic was not applied to default exported function and class expressions with ids as they were faultily treated as declarations in one place.