### PR TITLE
Fix a situation where two different imports with the same name are rendered

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -830,21 +830,23 @@ export default class Chunk {
 		}
 
 		const importsAsArray = Array.from(this.imports);
+		const renderedImports = new Set<Variable>();
 		const dependencies: ChunkDependencies = [];
 
 		for (const dep of this.dependencies) {
 			const imports: ImportSpecifier[] = [];
 			for (const variable of importsAsArray) {
+				const renderedVariable =
+					variable instanceof ExportDefaultVariable && variable.referencesOriginal()
+						? variable.getOriginalVariable()
+						: variable;
 				if (
 					(variable.module instanceof Module
 						? variable.module.chunk === dep
 						: variable.module === dep) &&
-					!(
-						variable instanceof ExportDefaultVariable &&
-						variable.referencesOriginal() &&
-						this.imports.has(variable.getOriginalVariable())
-					)
+					!renderedImports.has(renderedVariable)
 				) {
+					renderedImports.add(renderedVariable);
 					const local = variable.getName();
 					const imported =
 						variable.module instanceof ExternalModule

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_config.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description:
+		'do not import variables that reference an original if another variable referencing it is already imported',
+	options: {
+		input: ['main1', 'main2']
+	}
+};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/generated-chunk.js
@@ -1,0 +1,8 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = {};
+
+	exports.foo = foo;
+	exports.bar = foo;
+
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main1.js
@@ -1,0 +1,5 @@
+define(['./generated-chunk.js'], function (__chunk_1) { 'use strict';
+
+	console.log(__chunk_1.bar, __chunk_1.bar);
+
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main2.js
@@ -1,0 +1,5 @@
+define(['./generated-chunk.js'], function (__chunk_1) { 'use strict';
+
+	console.log(__chunk_1.bar, __chunk_1.bar);
+
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/generated-chunk.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const foo = {};
+
+exports.foo = foo;
+exports.bar = foo;

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var __chunk_1 = require('./generated-chunk.js');
+
+console.log(__chunk_1.bar, __chunk_1.bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var __chunk_1 = require('./generated-chunk.js');
+
+console.log(__chunk_1.bar, __chunk_1.bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/generated-chunk.js
@@ -1,0 +1,3 @@
+const foo = {};
+
+export { foo as a, foo as b };

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main1.js
@@ -1,0 +1,3 @@
+import { a as bar } from './generated-chunk.js';
+
+console.log(bar, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main2.js
@@ -1,0 +1,3 @@
+import { a as bar } from './generated-chunk.js';
+
+console.log(bar, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/generated-chunk.js
@@ -1,0 +1,14 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = {};
+
+			exports('a', foo);
+
+			exports('b', foo);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main1.js
@@ -1,0 +1,14 @@
+System.register(['./generated-chunk.js'], function (exports, module) {
+	'use strict';
+	var bar;
+	return {
+		setters: [function (module) {
+			bar = module.a;
+		}],
+		execute: function () {
+
+			console.log(bar, bar);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main2.js
@@ -1,0 +1,14 @@
+System.register(['./generated-chunk.js'], function (exports, module) {
+	'use strict';
+	var bar;
+	return {
+		setters: [function (module) {
+			bar = module.a;
+		}],
+		execute: function () {
+
+			console.log(bar, bar);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/foo.js
@@ -1,0 +1,1 @@
+export const foo = {};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/main1.js
@@ -1,0 +1,4 @@
+import foo from './proxy1';
+import bar from './proxy2';
+
+console.log(foo, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/main2.js
@@ -1,0 +1,4 @@
+import foo from './proxy1';
+import bar from './proxy2';
+
+console.log(foo, bar);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/proxy1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/proxy1.js
@@ -1,0 +1,3 @@
+import { foo } from './foo';
+
+export default foo;

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/proxy2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/proxy2.js
@@ -1,0 +1,3 @@
+import { foo } from './foo';
+
+export default foo;


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Hopefully resolves #2726 

### Description
This is basically a generalization of #2719. When two different default exports reference the same variable, it is possible that both are rendered as separate imports.

This is just again a fix for the import situation; the exports will still be rendered several times. The problem is that it is only known after tree-shaking if a default export can be identified with the original variable, at which point many other things have already been initialized using the separate variables.

A proper fix for the future might include
* calculating module dependencies AFTER tree-shaking
* before doing that
  - replacing default exports in the same module with exports of their original variables
  - removing default exports referencing variables from different modules
  - replacing imports with imports of the original variables (possibly from different modules)

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
