### PR TITLE
Fix crash when returning undefined sourcemaps from renderChunk hook

### DIFF
--- a/test/form/samples/render-chunk-plugin-sourcemaps/_config.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	description:
+		'supports returning undefined source maps from render chunk hooks, when source maps are enabled',
+	options: {
+		output: {
+			sourcemap: true
+		},
+		plugins: [
+			{
+				renderChunk(code) {
+					return '/* first plugin */';
+				}
+			},
+			{
+				renderChunk(code) {
+					return code + '\n/* second plugin */';
+				}
+			}
+		]
+	}
+};

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/amd.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/amd.js
@@ -1,0 +1,3 @@
+/* first plugin */
+/* second plugin */
+//# sourceMappingURL=amd.js.map

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/amd.js.map
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/amd.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"amd.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/cjs.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/cjs.js
@@ -1,0 +1,3 @@
+/* first plugin */
+/* second plugin */
+//# sourceMappingURL=cjs.js.map

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/cjs.js.map
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/cjs.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"cjs.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/es.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/es.js
@@ -1,0 +1,3 @@
+/* first plugin */
+/* second plugin */
+//# sourceMappingURL=es.js.map

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/es.js.map
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/es.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"es.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/iife.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/iife.js
@@ -1,0 +1,3 @@
+/* first plugin */
+/* second plugin */
+//# sourceMappingURL=iife.js.map

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/iife.js.map
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/iife.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"iife.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/system.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/system.js
@@ -1,0 +1,3 @@
+/* first plugin */
+/* second plugin */
+//# sourceMappingURL=system.js.map

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/system.js.map
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/system.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"system.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/umd.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/umd.js
@@ -1,0 +1,3 @@
+/* first plugin */
+/* second plugin */
+//# sourceMappingURL=umd.js.map

--- a/test/form/samples/render-chunk-plugin-sourcemaps/_expected/umd.js.map
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/_expected/umd.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"umd.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}

--- a/test/form/samples/render-chunk-plugin-sourcemaps/main.js
+++ b/test/form/samples/render-chunk-plugin-sourcemaps/main.js
@@ -1,0 +1,1 @@
+console.log( 1 + 1 );


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#2557 

### Description
Fixes #2557.

Previously, if source maps were enabled and a renderChunk hook returned just the transformed code (i.e., an `undefined` source map), Rollup would throw an error -- this was because `undefined` source maps are replaced with a placeholder object, used to signal that the source map is missing, and which plugin generated it. These objects were not being detected everywhere, so they would sometimes be used as source maps when they should not be.

This fixes the issue by reusing an existing block of code to detect these placeholder objects, issue a warning, and replace them with an empty source map.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->