### PR TITLE
Add hook for modifying OutputOptions

### DIFF
--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -149,6 +149,12 @@ Kind: `sync, sequential`
 
 Reads and replaces or manipulates the options object passed to `rollup.rollup`. Returning `null` does not replace anything. This is the only hook that does not have access to most [plugin context](guide/en#plugin-context) utility functions as it is run before rollup is fully configured.
 
+#### `outputOptions`
+Type: `(outputOptions: OutputOptions) => OutputOptions | null`<br>
+Kind: `sync, sequential`
+
+Reads and replaces or manipulates the output options object passed to `bundle.generate`. Returning `null` does not replace anything.
+
 #### `outro`
 Type: `string | (() => string)`<br>
 Kind: `async, parallel`

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -432,9 +432,7 @@ function normalizeOutputOptions(
 	// now outputOptions is an array, but rollup.rollup API doesn't support arrays
 	const mergedOutputOptions = mergedOptions.outputOptions[0];
 	const outputOptionsReducer = (outputOptions: OutputOptions, result: OutputOptions) => {
-		if (!result) return outputOptions;
-
-		return {...outputOptions, ...result};
+		return result || outputOptions;
 	};
 	const outputOptions = pluginDriver.hookReduceArg0Sync(
 		'outputOptions',

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -237,10 +237,7 @@ export interface Plugin {
 		chunk: OutputChunk
 	) => void | Promise<void>;
 	options?: (this: MinimalPluginContext, options: InputOptions) => InputOptions | void | null;
-	outputOptions?: (
-		this: MinimalPluginContext,
-		options: OutputOptions
-	) => OutputOptions | void | null;
+	outputOptions?: (this: PluginContext, options: OutputOptions) => OutputOptions | void | null;
 	outro?: AddonHook;
 	renderChunk?: RenderChunkHook;
 	renderError?: (this: PluginContext, err?: Error) => Promise<void> | void;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -237,6 +237,10 @@ export interface Plugin {
 		chunk: OutputChunk
 	) => void | Promise<void>;
 	options?: (this: MinimalPluginContext, options: InputOptions) => InputOptions | void | null;
+	outputOptions?: (
+		this: MinimalPluginContext,
+		options: OutputOptions
+	) => OutputOptions | void | null;
 	outro?: AddonHook;
 	renderChunk?: RenderChunkHook;
 	renderError?: (this: PluginContext, err?: Error) => Promise<void> | void;

--- a/src/utils/pluginDriver.ts
+++ b/src/utils/pluginDriver.ts
@@ -29,6 +29,12 @@ export interface PluginDriver {
 		reduce: Reduce<R, T>,
 		hookContext?: HookContext
 	): Promise<T>;
+	hookReduceArg0Sync<R = any, T = any>(
+		hook: string,
+		args: any[],
+		reduce: Reduce<R, T>,
+		hookContext?: HookContext
+	): T;
 	hookReduceValue<R = any, T = any>(
 		hook: string,
 		value: T | Promise<T>,
@@ -306,6 +312,14 @@ export function createPluginDriver(
 				});
 			}
 			return promise;
+		},
+		// chains, synchronically reduces returns of type R, to type T, handling the reduced value as the first hook argument
+		hookReduceArg0Sync(name, [arg0, ...args], reduce, hookContext) {
+			for (let i = 0; i < plugins.length; i++) {
+				const result = runHookSync(name, [arg0, ...args], i, false, hookContext);
+				arg0 = reduce.call(pluginContexts[i], arg0, result, plugins[i]);
+			}
+			return arg0;
 		},
 		// chains, reduces returns of type R, to type T, handling the reduced value separately. permits hooks as values.
 		hookReduceValue(name, initial, args, reduce, hookContext) {

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -29,6 +29,34 @@ describe('hooks', () => {
 			.then(bundle => {});
 	});
 
+	it('allows to read and modify output options in the outputOptions hook', () => {
+		return rollup
+			.rollup({
+				input: 'input',
+				treeshake: false,
+				output: {
+					format: 'esm',
+					banner: 'banner'
+				},
+				plugins: [
+					loader({ input: `alert('hello')` }),
+					{
+						renderChunk(code, chunk, options) {
+							assert.strictEqual(options.format, 'cjs');
+							assert.strictEqual(options.banner, 'banner');
+						},
+						outputOptions(options) {
+							assert.strictEqual(options.format, 'esm');
+							assert.strictEqual(options.banner, 'banner');
+							assert.ok(/^\d+\.\d+\.\d+/.test(this.meta.rollupVersion));
+							return Object.assign({}, options, { format: 'cjs' });
+						}
+					}
+				]
+			})
+			.then(bundle => {});
+	});
+
 	it('supports buildStart and buildEnd hooks', () => {
 		let buildStartCnt = 0;
 		let buildEndCnt = 0;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

#2735

### Description

This PR adds `outputOptions` hook for plugins, that allows overriding of `OutputOptions` passed to `bundle.generate`. I've based the code on the existing `options` hook. The hook is run inside `normalizeOutputOptions`, as it seemed to be the place, where the final form of output options is created.