### PR TITLE
Show how to skip imports for optional plugins

### DIFF
--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -210,19 +210,20 @@ See [Using plugins](guide/en#using-plugins) for more information on how to use p
 // rollup.config.js
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
-import {terser} from 'rollup-plugin-terser';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-export default {
+export default (async () => ({
   entry: 'main.js',
   plugins: [
     resolve(),
     commonjs(),
-    isProduction && terser()
+    isProduction && (await import('rollup-plugin-terser')).terser()
   ]
-};
+})();
 ```
+
+(This example also demonstrates how to use an async IIFE and dynamic imports to avoid unnecessary module loading, which can be surprisingly slow.)
 
 ### Advanced functionality
 


### PR DESCRIPTION
The most common Rollup plugins are pretty fast to import (by Node standards), but even those will commonly add on a handful of milliseconds, and it’s not unheard of to have imports literally take seconds. If you don’t need it, why load it? I think that this is a good pattern to recommend.

eslint and stylelint are two good examples of unreasonably slow modules that will commonly be optional. stylelint can take a second or two, and eslint a few hundred milliseconds, because neither of them care enough about startup time. https://github.com/stylelint/stylelint/issues/2454 was me reporting it for stylelint. I wish more people used Rollup on their packages before submitting them to npm.