### PR TITLE
Completely remove tree-shaken dynamic imports from bundle information

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -169,7 +169,7 @@ export default class Chunk {
 	}
 
 	getDynamicImportIds(): string[] {
-		return this.dynamicDependencies.map(chunk => chunk.id);
+		return this.dynamicDependencies.map(chunk => chunk.id).filter(Boolean);
 	}
 
 	getExportNames(): string[] {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:
Resolves #2659 

### Description
Before, tree-shaken dynamic imports would leave `undefined` in the `dynamicImports` section of the importing chunk in the bundle information.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
