### PR TITLE
Allow resolveId to return an object

### DIFF
--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -180,12 +180,12 @@ Kind: `async, first`
 Defines a custom resolver for dynamic imports. In case a dynamic import is not passed a string as argument, this hook gets access to the raw AST nodes to analyze. Returning `null` will defer to other resolvers and eventually to `resolveId` if this is possible; returning `false` signals that the import should be kept as it is and not be passed to other resolvers thus making it external. Note that the return value of this hook will not be passed to `resolveId` afterwards; if you need access to the static resolution algorithm, you can use `this.resolveId(importee, importer)` on the plugin context.
 
 #### `resolveId`
-Type: `(importee: string, importer: string) => string | false | null | {id: string, external: boolean}`<br>
+Type: `(importee: string, importer: string) => string | false | null | {id: string, external?: boolean}`<br>
 Kind: `async, first`
 
-Defines a custom resolver. A resolver loader can be useful for e.g. locating third-party dependencies. Returning `null` defers to other `resolveId` functions (and eventually the default resolution behavior); returning `false` signals that `importee` should be treated as an external module and not included in the bundle.
+Defines a custom resolver. A resolver can be useful for e.g. locating third-party dependencies. Returning `null` defers to other `resolveId` functions (and eventually the default resolution behavior); returning `false` signals that `importee` should be treated as an external module and not included in the bundle.
 
-If you return an object, then it is possible to resolve an import to a different id while marking it as external at the same time. This allows you to replace dependencies with (other) external dependencies without the need for the user to mark them as "external" manually via the `external` option:
+If you return an object, then it is possible to resolve an import to a different id while excluding it from the bundle at the same time. This allows you to replace dependencies with external dependencies without the need for the user to mark them as "external" manually via the `external` option:
 
 ```js
 resolveId(id) {

--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -180,10 +180,21 @@ Kind: `async, first`
 Defines a custom resolver for dynamic imports. In case a dynamic import is not passed a string as argument, this hook gets access to the raw AST nodes to analyze. Returning `null` will defer to other resolvers and eventually to `resolveId` if this is possible; returning `false` signals that the import should be kept as it is and not be passed to other resolvers thus making it external. Note that the return value of this hook will not be passed to `resolveId` afterwards; if you need access to the static resolution algorithm, you can use `this.resolveId(importee, importer)` on the plugin context.
 
 #### `resolveId`
-Type: `(importee: string, importer: string) => string | false | null`<br>
+Type: `(importee: string, importer: string) => string | false | null | {id: string, external: boolean}`<br>
 Kind: `async, first`
 
 Defines a custom resolver. A resolver loader can be useful for e.g. locating third-party dependencies. Returning `null` defers to other `resolveId` functions (and eventually the default resolution behavior); returning `false` signals that `importee` should be treated as an external module and not included in the bundle.
+
+If you return an object, then it is possible to resolve an import to a different id while marking it as external at the same time. This allows you to replace dependencies with (other) external dependencies without the need for the user to mark them as "external" manually via the `external` option:
+
+```js
+resolveId(id) {
+	if (id === 'my-dependency') {
+		return {id: 'my-dependency-develop', external: true};
+	}
+	return null;
+}
+```
 
 #### `transform`
 Type: `(code: string, id: string) => string | { code: string, map?: string | SourceMap, ast? : ESTree.Program } | null`

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -28,7 +28,14 @@ import Variable from './ast/variables/Variable';
 import Chunk from './Chunk';
 import ExternalModule from './ExternalModule';
 import Graph from './Graph';
-import { Asset, IdMap, ModuleJSON, RawSourceMap, RollupError, RollupWarning } from './rollup/types';
+import {
+	Asset,
+	ModuleJSON,
+	RawSourceMap,
+	ResolvedIdMap,
+	RollupError,
+	RollupWarning
+} from './rollup/types';
 import { error } from './utils/error';
 import getCodeFrame from './utils/getCodeFrame';
 import { getOriginalLocation } from './utils/getOriginalLocation';
@@ -187,7 +194,7 @@ export default class Module {
 	originalCode: string;
 	originalSourcemap: RawSourceMap | void;
 	reexports: { [name: string]: ReexportDescription } = Object.create(null);
-	resolvedIds: IdMap;
+	resolvedIds: ResolvedIdMap;
 	scope: ModuleScope;
 	sourcemapChain: RawSourceMap[];
 	sources: string[] = [];

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -3,10 +3,6 @@ import { EventEmitter } from 'events';
 
 export const VERSION: string;
 
-export interface IdMap {
-	[key: string]: { external: boolean; id: string };
-}
-
 export interface RollupError extends RollupLogProps {
 	stack?: string;
 }
@@ -84,7 +80,7 @@ export interface ModuleJSON {
 	id: string;
 	originalCode: string;
 	originalSourcemap: RawSourceMap | void;
-	resolvedIds: IdMap;
+	resolvedIds: ResolvedIdMap;
 	sourcemapChain: RawSourceMap[];
 	transformAssets: Asset[] | void;
 	transformDependencies: string[] | null;
@@ -134,11 +130,22 @@ export interface PluginContextMeta {
 	rollupVersion: string;
 }
 
+export interface ResolvedId {
+	external?: boolean | void;
+	id: string;
+}
+
+export type ResolveIdResult = string | false | void | ResolvedId;
+
+export interface ResolvedIdMap {
+	[key: string]: ResolvedId;
+}
+
 export type ResolveIdHook = (
 	this: PluginContext,
 	id: string,
 	parent: string
-) => Promise<string | false | null> | string | false | void | null;
+) => Promise<ResolveIdResult> | ResolveIdResult;
 
 export type IsExternal = (id: string, parentId: string, isResolved: boolean) => boolean | void;
 

--- a/test/function/samples/resolve-id-object/_config.js
+++ b/test/function/samples/resolve-id-object/_config.js
@@ -1,0 +1,28 @@
+const path = require('path');
+
+module.exports = {
+	description: 'allows resolving an id with an object',
+	options: {
+		plugins: {
+			resolveId(importee) {
+				const fooId = path.resolve(__dirname, 'foo.js');
+				switch (importee) {
+					case 'internal1':
+						return { id: fooId };
+					case 'internal2':
+						return { id: fooId, external: false };
+					case 'external':
+						return { id: 'my-external', external: true };
+				}
+			}
+		}
+	},
+	context: {
+		require(id) {
+			if (id === 'my-external') {
+				return 'external';
+			}
+			throw new Error(`Unexpected external id ${id}.`);
+		}
+	}
+};

--- a/test/function/samples/resolve-id-object/foo.js
+++ b/test/function/samples/resolve-id-object/foo.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/function/samples/resolve-id-object/main.js
+++ b/test/function/samples/resolve-id-object/main.js
@@ -1,0 +1,9 @@
+import external from 'external';
+import internal1 from 'internal1';
+import internal2 from 'internal2';
+
+assert.strictEqual(internal1, 42);
+
+assert.strictEqual(internal2, 42);
+
+assert.strictEqual(external, 'external');

--- a/test/function/samples/unused-import/_config.js
+++ b/test/function/samples/unused-import/_config.js
@@ -1,13 +1,14 @@
 module.exports = {
 	description: 'warns on unused imports ([#595])',
+	options: {
+		external: ['external']
+	},
+	context: {
+		require(id) {
+			return {};
+		}
+	},
 	warnings: [
-		{
-			code: 'UNRESOLVED_IMPORT',
-			importer: 'main.js',
-			source: 'external',
-			message: `'external' is imported by main.js, but could not be resolved – treating it as an external dependency`,
-			url: `https://rollupjs.org/guide/en#warning-treating-module-as-external-dependency`
-		},
 		{
 			code: 'UNUSED_EXTERNAL_IMPORT',
 			source: 'external',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This change will extend the syntax of the `resolveId` hook to support returning an object

```ts
interface ResolvedId {
  // the absence of this property is interpreted the same as "false"
  external?: boolean;
  id: string;
}
```

The immediate advantage of this change is to allow plugins to resolve an import to a new id while marking it as `external` at the same time. Previously, this required the user to also add the new `id` as an external id manually.

The main reason for this addition, however, is that I want to have an extended format that allows you to pass more meta information with this hook in the future (say, package side-effects... 😜).

A minor side-effects of this change is that you will only be warned about missing global names for an external dependency in a UMD bundle if the dependency is actually used.