### PR TITLE
Incremental external

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -571,7 +571,7 @@ export default class Graph {
 						}
 					}
 					module.exportAllSources.forEach(source => {
-						const id = module.resolvedIds[source];
+						const id = module.resolvedIds[source].id;
 						const exportAllModule = this.moduleById.get(id);
 						if (exportAllModule.isExternal) return;
 
@@ -642,8 +642,8 @@ export default class Graph {
 			module.sources.map(source => {
 				return Promise.resolve()
 					.then(() => {
-						const resolvedId = module.resolvedIds[source];
-						if (resolvedId) return resolvedId;
+						const resolved = module.resolvedIds[source];
+						if (resolved) return !resolved.external && resolved.id;
 						if (this.isExternal(source, module.id, false)) return false;
 						return this.pluginDriver.hookFirst<string | boolean | void>('resolveId', [
 							source,
@@ -682,7 +682,7 @@ export default class Graph {
 						}
 
 						if (isExternal) {
-							module.resolvedIds[source] = externalId;
+							module.resolvedIds[source] = { id: externalId, external: true };
 
 							if (!this.moduleById.has(externalId)) {
 								const module = new ExternalModule({ graph: this, id: externalId });
@@ -709,7 +709,7 @@ export default class Graph {
 								externalModule.getVariableForExportName(importDeclaration.name);
 							}
 						} else {
-							module.resolvedIds[source] = <string>resolvedId;
+							module.resolvedIds[source] = { id: <string>resolvedId, external: false };
 							return this.fetchModule(<string>resolvedId, module.id);
 						}
 					});

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -471,7 +471,7 @@ export default class Module {
 
 	linkDependencies() {
 		for (const source of this.sources) {
-			const id = this.resolvedIds[source];
+			const id = this.resolvedIds[source].id;
 
 			if (id) {
 				const module = this.graph.moduleById.get(id);
@@ -488,7 +488,7 @@ export default class Module {
 		this.addModulesToSpecifiers(this.reexports);
 
 		this.exportAllModules = this.exportAllSources.map(source => {
-			const id = this.resolvedIds[source];
+			const id = this.resolvedIds[source].id;
 			return this.graph.moduleById.get(id);
 		});
 	}
@@ -498,7 +498,8 @@ export default class Module {
 	}) {
 		for (const name of Object.keys(specifiers)) {
 			const specifier = specifiers[name];
-			specifier.module = this.graph.moduleById.get(this.resolvedIds[specifier.source]);
+			const id = this.resolvedIds[specifier.source].id;
+			specifier.module = this.graph.moduleById.get(id);
 		}
 	}
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events';
 export const VERSION: string;
 
 export interface IdMap {
-	[key: string]: string;
+	[key: string]: { id: string; external: boolean };
 }
 
 export interface RollupError extends RollupLogProps {

--- a/src/utils/pluginDriver.ts
+++ b/src/utils/pluginDriver.ts
@@ -148,7 +148,7 @@ export function createPluginDriver(
 					isExternal: !!foundModule.isExternal,
 					importedIds: foundModule.isExternal
 						? []
-						: (foundModule as Module).sources.map(id => (foundModule as Module).resolvedIds[id])
+						: (foundModule as Module).sources.map(id => (foundModule as Module).resolvedIds[id].id)
 				};
 			},
 			watcher: watcher

--- a/test/incremental/index.js
+++ b/test/incremental/index.js
@@ -240,8 +240,8 @@ describe('incremental', () => {
 				assert.equal(bundle.cache.modules[0].id, 'entry');
 
 				assert.deepEqual(bundle.cache.modules[0].resolvedIds, {
-					foo: 'foo',
-					external: 'external'
+					foo: { id: 'foo', external: false },
+					external: { id: 'external', external: true }
 				});
 			});
 	});

--- a/test/utils.js
+++ b/test/utils.js
@@ -59,16 +59,16 @@ function deindent(str) {
 		.trim();
 }
 
-function executeBundle(bundle) {
+function executeBundle(bundle, require) {
 	return bundle
 		.generate({
 			format: 'cjs'
 		})
 		.then(({ output: [cjs] }) => {
-			const m = new Function('module', 'exports', cjs.code);
+			const m = new Function('module', 'exports', 'require', cjs.code);
 
 			const module = { exports: {} };
-			m(module, module.exports);
+			m(module, module.exports, require);
 
 			return module.exports;
 		});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: 2670
### Description
I use a plugin that marks some imports as external by returning false from resolveId. This doesn't work in watch-mode. On all subsequent builds after initial, rollup will try to load the external modules, and fail. This seems to be the same problem as in #2670.

I solved it by explicitly storing external state in the cache.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
