### PR TITLE
Update basic commands to show renamed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
   </a>
     <a href="#backers" alt="sponsors on Open Collective">
       <img src="https://opencollective.com/rollup/backers/badge.svg" />
-  </a> 
+  </a>
   <a href="#sponsors" alt="Sponsors on Open Collective">
     <img src="https://opencollective.com/rollup/sponsors/badge.svg" />
-  </a> 
+  </a>
   <a href="https://github.com/rollup/rollup/blob/master/LICENSE.md">
     <img src="https://img.shields.io/npm/l/rollup.svg"
          alt="license">
@@ -50,21 +50,21 @@ For browsers:
 
 ```bash
 # compile to a <script> containing a self-executing function
-$ rollup main.js --format iife --name "myBundle" --file bundle.js
+$ rollup main.js --output.format iife --name "myBundle" --file bundle.js
 ```
 
 For Node.js:
 
 ```bash
 # compile to a CommonJS module
-$ rollup main.js --format cjs --file bundle.js
+$ rollup main.js --output.format cjs --file bundle.js
 ```
 
 For both browsers and Node.js:
 
 ```bash
 # UMD format requires a bundle name
-$ rollup main.js --format umd --name "myBundle" --file bundle.js
+$ rollup main.js --output.format umd --name "myBundle" --file bundle.js
 ```
 
 ## Why


### PR DESCRIPTION
Using the old options shows a warning currently so it seems best to
update the docs to reflect the updated commands that won't
show a warning.

Renamed options are described here:
https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
