### PR TITLE
 Add CLI option to listen to stdin to close when the channel closes

### DIFF
--- a/bin/src/help.md
+++ b/bin/src/help.md
@@ -50,6 +50,7 @@ Basic options:
 --no-treeshake              Disable tree-shaking optimisations
 --no-treeshake.propertyReadSideEffects Ignore property access side-effects
 --treeshake.pureExternalModules        Assume side-effect free externals
+--watchStdin                Same as `-w`, but listens on stdin to detect closing
 
 Examples:
 

--- a/bin/src/run/index.ts
+++ b/bin/src/run/index.ts
@@ -83,7 +83,7 @@ export default function runRollup(command: any) {
 			configFile = realpathSync(configFile);
 		}
 
-		if (command.watch) process.env.ROLLUP_WATCH = 'true';
+		if (command.watch || command.watchStdin) process.env.ROLLUP_WATCH = 'true';
 
 		loadConfigFile(configFile, command)
 			.then(configs => execute(configFile, configs, command))
@@ -94,7 +94,7 @@ export default function runRollup(command: any) {
 }
 
 function execute(configFile: string, configs: InputOptions[], command: any) {
-	if (command.watch) {
+	if (command.watch || command.watchStdin) {
 		watch(configFile, configs, command, command.silent);
 	} else {
 		let promise = Promise.resolve();

--- a/bin/src/run/watch.ts
+++ b/bin/src/run/watch.ts
@@ -117,8 +117,8 @@ export default function watch(
 							input = Array.isArray(input)
 								? input.join(', ')
 								: Object.keys(input)
-									.map(key => (<Record<string, string>>input)[key])
-									.join(', ');
+										.map(key => (<Record<string, string>>input)[key])
+										.join(', ');
 						}
 						stderr(
 							tc.cyan(
@@ -156,8 +156,9 @@ export default function watch(
 	process.on('uncaughtException', close);
 
 	// only listen to stdin if it is a pipe
-	if (!process.stdin.isTTY) {
+	if (!process.stdin.isTTY || command.watchStdin) {
 		process.stdin.on('end', close); // in case we ever support stdin!
+		process.stdin.resume();
 	}
 
 	function close(err: Error) {

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -135,7 +135,8 @@ export default function mergeOptions({
 			Object.keys(commandAliases),
 			'config',
 			'environment',
-			'silent'
+			'silent',
+			'watchStdin'
 		),
 		'CLI flag',
 		/^_|output|(config.*)$/


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Fixes https://github.com/rollup/rollup-watch/pull/57 again.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
