### PR TITLE
Assign chunk IDs before creating outputBundle chunks

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -284,9 +284,6 @@ export default function rollup(
 							// name all chunks
 							for (let i = 0; i < chunks.length; i++) {
 								const chunk = chunks[i];
-								const imports = chunk.getImportIds();
-								const exports = chunk.getExportNames();
-								const modules = chunk.renderedModules;
 
 								if (chunk === singleChunk) {
 									singleChunk.id = basename(
@@ -308,13 +305,18 @@ export default function rollup(
 									}
 									chunk.generateId(pattern, patternName, addons, outputOptions, outputBundle);
 								}
+							}
+
+							// assign to outputBundle
+							for (let i = 0; i < chunks.length; i++) {
+								const chunk = chunks[i];
 
 								outputBundle[chunk.id] = {
 									fileName: chunk.id,
 									isEntry: chunk.entryModule !== undefined,
-									imports,
-									exports,
-									modules,
+									imports: chunk.getImportIds(),
+									exports: chunk.getExportNames(),
+									modules: chunk.renderedModules,
 									code: undefined,
 									map: undefined
 								};

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -282,6 +282,7 @@ export default function rollup(
 							}
 
 							// name all chunks
+							const usedIds: Record<string, true> = {};
 							for (let i = 0; i < chunks.length; i++) {
 								const chunk = chunks[i];
 
@@ -303,7 +304,8 @@ export default function rollup(
 										pattern = outputOptions.chunkFileNames || '[name]-[hash].js';
 										patternName = 'output.chunkFileNames';
 									}
-									chunk.generateId(pattern, patternName, addons, outputOptions, outputBundle);
+									chunk.generateId(pattern, patternName, addons, outputOptions, usedIds);
+									usedIds[chunk.id] = true;
 								}
 							}
 

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -829,13 +829,13 @@ module.exports = input;
 						plugins: [
 							loader({ input: `alert('hello')` }),
 							{
-								name: name,
+								name,
 								buildStart() {
 									this.cache.set('asdf', 'asdf');
 								}
 							},
 							{
-								name: name,
+								name,
 								buildStart() {
 									this.cache.set('asdf', 'asdf');
 								}
@@ -845,7 +845,7 @@ module.exports = input;
 					.catch(err => {
 						assert.equal(err.code, 'PLUGIN_ERROR');
 						assert.equal(err.pluginCode, 'DUPLICATE_PLUGIN_NAME');
-						assert.equal(err.message.includes(name), true)
+						assert.equal(err.message.includes(name), true);
 					});
 			});
 	});
@@ -1071,6 +1071,64 @@ module.exports = input;
 				assert.equal(renderStartCount, 1, 'renderStart count');
 				assert.equal(generateBundleCount, 0, 'generateBundle count');
 				assert.equal(renderErrorCount, 1, 'renderError count');
+			});
+	});
+
+	it('assigns chunk IDs before creating outputBundle chunks', () => {
+		const chunks = [];
+		return rollup
+			.rollup({
+				input: 'input',
+				experimentalCodeSplitting: true,
+				plugins: [
+					loader({
+						input: `export default [import('a'), import('b')];`,
+						a: `import c from 'c'; import d from 'd'; export default () => c();`,
+						b: `import c from 'c'; export default () => c();`,
+						c: `export default () => console.log('c');`,
+						d: `export default {};`
+					}),
+					{
+						renderChunk(code, chunk, options) {
+							chunks.push({
+								fileName: chunk.fileName,
+								imports: chunk.imports,
+								modules: Object.keys(chunk.modules)
+							});
+						}
+					}
+				]
+			})
+			.then(bundle =>
+				bundle.generate({
+					entryFileNames: '[name].js',
+					chunkFileNames: '[name].js',
+					format: 'esm'
+				})
+			)
+			.then(() => {
+				assert.deepEqual(chunks, [
+					{
+						fileName: 'input.js',
+						imports: [],
+						modules: ['input']
+					},
+					{
+						fileName: 'chunk.js',
+						imports: [],
+						modules: ['c']
+					},
+					{
+						fileName: 'a.js',
+						imports: ['chunk.js'],
+						modules: ['d', 'a']
+					},
+					{
+						fileName: 'b.js',
+						imports: ['chunk.js'],
+						modules: ['b']
+					}
+				]);
 			});
 	});
 });

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -1074,7 +1074,7 @@ module.exports = input;
 			});
 	});
 
-	it('assigns chunk IDs before creating outputBundle chunks', () => {
+	it.only('assigns chunk IDs before creating outputBundle chunks', () => {
 		const chunks = [];
 		return rollup
 			.rollup({
@@ -1083,7 +1083,7 @@ module.exports = input;
 				plugins: [
 					loader({
 						input: `export default [import('a'), import('b')];`,
-						a: `import c from 'c'; import d from 'd'; export default () => c();`,
+						a: `import d from 'd'; import c from 'c'; export default () => c();`,
 						b: `import c from 'c'; export default () => c();`,
 						c: `export default () => console.log('c');`,
 						d: `export default {};`
@@ -1114,14 +1114,14 @@ module.exports = input;
 						modules: ['input']
 					},
 					{
-						fileName: 'chunk.js',
-						imports: [],
-						modules: ['c']
-					},
-					{
 						fileName: 'a.js',
 						imports: ['chunk.js'],
 						modules: ['d', 'a']
+					},
+					{
+						fileName: 'chunk.js',
+						imports: [],
+						modules: ['c']
 					},
 					{
 						fileName: 'b.js',

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -1074,7 +1074,7 @@ module.exports = input;
 			});
 	});
 
-	it.only('assigns chunk IDs before creating outputBundle chunks', () => {
+	it('assigns chunk IDs before creating outputBundle chunks', () => {
 		const chunks = [];
 		return rollup
 			.rollup({


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

#2461 

### Description

The `chunk` object that is passed to the `renderChunk` hook (and which forms the properties of the output bundle object) contains, inter alia, an `imports` array specifying the IDs of the external modules and chunks the chunk depends on.

Currently, the loop that assigns the IDs to the chunk is the same as the loop that gets the imported IDs; consequently the imported IDs are frequently `undefined`.

This PR separates ID assignation into a separate loop.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
