### PR TITLE
Fix ExistingRawSourceMap type

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -27,13 +27,13 @@ export interface RollupError {
 }
 
 export interface ExistingRawSourceMap {
-	version: string;
+	version: number;
 	sources: string[];
 	names: string[];
 	sourceRoot?: string;
 	sourcesContent?: string[];
 	mappings: string;
-	file: string;
+	file?: string;
 }
 
 export type RawSourceMap = { mappings: '' } | ExistingRawSourceMap;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [X] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [X] no

List any relevant issue numbers:

### Description

The current definition of the (TypeScript) `ExistingRawSourceMap` type is wrong, the property `version` is defined as "string" but the correct type is "number".

This conflicts with libraries that returns sourceMap with the correct type, like the next version of [gen-pug-source-map](https://github.com/aMarCruz/gen-pug-source-map) used in the [rollup-plugin-pug](https://github.com/aMarCruz/rollup-plugin-pug).

This is a screenshot with such error:

![image](https://user-images.githubusercontent.com/6636980/46912563-5d988a00-cf3e-11e8-90c0-cfc61647a854.png)

After applying this fix the issue disappears.

See the [Source Map Revision 3 Proposal](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k)