### PR TITLE
Upgrade Mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "magic-string": "^0.25.2",
     "markdownlint-cli": "^0.15.0",
     "minimist": "^1.2.0",
-    "mocha": "^6.1.2",
+    "mocha": "^6.1.3",
     "prettier": "^1.16.4",
     "pretty-bytes": "^5.1.0",
     "pretty-ms": "^4.0.0",


### PR DESCRIPTION
npm is currently emitting a security warning for 6.1.2. I haven't looked into what the problem is but the amount of scary noise generated by `npm install` seems reason enough to upgrade.
