### PR TITLE
Catch invalid options.format values

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -34,7 +34,7 @@ function checkOutputOptions(options: OutputOptions) {
 		});
 	}
 
-	if (!options.format) {
+	if (['amd', 'cjs', 'system', 'es', 'iife', 'umd'].indexOf(options.format) < 0) {
 		error({
 			message: `You must specify "output.format", which can be one of "amd", "cjs", "system", "esm", "iife" or "umd".`,
 			url: `https://rollupjs.org/guide/en#output-format`


### PR DESCRIPTION
Before, it'd nebulously crash when trying to dereference `RESERVED_NAMES_BY_FORMAT` instead.

(It'd be nice if the formats were centrally defined, but since they aren't I decided to just add another list.)

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

