### PR TITLE
Fix sourcemaps for large minified bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4733,9 +4733,9 @@
       "dev": true
     },
     "sourcemap-codec": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
-      "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "signal-exit": "^3.0.2",
     "source-map": "^0.6.1",
     "source-map-support": "^0.5.9",
-    "sourcemap-codec": "^1.4.1",
+    "sourcemap-codec": "^1.4.4",
     "terser": "^3.8.2",
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
- fixes #2525

### Description

Sourcemaps were broken for lines longer than 32767 characters, which can happen if a large bundle was generated and minifed using Rollup.

https://github.com/Rich-Harris/sourcemap-codec/pull/77

Regressed in v0.66.3 8a8721ea0657073de9db35862d4ab9e1dc402973