### PR TITLE
Take chunk export mode into account when reexporting default

### DIFF
--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/amd/generated-m1.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/amd/generated-m1.js
@@ -6,7 +6,7 @@ define(['exports', './m2.js'], function (exports, m2) { 'use strict';
 		m2: m2
 	});
 
-	exports.m2 = m2.default;
+	exports.m2 = m2;
 	exports.ms = ms;
 
 });

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/amd/m1.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/amd/m1.js
@@ -2,7 +2,7 @@ define(['exports', './m2.js', './generated-m1.js'], function (exports, m2, m1) {
 
 
 
-	exports.m2 = m2.default;
+	exports.m2 = m2;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/cjs/generated-m1.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/cjs/generated-m1.js
@@ -8,5 +8,5 @@ var ms = /*#__PURE__*/Object.freeze({
 	m2: m2
 });
 
-exports.m2 = m2.default;
+exports.m2 = m2;
 exports.ms = ms;

--- a/test/chunking-form/samples/export-default-from-entry/_config.js
+++ b/test/chunking-form/samples/export-default-from-entry/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'correctly imports the default from an entry point',
+	options: {
+		input: ['main', 'dep']
+	}
+};

--- a/test/chunking-form/samples/export-default-from-entry/_expected/amd/dep.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/amd/dep.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var dep = 42;
+
+	return dep;
+
+});

--- a/test/chunking-form/samples/export-default-from-entry/_expected/amd/main.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/amd/main.js
@@ -1,0 +1,9 @@
+define(['exports', './dep.js'], function (exports, dep) { 'use strict';
+
+
+
+	exports.value = dep;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/export-default-from-entry/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/cjs/dep.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var dep = 42;
+
+module.exports = dep;

--- a/test/chunking-form/samples/export-default-from-entry/_expected/cjs/main.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/cjs/main.js
@@ -2,9 +2,8 @@
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
-var m2 = require('./m2.js');
-require('./generated-m1.js');
+var dep = require('./dep.js');
 
 
 
-exports.m2 = m2;
+exports.value = dep;

--- a/test/chunking-form/samples/export-default-from-entry/_expected/es/dep.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/es/dep.js
@@ -1,0 +1,3 @@
+var dep = 42;
+
+export default dep;

--- a/test/chunking-form/samples/export-default-from-entry/_expected/es/main.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/es/main.js
@@ -1,0 +1,1 @@
+export { default as value } from './dep.js';

--- a/test/chunking-form/samples/export-default-from-entry/_expected/system/dep.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/system/dep.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var dep = exports('default', 42);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/export-default-from-entry/_expected/system/main.js
+++ b/test/chunking-form/samples/export-default-from-entry/_expected/system/main.js
@@ -1,0 +1,13 @@
+System.register(['./dep.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('value', module.default);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/export-default-from-entry/dep.js
+++ b/test/chunking-form/samples/export-default-from-entry/dep.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/chunking-form/samples/export-default-from-entry/main.js
+++ b/test/chunking-form/samples/export-default-from-entry/main.js
@@ -1,0 +1,1 @@
+export {default as value} from './dep';

--- a/test/function/samples/code-splitting-export-default-from-entry/_config.js
+++ b/test/function/samples/code-splitting-export-default-from-entry/_config.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'correctly imports the default from an entry point',
+	options: {
+		input: ['main', 'dep']
+	},
+	exports(exports) {
+		assert.deepStrictEqual(exports, {
+			value: 42
+		});
+	}
+};

--- a/test/function/samples/code-splitting-export-default-from-entry/dep.js
+++ b/test/function/samples/code-splitting-export-default-from-entry/dep.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/function/samples/code-splitting-export-default-from-entry/main.js
+++ b/test/function/samples/code-splitting-export-default-from-entry/main.js
@@ -1,0 +1,1 @@
+export {default as value} from './dep';


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2721 

### Description
As stated in the title, the finaliser always assumed chunks to use named exports mode (which is true for internal chunks but not necessarily true for entry points). This is now taken into account, fixing this:

https://rollupjs.org/repl?version=1.3.0&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMFRoaXMlMjBpcyUyMGFjY2Vzc2luZyUyMGRlcC5kZWZhdWx0JTIwd2hpbGUlMjBpdCUyMHNob3VsZCUyMGJlJTIwdXNpbmclMjBkZXAlNUNuZXhwb3J0JTIwJTdCZGVmYXVsdCUyMGFzJTIwdmFsdWUlN0QlMjBmcm9tJTIwJy4lMkZkZXAnJTNCJTIyJTJDJTIyaXNFbnRyeSUyMiUzQXRydWUlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIyZGVwLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGRlZmF1bHQlMjA0MiUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmNqcyUyMiUyQyUyMm5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmFtZCUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyJTIyJTdEJTJDJTIyZ2xvYmFscyUyMiUzQSU3QiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
