### PR TITLE
Properly render dynamic imports when imported module is empty

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -382,7 +382,7 @@ export default class Chunk {
 			for (const { node, resolution } of module.dynamicImports) {
 				if (!resolution) continue;
 				if (resolution instanceof Module) {
-					if (resolution.isIncluded() && resolution.chunk !== this) {
+					if (!resolution.chunk.isEmpty && resolution.chunk !== this) {
 						const resolutionChunk = resolution.facadeChunk || resolution.chunk;
 						let relPath = normalize(relative(dirname(this.id), resolutionChunk.id));
 						if (!relPath.startsWith('../')) relPath = './' + relPath;

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_config.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'handles dynamic imports when the imported module only reexports from other modules',
+	options: {
+		input: ['main']
+	}
+};

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/amd/generated-chunk.js
@@ -1,0 +1,7 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const value = 42;
+
+	exports.value = value;
+
+});

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/amd/main.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(['require'], function (require) { 'use strict';
+
+	new Promise(function (resolve, reject) { require(['./generated-chunk.js'], resolve, reject) }).then(({ value }) => console.log(value));
+
+});

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/cjs/generated-chunk.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const value = 42;
+
+exports.value = value;

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/cjs/main.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/cjs/main.js
@@ -1,0 +1,3 @@
+'use strict';
+
+Promise.resolve(require('./generated-chunk.js')).then(({ value }) => console.log(value));

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/es/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/es/generated-chunk.js
@@ -1,0 +1,3 @@
+const value = 42;
+
+export { value };

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/es/main.js
@@ -1,0 +1,1 @@
+import('./generated-chunk.js').then(({ value }) => console.log(value));

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/system/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/system/generated-chunk.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const value = exports('value', 42);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/dynamic-import-only-reexports/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/_expected/system/main.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			module.import('./generated-chunk.js').then(({ value }) => console.log(value));
+
+		}
+	};
+});

--- a/test/chunking-form/samples/dynamic-import-only-reexports/dep.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/dep.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/chunking-form/samples/dynamic-import-only-reexports/dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/dynamic.js
@@ -1,0 +1,1 @@
+export {value} from './dep';

--- a/test/chunking-form/samples/dynamic-import-only-reexports/main.js
+++ b/test/chunking-form/samples/dynamic-import-only-reexports/main.js
@@ -1,0 +1,1 @@
+import('./dynamic').then(({ value }) => console.log(value));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolve #2713 

### Description
The logic to render dynamic imports was only looking if the directly imported module was empty while it should have been looking at the whole chunk. Thus such a chunk would be treated as tree-shaken by some (but not all) parts of the logic, resulting in the wrong import.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
