### PR TITLE
Resolve relative external ids

### DIFF
--- a/test/form/samples/relative-external-ids/_config.js
+++ b/test/form/samples/relative-external-ids/_config.js
@@ -1,0 +1,37 @@
+const path = require('path');
+
+module.exports = {
+	description: 'relative external ids are absolutely resolved',
+	options: {
+		external(id) {
+			switch (id) {
+				case './optionDirect.js':
+					return true;
+				case './optionDirectNested.js':
+					return true;
+				case path.resolve(__dirname, 'optionIndirect.js'):
+					return true;
+				case path.resolve(__dirname, 'nested', 'optionIndirectNested.js'):
+					return true;
+				default:
+					return false;
+			}
+		},
+		plugins: {
+			resolveId(id) {
+				switch (id) {
+					case './hook.js':
+						return false;
+					case './hookNested.js':
+						return false;
+					case 'resolved':
+						return { id: './resolved.js', external: true };
+					case 'resolvedNested':
+						return { id: './resolvedNested.js', external: true };
+					default:
+						return null;
+				}
+			}
+		}
+	}
+};

--- a/test/form/samples/relative-external-ids/_expected.js
+++ b/test/form/samples/relative-external-ids/_expected.js
@@ -1,0 +1,8 @@
+import './optionDirect.js';
+import './optionIndirect.js';
+import './hook.js';
+import './resolved.js';
+import './nested/optionDirectNested.js';
+import './nested/optionIndirectNested.js';
+import './nested/hookNested.js';
+import './nested/resolvedNested.js';

--- a/test/form/samples/relative-external-ids/main.js
+++ b/test/form/samples/relative-external-ids/main.js
@@ -1,0 +1,6 @@
+import './optionDirect.js';
+import './optionIndirect.js';
+import './hook.js';
+import 'resolved';
+
+import './nested/nested';

--- a/test/form/samples/relative-external-ids/nested/nested.js
+++ b/test/form/samples/relative-external-ids/nested/nested.js
@@ -1,0 +1,4 @@
+import './optionDirectNested.js';
+import './optionIndirectNested.js';
+import './hookNested.js';
+import 'resolvedNested';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2762 

### Description
A previous refactoring had broken the functionality that Rollup normalizes relative external ids to the common parent directory of all entry points. This PR restores this functionality and adds proper tests.
