### PR TITLE
Make sure object prototype methods are not considered to be falsy

### DIFF
--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -78,6 +78,7 @@ export default class ObjectExpression extends NodeBase {
 		if (
 			path.length === 1 &&
 			!this.propertyMap[key] &&
+			!objectMembers[key] &&
 			this.unmatchablePropertiesRead.length === 0
 		) {
 			if (!this.expressionsToBeDeoptimized[key]) {
@@ -167,8 +168,8 @@ export default class ObjectExpression extends NodeBase {
 		for (const property of typeof key !== 'string'
 			? this.properties
 			: this.propertyMap[key]
-				? this.propertyMap[key].propertiesRead
-				: []) {
+			? this.propertyMap[key].propertiesRead
+			: []) {
 			if (property.hasEffectsWhenAccessedAtPath(subPath, options)) return true;
 		}
 		return false;
@@ -191,10 +192,10 @@ export default class ObjectExpression extends NodeBase {
 		for (const property of typeof key !== 'string'
 			? this.properties
 			: path.length > 1
-				? this.propertyMap[key].propertiesRead
-				: this.propertyMap[key]
-					? this.propertyMap[key].propertiesSet
-					: []) {
+			? this.propertyMap[key].propertiesRead
+			: this.propertyMap[key]
+			? this.propertyMap[key].propertiesSet
+			: []) {
 			if (property.hasEffectsWhenAssignedAtPath(subPath, options)) return true;
 		}
 		return false;

--- a/test/function/samples/builtin-prototypes/truthiness/_config.js
+++ b/test/function/samples/builtin-prototypes/truthiness/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'regards builtin methods as truthy in objects'
+};

--- a/test/function/samples/builtin-prototypes/truthiness/main.js
+++ b/test/function/samples/builtin-prototypes/truthiness/main.js
@@ -1,0 +1,5 @@
+if (!{}.hasOwnProperty) {
+	throw new Error('Prototype method evaluated as falsy');
+}
+
+assert.strictEqual({}.hasOwnProperty ? true : false, true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2651 

### Description
This will make sure that when checking the value of object expression members, builtin prototype methods will not be considered to be falsy
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
