### PR TITLE
Fix support for BigInt literals when using the acorn plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,12 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
       "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
     },
+    "acorn-bigint": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-bigint/-/acorn-bigint-0.3.1.tgz",
+      "integrity": "sha512-WT9LheDC4/d/sD/jgC6L5UMq4U9X3KNMy0JrXp/MdJL83ZqcuPQuMkj50beOX0dMub8IoZUYycfN7bIVZuU5zg==",
+      "dev": true
+    },
     "acorn-dynamic-import": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/chokidar": "^1.7.5",
     "@types/minimist": "^1.2.0",
     "@types/pretty-ms": "^3.0.0",
+    "acorn-bigint": "^0.3.1",
     "acorn-dynamic-import": "^4.0.0",
     "acorn-import-meta": "^0.3.0",
     "acorn-jsx": "^5.0.1",

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -28,7 +28,8 @@ const binaryOperators: {
 	'|': (left: any, right: any) => left | right,
 	'^': (left: any, right: any) => left ^ right,
 	'&': (left: any, right: any) => left & right,
-	'**': (left: any, right: any) => Math.pow(left, right),
+	// At the moment, "**" will be transpiled to Math.pow
+	'**': (left: any, right: any) => left ** right,
 	in: () => UNKNOWN_VALUE,
 	instanceof: () => UNKNOWN_VALUE
 };

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -28,11 +28,15 @@ export default class Literal<T = LiteralValue> extends NodeBase {
 	private members: { [key: string]: MemberDescription };
 
 	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
-		if (path.length > 0) {
+		if (
+			path.length > 0 ||
+			// unknown literals such as bigints can also be null but do not start with an "n"
+			(this.value === null && this.context.code.charCodeAt(this.start) !== 110) ||
+			typeof this.value === 'bigint'
+		) {
 			return UNKNOWN_VALUE;
 		}
-		// not sure why we need this type cast here
-		return <any>this.value;
+		return this.value as any;
 	}
 
 	getReturnExpressionWhenCalledAtPath(path: ObjectPath) {

--- a/test/form/samples/big-int/_config.js
+++ b/test/form/samples/big-int/_config.js
@@ -1,0 +1,8 @@
+const bigInt = require('acorn-bigint');
+
+module.exports = {
+	description: 'supports bigint via acorn plugin',
+	options: {
+		acornInjectPlugins: [bigInt]
+	}
+};

--- a/test/form/samples/big-int/_expected.js
+++ b/test/form/samples/big-int/_expected.js
@@ -1,0 +1,20 @@
+if (1n > 0) {
+	console.log('ok');
+}
+
+if (1n + 1n > 0) {
+	console.log('ok');
+}
+
+if (1n ** 1n > 0) {
+	console.log('ok');
+}
+
+const max = 2n**64n;
+const min = -max;
+
+function isSafe (int) {
+	return min<=int && int<=max;
+}
+
+export default isSafe;

--- a/test/form/samples/big-int/main.js
+++ b/test/form/samples/big-int/main.js
@@ -1,0 +1,18 @@
+if (1n > 0) {
+	console.log('ok');
+}
+
+if (1n + 1n > 0) {
+	console.log('ok');
+}
+
+if (1n ** 1n > 0) {
+	console.log('ok');
+}
+
+const max = 2n**64n;
+const min = -max;
+
+export default function isSafe (int) {
+	return min<=int && int<=max;
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Closes #2626 

### Description
This should address the following issues when using the acorn-bigint plugin:
- bigint numbers wrongly being treated like "null" when checking conditionals for tree-shakeability on older environments
- bigints being passed to `Math.pow` when checking conditionals on newer environments

At the moment to ensure Node 6 compatibility, "**" will be transpiled to `Math.pow` which does not support bigints. At the same time, the acorn plugin will wrongly mark bigint literals to have the value "null" on older systems that do not support them. This solves those issues by treating bigint literals as "unknown" on all systems. Theoretically, it would also be possible to leave them as literals on newer environments and just fix the `Math.pow` issue but then this would make testing much harder and I was lazy.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
