### PR TITLE
Make all properties in TreeshakingOptions optional

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -254,9 +254,9 @@ export interface Plugin {
 }
 
 export interface TreeshakingOptions {
-	annotations: boolean;
-	propertyReadSideEffects: boolean;
-	pureExternalModules: boolean;
+	annotations?: boolean;
+	propertyReadSideEffects?: boolean;
+	pureExternalModules?: boolean;
 }
 
 export type ExternalOption = string[] | IsExternal;


### PR DESCRIPTION
This is what the docs are telling me the types should be: https://rollupjs.org/guide/en#treeshake

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes
- [x] no

Breaking Changes?
- [ ] yes
- [x] no

### Description

I was using the Node API in typescript and typescript was telling me:

```
Type '{ pureExternalModules: boolean; }' is not assignable to type 'boolean | TreeshakingOptions'.
  Type '{ pureExternalModules: boolean; }' is missing the following properties from type 'TreeshakingOptions': annotations, propertyReadSideEffectsts(2322)
rollup.d.ts(286, 2): The expected type comes from property 'treeshake' which is declared here on type 'RollupOptions'
```

I was able to fix the warning by adding all 3 properties to the `TreeshakingOptions`.

Looking at the docs, I concluded that the interface is actually wrong.

I'm unsure this qualifies as a bugfix.