### PR TITLE
Do not fail when generating hashes for tree-shaken dynamic imports

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -132,7 +132,7 @@ export default class Chunk {
 	} = undefined;
 	private renderedHash: string = undefined;
 	private renderedModuleSources: MagicString[] = undefined;
-	private renderedSource: MagicStringBundle = undefined;
+	private renderedSource: MagicStringBundle | null = null;
 	private renderedSourceLength: number = undefined;
 
 	constructor(graph: Graph, orderedModules: Module[], inlineDynamicImports: boolean) {
@@ -662,8 +662,9 @@ export default class Chunk {
 		return exports;
 	}
 
-	getRenderedHash() {
+	getRenderedHash(): string {
 		if (this.renderedHash) return this.renderedHash;
+		if (!this.renderedSource) return '';
 		const hash = sha256();
 		hash.update(this.renderedSource.toString());
 		return (this.renderedHash = hash.digest('hex'));

--- a/test/chunking-form/samples/tree-shaken-dynamic-hash/_config.js
+++ b/test/chunking-form/samples/tree-shaken-dynamic-hash/_config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	description:
+		'Does not fail when calculating the hash of a file containing a tree-shaken dynamic import',
+	options: {
+		input: ['main.js'],
+		output: {
+			entryFileNames: '[hash].js'
+		}
+	}
+};

--- a/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/amd/5654511d.js
+++ b/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/amd/5654511d.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var main = null;
+
+	return main;
+
+});

--- a/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/cjs/69b0b1f3.js
+++ b/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/cjs/69b0b1f3.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var main = null;
+
+module.exports = main;

--- a/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/es/21d179d7.js
+++ b/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/es/21d179d7.js
@@ -1,0 +1,3 @@
+var main = null;
+
+export default main;

--- a/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/system/8714c598.js
+++ b/test/chunking-form/samples/tree-shaken-dynamic-hash/_expected/system/8714c598.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var main = exports('default', null);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/tree-shaken-dynamic-hash/foo.js
+++ b/test/chunking-form/samples/tree-shaken-dynamic-hash/foo.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/chunking-form/samples/tree-shaken-dynamic-hash/main.js
+++ b/test/chunking-form/samples/tree-shaken-dynamic-hash/main.js
@@ -1,0 +1,3 @@
+export default false
+	? import('./foo.js')
+	: null;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2625

### Description
When a dynamic import is tree-shaken, trying to calculate a hash for the importing chunk will result in an error as there is no rendered chunk for the dynamic import. This is a very simple fix.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
