### PR TITLE
Make this.meta available in options hook, pass input options to buildStart hook

### DIFF
--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -147,7 +147,7 @@ Defines a custom loader. Returning `null` defers to other `load` functions (and 
 Type: `(options: InputOptions) => InputOptions | null`<br>
 Kind: `sync, sequential`
 
-Reads and replaces or manipulates the options object passed to `rollup.rollup`. Returning `null` does not replace anything.
+Reads and replaces or manipulates the options object passed to `rollup.rollup`. Returning `null` does not replace anything. This is the only hook that does not have access to most [plugin context](guide/en#plugin-context) utility functions as it is run before rollup is fully configured.
 
 #### `outro`
 Type: `string | (() => string)`<br>
@@ -225,7 +225,7 @@ More properties may be supported in future, as and when they prove necessary.
 
 ### Plugin Context
 
-A number of utility functions and informational bits can be accessed from within all [hooks](guide/en#hooks) via `this`:
+A number of utility functions and informational bits can be accessed from within most [hooks](guide/en#hooks) via `this`:
 
 #### `this.addWatchFile(id: string) => void`
 
@@ -267,7 +267,7 @@ Determine if a given module ID is external.
 
 #### `this.meta: {rollupVersion: string}`
 
-An `Object` containing potentially useful Rollup metadata.
+An `Object` containing potentially useful Rollup metadata. `meta` is the only context property accessible from the [`options`](guide/en#options) hook.
 
 #### `this.moduleIds: IterableIterator<string>`
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -1,3 +1,4 @@
+import { version as rollupVersion } from 'package.json';
 import Chunk from '../Chunk';
 import { optimizeChunks } from '../chunk-optimization';
 import Graph from '../Graph';
@@ -59,7 +60,8 @@ const throwAsyncGenerateError = {
 };
 
 function applyOptionHook(inputOptions: InputOptions, plugin: Plugin) {
-	if (plugin.options) return plugin.options(inputOptions) || inputOptions;
+	if (plugin.options)
+		return plugin.options.call({ meta: { rollupVersion } }, inputOptions) || inputOptions;
 
 	return inputOptions;
 }
@@ -144,7 +146,7 @@ export default function rollup(rawInputOptions: GenericConfigObject): Promise<Ro
 		timeStart('BUILD', 1);
 
 		return graph.pluginDriver
-			.hookParallel('buildStart')
+			.hookParallel('buildStart', [inputOptions])
 			.then(() =>
 				graph.build(
 					inputOptions.input,

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -104,14 +104,17 @@ export interface PluginCache {
 	delete(id: string): boolean;
 }
 
-export interface PluginContext {
+export interface MinimalPluginContext {
+	meta: PluginContextMeta;
+}
+
+export interface PluginContext extends MinimalPluginContext {
 	/** @deprecated */
 	watcher: EventEmitter;
 	addWatchFile: (id: string) => void;
 	cache: PluginCache;
 	resolveId: ResolveIdHook;
 	isExternal: IsExternal;
-	meta: PluginContextMeta;
 	parse: (input: string, options: any) => ESTree.Program;
 	emitAsset(name: string, source?: string | Buffer): string;
 	setAssetSource: (assetId: string, source: string | Buffer) => void;
@@ -228,7 +231,7 @@ export interface Plugin {
 		options: OutputOptions,
 		chunk: OutputChunk
 	) => void | Promise<void>;
-	options?: (options: InputOptions) => InputOptions | void | null;
+	options?: (this: MinimalPluginContext, options: InputOptions) => InputOptions | void | null;
 	outro?: AddonHook;
 	renderChunk?: RenderChunkHook;
 	renderError?: (this: PluginContext, err?: Error) => Promise<void> | void;

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -5,6 +5,30 @@ const { loader } = require('../utils.js');
 const rollup = require('../../dist/rollup.js');
 
 describe('hooks', () => {
+	it('allows to read and modify options in the options hook', () => {
+		return rollup
+			.rollup({
+				input: 'input',
+				treeshake: false,
+				plugins: [
+					loader({ newInput: `alert('hello')` }),
+					{
+						buildStart(options) {
+							assert.strictEqual(options.input, 'newInput');
+							assert.strictEqual(options.treeshake, false);
+						},
+						options(options) {
+							assert.strictEqual(options.input, 'input');
+							assert.strictEqual(options.treeshake, false);
+							assert.ok(/^\d+\.\d+\.\d+/.test(this.meta.rollupVersion));
+							return Object.assign({}, options, { input: 'newInput' });
+						}
+					}
+				]
+			})
+			.then(bundle => {});
+	});
+
 	it('supports buildStart and buildEnd hooks', () => {
 		let buildStartCnt = 0;
 		let buildEndCnt = 0;


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2624 

### Description
This makes this.meta and thus the rollup version available to the `options` hook. It also passes the input options to the `buildStart` hook (which was already part of the signature).

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
