### PR TITLE
docs: swap descriptions for [extname] and [ext]

### DIFF
--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -317,8 +317,8 @@ CLI: `--assetFileNames <pattern>`<br>
 Default: `"assets/[name]-[hash][extname]"`
 
 The pattern to use for naming custom emitted assets to include in the build output. Pattern supports the following placeholders:
- * `[ext]`: The file extension of the asset including a leading dot, e.g. `.css`.
- * `[extname]`: The file extension without a leading dot, e.g. `css`.
+ * `[extname]`: The file extension of the asset including a leading dot, e.g. `.css`.
+ * `[ext]`: The file extension without a leading dot, e.g. `css`.
  * `[hash]`: A hash based on the name and content of the asset.
  * `[name]`: The file name of the asset excluding any extension.
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

While working on plugin stuff I noticed that I was using `[extname]` and seeing a leading period in the result, which the docs said I shouldn't. I went and looked at the rollup source for this functionality:

https://github.com/rollup/rollup/blob/00d752181ca2a582b03911646be0f7a4ea44bda6/src/utils/assetHooks.ts#L34-L37

Which sure makes it look like the docs were wrong. So I swapped `[extname]` and `[ext]` so now they line up correctly based on what they do.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
