### PR TITLE
Make sure unused default exports are deconflicted when not tree-shaking

### DIFF
--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -46,6 +46,13 @@ export default class ExportDefaultDeclaration extends NodeBase {
 	variable: ExportDefaultVariable;
 	private declarationName: string;
 
+	include(includeAllChildrenRecursively: boolean) {
+		super.include(includeAllChildrenRecursively);
+		if (includeAllChildrenRecursively) {
+			this.context.includeVariable(this.variable);
+		}
+	}
+
 	initialise() {
 		this.included = false;
 		this.declarationName =

--- a/test/form/samples/no-treeshake-default-export-conflict/_config.js
+++ b/test/form/samples/no-treeshake-default-export-conflict/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'properly deconflicts default exports when not tree-shaking',
+	options: {
+		treeshake: false
+	}
+};

--- a/test/form/samples/no-treeshake-default-export-conflict/_expected.js
+++ b/test/form/samples/no-treeshake-default-export-conflict/_expected.js
@@ -1,0 +1,7 @@
+function foo() {
+	return 'foo';
+}
+
+function foo$1() {
+	return 'default';
+}

--- a/test/form/samples/no-treeshake-default-export-conflict/foo.js
+++ b/test/form/samples/no-treeshake-default-export-conflict/foo.js
@@ -1,0 +1,7 @@
+export function foo() {
+	return 'foo';
+}
+
+export default function() {
+	return 'default';
+}

--- a/test/form/samples/no-treeshake-default-export-conflict/main.js
+++ b/test/form/samples/no-treeshake-default-export-conflict/main.js
@@ -1,0 +1,1 @@
+import './foo';


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2752 

### Description
The algorithm used when skipping tree-shaking did not include variables reflecting unused default exports which resulted in those exports being ignored for deconflicting.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
