### PR TITLE
Sort modules before binding, sort exports

### DIFF
--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/generated-chunk.js
@@ -2,7 +2,7 @@ define(['exports'], function (exports) { 'use strict';
 
 	const foo = {};
 
-	exports.foo = foo;
 	exports.bar = foo;
+	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/generated-chunk.js
@@ -2,5 +2,5 @@
 
 const foo = {};
 
-exports.foo = foo;
 exports.bar = foo;
+exports.foo = foo;

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/generated-chunk.js
@@ -2,7 +2,7 @@ define(['exports'], function (exports) { 'use strict';
 
 	const foo = {};
 
-	exports.foo = foo;
 	exports.bar = foo;
+	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/generated-chunk.js
@@ -2,5 +2,5 @@
 
 const foo = {};
 
-exports.foo = foo;
 exports.bar = foo;
+exports.foo = foo;

--- a/test/chunking-form/samples/dynamic-import-facade/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-facade/_expected/amd/generated-chunk.js
@@ -7,7 +7,7 @@ define(['exports'], function (exports) { 'use strict';
 	console.log('dynamic', dep);
 	const dynamic = 'dynamic';
 
-	exports.dynamic = dynamic;
 	exports.dep = dep;
+	exports.dynamic = dynamic;
 
 });

--- a/test/chunking-form/samples/dynamic-import-facade/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-facade/_expected/cjs/generated-chunk.js
@@ -7,5 +7,5 @@ const dep = 'dep';
 console.log('dynamic', dep);
 const dynamic = 'dynamic';
 
-exports.dynamic = dynamic;
 exports.dep = dep;
+exports.dynamic = dynamic;

--- a/test/chunking-form/samples/dynamic-import-statically-imported-2/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-statically-imported-2/_expected/amd/generated-chunk.js
@@ -14,7 +14,7 @@ define(['require', 'exports'], function (require, exports) { 'use strict';
 		bar: bar
 	});
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/dynamic-import-statically-imported-2/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-statically-imported-2/_expected/cjs/generated-chunk.js
@@ -14,5 +14,5 @@ var dep1 = /*#__PURE__*/Object.freeze({
 	bar: bar
 });
 
-exports.foo = foo;
 exports.bar = bar;
+exports.foo = foo;

--- a/test/chunking-form/samples/dynamic-import-statically-imported/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-statically-imported/_expected/amd/generated-chunk.js
@@ -14,7 +14,7 @@ define(['require', 'exports'], function (require, exports) { 'use strict';
 		bar: bar
 	});
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/dynamic-import-statically-imported/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/dynamic-import-statically-imported/_expected/cjs/generated-chunk.js
@@ -14,5 +14,5 @@ var dep1 = /*#__PURE__*/Object.freeze({
 	bar: bar
 });
 
-exports.foo = foo;
 exports.bar = bar;
+exports.foo = foo;

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/generated-main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/amd/generated-main2alias.js
@@ -8,7 +8,7 @@ define(['exports'], function (exports) { 'use strict';
     }
   }
 
-  exports.log = log;
   exports.dep = dep;
+  exports.log = log;
 
 });

--- a/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/generated-main2alias.js
+++ b/test/chunking-form/samples/entrypoint-aliasing/_expected/cjs/generated-main2alias.js
@@ -8,5 +8,5 @@ function log (x) {
   }
 }
 
-exports.log = log;
 exports.dep = dep;
+exports.log = log;

--- a/test/chunking-form/samples/entrypoint-facade/_expected/amd/generated-main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/amd/generated-main2.js
@@ -8,7 +8,7 @@ define(['exports'], function (exports) { 'use strict';
     }
   }
 
-  exports.log = log;
   exports.dep = dep;
+  exports.log = log;
 
 });

--- a/test/chunking-form/samples/entrypoint-facade/_expected/cjs/generated-main2.js
+++ b/test/chunking-form/samples/entrypoint-facade/_expected/cjs/generated-main2.js
@@ -8,5 +8,5 @@ function log (x) {
   }
 }
 
-exports.log = log;
 exports.dep = dep;
+exports.log = log;

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/chunk-main2-6bb39c19-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/chunk-main2-6bb39c19-amd.js
@@ -8,7 +8,7 @@ define(['exports'], function (exports) { 'use strict';
     }
   }
 
-  exports.log = log;
   exports.dep = dep;
+  exports.log = log;
 
 });

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main1-174b752b-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main1-174b752b-amd.js
@@ -1,5 +1,0 @@
-define(['./chunk-main2-ed4460c9-amd.js'], function (main2) { 'use strict';
-
-	main2.log(main2.dep);
-
-});

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main1-e7c7d1b5-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main1-e7c7d1b5-amd.js
@@ -1,0 +1,5 @@
+define(['./chunk-main2-6bb39c19-amd.js'], function (main2) { 'use strict';
+
+	main2.log(main2.dep);
+
+});

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main2-a8c16f0a-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main2-a8c16f0a-amd.js
@@ -1,7 +1,0 @@
-define(['./chunk-main2-ed4460c9-amd.js'], function (main2) { 'use strict';
-
-
-
-	return main2.log;
-
-});

--- a/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main2-f9a2200a-amd.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/amd/entry-main2-f9a2200a-amd.js
@@ -1,0 +1,7 @@
+define(['./chunk-main2-6bb39c19-amd.js'], function (main2) { 'use strict';
+
+
+
+	return main2.log;
+
+});

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/chunk-main2-33c8b40d-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/chunk-main2-33c8b40d-cjs.js
@@ -8,5 +8,5 @@ function log (x) {
   }
 }
 
-exports.log = log;
 exports.dep = dep;
+exports.log = log;

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main1-544352cb-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main1-544352cb-cjs.js
@@ -1,5 +1,0 @@
-'use strict';
-
-var main2 = require('./chunk-main2-690ec2d2-cjs.js');
-
-main2.log(main2.dep);

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main1-639831da-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main1-639831da-cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var main2 = require('./chunk-main2-33c8b40d-cjs.js');
+
+main2.log(main2.dep);

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main2-4508233a-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main2-4508233a-cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var main2 = require('./chunk-main2-33c8b40d-cjs.js');
+
+
+
+module.exports = main2.log;

--- a/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main2-a45eef7f-cjs.js
+++ b/test/chunking-form/samples/filenames-patterns/_expected/cjs/entry-main2-a45eef7f-cjs.js
@@ -1,7 +1,0 @@
-'use strict';
-
-var main2 = require('./chunk-main2-690ec2d2-cjs.js');
-
-
-
-module.exports = main2.log;

--- a/test/chunking-form/samples/manual-chunks-dynamic-facades/_expected/amd/generated-dynamic.js
+++ b/test/chunking-form/samples/manual-chunks-dynamic-facades/_expected/amd/generated-dynamic.js
@@ -8,8 +8,8 @@ define(['exports'], function (exports) { 'use strict';
 
 	const DYNAMIC_1 = 'DYNAMIC_1';
 
-	exports.DYNAMIC_1 = DYNAMIC_1;
 	exports.DEP = DEP;
+	exports.DYNAMIC_1 = DYNAMIC_1;
 	exports.DYNAMIC_2 = DYNAMIC_2;
 	exports.DYNAMIC_3 = DYNAMIC_3;
 

--- a/test/chunking-form/samples/manual-chunks-dynamic-facades/_expected/cjs/generated-dynamic.js
+++ b/test/chunking-form/samples/manual-chunks-dynamic-facades/_expected/cjs/generated-dynamic.js
@@ -8,7 +8,7 @@ const DYNAMIC_3 = 'DYNAMIC_3';
 
 const DYNAMIC_1 = 'DYNAMIC_1';
 
-exports.DYNAMIC_1 = DYNAMIC_1;
 exports.DEP = DEP;
+exports.DYNAMIC_1 = DYNAMIC_1;
 exports.DYNAMIC_2 = DYNAMIC_2;
 exports.DYNAMIC_3 = DYNAMIC_3;

--- a/test/chunking-form/samples/manual-chunks-dynamic-facades/_expected/es/generated-dynamic.js
+++ b/test/chunking-form/samples/manual-chunks-dynamic-facades/_expected/es/generated-dynamic.js
@@ -6,4 +6,4 @@ const DYNAMIC_3 = 'DYNAMIC_3';
 
 const DYNAMIC_1 = 'DYNAMIC_1';
 
-export { DYNAMIC_1, DEP, DYNAMIC_2, DYNAMIC_3 };
+export { DEP, DYNAMIC_1, DYNAMIC_2, DYNAMIC_3 };

--- a/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/amd/generated-dynamic2.js
+++ b/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/amd/generated-dynamic2.js
@@ -2,7 +2,7 @@ define(['exports', './generated-dynamic.js'], function (exports, dynamic) { 'use
 
 
 
-	exports.DYNAMIC_B = dynamic.DYNAMIC_A;
 	exports.DYNAMIC_A = dynamic.DYNAMIC_B;
+	exports.DYNAMIC_B = dynamic.DYNAMIC_A;
 
 });

--- a/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/cjs/generated-dynamic2.js
+++ b/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/cjs/generated-dynamic2.js
@@ -4,5 +4,5 @@ var dynamic = require('./generated-dynamic.js');
 
 
 
-exports.DYNAMIC_B = dynamic.DYNAMIC_A;
 exports.DYNAMIC_A = dynamic.DYNAMIC_B;
+exports.DYNAMIC_B = dynamic.DYNAMIC_A;

--- a/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/es/generated-dynamic2.js
+++ b/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/es/generated-dynamic2.js
@@ -1,1 +1,1 @@
-export { DYNAMIC_A as DYNAMIC_B, DYNAMIC_B as DYNAMIC_A } from './generated-dynamic.js';
+export { DYNAMIC_B as DYNAMIC_A, DYNAMIC_A as DYNAMIC_B } from './generated-dynamic.js';

--- a/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/system/generated-dynamic2.js
+++ b/test/chunking-form/samples/manual-chunks-dynamic-name-conflict/_expected/system/generated-dynamic2.js
@@ -3,8 +3,8 @@ System.register(['./generated-dynamic.js'], function (exports, module) {
 	return {
 		setters: [function (module) {
 			var _setter = {};
-			_setter.DYNAMIC_B = module.DYNAMIC_A;
 			_setter.DYNAMIC_A = module.DYNAMIC_B;
+			_setter.DYNAMIC_B = module.DYNAMIC_A;
 			exports(_setter);
 		}],
 		execute: function () {

--- a/test/chunking-form/samples/missing-export-compact/_expected/amd/dep.js
+++ b/test/chunking-form/samples/missing-export-compact/_expected/amd/dep.js
@@ -1,3 +1,3 @@
 define(['exports'],function(exports){'use strict';var _missingExportShim=void 0;function x () {
   sideEffect();
-}exports.x=x;exports.missingFn=_missingExportShim;exports.missingExport=_missingExportShim;Object.defineProperty(exports,'__esModule',{value:true});});
+}exports.missingExport=_missingExportShim;exports.missingFn=_missingExportShim;exports.x=x;Object.defineProperty(exports,'__esModule',{value:true});});

--- a/test/chunking-form/samples/missing-export-compact/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/missing-export-compact/_expected/cjs/dep.js
@@ -1,3 +1,3 @@
 'use strict';Object.defineProperty(exports,'__esModule',{value:true});var _missingExportShim=void 0;function x () {
   sideEffect();
-}exports.x=x;exports.missingFn=_missingExportShim;exports.missingExport=_missingExportShim;
+}exports.missingExport=_missingExportShim;exports.missingFn=_missingExportShim;exports.x=x;

--- a/test/chunking-form/samples/missing-export-compact/_expected/es/dep.js
+++ b/test/chunking-form/samples/missing-export-compact/_expected/es/dep.js
@@ -1,3 +1,3 @@
 var _missingExportShim=void 0;function x () {
   sideEffect();
-}export{x,_missingExportShim as missingFn,_missingExportShim as missingExport};
+}export{_missingExportShim as missingExport,_missingExportShim as missingFn,x};

--- a/test/chunking-form/samples/missing-export-compact/_expected/system/dep.js
+++ b/test/chunking-form/samples/missing-export-compact/_expected/system/dep.js
@@ -1,3 +1,3 @@
 System.register([],function(exports,module){'use strict';return{execute:function(){exports('x',x);var _missingExportShim=void 0;function x () {
   sideEffect();
-}exports({missingFn:_missingExportShim,missingExport:_missingExportShim});}}});
+}exports({missingExport:_missingExportShim,missingFn:_missingExportShim});}}});

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/amd/dep2.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/amd/dep2.js
@@ -8,7 +8,7 @@ define(['exports'], function (exports) { 'use strict';
 
 	console.log(_missingExportShim$1);
 
-	exports.previousShimmedExport = _missingExportShim$1;
 	exports.missing2 = _missingExportShim;
+	exports.previousShimmedExport = _missingExportShim$1;
 
 });

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/cjs/dep2.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/cjs/dep2.js
@@ -8,5 +8,5 @@ var _missingExportShim$1 = void 0;
 
 console.log(_missingExportShim$1);
 
-exports.previousShimmedExport = _missingExportShim$1;
 exports.missing2 = _missingExportShim;
+exports.previousShimmedExport = _missingExportShim$1;

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/es/dep2.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/es/dep2.js
@@ -6,4 +6,4 @@ var _missingExportShim$1 = void 0;
 
 console.log(_missingExportShim$1);
 
-export { _missingExportShim$1 as previousShimmedExport, _missingExportShim as missing2 };
+export { _missingExportShim as missing2, _missingExportShim$1 as previousShimmedExport };

--- a/test/chunking-form/samples/missing-export/_expected/amd/dep.js
+++ b/test/chunking-form/samples/missing-export/_expected/amd/dep.js
@@ -6,10 +6,10 @@ define(['exports'], function (exports) { 'use strict';
     sideEffect();
   }
 
-  exports.x = x;
-  exports.missingFn = _missingExportShim;
-  exports.missingExport = _missingExportShim;
   exports.default = _missingExportShim;
+  exports.missingExport = _missingExportShim;
+  exports.missingFn = _missingExportShim;
+  exports.x = x;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/chunking-form/samples/missing-export/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/missing-export/_expected/cjs/dep.js
@@ -8,7 +8,7 @@ function x () {
   sideEffect();
 }
 
-exports.x = x;
-exports.missingFn = _missingExportShim;
-exports.missingExport = _missingExportShim;
 exports.default = _missingExportShim;
+exports.missingExport = _missingExportShim;
+exports.missingFn = _missingExportShim;
+exports.x = x;

--- a/test/chunking-form/samples/missing-export/_expected/es/dep.js
+++ b/test/chunking-form/samples/missing-export/_expected/es/dep.js
@@ -5,4 +5,4 @@ function x () {
 }
 
 export default _missingExportShim;
-export { x, _missingExportShim as missingFn, _missingExportShim as missingExport };
+export { _missingExportShim as missingExport, _missingExportShim as missingFn, x };

--- a/test/chunking-form/samples/missing-export/_expected/system/dep.js
+++ b/test/chunking-form/samples/missing-export/_expected/system/dep.js
@@ -12,9 +12,9 @@ System.register([], function (exports, module) {
       }
 
       exports({
-        missingFn: _missingExportShim,
+        default: _missingExportShim,
         missingExport: _missingExportShim,
-        default: _missingExportShim
+        missingFn: _missingExportShim
       });
 
     }

--- a/test/chunking-form/samples/namespace-object-import/_expected/amd/generated-main2.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/amd/generated-main2.js
@@ -9,7 +9,7 @@ define(['exports'], function (exports) { 'use strict';
 	});
 
 	exports.a = a;
-	exports.main2 = main2;
 	exports.b = b;
+	exports.main2 = main2;
 
 });

--- a/test/chunking-form/samples/namespace-object-import/_expected/cjs/generated-main2.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/cjs/generated-main2.js
@@ -9,5 +9,5 @@ var main2 = /*#__PURE__*/Object.freeze({
 });
 
 exports.a = a;
-exports.main2 = main2;
 exports.b = b;
+exports.main2 = main2;

--- a/test/chunking-form/samples/namespace-retracing/_expected/amd/generated-chunk.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/amd/generated-chunk.js
@@ -12,7 +12,7 @@ define(['exports'], function (exports) { 'use strict';
 
 	Other.doSomething = function() { console.log('other'); };
 
-	exports.Other = Other;
 	exports.Broken = Broken;
+	exports.Other = Other;
 
 });

--- a/test/chunking-form/samples/namespace-retracing/_expected/cjs/generated-chunk.js
+++ b/test/chunking-form/samples/namespace-retracing/_expected/cjs/generated-chunk.js
@@ -12,5 +12,5 @@ class Other {
 
 Other.doSomething = function() { console.log('other'); };
 
-exports.Other = Other;
 exports.Broken = Broken;
+exports.Other = Other;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/dep.js
@@ -2,7 +2,7 @@ define(['exports'], function (exports) { 'use strict';
 
 	const foo = 1;
 
-	exports.foo = foo;
 	exports.bar = foo;
+	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/amd/main1.js
@@ -2,8 +2,8 @@ define(['exports', './dep.js'], function (exports, __chunk_1) { 'use strict';
 
 
 
-	exports.foo = __chunk_1.foo;
 	exports.bar = __chunk_1.foo;
+	exports.foo = __chunk_1.foo;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/dep.js
@@ -2,5 +2,5 @@
 
 const foo = 1;
 
-exports.foo = foo;
 exports.bar = foo;
+exports.foo = foo;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/cjs/main1.js
@@ -6,5 +6,5 @@ var __chunk_1 = require('./dep.js');
 
 
 
-exports.foo = __chunk_1.foo;
 exports.bar = __chunk_1.foo;
+exports.foo = __chunk_1.foo;

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/dep.js
@@ -1,3 +1,3 @@
 const foo = 1;
 
-export { foo, foo as bar };
+export { foo as bar, foo };

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/es/main1.js
@@ -1,1 +1,1 @@
-export { foo, foo as bar } from './dep.js';
+export { foo as bar, foo } from './dep.js';

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/dep.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/dep.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			const foo = exports('bar', 1);
+			const foo = exports('foo', 1);
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/main1.js
+++ b/test/chunking-form/samples/preserve-modules-export-alias/_expected/system/main1.js
@@ -3,8 +3,8 @@ System.register(['./dep.js'], function (exports, module) {
 	return {
 		setters: [function (module) {
 			var _setter = {};
-			_setter.foo = module.foo;
 			_setter.bar = module.foo;
+			_setter.foo = module.foo;
 			exports(_setter);
 		}],
 		execute: function () {

--- a/test/form/samples/assignment-to-exports/_expected/es.js
+++ b/test/form/samples/assignment-to-exports/_expected/es.js
@@ -22,4 +22,4 @@ baz2 = 2;
 
 console.log( kept1, kept2 );
 
-export { foo1, bar1, baz1, foo2, bar2, baz2 };
+export { bar1, bar2, baz1, baz2, foo1, foo2 };

--- a/test/form/samples/assignment-to-exports/_expected/system.js
+++ b/test/form/samples/assignment-to-exports/_expected/system.js
@@ -4,10 +4,10 @@ System.register('bundle', [], function (exports, module) {
 		execute: function () {
 
 			exports({
-				foo1: void 0,
 				bar1: void 0,
-				foo2: void 0,
-				bar2: void 0
+				bar2: void 0,
+				foo1: void 0,
+				foo2: void 0
 			});
 
 			// Unassigned export

--- a/test/form/samples/computed-properties/_expected/amd.js
+++ b/test/form/samples/computed-properties/_expected/amd.js
@@ -13,8 +13,8 @@ define(['exports'], function (exports) { 'use strict';
 		set [bam] ( value ) {}
 	}
 
-	exports.x = x;
 	exports.X = X;
+	exports.x = x;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/computed-properties/_expected/cjs.js
+++ b/test/form/samples/computed-properties/_expected/cjs.js
@@ -15,5 +15,5 @@ class X {
 	set [bam] ( value ) {}
 }
 
-exports.x = x;
 exports.X = X;
+exports.x = x;

--- a/test/form/samples/computed-properties/_expected/es.js
+++ b/test/form/samples/computed-properties/_expected/es.js
@@ -11,4 +11,4 @@ class X {
 	set [bam] ( value ) {}
 }
 
-export { x, X };
+export { X, x };

--- a/test/form/samples/computed-properties/_expected/iife.js
+++ b/test/form/samples/computed-properties/_expected/iife.js
@@ -14,8 +14,8 @@ var computedProperties = (function (exports) {
 		set [bam] ( value ) {}
 	}
 
-	exports.x = x;
 	exports.X = X;
+	exports.x = x;
 
 	return exports;
 

--- a/test/form/samples/computed-properties/_expected/umd.js
+++ b/test/form/samples/computed-properties/_expected/umd.js
@@ -17,8 +17,8 @@
 		set [bam] ( value ) {}
 	}
 
-	exports.x = x;
 	exports.X = X;
+	exports.x = x;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/dedupes-external-imports/_expected/amd.js
+++ b/test/form/samples/dedupes-external-imports/_expected/amd.js
@@ -25,9 +25,9 @@ define(['exports', 'external'], function (exports, external) { 'use strict';
 	const bar = new Bar();
 	const baz = new Baz();
 
-	exports.foo = foo;
 	exports.bar = bar;
 	exports.baz = baz;
+	exports.foo = foo;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/dedupes-external-imports/_expected/cjs.js
+++ b/test/form/samples/dedupes-external-imports/_expected/cjs.js
@@ -29,6 +29,6 @@ const foo = new Foo();
 const bar = new Bar();
 const baz = new Baz();
 
-exports.foo = foo;
 exports.bar = bar;
 exports.baz = baz;
+exports.foo = foo;

--- a/test/form/samples/dedupes-external-imports/_expected/es.js
+++ b/test/form/samples/dedupes-external-imports/_expected/es.js
@@ -25,4 +25,4 @@ const foo = new Foo();
 const bar = new Bar();
 const baz = new Baz();
 
-export { foo, bar, baz };
+export { bar, baz, foo };

--- a/test/form/samples/dedupes-external-imports/_expected/iife.js
+++ b/test/form/samples/dedupes-external-imports/_expected/iife.js
@@ -26,9 +26,9 @@ var myBundle = (function (exports, external) {
 	const bar = new Bar();
 	const baz = new Baz();
 
-	exports.foo = foo;
 	exports.bar = bar;
 	exports.baz = baz;
+	exports.foo = foo;
 
 	return exports;
 

--- a/test/form/samples/dedupes-external-imports/_expected/umd.js
+++ b/test/form/samples/dedupes-external-imports/_expected/umd.js
@@ -29,9 +29,9 @@
 	const bar = new Bar();
 	const baz = new Baz();
 
-	exports.foo = foo;
 	exports.bar = bar;
 	exports.baz = baz;
+	exports.foo = foo;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/export-live-bindings/_expected/amd.js
+++ b/test/form/samples/export-live-bindings/_expected/amd.js
@@ -28,9 +28,9 @@ define(['exports'], function (exports) { 'use strict';
   update$2();
   console.log(exports.baz);
 
-  exports.updateFoo = update;
   exports.updateBar = update$1;
   exports.updateBaz = update$2;
+  exports.updateFoo = update;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/export-live-bindings/_expected/cjs.js
+++ b/test/form/samples/export-live-bindings/_expected/cjs.js
@@ -30,6 +30,6 @@ console.log(exports.baz);
 update$2();
 console.log(exports.baz);
 
-exports.updateFoo = update;
 exports.updateBar = update$1;
 exports.updateBaz = update$2;
+exports.updateFoo = update;

--- a/test/form/samples/export-live-bindings/_expected/es.js
+++ b/test/form/samples/export-live-bindings/_expected/es.js
@@ -26,4 +26,4 @@ console.log(baz);
 update$2();
 console.log(baz);
 
-export { update as updateFoo, update$1 as updateBar, update$2 as updateBaz, foo, bar, baz };
+export { bar, baz, foo, update$1 as updateBar, update$2 as updateBaz, update as updateFoo };

--- a/test/form/samples/export-live-bindings/_expected/iife.js
+++ b/test/form/samples/export-live-bindings/_expected/iife.js
@@ -29,9 +29,9 @@ var iife = (function (exports) {
   update$2();
   console.log(exports.baz);
 
-  exports.updateFoo = update;
   exports.updateBar = update$1;
   exports.updateBaz = update$2;
+  exports.updateFoo = update;
 
   return exports;
 

--- a/test/form/samples/export-live-bindings/_expected/system.js
+++ b/test/form/samples/export-live-bindings/_expected/system.js
@@ -4,9 +4,9 @@ System.register('iife', [], function (exports, module) {
     execute: function () {
 
       exports({
-        updateFoo: update,
         updateBar: update$1,
-        updateBaz: update$2
+        updateBaz: update$2,
+        updateFoo: update
       });
 
       function update () {

--- a/test/form/samples/export-live-bindings/_expected/umd.js
+++ b/test/form/samples/export-live-bindings/_expected/umd.js
@@ -32,9 +32,9 @@
   update$2();
   console.log(exports.baz);
 
-  exports.updateFoo = update;
   exports.updateBar = update$1;
   exports.updateBaz = update$2;
+  exports.updateFoo = update;
 
   Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/interop-false-reexport/_expected/amd.js
+++ b/test/form/samples/interop-false-reexport/_expected/amd.js
@@ -2,8 +2,8 @@ define(['exports', 'external'], function (exports, external) { 'use strict';
 
 
 
-	exports.q = external.p;
 	exports.p = external.default;
+	exports.q = external.p;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/interop-false-reexport/_expected/cjs.js
+++ b/test/form/samples/interop-false-reexport/_expected/cjs.js
@@ -6,5 +6,5 @@ var external = require('external');
 
 
 
-exports.q = external.p;
 exports.p = external.default;
+exports.q = external.p;

--- a/test/form/samples/interop-false-reexport/_expected/es.js
+++ b/test/form/samples/interop-false-reexport/_expected/es.js
@@ -1,1 +1,1 @@
-export { p as q, default as p } from 'external';
+export { default as p, p as q } from 'external';

--- a/test/form/samples/interop-false-reexport/_expected/iife.js
+++ b/test/form/samples/interop-false-reexport/_expected/iife.js
@@ -3,8 +3,8 @@ var foo = (function (exports, external) {
 
 
 
-	exports.q = external.p;
 	exports.p = external.default;
+	exports.q = external.p;
 
 	return exports;
 

--- a/test/form/samples/interop-false-reexport/_expected/system.js
+++ b/test/form/samples/interop-false-reexport/_expected/system.js
@@ -3,8 +3,8 @@ System.register('foo', ['external'], function (exports, module) {
 	return {
 		setters: [function (module) {
 			var _setter = {};
-			_setter.q = module.p;
 			_setter.p = module.default;
+			_setter.q = module.p;
 			exports(_setter);
 		}],
 		execute: function () {

--- a/test/form/samples/interop-false-reexport/_expected/umd.js
+++ b/test/form/samples/interop-false-reexport/_expected/umd.js
@@ -4,8 +4,8 @@
 	(global = global || self, factory(global.foo = {}, global.external));
 }(this, function (exports, external) { 'use strict';
 
-	exports.q = external.p;
 	exports.p = external.default;
+	exports.q = external.p;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/multiple-exports/_expected/amd.js
+++ b/test/form/samples/multiple-exports/_expected/amd.js
@@ -3,8 +3,8 @@ define(['exports'], function (exports) { 'use strict';
 	var foo = 1;
 	var bar = 2;
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/multiple-exports/_expected/cjs.js
+++ b/test/form/samples/multiple-exports/_expected/cjs.js
@@ -5,5 +5,5 @@ Object.defineProperty(exports, '__esModule', { value: true });
 var foo = 1;
 var bar = 2;
 
-exports.foo = foo;
 exports.bar = bar;
+exports.foo = foo;

--- a/test/form/samples/multiple-exports/_expected/es.js
+++ b/test/form/samples/multiple-exports/_expected/es.js
@@ -1,4 +1,4 @@
 var foo = 1;
 var bar = 2;
 
-export { foo, bar };
+export { bar, foo };

--- a/test/form/samples/multiple-exports/_expected/iife.js
+++ b/test/form/samples/multiple-exports/_expected/iife.js
@@ -4,8 +4,8 @@ var myBundle = (function (exports) {
 	var foo = 1;
 	var bar = 2;
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 	return exports;
 

--- a/test/form/samples/multiple-exports/_expected/umd.js
+++ b/test/form/samples/multiple-exports/_expected/umd.js
@@ -7,8 +7,8 @@
 	var foo = 1;
 	var bar = 2;
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/reassigned-exported-functions-and-classes/_expected/amd.js
+++ b/test/form/samples/reassigned-exported-functions-and-classes/_expected/amd.js
@@ -6,8 +6,8 @@ define(['exports'], function (exports) { 'use strict';
 	class bar {}
 	bar = 1;
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/reassigned-exported-functions-and-classes/_expected/cjs.js
+++ b/test/form/samples/reassigned-exported-functions-and-classes/_expected/cjs.js
@@ -8,5 +8,5 @@ foo = 1;
 class bar {}
 bar = 1;
 
-exports.foo = foo;
 exports.bar = bar;
+exports.foo = foo;

--- a/test/form/samples/reassigned-exported-functions-and-classes/_expected/es.js
+++ b/test/form/samples/reassigned-exported-functions-and-classes/_expected/es.js
@@ -4,4 +4,4 @@ foo = 1;
 class bar {}
 bar = 1;
 
-export { foo, bar };
+export { bar, foo };

--- a/test/form/samples/reassigned-exported-functions-and-classes/_expected/iife.js
+++ b/test/form/samples/reassigned-exported-functions-and-classes/_expected/iife.js
@@ -7,8 +7,8 @@ var bundle = (function (exports) {
 	class bar {}
 	bar = 1;
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 	return exports;
 

--- a/test/form/samples/reassigned-exported-functions-and-classes/_expected/umd.js
+++ b/test/form/samples/reassigned-exported-functions-and-classes/_expected/umd.js
@@ -10,8 +10,8 @@
 	class bar {}
 	bar = 1;
 
-	exports.foo = foo;
 	exports.bar = bar;
+	exports.foo = foo;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/render-named-export-declarations/_expected/es.js
+++ b/test/form/samples/render-named-export-declarations/_expected/es.js
@@ -10,4 +10,4 @@ cBar = 2;
 var dFoo = 1, dBar;
 dFoo = 2;
 
-export { aFoo, aBar, bFoo, bBar, cFoo, cBar, dFoo, dBar };
+export { aBar, aFoo, bBar, bFoo, cBar, cFoo, dBar, dFoo };

--- a/test/form/samples/render-named-export-declarations/_expected/system.js
+++ b/test/form/samples/render-named-export-declarations/_expected/system.js
@@ -4,10 +4,10 @@ System.register('bundle', [], function (exports, module) {
 		execute: function () {
 
 			exports({
-				aFoo: void 0,
 				aBar: void 0,
-				bFoo: void 0,
+				aFoo: void 0,
 				bBar: void 0,
+				bFoo: void 0,
 				cFoo: void 0,
 				dBar: void 0
 			});

--- a/test/form/samples/resolution-order/_config.js
+++ b/test/form/samples/resolution-order/_config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	description: 'does not depend on the resolution order of modules for tree-shaking (#2753)',
+	options: {
+		plugins: {
+			resolveId(id) {
+				if (id === './utcWeek') {
+					return new Promise(resolve => setTimeout(resolve, 0));
+				}
+			}
+		}
+	}
+};

--- a/test/form/samples/resolution-order/_expected.js
+++ b/test/form/samples/resolution-order/_expected.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/test/form/samples/resolution-order/locale.js
+++ b/test/form/samples/resolution-order/locale.js
@@ -1,0 +1,8 @@
+import {
+  utcSunday,
+  utcTuesday
+} from './utcWeek'
+
+export default function formatLocale(locale) {
+  utcSunday()
+}

--- a/test/form/samples/resolution-order/main.js
+++ b/test/form/samples/resolution-order/main.js
@@ -1,0 +1,5 @@
+import { utcMonday } from './utcWeek';
+import formatLocale from './locale';
+utcMonday();
+formatLocale();
+console.log('main');

--- a/test/form/samples/resolution-order/utcWeek.js
+++ b/test/form/samples/resolution-order/utcWeek.js
@@ -1,0 +1,25 @@
+function interval() {
+	var i = function() {};
+	i.range = function() {};
+	return i;
+}
+
+function utcWeekday(i) {
+	return interval();
+}
+
+export var utcSunday = utcWeekday(0);
+export var utcMonday = utcWeekday(1);
+export var utcTuesday = utcWeekday(2);
+export var utcWednesday = utcWeekday(3);
+export var utcThursday = utcWeekday(4);
+export var utcFriday = utcWeekday(5);
+export var utcSaturday = utcWeekday(6);
+
+export var utcSundays = utcSunday.range;
+export var utcMondays = utcMonday.range;
+export var utcTuesdays = utcTuesday.range;
+export var utcWednesdays = utcWednesday.range;
+export var utcThursdays = utcThursday.range;
+export var utcFridays = utcFriday.range;
+export var utcSaturdays = utcSaturday.range;

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/amd.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/amd.js
@@ -6,8 +6,8 @@ define(['require', 'exports', 'external'], function (require, exports, myExterna
 
 	const someDynamicImport = () => new Promise(function (resolve, reject) { require(['external'], resolve, reject) });
 
-	exports.test = test;
 	exports.someDynamicImport = someDynamicImport;
+	exports.test = test;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/cjs.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/cjs.js
@@ -10,5 +10,5 @@ const test = () => myExternal;
 
 const someDynamicImport = () => Promise.resolve(require('external'));
 
-exports.test = test;
 exports.someDynamicImport = someDynamicImport;
+exports.test = test;

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/es.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/es.js
@@ -4,4 +4,4 @@ const test = () => myExternal;
 
 const someDynamicImport = () => import('external');
 
-export { test, someDynamicImport };
+export { someDynamicImport, test };

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/iife.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/iife.js
@@ -7,8 +7,8 @@ var bundle = (function (exports, myExternal) {
 
 	const someDynamicImport = () => import('external');
 
-	exports.test = test;
 	exports.someDynamicImport = someDynamicImport;
+	exports.test = test;
 
 	return exports;
 

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/umd.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/umd.js
@@ -10,8 +10,8 @@
 
 	const someDynamicImport = () => import('external');
 
-	exports.test = test;
 	exports.someDynamicImport = someDynamicImport;
+	exports.test = test;
 
 	Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/test/function/samples/has-modules-array/_config.js
+++ b/test/function/samples/has-modules-array/_config.js
@@ -6,7 +6,7 @@ module.exports = {
 	bundle(bundle) {
 		assert.ok(bundle.cache.modules);
 		assert.equal(bundle.cache.modules.length, 2);
-		assert.equal(path.relative(bundle.cache.modules[1].id, path.resolve(__dirname, 'foo.js')), '');
-		assert.equal(path.relative(bundle.cache.modules[0].id, path.resolve(__dirname, 'main.js')), '');
+		assert.equal(path.relative(bundle.cache.modules[0].id, path.resolve(__dirname, 'foo.js')), '');
+		assert.equal(path.relative(bundle.cache.modules[1].id, path.resolve(__dirname, 'main.js')), '');
 	}
 };

--- a/test/function/samples/module-tree/_config.js
+++ b/test/function/samples/module-tree/_config.js
@@ -13,24 +13,24 @@ module.exports = {
 
 		assert.deepEqual(modules, [
 			{
-				id: 'main.js',
-				dependencies: ['foo.js', 'bar.js']
-			},
-			{
-				id: 'foo.js',
-				dependencies: ['bar.js']
-			},
-			{
-				id: 'bar.js',
-				dependencies: [path.normalize('nested/baz.js')]
+				id: path.normalize('nested/qux.js'),
+				dependencies: []
 			},
 			{
 				id: path.normalize('nested/baz.js'),
 				dependencies: [path.normalize('nested/qux.js')]
 			},
 			{
-				id: path.normalize('nested/qux.js'),
-				dependencies: []
+				id: 'bar.js',
+				dependencies: [path.normalize('nested/baz.js')]
+			},
+			{
+				id: 'foo.js',
+				dependencies: ['bar.js']
+			},
+			{
+				id: 'main.js',
+				dependencies: ['foo.js', 'bar.js']
 			}
 		]);
 	},

--- a/test/incremental/index.js
+++ b/test/incremental/index.js
@@ -236,10 +236,10 @@ describe('incremental', () => {
 				plugins: [plugin]
 			})
 			.then(bundle => {
-				assert.equal(bundle.cache.modules[1].id, 'foo');
-				assert.equal(bundle.cache.modules[0].id, 'entry');
+				assert.equal(bundle.cache.modules[0].id, 'foo');
+				assert.equal(bundle.cache.modules[1].id, 'entry');
 
-				assert.deepEqual(bundle.cache.modules[0].resolvedIds, {
+				assert.deepEqual(bundle.cache.modules[1].resolvedIds, {
 					foo: { id: 'foo', external: false },
 					external: { id: 'external', external: true }
 				});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2753 

### Description
This resolves #2753 and even improves tree-shaking results in some cases by sorting all modules by their execution order before binding variables to their definitions. When binding variables, some tree-shaking preparations are performed as well which do not work as well when the modules are execution in an order different from their execution order, resulting in more included code.

To also make the output more stable, readable, and less dependent on implementation details, exports are also sorted by name now.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
