### PR TITLE
Deduplicate imports referencing default exports and their original variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # rollup changelog
 
+## 1.2.4
+*2019-02-25*
+
+### Bug Fixes
+* Fix an issue where a variable was imported twice under the same name (#2715)
+
+### Pull Requests
+* [#2715](https://github.com/rollup/rollup/pull/2715): Deduplicate imports referencing default exports and their original variables (@lukastaegert)
+
 ## 1.2.3
 *2019-02-23*
 

--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -47,6 +47,10 @@ export default class ExportDefaultVariable extends LocalVariable {
 		return this.referencesOriginal() ? this.originalId.variable.getName() : super.getName();
 	}
 
+	getOriginalVariable(): Variable | null {
+		return (this.originalId && this.originalId.variable) || null;
+	}
+
 	getOriginalVariableName(): string | null {
 		return (this.originalId && this.originalId.name) || null;
 	}

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_config.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description:
+		'do not import variables that reference an original if the original is already imported',
+	options: {
+		input: ['main1', 'main2']
+	}
+};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/generated-chunk.js
@@ -1,0 +1,8 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = {};
+
+	exports.foo = foo;
+	exports.bar = foo;
+
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main1.js
@@ -1,0 +1,5 @@
+define(['./generated-chunk.js'], function (__chunk_1) { 'use strict';
+
+	console.log(__chunk_1.bar, __chunk_1.bar);
+
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main2.js
@@ -1,0 +1,5 @@
+define(['./generated-chunk.js'], function (__chunk_1) { 'use strict';
+
+	console.log(__chunk_1.bar, __chunk_1.bar);
+
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/generated-chunk.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const foo = {};
+
+exports.foo = foo;
+exports.bar = foo;

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var __chunk_1 = require('./generated-chunk.js');
+
+console.log(__chunk_1.bar, __chunk_1.bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var __chunk_1 = require('./generated-chunk.js');
+
+console.log(__chunk_1.bar, __chunk_1.bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/generated-chunk.js
@@ -1,0 +1,3 @@
+const foo = {};
+
+export { foo as a, foo as b };

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main1.js
@@ -1,0 +1,3 @@
+import { a as bar } from './generated-chunk.js';
+
+console.log(bar, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main2.js
@@ -1,0 +1,3 @@
+import { a as bar } from './generated-chunk.js';
+
+console.log(bar, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/generated-chunk.js
@@ -1,0 +1,12 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = exports('a', {});
+
+			exports('b', foo);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main1.js
@@ -1,0 +1,14 @@
+System.register(['./generated-chunk.js'], function (exports, module) {
+	'use strict';
+	var bar;
+	return {
+		setters: [function (module) {
+			bar = module.a;
+		}],
+		execute: function () {
+
+			console.log(bar, bar);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main2.js
@@ -1,0 +1,14 @@
+System.register(['./generated-chunk.js'], function (exports, module) {
+	'use strict';
+	var bar;
+	return {
+		setters: [function (module) {
+			bar = module.a;
+		}],
+		execute: function () {
+
+			console.log(bar, bar);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/foo.js
@@ -1,0 +1,1 @@
+export const foo = {};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/main1.js
@@ -1,0 +1,4 @@
+import { foo } from './foo';
+import bar from './proxy';
+
+console.log(foo, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/main2.js
@@ -1,0 +1,4 @@
+import { foo } from './foo';
+import bar from './proxy';
+
+console.log(foo, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/proxy.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/proxy.js
@@ -1,0 +1,2 @@
+import { foo } from './foo';
+export default foo;


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2715

### Description
There has always been an optimization in Rollup where default exports are treated as a placeholder for another variable that has been exported in certain situations (e.g. default exporting a function declaration or a variable that is not mutated)

After the latest refactoring of the scope hoisting, this could cause rendering issues as both variables would be rendered using the same name.

This fixes this by manually deduplicating imports. This is probably not the best possible fix, which would be to add a step where those variables are replaced by their originals. Such a solution, however, would have touched many more places for possibly dubious improvements. The only known downside of the approach at hand is that it can lead to additional unused exports in shared chunks.

(Just for reference, before the refactoring the approach was to treat those variables as completely separate between imports).

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
