### PR TITLE
Fixed issue with reexporting default as default with {exports: named,…

### DIFF
--- a/src/finalisers/shared/getExportBlock.ts
+++ b/src/finalisers/shared/getExportBlock.ts
@@ -62,8 +62,15 @@ export default function getExportBlock(
 							reexports.some(
 								specifier => specifier.imported !== 'default' && specifier.imported !== '*'
 							));
+
+					const reexportsDefaultAsDefault =
+						reexports &&
+						reexports.some(
+							specifier => specifier.imported === 'default' && specifier.reexported === 'default'
+						);
+
 					if (exportBlock && !compact) exportBlock += '\n';
-					if (exportsNamesOrNamespace)
+					if (exportsNamesOrNamespace || reexportsDefaultAsDefault)
 						exportBlock += `exports.${specifier.reexported}${_}=${_}${name}${
 							interop !== false ? '__default' : '.default'
 						};`;

--- a/test/form/samples/re-export-default-external-as-default/_config.js
+++ b/test/form/samples/re-export-default-external-as-default/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 're-exports a default external import as default export (when using named exports)',
+	options: {
+		output: { name: 'reexportsDefaultExternalAsDefault', exports: 'named' },
+		external: ['external']
+	}
+};

--- a/test/form/samples/re-export-default-external-as-default/_expected/amd.js
+++ b/test/form/samples/re-export-default-external-as-default/_expected/amd.js
@@ -1,0 +1,12 @@
+define(['exports', 'external'], function (exports, external) { 'use strict';
+
+	var external__default = 'default' in external ? external['default'] : external;
+
+
+
+	Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+	exports.default = external__default;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/re-export-default-external-as-default/_expected/cjs.js
+++ b/test/form/samples/re-export-default-external-as-default/_expected/cjs.js
@@ -1,0 +1,13 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var external = require('external');
+var external__default = _interopDefault(external);
+
+
+
+Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+exports.default = external__default;

--- a/test/form/samples/re-export-default-external-as-default/_expected/es.js
+++ b/test/form/samples/re-export-default-external-as-default/_expected/es.js
@@ -1,0 +1,2 @@
+export * from 'external';
+export { default } from 'external';

--- a/test/form/samples/re-export-default-external-as-default/_expected/iife.js
+++ b/test/form/samples/re-export-default-external-as-default/_expected/iife.js
@@ -1,0 +1,13 @@
+var reexportsDefaultExternalAsDefault = (function (exports, external) {
+	'use strict';
+
+	var external__default = 'default' in external ? external['default'] : external;
+
+
+
+	Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+	exports.default = external__default;
+
+	return exports;
+
+}({}, external));

--- a/test/form/samples/re-export-default-external-as-default/_expected/system.js
+++ b/test/form/samples/re-export-default-external-as-default/_expected/system.js
@@ -1,0 +1,19 @@
+System.register('reexportsDefaultExternalAsDefault', ['external'], function (exports, module) {
+	'use strict';
+	var _starExcludes = { default: 1 };
+	return {
+		setters: [function (module) {
+			var _setter = {};
+			for (var _$p in module) {
+				if (!_starExcludes[_$p]) _setter[_$p] = module[_$p];
+			}
+			_setter.default = module.default;
+			exports(_setter);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/form/samples/re-export-default-external-as-default/_expected/umd.js
+++ b/test/form/samples/re-export-default-external-as-default/_expected/umd.js
@@ -1,0 +1,16 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('external')) :
+	typeof define === 'function' && define.amd ? define(['exports', 'external'], factory) :
+	(global = global || self, factory(global.reexportsDefaultExternalAsDefault = {}, global.external));
+}(this, function (exports, external) { 'use strict';
+
+	var external__default = 'default' in external ? external['default'] : external;
+
+
+
+	Object.keys(external).forEach(function (key) { exports[key] = external[key]; });
+	exports.default = external__default;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+}));

--- a/test/form/samples/re-export-default-external-as-default/main.js
+++ b/test/form/samples/re-export-default-external-as-default/main.js
@@ -1,0 +1,2 @@
+export * from 'external';
+export { default } from 'external';


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no (in some weird scenario technically this can be breaking for somebody)

List any relevant issue numbers:

### Description

Without this it hit this branch - https://github.com/rollup/rollup/blob/7cc2f62ed38951c62cbd144125847e0942ef540f/src/finalisers/shared/getExportBlock.ts#L70 and thus emitted invalid reexport.