### PR TITLE
Make sure cli entry points with the same name but on different paths are deconflicted

### DIFF
--- a/bin/src/run/index.ts
+++ b/bin/src/run/index.ts
@@ -20,26 +20,22 @@ export default function runRollup(command: any) {
 	}
 
 	if (command.dir) {
-		if (command._.length && !command._.some((input: string) => input.indexOf('=') !== -1)) {
-			command.input = command._;
-		} else if (
-			command._.length ||
-			Array.isArray(command.input) ||
-			typeof command.input === 'string'
-		) {
-			let input: string[];
-			if (command._.length) input = command._;
-			else input = typeof command.input === 'string' ? [command.input] : command.input;
-			command.input = {};
-			input.forEach((input: string) => {
-				const equalsIndex = input.indexOf('=');
-				const value = input.substr(equalsIndex + 1);
-				let key = input.substr(0, equalsIndex);
-				if (!key) key = getAliasName(input);
-				command.input[key] = value;
-			});
+		if (command._.length) {
+			if (command._.some((input: string) => input.indexOf('=') !== -1)) {
+				command.input = {};
+				command._.forEach((input: string) => {
+					const equalsIndex = input.indexOf('=');
+					const value = input.substr(equalsIndex + 1);
+					let key = input.substr(0, equalsIndex);
+					if (!key) key = getAliasName(input);
+					command.input[key] = value;
+				});
+			} else {
+				command.input = command._;
+			}
+		} else if (typeof command.input === 'string') {
+			command.input = [command.input];
 		}
-		command._ = [];
 	} else if (command._.length === 1) {
 		command.input = command._[0];
 	}

--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -1,8 +1,6 @@
 const path = require('path');
-const assert = require('assert');
-const fixturify = require('fixturify');
 const rollup = require('../../dist/rollup');
-const { extend, runTestSuiteWithSamples } = require('../utils.js');
+const { extend, runTestSuiteWithSamples, assertDirectoriesAreEqual } = require('../utils.js');
 
 const FORMATS = ['es', 'cjs', 'amd', 'system'];
 
@@ -52,30 +50,7 @@ runTestSuiteWithSamples('chunking form', path.resolve(__dirname, 'samples'), (di
 });
 
 function generateAndTestBundle(bundle, outputOptions, expectedDir) {
-	return bundle.write(outputOptions).then(() => {
-		const actualFiles = fixturify.readSync(outputOptions.dir);
-
-		let expectedFiles;
-		try {
-			expectedFiles = fixturify.readSync(expectedDir);
-		} catch (err) {
-			expectedFiles = [];
-		}
-		assertFilesAreEqual(actualFiles, expectedFiles, []);
-	});
-}
-
-function assertFilesAreEqual(actualFiles, expectedFiles, dirs) {
-	Object.keys(Object.assign({}, actualFiles, expectedFiles)).forEach(fileName => {
-		const pathSegments = dirs.concat(fileName);
-		if (typeof actualFiles[fileName] === 'object' && typeof expectedFiles[fileName] === 'object') {
-			return assertFilesAreEqual(actualFiles[fileName], expectedFiles[fileName], pathSegments);
-		}
-
-		const shortName = pathSegments.join('/');
-		assert.strictEqual(
-			`${shortName}: ${actualFiles[fileName]}`,
-			`${shortName}: ${expectedFiles[fileName]}`
-		);
-	});
+	return bundle
+		.write(outputOptions)
+		.then(() => assertDirectoriesAreEqual(outputOptions.dir, expectedDir));
 }

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -3,7 +3,11 @@ const assert = require('assert');
 const sander = require('sander');
 const buble = require('buble');
 const { exec } = require('child_process');
-const { normaliseOutput, runTestSuiteWithSamples } = require('../utils.js');
+const {
+	normaliseOutput,
+	runTestSuiteWithSamples,
+	assertDirectoriesAreEqual
+} = require('../utils.js');
 
 const cwd = process.cwd();
 
@@ -91,17 +95,12 @@ runTestSuiteWithSamples(
 							done(err);
 						}
 					} else if (sander.existsSync('_expected') && sander.statSync('_expected').isDirectory()) {
-						let error = null;
-						sander.readdirSync('_expected').forEach(child => {
-							const expected = sander.readFileSync(path.join('_expected', child)).toString();
-							const actual = sander.readFileSync(path.join('_actual', child)).toString();
-							try {
-								assert.equal(normaliseOutput(actual), normaliseOutput(expected));
-							} catch (err) {
-								error = err;
-							}
-						});
-						done(error);
+						try {
+							assertDirectoriesAreEqual('_actual', '_expected');
+							done();
+						} catch (err) {
+							done(err);
+						}
 					} else {
 						const expected = sander.readFileSync('_expected.js').toString();
 						try {

--- a/test/cli/samples/deconflict-entry-point-in-subdir/_config.js
+++ b/test/cli/samples/deconflict-entry-point-in-subdir/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'deconflict entry points with the same name in different directories',
+	command:
+		'rollup --input main.js --input sub/main.js --format esm --dir _actual --experimentalCodeSplitting'
+};

--- a/test/cli/samples/deconflict-entry-point-in-subdir/_expected/main.js
+++ b/test/cli/samples/deconflict-entry-point-in-subdir/_expected/main.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/test/cli/samples/deconflict-entry-point-in-subdir/_expected/main2.js
+++ b/test/cli/samples/deconflict-entry-point-in-subdir/_expected/main2.js
@@ -1,0 +1,1 @@
+console.log('sub');

--- a/test/cli/samples/deconflict-entry-point-in-subdir/main.js
+++ b/test/cli/samples/deconflict-entry-point-in-subdir/main.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/test/cli/samples/deconflict-entry-point-in-subdir/sub/main.js
+++ b/test/cli/samples/deconflict-entry-point-in-subdir/sub/main.js
@@ -1,0 +1,1 @@
+console.log('sub');


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2543 

### Description
The special logic for naming entry points via the CLI by using "=" in the name always kicked in regardless if "=" was used or not. This lead to entry points overwriting each other. This PR only uses this naming logic in case at least one input uses "="

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
