### PR TITLE
Properly deconflict ids of default exports that have been reassigned

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -7,8 +7,6 @@ import ExportDefaultDeclaration, {
 	isExportDefaultDeclaration
 } from './ast/nodes/ExportDefaultDeclaration';
 import ExportNamedDeclaration from './ast/nodes/ExportNamedDeclaration';
-import FunctionDeclaration from './ast/nodes/FunctionDeclaration';
-import Identifier from './ast/nodes/Identifier';
 import Import from './ast/nodes/Import';
 import ImportDeclaration from './ast/nodes/ImportDeclaration';
 import ImportSpecifier from './ast/nodes/ImportSpecifier';
@@ -366,10 +364,6 @@ export default class Module {
 			// export default function foo () {}
 			// export default foo;
 			// export default 42;
-			const identifier =
-				((<FunctionDeclaration>node.declaration).id &&
-					(<FunctionDeclaration>node.declaration).id.name) ||
-				(<Identifier>node.declaration).name;
 			if (this.exports.default) {
 				this.error(
 					{
@@ -382,7 +376,7 @@ export default class Module {
 
 			this.exports.default = {
 				localName: 'default',
-				identifier,
+				identifier: node.variable.getOriginalVariableName(),
 				node
 			};
 		} else if ((<ExportNamedDeclaration>node).declaration) {

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -8,7 +8,7 @@ import {
 import ExportDefaultVariable from '../variables/ExportDefaultVariable';
 import ClassDeclaration, { isClassDeclaration } from './ClassDeclaration';
 import FunctionDeclaration, { isFunctionDeclaration } from './FunctionDeclaration';
-import Identifier, { isIdentifier } from './Identifier';
+import Identifier from './Identifier';
 import * as NodeType from './NodeType';
 import { ExpressionNode, Node, NodeBase } from './shared/Node';
 
@@ -43,19 +43,6 @@ export default class ExportDefaultDeclaration extends NodeBase {
 	needsBoundaries: true;
 	variable: ExportDefaultVariable;
 	private declarationName: string;
-
-	bind() {
-		super.bind();
-		if (
-			this.declarationName &&
-			// Do not set it for Class and FunctionExpressions otherwise they get treeshaken away
-			(isFunctionDeclaration(this.declaration) ||
-				isClassDeclaration(this.declaration) ||
-				isIdentifier(this.declaration))
-		) {
-			this.variable.setOriginalVariable(this.scope.findVariable(this.declarationName));
-		}
-	}
 
 	initialise() {
 		this.included = false;

--- a/test/function/samples/deconflict-ids/_config.js
+++ b/test/function/samples/deconflict-ids/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deconflicts reassigned ids'
+};

--- a/test/function/samples/deconflict-ids/conflict1.js
+++ b/test/function/samples/deconflict-ids/conflict1.js
@@ -1,0 +1,3 @@
+function foo(){
+	throw new Error('Wrong foo function referenced.')
+}

--- a/test/function/samples/deconflict-ids/conflict2.js
+++ b/test/function/samples/deconflict-ids/conflict2.js
@@ -1,0 +1,3 @@
+function foo(){
+	throw new Error('Wrong foo function referenced.')
+}

--- a/test/function/samples/deconflict-ids/main.js
+++ b/test/function/samples/deconflict-ids/main.js
@@ -1,0 +1,5 @@
+import './conflict1.js';
+import './conflict2.js';
+import foo from './used.js';
+
+assert.equal(foo(1), 2);

--- a/test/function/samples/deconflict-ids/used.js
+++ b/test/function/samples/deconflict-ids/used.js
@@ -1,0 +1,6 @@
+export default function foo() {
+	foo = function(x){
+		return x + 1;
+	};
+	return foo.apply(this, arguments);
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2414 

### Description
See also #2414. The logic for handling default exports of function and class declarations did not properly take into account that those not only declare a local variable as well but that reassigning this local variable *will* reassign the default export. Cf. these examples:

```js
// the default export will be 42 because it is the value of a that is exported
var a = 42;
export default a;
a = 43;
```

vs.

```js
// the default export will return 43 because it is the binding of a that is exported
export default function a() {return 42;};
a = () => 43;
```

Previously, only the first case was handled properly while this PR also handles the second case right. This also cleans up some logic so that almost everything related to default exports with ids is now handled together in `ExportDefaultVariable`.