### PR TITLE
Support Node-style format aliases

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -287,7 +287,16 @@ export interface InputOptions {
 	watch?: WatcherOptions;
 }
 
-export type ModuleFormat = 'amd' | 'cjs' | 'system' | 'es' | 'esm' | 'iife' | 'umd';
+export type ModuleFormat =
+	| 'amd'
+	| 'cjs'
+	| 'commonjs'
+	| 'es'
+	| 'esm'
+	| 'iife'
+	| 'module'
+	| 'system'
+	| 'umd';
 
 export type OptionsPaths = Record<string, string> | ((id: string) => string);
 

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -239,7 +239,6 @@ function getOutputOptions(
 			break;
 		case 'commonjs':
 			format = 'cjs';
-			break;
 	}
 
 	return {

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -229,7 +229,18 @@ function getOutputOptions(
 	command: GenericConfigObject = {}
 ): OutputOptions {
 	const getOption = createGetOption(config, command);
-	const format = getOption('format');
+	let format = getOption('format');
+
+	// Handle format aliases
+	switch (format) {
+		case 'esm':
+		case 'module':
+			format = 'es';
+			break;
+		case 'commonjs':
+			format = 'cjs';
+			break;
+	}
 
 	return {
 		amd: { ...config.amd, ...command.amd },


### PR DESCRIPTION
Now that Node.js --experimental-modules has been updated, it has moved to longer names for formats as a standard in use in flags, package.json and loaders. So instead of `"cjs"` it is `"commonjs"` and instead of `"esm"` it is `"module"`.

I know it's a pain, but I think it would be beneficial if we can support these aliases now, and possibly even consider them as the defaults in the long terms.

Apologies for whatever role I've played in churn here too :)