### PR TITLE
Observe modified output options in bundle.write

### DIFF
--- a/test/misc/write-bundle.js
+++ b/test/misc/write-bundle.js
@@ -21,10 +21,10 @@ describe('bundle.write()', () => {
 			.then(bundle => {
 				assert.throws(() => {
 					bundle.write();
-				}, /You must specify "output\.file"/);
+				}, /You must supply an options object/);
 
 				assert.throws(() => {
-					bundle.write({});
+					bundle.write({format: 'esm'});
 				}, /You must specify "output\.file"/);
 			});
 	});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
resolves #2801 

### Description
When checking if `file` or `dir` had been passed in `bundle.write`, Rollup did not use the normalized output options that had been run through the `outputOptions` hook but the raw output options.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
