### PR TITLE
Handle out-of-order binding of identifiers to improve tree-shaking

### DIFF
--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -86,6 +86,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 		recursionTracker: ImmutableEntityPathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown {
+		if (!this.bound) this.bind();
 		if (this.variable !== null) {
 			return this.variable.getLiteralValueAtPath(path, recursionTracker, origin);
 		}
@@ -97,6 +98,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 		recursionTracker: ImmutableEntityPathTracker,
 		origin: DeoptimizableEntity
 	) {
+		if (!this.bound) this.bind();
 		if (this.variable !== null) {
 			return this.variable.getReturnExpressionWhenCalledAtPath(path, recursionTracker, origin);
 		}

--- a/test/form/samples/simplify-return-expression/_config.js
+++ b/test/form/samples/simplify-return-expression/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Simplifies conditionals in return expression'
+};

--- a/test/form/samples/simplify-return-expression/_expected.js
+++ b/test/form/samples/simplify-return-expression/_expected.js
@@ -1,0 +1,14 @@
+const test = () => {
+	console.log(foo());
+	console.log(bar());
+};
+
+const foo = () => {
+	return A;
+};
+
+const bar = () => {
+	return A;
+};
+
+export { test };

--- a/test/form/samples/simplify-return-expression/main.js
+++ b/test/form/samples/simplify-return-expression/main.js
@@ -1,0 +1,16 @@
+export const test = () => {
+	console.log(foo());
+	console.log(bar());
+};
+
+const foo = () => {
+	return BUILD ? A : B;
+};
+
+const bar = () => {
+	return getBuild() ? A : B;
+};
+
+const getBuild = () => BUILD;
+
+const BUILD = true;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2799 

### Description
It is possible that Rollup needs to analyze values of identifiers before they have been bound to their variables, which can cause in sub-optimal tree-shaking results. This is fixed here by allowing out-of-order binding of identifiers if their value is needed earlier. This allows for the following:

```js
// input
export const test = () => {
	console.log(foo());
	console.log(bar());
};

const foo = () => {
	return BUILD ? A : B;
};

const bar = () => {
	return getBuild() ? A : B;
};

const getBuild = () => BUILD;

const BUILD = true;

// output
const test = () => {
	console.log(foo());
	console.log(bar());
};

const foo = () => {
	return A;
};

const bar = () => {
	return A;
};

export { test };
```

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
