### PR TITLE
Sanitize chunk names to allow for virtually created chunks

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -30,6 +30,7 @@ import { basename, dirname, isAbsolute, normalize, relative, resolve } from './u
 import renderChunk from './utils/renderChunk';
 import { RenderOptions } from './utils/renderHelpers';
 import { makeUnique, renderNamePattern } from './utils/renderNamePattern';
+import { sanitizeFileName } from './utils/sanitize-file-name';
 import { timeEnd, timeStart } from './utils/timers';
 import { MISSING_EXPORT_SHIM_VARIABLE } from './utils/variableNames';
 
@@ -561,11 +562,8 @@ export default class Chunk {
 		const dependencies: ChunkDependencies = [];
 
 		this.dependencies.forEach(dep => {
-			const importsFromDependency = Array.from(this.imports).filter(
-				variable =>
-					variable.module instanceof Module
-						? variable.module.chunk === dep
-						: variable.module === dep
+			const importsFromDependency = Array.from(this.imports).filter(variable =>
+				variable.module instanceof Module ? variable.module.chunk === dep : variable.module === dep
 			);
 
 			let imports: ImportSpecifier[];
@@ -733,7 +731,6 @@ export default class Chunk {
 
 		// Make sure the direct dependencies of a chunk are present to maintain execution order
 		for (const { module } of Array.from(this.imports)) {
-			if (module.chunk === this) console.log(module.id);
 			const chunkOrExternal = module instanceof Module ? module.chunk : module;
 			if (this.dependencies.indexOf(chunkOrExternal) === -1) {
 				this.dependencies.push(chunkOrExternal);
@@ -938,7 +935,7 @@ export default class Chunk {
 		preserveModulesRelativeDir: string,
 		existingNames: Record<string, true>
 	) {
-		const sanitizedId = this.orderedModules[0].id.replace('\0', '_');
+		const sanitizedId = sanitizeFileName(this.orderedModules[0].id);
 		this.id = makeUnique(
 			normalize(
 				isAbsolute(this.orderedModules[0].id)
@@ -977,10 +974,10 @@ export default class Chunk {
 
 	private computeChunkName(): string {
 		if (this.facadeModule !== null && this.facadeModule.chunkAlias) {
-			return this.facadeModule.chunkAlias;
+			return sanitizeFileName(this.facadeModule.chunkAlias);
 		}
 		for (const module of this.orderedModules) {
-			if (module.chunkAlias) return module.chunkAlias;
+			if (module.chunkAlias) return sanitizeFileName(module.chunkAlias);
 		}
 		return 'chunk';
 	}

--- a/src/utils/relativeId.ts
+++ b/src/utils/relativeId.ts
@@ -19,7 +19,5 @@ export function isPlainName(name: string) {
 		(name[1] === '.' && (name[2] === '/' || (name[2] === '.' && name[3] === '/')))
 	)
 		return false;
-	// not a URL
-	if (name.indexOf(':') !== -1) return false;
 	return true;
 }

--- a/src/utils/sanitize-file-name.ts
+++ b/src/utils/sanitize-file-name.ts
@@ -1,0 +1,3 @@
+export function sanitizeFileName(name: string): string {
+	return name.replace(/[\0]/g, '_');
+}

--- a/test/chunking-form/samples/sanitize-chunk-names/_config.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_config.js
@@ -1,0 +1,20 @@
+module.exports = {
+	description: 'sanitizes chunk names from virtual entry points',
+	options: {
+		input: ['main1'],
+		plugins: [
+			{
+				options(options) {
+					options.input = ['\0virtual:entry-1', '\0virtual:entry-2'];
+					return options;
+				},
+				resolveId(id) {
+					return id;
+				},
+				load(id) {
+					return 'export default ' + JSON.stringify(id);
+				}
+			}
+		]
+	}
+};

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual:entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual:entry-1.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var _virtual_entry1 = "\u0000virtual:entry-1";
+
+	return _virtual_entry1;
+
+});

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual:entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual:entry-2.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var _virtual_entry2 = "\u0000virtual:entry-2";
+
+	return _virtual_entry2;
+
+});

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual:entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual:entry-1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var _virtual_entry1 = "\u0000virtual:entry-1";
+
+module.exports = _virtual_entry1;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual:entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual:entry-2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var _virtual_entry2 = "\u0000virtual:entry-2";
+
+module.exports = _virtual_entry2;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual:entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual:entry-1.js
@@ -1,0 +1,3 @@
+var _virtual_entry1 = "\u0000virtual:entry-1";
+
+export default _virtual_entry1;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual:entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual:entry-2.js
@@ -1,0 +1,3 @@
+var _virtual_entry2 = "\u0000virtual:entry-2";
+
+export default _virtual_entry2;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual:entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual:entry-1.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var _virtual_entry1 = exports('default', "\u0000virtual:entry-1");
+
+		}
+	};
+});

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual:entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual:entry-2.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var _virtual_entry2 = exports('default', "\u0000virtual:entry-2");
+
+		}
+	};
+});

--- a/test/chunking-form/samples/sanitize-chunk-names/main1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/main1.js
@@ -1,0 +1,1 @@
+console.log('main1');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

This will allow plugins to use virtual modules (i.e. starting with a `\0`) as entry points. This will enable `rollup-plugin-multi-entry` to work with rollup@1.0 as it creates such a virtual entry point,.