### PR TITLE
Simplify RollupOptions

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -383,8 +383,6 @@ export interface RollupBuild {
 }
 
 export interface RollupOptions extends InputOptions {
-	cache?: RollupCache;
-	input: string | string[] | { [entryName: string]: string };
 	output?: OutputOptions;
 }
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:

https://github.com/rollup/rollup/issues/2621

### Description

Removes `input` and `cache` properties from `RollupOptions` interface in [`types.d.ts`](https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts)

Closes https://github.com/rollup/rollup/issues/2621

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
