### PR TITLE
Fix typo in export-globals test

### DIFF
--- a/test/form/samples/export-globals/Number.js
+++ b/test/form/samples/export-globals/Number.js
@@ -1,9 +1,9 @@
-const localIsNan = isNan;
+const localIsNaN = isNaN;
 const localIsFinite = isFinite;
 const localParseFloat = parseFloat;
 const localNumber = Number;
 export {
-	localIsNan as isNaN,
+	localIsNaN as isNaN,
 	localIsFinite as isFinite,
 	localParseFloat as parseFloat,
 	localNumber as Number

--- a/test/form/samples/export-globals/_expected/amd.js
+++ b/test/form/samples/export-globals/_expected/amd.js
@@ -1,10 +1,10 @@
 define(['exports'], function (exports) { 'use strict';
 
-	const localIsNan = isNan;
+	const localIsNaN = isNaN;
 
-	const isNaN = localIsNan;
+	const isNaN$1 = localIsNaN;
 
-	exports.isNaN = isNaN;
+	exports.isNaN = isNaN$1;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/export-globals/_expected/cjs.js
+++ b/test/form/samples/export-globals/_expected/cjs.js
@@ -2,8 +2,8 @@
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
-const localIsNan = isNan;
+const localIsNaN = isNaN;
 
-const isNaN = localIsNan;
+const isNaN$1 = localIsNaN;
 
-exports.isNaN = isNaN;
+exports.isNaN = isNaN$1;

--- a/test/form/samples/export-globals/_expected/es.js
+++ b/test/form/samples/export-globals/_expected/es.js
@@ -1,5 +1,5 @@
-const localIsNan = isNan;
+const localIsNaN = isNaN;
 
-const isNaN = localIsNan;
+const isNaN$1 = localIsNaN;
 
-export { isNaN };
+export { isNaN$1 as isNaN };

--- a/test/form/samples/export-globals/_expected/iife.js
+++ b/test/form/samples/export-globals/_expected/iife.js
@@ -1,11 +1,11 @@
 var myBundle = (function (exports) {
 	'use strict';
 
-	const localIsNan = isNan;
+	const localIsNaN = isNaN;
 
-	const isNaN = localIsNan;
+	const isNaN$1 = localIsNaN;
 
-	exports.isNaN = isNaN;
+	exports.isNaN = isNaN$1;
 
 	return exports;
 

--- a/test/form/samples/export-globals/_expected/system.js
+++ b/test/form/samples/export-globals/_expected/system.js
@@ -3,9 +3,9 @@ System.register('myBundle', [], function (exports, module) {
 	return {
 		execute: function () {
 
-			const localIsNan = isNan;
+			const localIsNaN = isNaN;
 
-			const isNaN = exports('isNaN', localIsNan);
+			const isNaN$1 = exports('isNaN', localIsNaN);
 
 		}
 	};

--- a/test/form/samples/export-globals/_expected/umd.js
+++ b/test/form/samples/export-globals/_expected/umd.js
@@ -4,11 +4,11 @@
 	(global = global || self, factory(global.myBundle = {}));
 }(this, function (exports) { 'use strict';
 
-	const localIsNan = isNan;
+	const localIsNaN = isNaN;
 
-	const isNaN = localIsNan;
+	const isNaN$1 = localIsNaN;
 
-	exports.isNaN = isNaN;
+	exports.isNaN = isNaN$1;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

#2691 introduced a small typo in the `exports-globals` form test. This fixes the typo, so the test does the right thing once again.