### PR TITLE
Expose full SHA256 hash in file name placeholders

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -208,13 +208,16 @@ export default class Chunk {
 		options: OutputOptions,
 		existingNames: Record<string, true>
 	) {
+		const hash = () => this.computeContentHashWithDependencies(addons, options);
 		this.id = makeUnique(
 			renderNamePattern(pattern, patternName, type => {
 				switch (type) {
 					case 'format':
 						return options.format === 'es' ? 'esm' : options.format;
 					case 'hash':
-						return this.computeContentHashWithDependencies(addons, options);
+						return hash().substr(0, 8);
+					case 'fullhash':
+						return hash();
 					case 'name':
 						return this.getChunkName();
 				}
@@ -765,7 +768,7 @@ export default class Chunk {
 			else hash.update(dep.getRenderedHash());
 		});
 
-		return hash.digest('hex').substr(0, 8);
+		return hash.digest('hex');
 	}
 
 	private finaliseDynamicImports() {

--- a/src/utils/assetHooks.ts
+++ b/src/utils/assetHooks.ts
@@ -22,13 +22,19 @@ export function getAssetFileName(
 
 	return makeUnique(
 		renderNamePattern(assetFileNames, 'assetFileNames', name => {
+			function computeHash() {
+				const hash = sha256();
+				hash.update(name);
+				hash.update(':');
+				hash.update(asset.source);
+				return hash.digest('hex');
+			}
+
 			switch (name) {
 				case 'hash':
-					const hash = sha256();
-					hash.update(name);
-					hash.update(':');
-					hash.update(asset.source);
-					return hash.digest('hex').substr(0, 8);
+					return computeHash().substr(0, 8);
+				case 'fullhash':
+					return computeHash();
 				case 'name':
 					return asset.name.substr(0, asset.name.length - extname(asset.name).length);
 				case 'extname':


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

### Description

Currently, `[hash]` is truncated to 8 characters, so add another placeholder `[fullhash]` to gain access to the untruncated value. The problem with truncated values is that the risk of collisions is larger.

Ideally, `[hash]` would be the full value itself and users could be given some other mechanism of truncating the value to a specific number of characters (e.g. `[hash:8]`), but changing that at this point would break backwards compatibility.

This is WIP and soliciting feedback! Open questions:
* Is `[fullhash]` an OK placeholder name?
* Where should I add tests for this? It's not clear to me where `[hash]` is tested in the first place; many different tests break if I purposely change `[hash]` behavior.

Thank you!

/cc @keithamus 