### PR TITLE
Detect side-effects in method arguments of virtual string literals

### DIFF
--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -254,10 +254,9 @@ const UNKNOWN_LITERAL_STRING: ExpressionEntity = {
 	},
 	hasEffectsWhenAccessedAtPath: path => path.length > 1,
 	hasEffectsWhenAssignedAtPath: path => path.length > 0,
-	hasEffectsWhenCalledAtPath: path => {
+	hasEffectsWhenCalledAtPath: (path, callOptions, options) => {
 		if (path.length === 1) {
-			const subPath = path[0];
-			return typeof subPath !== 'string' || !literalStringMembers[subPath];
+			return hasMemberEffectWhenCalled(literalStringMembers, path[0], true, callOptions, options);
 		}
 		return true;
 	},

--- a/test/function/samples/builtin-prototypes/argument-side-effects/_config.js
+++ b/test/function/samples/builtin-prototypes/argument-side-effects/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'detects side-effects in chained string method arguments'
+};

--- a/test/function/samples/builtin-prototypes/argument-side-effects/main.js
+++ b/test/function/samples/builtin-prototypes/argument-side-effects/main.js
@@ -1,0 +1,11 @@
+function getData() {
+	var data = [];
+
+	'abc'.trim().replace('b', function() {
+		data.push('replaced');
+	});
+
+	return data;
+}
+
+assert.deepEqual(getData(), ['replaced']);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2475 

### Description

As it turns out, the logic to detect side-effects when arguments of string prototype are called was present but not wired up properly in the case where the string itself was the return value of another prototype method. I.e.

```js
'abc'.replace('b', () => console.log('effect'));
```

was retained but

```js
'abc'.trim().replace('b', () => console.log('effect'));
```
was removed. This PR fixes this.
