### PR TITLE
Properly export destructured export declarations in SystemJS

### DIFF
--- a/src/ast/nodes/ArrayPattern.ts
+++ b/src/ast/nodes/ArrayPattern.ts
@@ -1,5 +1,6 @@
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EMPTY_PATH, ObjectPath, UNKNOWN_EXPRESSION } from '../values';
+import Variable from '../variables/Variable';
 import * as NodeType from './NodeType';
 import { ExpressionEntity } from './shared/Expression';
 import { NodeBase } from './shared/Node';
@@ -8,6 +9,14 @@ import { PatternNode } from './shared/Pattern';
 export default class ArrayPattern extends NodeBase implements PatternNode {
 	type: NodeType.tArrayPattern;
 	elements: (PatternNode | null)[];
+
+	addExportedVariables(variables: Variable[]): void {
+		for (const element of this.elements) {
+			if (element !== null) {
+				element.addExportedVariables(variables);
+			}
+		}
+	}
 
 	declare(kind: string, _init: ExpressionEntity) {
 		for (const element of this.elements) {

--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -1,7 +1,9 @@
 import MagicString from 'magic-string';
 import { RenderOptions } from '../../utils/renderHelpers';
+import { getSystemExportStatement } from '../../utils/systemJsRendering';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EMPTY_PATH, ObjectPath, UNKNOWN_PATH } from '../values';
+import Variable from '../variables/Variable';
 import * as NodeType from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { PatternNode } from './shared/Pattern';
@@ -47,12 +49,24 @@ export default class AssignmentExpression extends NodeBase {
 	render(code: MagicString, options: RenderOptions) {
 		this.left.render(code, options);
 		this.right.render(code, options);
-		if (options.format === 'system' && this.left.variable && this.left.variable.exportName) {
-			code.prependLeft(
-				code.original.indexOf('=', this.left.end) + 1,
-				` exports('${this.left.variable.exportName}',`
-			);
-			code.appendLeft(this.right.end, `)`);
+		if (options.format === 'system') {
+			if (this.left.variable && this.left.variable.exportName) {
+				code.prependLeft(
+					code.original.indexOf('=', this.left.end) + 1,
+					` exports('${this.left.variable.exportName}',`
+				);
+				code.appendLeft(this.right.end, `)`);
+			} else if ('addExportedVariables' in this.left) {
+				const systemPatternExports: Variable[] = [];
+				this.left.addExportedVariables(systemPatternExports);
+				if (systemPatternExports.length > 0) {
+					code.prependRight(
+						this.start,
+						`function (v) {${getSystemExportStatement(systemPatternExports)} return v;} (`
+					);
+					code.appendLeft(this.end, ')');
+				}
+			}
 		}
 	}
 }

--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -3,6 +3,7 @@ import { BLANK } from '../../utils/blank';
 import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EMPTY_PATH, ObjectPath, UNKNOWN_PATH } from '../values';
+import Variable from '../variables/Variable';
 import * as NodeType from './NodeType';
 import { ExpressionEntity } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
@@ -12,6 +13,10 @@ export default class AssignmentPattern extends NodeBase implements PatternNode {
 	type: NodeType.tAssignmentPattern;
 	left: PatternNode;
 	right: ExpressionNode;
+
+	addExportedVariables(variables: Variable[]): void {
+		this.left.addExportedVariables(variables);
+	}
 
 	bind() {
 		super.bind();

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -13,17 +13,24 @@ import Variable from '../variables/Variable';
 import * as NodeType from './NodeType';
 import { ExpressionEntity } from './shared/Expression';
 import { Node, NodeBase } from './shared/Node';
+import { PatternNode } from './shared/Pattern';
 
 export function isIdentifier(node: Node): node is Identifier {
 	return node.type === NodeType.Identifier;
 }
 
-export default class Identifier extends NodeBase {
+export default class Identifier extends NodeBase implements PatternNode {
 	type: NodeType.tIdentifier;
 	name: string;
 
 	variable: Variable;
 	private bound: boolean;
+
+	addExportedVariables(variables: Variable[]): void {
+		if (this.variable.exportName) {
+			variables.push(this.variable);
+		}
+	}
 
 	bind() {
 		if (this.bound) return;

--- a/src/ast/nodes/ObjectPattern.ts
+++ b/src/ast/nodes/ObjectPattern.ts
@@ -1,5 +1,6 @@
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EMPTY_PATH, ObjectPath } from '../values';
+import Variable from '../variables/Variable';
 import * as NodeType from './NodeType';
 import Property from './Property';
 import RestElement from './RestElement';
@@ -10,6 +11,16 @@ import { PatternNode } from './shared/Pattern';
 export default class ObjectPattern extends NodeBase implements PatternNode {
 	type: NodeType.tObjectPattern;
 	properties: (Property | RestElement)[];
+
+	addExportedVariables(variables: Variable[]): void {
+		for (const property of this.properties) {
+			if (property.type === NodeType.Property) {
+				(<PatternNode>(<unknown>property.value)).addExportedVariables(variables);
+			} else {
+				property.argument.addExportedVariables(variables);
+			}
+		}
+	}
 
 	declare(kind: string, init: ExpressionEntity) {
 		for (const property of this.properties) {

--- a/src/ast/nodes/RestElement.ts
+++ b/src/ast/nodes/RestElement.ts
@@ -1,5 +1,6 @@
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EMPTY_PATH, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_KEY } from '../values';
+import Variable from '../variables/Variable';
 import * as NodeType from './NodeType';
 import { ExpressionEntity } from './shared/Expression';
 import { NodeBase } from './shared/Node';
@@ -10,6 +11,10 @@ export default class RestElement extends NodeBase implements PatternNode {
 	argument: PatternNode;
 
 	private declarationInit: ExpressionEntity | null = null;
+
+	addExportedVariables(variables: Variable[]): void {
+		this.argument.addExportedVariables(variables);
+	}
 
 	bind() {
 		super.bind();

--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -5,6 +5,7 @@ import {
 	NodeRenderOptions,
 	RenderOptions
 } from '../../utils/renderHelpers';
+import { getSystemExportStatement } from '../../utils/systemJsRendering';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { EMPTY_PATH, ObjectPath } from '../values';
 import Variable from '../variables/Variable';
@@ -36,27 +37,6 @@ function areAllDeclarationsIncludedAndNotExported(declarations: VariableDeclarat
 		}
 	}
 	return true;
-}
-
-function renderSystemExports(
-	code: MagicString,
-	systemPatternExports: Variable[],
-	appendPosition: number
-) {
-	if (systemPatternExports.length === 1) {
-		code.appendRight(
-			appendPosition,
-			` exports('${systemPatternExports[0].safeExportName ||
-				systemPatternExports[0].exportName}', ${systemPatternExports[0].getName()});`
-		);
-	} else {
-		code.appendRight(
-			appendPosition,
-			` exports({${systemPatternExports
-				.map(variable => `${variable.safeExportName || variable.exportName}: ${variable.getName()}`)
-				.join(', ')}});`
-		);
-	}
 }
 
 export default class VariableDeclaration extends NodeBase {
@@ -238,7 +218,7 @@ export default class VariableDeclaration extends NodeBase {
 			code.appendLeft(renderedContentEnd, separatorString);
 		}
 		if (systemPatternExports.length > 0) {
-			renderSystemExports(code, systemPatternExports, renderedContentEnd);
+			code.appendLeft(renderedContentEnd, ' ' + getSystemExportStatement(systemPatternExports));
 		}
 	}
 }

--- a/src/ast/nodes/shared/Pattern.ts
+++ b/src/ast/nodes/shared/Pattern.ts
@@ -1,4 +1,7 @@
 import { WritableEntity } from '../../Entity';
+import Variable from '../../variables/Variable';
 import { Node } from './Node';
 
-export interface PatternNode extends WritableEntity, Node {}
+export interface PatternNode extends WritableEntity, Node {
+	addExportedVariables(variables: Variable[]): void;
+}

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -237,7 +237,6 @@ export interface InputOptions {
 	moduleContext?: string | ((id: string) => string) | { [id: string]: string };
 	watch?: WatcherOptions;
 	experimentalCodeSplitting?: boolean;
-	experimentalDynamicImport?: boolean;
 	experimentalTopLevelAwait?: boolean;
 	inlineDynamicImports?: boolean;
 	preserveSymlinks?: boolean;

--- a/src/utils/systemJsRendering.ts
+++ b/src/utils/systemJsRendering.ts
@@ -1,0 +1,12 @@
+import Variable from '../ast/variables/Variable';
+
+export function getSystemExportStatement(exportedVariables: Variable[]): string {
+	if (exportedVariables.length === 1) {
+		return `exports('${exportedVariables[0].safeExportName ||
+			exportedVariables[0].exportName}', ${exportedVariables[0].getName()});`;
+	} else {
+		return `exports({${exportedVariables
+			.map(variable => `${variable.safeExportName || variable.exportName}: ${variable.getName()}`)
+			.join(', ')}});`;
+	}
+}

--- a/test/form/samples/system-export-destructuring-assignment/_config.js
+++ b/test/form/samples/system-export-destructuring-assignment/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'Supports destructuring declarations and assignments for SystemJS',
+	options: {
+		output: {
+			format: 'system'
+		}
+	}
+};

--- a/test/form/samples/system-export-destructuring-assignment/_config.js
+++ b/test/form/samples/system-export-destructuring-assignment/_config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	description: 'Supports destructuring declarations and assignments for SystemJS',
+	description: 'supports destructuring assignments of exports for systemJS',
 	options: {
 		output: {
 			format: 'system'

--- a/test/form/samples/system-export-destructuring-assignment/_expected.js
+++ b/test/form/samples/system-export-destructuring-assignment/_expected.js
@@ -1,0 +1,15 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const {a = 1, ...b} = global1, c = exports('c', global2), {d} = global3; exports({a: a, b: b, d: d});
+			const [e, ...f] = global4; exports({e: e, f: f});
+			const {g, x: h = 2, y: {z: i}, a: [j ,k,, l]} = global5; exports({g: g, h: h, i: i, j: j, k: k, l: l});
+
+			var m = exports('m', 1);
+			var {m} = global6; exports('m', m);
+
+		}
+	};
+});

--- a/test/form/samples/system-export-destructuring-assignment/_expected.js
+++ b/test/form/samples/system-export-destructuring-assignment/_expected.js
@@ -3,12 +3,16 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			const {a = 1, ...b} = global1, c = exports('c', global2), {d} = global3; exports({a: a, b: b, d: d});
-			const [e, ...f] = global4; exports({e: e, f: f});
-			const {g, x: h = 2, y: {z: i}, a: [j ,k,, l]} = global5; exports({g: g, h: h, i: i, j: j, k: k, l: l});
+			exports({
+				a: void 0,
+				b: void 0,
+				c: void 0
+			});
 
-			var m = exports('m', 1);
-			var {m} = global6; exports('m', m);
+			let a, b, c;
+
+			console.log(function (v) {exports('a', a); return v;} ({a} = someObject));
+			(function (v) {exports({b: b, c: c}); return v;} ({b, c} = someObject));
 
 		}
 	};

--- a/test/form/samples/system-export-destructuring-assignment/main.js
+++ b/test/form/samples/system-export-destructuring-assignment/main.js
@@ -1,0 +1,6 @@
+export const {a = 1, ...b} = global1, c = global2, {d} = global3;
+export const [e, ...f] = global4;
+export const {g, x: h = 2, y: {z: i}, a: [j ,k,, l]} = global5;
+
+export var m = 1;
+var {m} = global6;

--- a/test/form/samples/system-export-destructuring-assignment/main.js
+++ b/test/form/samples/system-export-destructuring-assignment/main.js
@@ -1,6 +1,4 @@
-export const {a = 1, ...b} = global1, c = global2, {d} = global3;
-export const [e, ...f] = global4;
-export const {g, x: h = 2, y: {z: i}, a: [j ,k,, l]} = global5;
+export let a, b, c;
 
-export var m = 1;
-var {m} = global6;
+console.log({a} = someObject);
+({b, c} = someObject);

--- a/test/form/samples/system-export-destructuring-declaration/_config.js
+++ b/test/form/samples/system-export-destructuring-declaration/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'supports destructuring declarations for systemJS',
+	options: {
+		output: {
+			format: 'system'
+		}
+	}
+};

--- a/test/form/samples/system-export-destructuring-declaration/_expected.js
+++ b/test/form/samples/system-export-destructuring-declaration/_expected.js
@@ -1,0 +1,15 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const {a = 1, ...b} = global1, c = exports('c', global2), {d} = global3; exports({a: a, b: b, d: d});
+			const [e, ...f] = global4; exports({e: e, f: f});
+			const {g, x: h = 2, y: {z: i}, a: [j ,k,, l]} = global5; exports({g: g, h: h, i: i, j: j, k: k, l: l});
+
+			var m = exports('m', 1);
+			var {m} = global6; exports('m', m);
+
+		}
+	};
+});

--- a/test/form/samples/system-export-destructuring-declaration/main.js
+++ b/test/form/samples/system-export-destructuring-declaration/main.js
@@ -1,0 +1,6 @@
+export const {a = 1, ...b} = global1, c = global2, {d} = global3;
+export const [e, ...f] = global4;
+export const {g, x: h = 2, y: {z: i}, a: [j ,k,, l]} = global5;
+
+export var m = 1;
+var {m} = global6;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Closes #2556

### Description
This will make sure variables defined via a destructuring assignment are exported when building SystemJS output. Example:

```js
// input
export const {x, y: {z: a}, [u, v]} = someObject;
export const {w} = someOtherObject;

// output
const {x, y: {z: a}, [u, v]} = someObject; exports({x: x, a: a, u: u, v: v});
const {w} = someOtherObject; exports('w', w);
```

The exports are added inline with the declaration as otherwise the rendering logic would have become quite a bit more complex to get the indentation right.

**Update**: This will now also update exported variables which are reassigned in a non-declaration destructuring assignment via injecting an IIFE! Example:

```js
// input
export let a, b;
console.log({a, b} = someObject);

// output
let a, b;
console.log(function (v) {exports({a: a, b: b}; return v;} ({a, b} = someObject));
```

As far as I can see, this transformation should always produce valid, though not 100% readable, code but please check if I missed something.
