### PR TITLE
Provide better error when creating a namespace object containing a reexported external namespace

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -247,7 +247,10 @@ export default class Chunk {
 		const tracedExports: { variable: Variable; module: Module | ExternalModule }[] = [];
 		for (const [index, exportName] of entryExportEntries) {
 			const traced = this.traceExport(exportName, this.entryModule);
-			if (traced.variable && !traced.variable.included && !traced.variable.isExternal) {
+			if (
+				!traced ||
+				(traced.variable && !traced.variable.included && !traced.variable.isExternal)
+			) {
 				continue;
 			}
 			tracedExports[index] = traced;
@@ -332,8 +335,8 @@ export default class Chunk {
 	): {
 		variable: Variable;
 		module: Module | ExternalModule;
-	} {
-		if (name === '*' || module instanceof ExternalModule) {
+	} | void {
+		if (name[0] === '*' || module instanceof ExternalModule) {
 			return { variable: module.traceExport(name), module };
 		}
 
@@ -363,11 +366,6 @@ export default class Chunk {
 
 		if (name === 'default') {
 			return;
-		}
-
-		// external star exports
-		if (name[0] === '*') {
-			return { variable: undefined, module: this.graph.moduleById.get(name.substr(1)) };
 		}
 
 		// resolve known star exports

--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -11,17 +11,19 @@ export default class NamespaceVariable extends Variable {
 	// Not initialised during construction
 	originals: { [name: string]: Variable } = Object.create(null);
 	needsNamespaceBlock: boolean = false;
-	
+
 	// only to be used for chunk-to-chunk import tracing, use context for data manipulation
 	module: Module;
 	private referencedEarly: boolean = false;
 	private references: Identifier[] = [];
+	private containsExternalNamespace: boolean = false;
 
 	constructor(context: AstContext, module: Module) {
 		super(context.getModuleName());
 		this.context = context;
 		this.module = module;
 		for (const name of this.context.getExports().concat(this.context.getReexports())) {
+			if (name[0] === '*' && name.length > 1) this.containsExternalNamespace = true;
 			this.originals[name] = this.context.traceExport(name);
 		}
 	}
@@ -33,6 +35,16 @@ export default class NamespaceVariable extends Variable {
 
 	include() {
 		if (!this.included) {
+			if (this.containsExternalNamespace) {
+				this.context.error(
+					{
+						code: 'NAMESPACE_CANNOT_CONTAIN_EXTERNAL',
+						message: `Cannot create an explicit namespace object for module "${this.context.getModuleName()}" because it contains a reexported external namespace`,
+						id: this.module.id
+					},
+					undefined
+				);
+			}
 			this.context.includeNamespace();
 			this.included = true;
 			this.needsNamespaceBlock = true;

--- a/test/function/samples/internal-reexports-from-external/_config.js
+++ b/test/function/samples/internal-reexports-from-external/_config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	description:
+		'fails with a helpful error if creating a namespace object containing a reexported external namespace',
+	options: {
+		external: ['external']
+	},
+	error: {
+		code: 'NAMESPACE_CANNOT_CONTAIN_EXTERNAL',
+		message:
+			'Cannot create an explicit namespace object for module "reexport" because it contains a reexported external namespace',
+		id: __dirname + '/reexport.js'
+	}
+};

--- a/test/function/samples/internal-reexports-from-external/main.js
+++ b/test/function/samples/internal-reexports-from-external/main.js
@@ -1,0 +1,3 @@
+import * as namespace from './reexport.js';
+
+console.log(namespace);

--- a/test/function/samples/internal-reexports-from-external/reexport.js
+++ b/test/function/samples/internal-reexports-from-external/reexport.js
@@ -1,0 +1,1 @@
+export * from 'external';


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Currently, it is not possible to create an explicit namespace object for a module that reexports the namespace of an external module. Doing this properly would definitely require a new logic for creating namespaces as we would now need to combine an existing namespace with new exports.
Until a solution is found, this PR will throw a proper error instead of either creating garbage
https://rollupjs.org/repl?version=0.64.1&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMColMjBhcyUyMG4lMjBmcm9tJTIwJy4lMkZtb2R1bGVfMS5qcyclM0IlNUNuY29uc29sZS5sb2cobiklM0IlMjIlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIybW9kdWxlXzEuanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyZXhwb3J0JTIwKiUyMGZyb20lMjAnZXh0ZXJuYWwnJTNCJTVDbmV4cG9ydCUyMGNvbnN0JTIweCUyMCUzRCUyMDElM0IlMjIlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyZm9ybWF0JTIyJTNBJTIyZXNtJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlN0QlMkMlMjJleGFtcGxlJTIyJTNBbnVsbCU3RA==

or failing with a type error
https://rollupjs.org/repl?version=0.66.4&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMColMjBhcyUyMG4lMjBmcm9tJTIwJy4lMkZtb2R1bGVfMS5qcyclM0IlNUNuY29uc29sZS5sb2cobiklM0IlMjIlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIybW9kdWxlXzEuanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyZXhwb3J0JTIwKiUyMGZyb20lMjAnZXh0ZXJuYWwnJTNCJTVDbmV4cG9ydCUyMGNvbnN0JTIweCUyMCUzRCUyMDElM0IlMjIlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyZm9ybWF0JTIyJTNBJTIyZXNtJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlN0QlMkMlMjJleGFtcGxlJTIyJTNBbnVsbCU3RA==

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
