### PR TITLE
fix: the empty string importee should not always be treated as external module id

### DIFF
--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -168,7 +168,7 @@ function addUnknownOptionErrors(
 
 function getCommandOptions(rawCommandOptions: GenericConfigObject): GenericConfigObject {
 	const command = { ...rawCommandOptions };
-	command.external = (rawCommandOptions.external || '').split(',');
+	command.external = rawCommandOptions.external ? rawCommandOptions.external.split(',') : [];
 
 	if (rawCommandOptions.globals) {
 		command.globals = Object.create(null);

--- a/test/function/samples/empty-string-as-module-name/_config.js
+++ b/test/function/samples/empty-string-as-module-name/_config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	description: 'allows using empty string as a valid module name',
+	options: {
+		external: () => false,
+		plugins: [
+			{
+				resolveId(importee, importer) {
+					if (importee === '') {
+						return importer + '#.js';
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/empty-string-as-module-name/main.js
+++ b/test/function/samples/empty-string-as-module-name/main.js
@@ -1,0 +1,2 @@
+import { importee } from '';
+assert.strictEqual(importee, 'xxx');

--- a/test/function/samples/empty-string-as-module-name/main.js#.js
+++ b/test/function/samples/empty-string-as-module-name/main.js#.js
@@ -1,0 +1,1 @@
+export var importee = 'xxx';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

I'm not sure which category to put test about this bug.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
