### PR TITLE
Inline interopDefault in config loading

### DIFF
--- a/bin/src/run/loadConfigFile.ts
+++ b/bin/src/run/loadConfigFile.ts
@@ -10,10 +10,6 @@ interface NodeModuleWithCompile extends NodeModule {
 	_compile(code: string, filename: string): any;
 }
 
-function interopDefault<T>(ex: T): T {
-	return ex && typeof ex === 'object' && 'default' in ex ? (ex as any).default : ex;
-}
-
 export default function loadConfigFile(
 	configFile: string,
 	commandOptions: any = {}
@@ -54,8 +50,9 @@ export default function loadConfigFile(
 
 			delete require.cache[configFile];
 
-			return Promise.resolve(interopDefault(require(configFile)))
+			return Promise.resolve(require(configFile))
 				.then(configFileContent => {
+					if (configFileContent.default) configFileContent = configFileContent.default;
 					if (typeof configFileContent === 'function') {
 						return configFileContent(commandOptions);
 					}


### PR DESCRIPTION
This inlines the interopDefault handling.

Note that we don't need to explicitly handle the null case (the rare chance of `module.exports = undefined`), because that would fail anyway in subsequent code paths.

The benefit of this approach is that as discussed previously I'm working on supporting Rollup itself in a transformation that can convert CJS packages to ESM packages, and we can support dynamic require fine when it is detected as `Promise.resolve(require(x))`, but the `interopDefault` wrapper stops this from working out.

Would be amazing to merge this to support the dynamic import conversion for full Rollup support in this work here.