### PR TITLE
Fix links in warnings and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,6 @@ Rollup can import existing CommonJS modules [through a plugin](https://github.co
 
 To make sure your ES modules are immediately usable by tools that work with CommonJS such as Node.js and webpack, you can use Rollup to compile to UMD or CommonJS format, and then point to that compiled version with the `main` property in your `package.json` file. If your `package.json` file also has a `module` field, ES-module-aware tools like Rollup and [webpack 2](https://webpack.js.org/) will [import the ES module version](https://github.com/rollup/rollup/wiki/pkg.module) directly.
 
-## Links
-
-- step-by-step [tutorial video series](https://code.lengstorf.com/learn-rollup-js/), with accompanying written walkthrough
-- miscellaneous issues in the [wiki](https://github.com/rollup/rollup/wiki)
-
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].

--- a/bin/src/run/batchWarnings.ts
+++ b/bin/src/run/batchWarnings.ts
@@ -143,9 +143,7 @@ const deferredHandlers: {
 		priority: 1,
 		fn: warnings => {
 			title('Unresolved dependencies');
-			info(
-				'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
-			);
+			info('https://rollupjs.org/guide/en#warning-treating-module-as-external-dependency');
 
 			const dependencies = new Map();
 			warnings.forEach(warning => {
@@ -164,7 +162,7 @@ const deferredHandlers: {
 		priority: 1,
 		fn: warnings => {
 			title('Missing exports');
-			info('https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module');
+			info('https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-');
 
 			warnings.forEach(warning => {
 				stderr(tc.bold(warning.importer));
@@ -178,7 +176,7 @@ const deferredHandlers: {
 		priority: 1,
 		fn: warnings => {
 			title('`this` has been rewritten to `undefined`');
-			info('https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined');
+			info('https://rollupjs.org/guide/en#error-this-is-undefined');
 			showTruncatedWarnings(warnings);
 		}
 	},
@@ -187,7 +185,7 @@ const deferredHandlers: {
 		priority: 1,
 		fn: warnings => {
 			title('Use of eval is strongly discouraged');
-			info('https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval');
+			info('https://rollupjs.org/guide/en#avoiding-eval');
 			showTruncatedWarnings(warnings);
 		}
 	},
@@ -233,9 +231,7 @@ const deferredHandlers: {
 		priority: 1,
 		fn: warnings => {
 			title(`Broken sourcemap`);
-			info(
-				'https://github.com/rollup/rollup/wiki/Troubleshooting#sourcemap-is-likely-to-be-incorrect'
-			);
+			info('https://rollupjs.org/guide/en#warning-sourcemap-is-likely-to-be-incorrect');
 
 			const plugins = Array.from(new Set(warnings.map(w => w.plugin).filter(Boolean)));
 			const detail =

--- a/bin/src/run/loadConfigFile.ts
+++ b/bin/src/run/loadConfigFile.ts
@@ -60,7 +60,7 @@ export default function loadConfigFile(
 						handleError({
 							code: 'MISSING_CONFIG',
 							message: 'Config file must export an options object, or an array of options objects',
-							url: 'https://rollupjs.org/#using-config-files'
+							url: 'https://rollupjs.org/guide/en#configuration-files'
 						});
 					}
 

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -812,7 +812,7 @@ Try defining "${chunkName}" first in the manualChunks definitions of the Rollup 
 										module.id
 									)}, but could not be resolved – treating it as an external dependency`,
 									url:
-										'https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency'
+										'https://rollupjs.org/guide/en#warning-treating-module-as-external-dependency'
 								});
 							}
 							isExternal = true;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -159,7 +159,7 @@ function handleMissingExport(
 		{
 			code: 'MISSING_EXPORT',
 			message: `'${exportName}' is not exported by ${relativeId(importedModule)}`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module`
+			url: `https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-`
 		},
 		importerStart
 	);

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -51,7 +51,7 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 					{
 						code: 'EVAL',
 						message: `Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification`,
-						url: 'https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval'
+						url: 'https://rollupjs.org/guide/en#avoiding-eval'
 					},
 					this.start
 				);

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -266,7 +266,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 					importer: relativeId(this.context.fileName),
 					exporter: relativeId(fileName),
 					message: `'${exportName}' is not exported by '${relativeId(fileName)}'`,
-					url: `https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module`
+					url: `https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-`
 				},
 				path[0].pos
 			);

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -33,7 +33,7 @@ export default class TaggedTemplateExpression extends NodeBase {
 					{
 						code: 'EVAL',
 						message: `Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification`,
-						url: 'https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval'
+						url: 'https://rollupjs.org/guide/en#avoiding-eval'
 					},
 					this.start
 				);

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -34,7 +34,7 @@ export default class ThisExpression extends NodeBase {
 				{
 					code: 'THIS_IS_UNDEFINED',
 					message: `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`,
-					url: `https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined`
+					url: `https://rollupjs.org/guide/en#error-this-is-undefined`
 				},
 				this.start
 			);

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -39,7 +39,7 @@ function addDeprecations(deprecations: Deprecation[], warn: WarningHandler) {
 function checkInputOptions(options: InputOptions) {
 	if (options.transform || options.load || options.resolveId || options.resolveExternal) {
 		throw new Error(
-			'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://github.com/rollup/rollup/wiki/Plugins for details'
+			'The `transform`, `load`, `resolveId` and `resolveExternal` options are deprecated in favour of a unified plugin API. See https://rollupjs.org/guide/en#plugins'
 		);
 	}
 }
@@ -48,14 +48,14 @@ function checkOutputOptions(options: OutputOptions) {
 	if (<string>options.format === 'es6') {
 		error({
 			message: 'The `es6` output format is deprecated – use `es` instead',
-			url: `https://rollupjs.org/#format-f-output-format-`
+			url: `https://rollupjs.org/guide/en#output-format-f-format`
 		});
 	}
 
 	if (!options.format) {
 		error({
 			message: `You must specify output.format, which can be one of 'amd', 'cjs', 'system', 'esm', 'iife' or 'umd'`,
-			url: `https://rollupjs.org/#format-f-output-format-`
+			url: `https://rollupjs.org/guide/en#output-format-f-format`
 		});
 	}
 

--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -177,7 +177,7 @@ export default function collapseSourcemaps(
 					message: `Sourcemap is likely to be incorrect: a plugin${
 						map.plugin ? ` ('${map.plugin}')` : ``
 					} was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
-					url: `https://github.com/rollup/rollup/wiki/Troubleshooting#sourcemap-is-likely-to-be-incorrect`
+					url: `https://rollupjs.org/guide/en#warning-sourcemap-is-likely-to-be-incorrect`
 				});
 
 				map = {

--- a/src/utils/default-plugin.ts
+++ b/src/utils/default-plugin.ts
@@ -49,7 +49,7 @@ function createResolveId(options: InputOptions) {
 			error({
 				code: 'MISSING_PROCESS',
 				message: `It looks like you're using Rollup in a non-Node.js environment. This means you must supply a plugin with custom resolveId and load functions`,
-				url: 'https://github.com/rollup/rollup/wiki/Plugins'
+				url: 'https://rollupjs.org/guide/en#a-simple-example'
 			});
 		}
 

--- a/src/utils/getExportMode.ts
+++ b/src/utils/getExportMode.ts
@@ -35,8 +35,8 @@ export default function getExportMode(
 				chunk.graph.warn({
 					code: 'MIXED_EXPORTS',
 					message: `Using named and default exports together. Consumers of your bundle will have to use ${name ||
-						'bundle'}['default'] to access the default export, which may not be what you want. Use \`exports: 'named'\` to disable this warning`,
-					url: `https://rollupjs.org/#exports`
+						'bundle'}['default'] to access the default export, which may not be what you want. Use \`output.exports: 'named'\` to disable this warning`,
+					url: `https://rollupjs.org/guide/en#output-exports-exports`
 				});
 			}
 			exportMode = 'named';
@@ -46,7 +46,8 @@ export default function getExportMode(
 	if (!/(?:default|named|none)/.test(exportMode)) {
 		error({
 			code: 'INVALID_EXPORT_OPTION',
-			message: `output.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`
+			message: `output.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`,
+			url: `https://rollupjs.org/guide/en#output-exports-exports`
 		});
 	}
 

--- a/test/function/samples/default-not-reexported/_config.js
+++ b/test/function/samples/default-not-reexported/_config.js
@@ -17,6 +17,6 @@ module.exports = {
 			2:
 			3: console.log( def );
 		`,
-		url: `https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module`
+		url: `https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-`
 	}
 };

--- a/test/function/samples/does-not-hang-on-missing-module/_config.js
+++ b/test/function/samples/does-not-hang-on-missing-module/_config.js
@@ -8,7 +8,7 @@ module.exports = {
 			importer: 'main.js',
 			source: 'unlessYouCreatedThisFileForSomeReason',
 			message: `'unlessYouCreatedThisFileForSomeReason' is imported by main.js, but could not be resolved – treating it as an external dependency`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`
+			url: `https://rollupjs.org/guide/en#warning-treating-module-as-external-dependency`
 		}
 	],
 	runtimeError(error) {

--- a/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
+++ b/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
@@ -33,6 +33,6 @@ module.exports = {
 			2:
 			3: Object.assign({}, a);
 		`,
-		url: `https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module`
+		url: `https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-`
 	}
 };

--- a/test/function/samples/export-type-mismatch-b/_config.js
+++ b/test/function/samples/export-type-mismatch-b/_config.js
@@ -3,6 +3,7 @@ module.exports = {
 	options: { output: { exports: 'blah' } },
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
-		message: `output.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`
+		message: `output.exports must be 'default', 'named', 'none', 'auto', or left unspecified (defaults to 'auto')`,
+		url: 'https://rollupjs.org/guide/en#output-exports-exports'
 	}
 };

--- a/test/function/samples/import-of-unexported-fails/_config.js
+++ b/test/function/samples/import-of-unexported-fails/_config.js
@@ -17,6 +17,6 @@ module.exports = {
 			2:
 			3: a();
 		`,
-		url: `https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module`
+		url: `https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-`
 	}
 };

--- a/test/function/samples/namespace-missing-export/_config.js
+++ b/test/function/samples/namespace-missing-export/_config.js
@@ -21,7 +21,7 @@ module.exports = {
 				3: assert.equal( typeof mod.foo, 'undefined' );
 				                            ^
 			`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module`
+			url: `https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-`
 		}
 	]
 };

--- a/test/function/samples/reexport-missing-error/_config.js
+++ b/test/function/samples/reexport-missing-error/_config.js
@@ -15,6 +15,6 @@ module.exports = {
 			1: export { foo as bar } from './empty.js';
 			            ^
 		`,
-		url: 'https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module'
+		url: 'https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-'
 	}
 };

--- a/test/function/samples/unused-import/_config.js
+++ b/test/function/samples/unused-import/_config.js
@@ -6,7 +6,7 @@ module.exports = {
 			importer: 'main.js',
 			source: 'external',
 			message: `'external' is imported by main.js, but could not be resolved – treating it as an external dependency`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-external-dependency`
+			url: `https://rollupjs.org/guide/en#warning-treating-module-as-external-dependency`
 		},
 		{
 			code: 'UNUSED_EXTERNAL_IMPORT',

--- a/test/function/samples/warn-on-auto-named-default-exports/_config.js
+++ b/test/function/samples/warn-on-auto-named-default-exports/_config.js
@@ -3,8 +3,8 @@ module.exports = {
 	warnings: [
 		{
 			code: 'MIXED_EXPORTS',
-			message: `Using named and default exports together. Consumers of your bundle will have to use bundle['default'] to access the default export, which may not be what you want. Use \`exports: 'named'\` to disable this warning`,
-			url: `https://rollupjs.org/#exports`
+			message: `Using named and default exports together. Consumers of your bundle will have to use bundle['default'] to access the default export, which may not be what you want. Use \`output.exports: 'named'\` to disable this warning`,
+			url: `https://rollupjs.org/guide/en#output-exports-exports`
 		}
 	]
 };

--- a/test/function/samples/warn-on-eval/_config.js
+++ b/test/function/samples/warn-on-eval/_config.js
@@ -17,7 +17,7 @@ module.exports = {
 				1: var result = eval( '1 + 1' );
 				                ^
 			`,
-			url: 'https://github.com/rollup/rollup/wiki/Troubleshooting#avoiding-eval'
+			url: 'https://rollupjs.org/guide/en#avoiding-eval'
 		}
 	]
 };

--- a/test/function/samples/warn-on-top-level-this/_config.js
+++ b/test/function/samples/warn-on-top-level-this/_config.js
@@ -20,7 +20,7 @@ module.exports = {
 				3: this.foo = 'bar';
 				   ^
 			`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined`
+			url: `https://rollupjs.org/guide/en#error-this-is-undefined`
 		}
 	],
 	runtimeError: err => {

--- a/test/sourcemaps/samples/transform-without-sourcemap-render-chunk/_config.js
+++ b/test/sourcemaps/samples/transform-without-sourcemap-render-chunk/_config.js
@@ -24,7 +24,7 @@ module.exports = {
 			code: `SOURCEMAP_BROKEN`,
 			plugin: 'fake plugin 1',
 			message: `Sourcemap is likely to be incorrect: a plugin ('fake plugin 1') was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#sourcemap-is-likely-to-be-incorrect`
+			url: `https://rollupjs.org/guide/en#warning-sourcemap-is-likely-to-be-incorrect`
 		}
 	]
 };

--- a/test/sourcemaps/samples/transform-without-sourcemap/_config.js
+++ b/test/sourcemaps/samples/transform-without-sourcemap/_config.js
@@ -24,7 +24,7 @@ module.exports = {
 			code: `SOURCEMAP_BROKEN`,
 			plugin: 'fake plugin 1',
 			message: `Sourcemap is likely to be incorrect: a plugin ('fake plugin 1') was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
-			url: `https://github.com/rollup/rollup/wiki/Troubleshooting#sourcemap-is-likely-to-be-incorrect`
+			url: `https://rollupjs.org/guide/en#warning-sourcemap-is-likely-to-be-incorrect`
 		}
 	]
 };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [x] yes (I.e. most of the links were tested and of course I adjusted the tests as well)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

One of the nicer features of Rollup is that some errors and warnings contain urls linking to further information. Since the plugin and troubleshooting sections are now part of the website, I used this chance to go through all these links, fix the broken ones and make sure all wiki links now point to the website instead. Once this is released, we can definitely replace the troubleshooting section in the wiki with a link to the website as well.