### PR TITLE
Handle member expressions in array patterns

### DIFF
--- a/src/ast/nodes/ArrayPattern.ts
+++ b/src/ast/nodes/ArrayPattern.ts
@@ -13,6 +13,11 @@ export default class ArrayPattern extends NodeBase implements PatternNode {
 	addExportedVariables(variables: Variable[]): void {
 		for (const element of this.elements) {
 			if (element !== null) {
+				if (!element.addExportedVariables) {
+					console.log('=== Unexpected pattern element:', element.type, '\n');
+					console.log('pattern:', this.toString());
+					console.log('parent:', this.parent.toString());
+				}
 				element.addExportedVariables(variables);
 			}
 		}

--- a/src/ast/nodes/ArrayPattern.ts
+++ b/src/ast/nodes/ArrayPattern.ts
@@ -13,11 +13,6 @@ export default class ArrayPattern extends NodeBase implements PatternNode {
 	addExportedVariables(variables: Variable[]): void {
 		for (const element of this.elements) {
 			if (element !== null) {
-				if (!element.addExportedVariables) {
-					console.log('=== Unexpected pattern element:', element.type, '\n');
-					console.log('pattern:', this.toString());
-					console.log('parent:', this.parent.toString());
-				}
 				element.addExportedVariables(variables);
 			}
 		}

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -44,6 +44,7 @@ export default class ExportDefaultDeclaration extends NodeBase {
 	scope: ModuleScope;
 	type: NodeType.tExportDefaultDeclaration;
 	variable: ExportDefaultVariable;
+
 	private declarationName: string;
 
 	initialise() {

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -24,6 +24,7 @@ import Identifier from './Identifier';
 import Literal from './Literal';
 import * as NodeType from './NodeType';
 import { ExpressionNode, Node, NodeBase } from './shared/Node';
+import { PatternNode } from './shared/Pattern';
 
 function getResolvablePropertyKey(memberExpression: MemberExpression): string | null {
 	return memberExpression.computed
@@ -72,7 +73,7 @@ export function isMemberExpression(node: Node): node is MemberExpression {
 	return node.type === NodeType.MemberExpression;
 }
 
-export default class MemberExpression extends NodeBase implements DeoptimizableEntity {
+export default class MemberExpression extends NodeBase implements DeoptimizableEntity, PatternNode {
 	computed: boolean;
 	object: ExpressionNode;
 	property: ExpressionNode;
@@ -83,6 +84,8 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 	private bound: boolean;
 	private expressionsToBeDeoptimized: DeoptimizableEntity[];
 	private replacement: string | null;
+
+	addExportedVariables(): void {}
 
 	bind() {
 		if (this.bound) return;

--- a/test/form/samples/pattern-member-expressions/_config.js
+++ b/test/form/samples/pattern-member-expressions/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles member expressions in patterns (#2750)'
+};

--- a/test/form/samples/pattern-member-expressions/_expected/amd.js
+++ b/test/form/samples/pattern-member-expressions/_expected/amd.js
@@ -1,0 +1,23 @@
+define(function () { 'use strict';
+
+	const array = [false];
+	const obj1 = {value: false};
+	const obj2 = {value: false};
+
+	([array[0]] = [true]);
+	({a: obj1.value} = {a: true});
+	({[globalVar1]: obj2[globalVar2]} = {[globalVar3]: true});
+
+	if (array[0]) {
+		console.log('retained');
+	}
+
+	if (obj1.value) {
+		console.log('retained');
+	}
+
+	if (obj2.value) {
+		console.log('retained');
+	}
+
+});

--- a/test/form/samples/pattern-member-expressions/_expected/cjs.js
+++ b/test/form/samples/pattern-member-expressions/_expected/cjs.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const array = [false];
+const obj1 = {value: false};
+const obj2 = {value: false};
+
+([array[0]] = [true]);
+({a: obj1.value} = {a: true});
+({[globalVar1]: obj2[globalVar2]} = {[globalVar3]: true});
+
+if (array[0]) {
+	console.log('retained');
+}
+
+if (obj1.value) {
+	console.log('retained');
+}
+
+if (obj2.value) {
+	console.log('retained');
+}

--- a/test/form/samples/pattern-member-expressions/_expected/es.js
+++ b/test/form/samples/pattern-member-expressions/_expected/es.js
@@ -1,0 +1,19 @@
+const array = [false];
+const obj1 = {value: false};
+const obj2 = {value: false};
+
+([array[0]] = [true]);
+({a: obj1.value} = {a: true});
+({[globalVar1]: obj2[globalVar2]} = {[globalVar3]: true});
+
+if (array[0]) {
+	console.log('retained');
+}
+
+if (obj1.value) {
+	console.log('retained');
+}
+
+if (obj2.value) {
+	console.log('retained');
+}

--- a/test/form/samples/pattern-member-expressions/_expected/iife.js
+++ b/test/form/samples/pattern-member-expressions/_expected/iife.js
@@ -1,0 +1,24 @@
+(function () {
+	'use strict';
+
+	const array = [false];
+	const obj1 = {value: false};
+	const obj2 = {value: false};
+
+	([array[0]] = [true]);
+	({a: obj1.value} = {a: true});
+	({[globalVar1]: obj2[globalVar2]} = {[globalVar3]: true});
+
+	if (array[0]) {
+		console.log('retained');
+	}
+
+	if (obj1.value) {
+		console.log('retained');
+	}
+
+	if (obj2.value) {
+		console.log('retained');
+	}
+
+}());

--- a/test/form/samples/pattern-member-expressions/_expected/system.js
+++ b/test/form/samples/pattern-member-expressions/_expected/system.js
@@ -1,0 +1,28 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const array = [false];
+			const obj1 = {value: false};
+			const obj2 = {value: false};
+
+			([array[0]] = [true]);
+			({a: obj1.value} = {a: true});
+			({[globalVar1]: obj2[globalVar2]} = {[globalVar3]: true});
+
+			if (array[0]) {
+				console.log('retained');
+			}
+
+			if (obj1.value) {
+				console.log('retained');
+			}
+
+			if (obj2.value) {
+				console.log('retained');
+			}
+
+		}
+	};
+});

--- a/test/form/samples/pattern-member-expressions/_expected/umd.js
+++ b/test/form/samples/pattern-member-expressions/_expected/umd.js
@@ -1,0 +1,26 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+}(function () { 'use strict';
+
+	const array = [false];
+	const obj1 = {value: false};
+	const obj2 = {value: false};
+
+	([array[0]] = [true]);
+	({a: obj1.value} = {a: true});
+	({[globalVar1]: obj2[globalVar2]} = {[globalVar3]: true});
+
+	if (array[0]) {
+		console.log('retained');
+	}
+
+	if (obj1.value) {
+		console.log('retained');
+	}
+
+	if (obj2.value) {
+		console.log('retained');
+	}
+
+}));

--- a/test/form/samples/pattern-member-expressions/main.js
+++ b/test/form/samples/pattern-member-expressions/main.js
@@ -1,0 +1,19 @@
+const array = [false];
+const obj1 = {value: false};
+const obj2 = {value: false};
+
+([array[0]] = [true]);
+({a: obj1.value} = {a: true});
+({[globalVar1]: obj2[globalVar2]} = {[globalVar3]: true});
+
+if (array[0]) {
+	console.log('retained');
+}
+
+if (obj1.value) {
+	console.log('retained');
+}
+
+if (obj2.value) {
+	console.log('retained');
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#2750 

### Description
Honestly, I was not aware that you could do this:

```js
const a = [1];
const b = {};
([a[1], b.value] = [8, 9]);
console.log(a); // [1, 8]
console.log(b); // {value: 9}
```

But as it seems, even the maintainers of the ESTree AST spec are struggling with this: https://github.com/estree/estree/issues/162

This triggered an issue in SystemJS builds, which rely on a special method present on those nodes.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
