### PR TITLE
ignore falsy plugins

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -90,7 +90,11 @@ function getInputOptions(rawInputOptions: GenericConfigObject): any {
 
 	checkInputOptions(inputOptions);
 	const plugins = inputOptions.plugins;
-	inputOptions.plugins = Array.isArray(plugins) ? plugins : plugins ? [plugins] : [];
+	inputOptions.plugins = Array.isArray(plugins)
+		? plugins.filter(Boolean)
+		: plugins
+			? [plugins]
+			: [];
 	inputOptions = inputOptions.plugins.reduce(applyOptionHook, inputOptions);
 
 	if (!inputOptions.experimentalCodeSplitting) {

--- a/test/misc/index.js
+++ b/test/misc/index.js
@@ -565,14 +565,19 @@ describe('misc', () => {
 				})
 			)
 			.then(() => {
-				const relevantWarnings = warnings.filter(
-					warning => warning.code === 'MISSING_GLOBAL_NAME'
-				);
+				const relevantWarnings = warnings.filter(warning => warning.code === 'MISSING_GLOBAL_NAME');
 				assert.equal(relevantWarnings.length, 1);
 				assert.equal(
 					relevantWarnings[0].message,
 					`No name was provided for external module 'lodash' in output.globals – guessing 'lodash'`
 				);
 			});
+	});
+
+	it('ignores falsy plugins', () => {
+		return rollup.rollup({
+			input: 'x',
+			plugins: [loader({ x: `console.log( 42 );` }), null, false, undefined]
+		});
 	});
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

I ticked the 'feature' box but this could also be considered a bugfix. Rollup ignores plugins that are `false`...

```js
// rollup.config.js
const dev = process.env.ROLLUP_WATCH === 'true';

export default {
  input: 'src/index.js',
  output: {
    file: 'dist/index.js',
    format: 'iife'
  },
  plugins: [
    dev && someDevModeOnlyPlugin()
  ]
};
```

...but it would be nice if it disregarded *all* falsy values so that we could do this sort of thing:

```diff
// rollup.config.js
-const dev = process.env.ROLLUP_WATCH === 'true';
+const dev = process.env.ROLLUP_WATCH;

export default {
  input: 'src/index.js',
  output: {
    file: 'dist/index.js',
    format: 'iife'
  },
  plugins: [
   dev && someDevModeOnlyPlugin()
  ]
};
```

I trip up on this frequently and the error you get is somewhat cryptic.