### PR TITLE
Always recreate paths for external modules

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -514,7 +514,7 @@ export default class Chunk {
 			let id: string;
 			let globalName: string;
 			if (dep instanceof ExternalModule) {
-				id = dep.renderPath || dep.setRenderPath(options, inputBase);
+				id = dep.setRenderPath(options, inputBase);
 				if (options.format === 'umd' || options.format === 'iife') {
 					globalName = getGlobalName(
 						dep,

--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -37,10 +37,10 @@ export default class ExternalModule {
 	}
 
 	setRenderPath(options: OutputOptions, inputBase: string) {
-		if (options.paths)
+		if (options.paths) {
 			this.renderPath =
 				typeof options.paths === 'function' ? options.paths(this.id) : options.paths[this.id];
-		if (!this.renderPath) {
+		} else {
 			if (!isAbsolute(this.id)) {
 				this.renderPath = this.id;
 			} else {

--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -37,10 +37,12 @@ export default class ExternalModule {
 	}
 
 	setRenderPath(options: OutputOptions, inputBase: string) {
+		this.renderPath = '';
 		if (options.paths) {
 			this.renderPath =
 				typeof options.paths === 'function' ? options.paths(this.id) : options.paths[this.id];
-		} else {
+		}
+		if (!this.renderPath) {
 			if (!isAbsolute(this.id)) {
 				this.renderPath = this.id;
 			} else {

--- a/test/function/samples/mixed-external-paths/_config.js
+++ b/test/function/samples/mixed-external-paths/_config.js
@@ -1,0 +1,22 @@
+module.exports = {
+	description: 'allows using the path option selectively',
+	options: {
+		external: ['dep-a', 'dep-b'],
+		output: {
+			paths: {
+				'dep-a': 'secret-dep'
+			}
+		}
+	},
+	context: {
+		require(id) {
+			if (id === 'secret-dep') {
+				return 'secret';
+			}
+			if (id === 'dep-b') {
+				return 'b';
+			}
+			throw new Error(`Unexpected dependency ${id}`);
+		}
+	}
+};

--- a/test/function/samples/mixed-external-paths/main.js
+++ b/test/function/samples/mixed-external-paths/main.js
@@ -1,0 +1,5 @@
+import a from 'dep-a';
+import b from 'dep-b';
+
+assert.equal(a, 'secret');
+assert.equal(b, 'b');

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -98,4 +98,28 @@ describe('misc', () => {
 			plugins: [loader({ x: `console.log( 42 );` }), null, false, undefined]
 		});
 	});
+
+	it('handles different import paths for different outputs', () => {
+		return rollup
+			.rollup({
+				input: 'x',
+				external: ['the-answer'],
+				plugins: [loader({ x: `import 'the-answer'` })]
+			})
+			.then(bundle =>
+				Promise.all([
+					bundle
+						.generate({ format: 'esm' })
+						.then(generated => assert.equal(generated.output[0].code, "import 'the-answer';\n", 'no render path 1')),
+					bundle
+						.generate({ format: 'esm', paths: id => `//unpkg.com/${id}@?module` })
+						.then(generated =>
+							assert.equal(generated.output[0].code, "import '//unpkg.com/the-answer@?module';\n", 'with render path')
+						),
+					bundle
+						.generate({ format: 'esm' })
+						.then(generated => assert.equal(generated.output[0].code, "import 'the-answer';\n", 'no render path 2'))
+				])
+			);
+	});
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2675 

### Description
There is a bug where if different outputs use different paths for external dependencies, then the path used by the first output is used for all other outputs as well. This fixes this by recreating the path for each output.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
