### PR TITLE
fix: experimentalPreserveModules not support in inlineDynamicImports …

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -117,6 +117,11 @@ function getInputOptions(rawInputOptions: GenericConfigObject): any {
 	}
 
 	if (inputOptions.inlineDynamicImports) {
+		if (inputOptions.experimentalPreserveModules)
+			error({
+				code: 'INVALID_OPTION',
+				message: `experimentalPreserveModules does not support the inlineDynamicImports option.`
+			});
 		if (inputOptions.manualChunks)
 			error({
 				code: 'INVALID_OPTION',
@@ -134,11 +139,6 @@ function getInputOptions(rawInputOptions: GenericConfigObject): any {
 				message: 'Multiple inputs are not supported for inlineDynamicImports.'
 			});
 	} else if (inputOptions.experimentalPreserveModules) {
-		if (inputOptions.inlineDynamicImports)
-			error({
-				code: 'INVALID_OPTION',
-				message: `experimentalPreserveModules does not support the inlineDynamicImports option.`
-			});
 		if (inputOptions.manualChunks)
 			error({
 				code: 'INVALID_OPTION',


### PR DESCRIPTION
…message

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Since `inlineDynamicImports` won't be truthy in `else if (inputOptions.experimentalPreserveModules)`, so move `INVALID_OPTION` above.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
