### PR TITLE
Fix placement of inserted semicolon when using SystemJS

### DIFF
--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -52,7 +52,7 @@ export default class AssignmentExpression extends NodeBase {
 				code.original.indexOf('=', this.left.end) + 1,
 				` exports('${this.left.variable.exportName}',`
 			);
-			code.prependRight(this.right.end, `)`);
+			code.appendLeft(this.right.end, `)`);
 		}
 	}
 }

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -205,7 +205,7 @@ export class NodeBase implements ExpressionNode {
 
 	insertSemicolon(code: MagicString) {
 		if (code.original[this.end - 1] !== ';') {
-			code.appendLeft(this.end, ';');
+			code.appendRight(this.end, ';');
 		}
 	}
 

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -205,7 +205,7 @@ export class NodeBase implements ExpressionNode {
 
 	insertSemicolon(code: MagicString) {
 		if (code.original[this.end - 1] !== ';') {
-			code.appendRight(this.end, ';');
+			code.appendLeft(this.end, ';');
 		}
 	}
 

--- a/test/form/samples/modify-export-semi/_config.js
+++ b/test/form/samples/modify-export-semi/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'inserts semicolons correctly when modifying SystemJS exports',
+	formats: ['system']
+};

--- a/test/form/samples/modify-export-semi/_expected/system.js
+++ b/test/form/samples/modify-export-semi/_expected/system.js
@@ -1,0 +1,12 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			let foo = exports('foo', 'foo');
+
+			foo = exports('foo', 'bar');
+
+		}
+	};
+});

--- a/test/form/samples/modify-export-semi/main.js
+++ b/test/form/samples/modify-export-semi/main.js
@@ -1,0 +1,3 @@
+export let foo = 'foo'
+
+foo = 'bar'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#2527

### Description

Fixes #2527.

Currently, semicolons are inserted using `appendLeft`. But this means that any code inserted after the end of the line will be inserted _after_ the semicolon, which is not what we want.

This fixes the issue by using `appendRight` instead.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
