### PR TITLE
Add es3 support for namespace object import

### DIFF
--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -1,5 +1,6 @@
 import Module, { AstContext } from '../../Module';
 import { RenderOptions } from '../../utils/renderHelpers';
+import { RESERVED_NAMES } from '../../utils/reservedNames';
 import Identifier from '../nodes/Identifier';
 import { UNKNOWN_PATH } from '../values';
 import Variable from './Variable';
@@ -82,7 +83,9 @@ export default class NamespaceVariable extends Variable {
 				}${_}}`;
 			}
 
-			return `${t}${name}: ${original.getName()}`;
+			const safeName = RESERVED_NAMES[name] ? `'${name}'` : name;
+
+			return `${t}${safeName}: ${original.getName()}`;
 		});
 
 		const name = this.getName();

--- a/src/utils/reservedNames.ts
+++ b/src/utils/reservedNames.ts
@@ -4,6 +4,11 @@ export interface NameCollection {
 	[name: string]: true;
 }
 
+// Verified on IE 6/7 that these keywords can't be used for object properties without escaping:
+//   break case catch class const continue debugger default delete do
+//   else enum export extends false finally for function if import
+//   in instanceof new null return super switch this throw true
+//   try typeof var void while with
 export const RESERVED_NAMES: NameCollection = Object.assign(Object.create(null), {
 	await: true,
 	break: true,
@@ -21,6 +26,7 @@ export const RESERVED_NAMES: NameCollection = Object.assign(Object.create(null),
 	eval: true,
 	export: true,
 	extends: true,
+	false: true,
 	finally: true,
 	for: true,
 	function: true,
@@ -41,7 +47,9 @@ export const RESERVED_NAMES: NameCollection = Object.assign(Object.create(null),
 	static: true,
 	super: true,
 	switch: true,
+	this: true,
 	throw: true,
+	true: true,
 	try: true,
 	typeof: true,
 	undefined: true,

--- a/test/form/samples/namespace-object-import/_config.js
+++ b/test/form/samples/namespace-object-import/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'properly encodes reserved names if namespace import is used',
+	options: {
+		input: ['main.js']
+	}
+};

--- a/test/form/samples/namespace-object-import/_expected/amd.js
+++ b/test/form/samples/namespace-object-import/_expected/amd.js
@@ -1,0 +1,11 @@
+define(function () { 'use strict';
+
+	var dep = "default";
+
+	var dep$1 = /*#__PURE__*/Object.freeze({
+		'default': dep
+	});
+
+	console.log(dep$1);
+
+});

--- a/test/form/samples/namespace-object-import/_expected/cjs.js
+++ b/test/form/samples/namespace-object-import/_expected/cjs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var dep = "default";
+
+var dep$1 = /*#__PURE__*/Object.freeze({
+	'default': dep
+});
+
+console.log(dep$1);

--- a/test/form/samples/namespace-object-import/_expected/es.js
+++ b/test/form/samples/namespace-object-import/_expected/es.js
@@ -1,0 +1,7 @@
+var dep = "default";
+
+var dep$1 = /*#__PURE__*/Object.freeze({
+	'default': dep
+});
+
+console.log(dep$1);

--- a/test/form/samples/namespace-object-import/_expected/iife.js
+++ b/test/form/samples/namespace-object-import/_expected/iife.js
@@ -1,0 +1,12 @@
+(function () {
+	'use strict';
+
+	var dep = "default";
+
+	var dep$1 = /*#__PURE__*/Object.freeze({
+		'default': dep
+	});
+
+	console.log(dep$1);
+
+}());

--- a/test/form/samples/namespace-object-import/_expected/system.js
+++ b/test/form/samples/namespace-object-import/_expected/system.js
@@ -1,0 +1,16 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var dep = "default";
+
+			var dep$1 = /*#__PURE__*/Object.freeze({
+				'default': dep
+			});
+
+			console.log(dep$1);
+
+		}
+	};
+});

--- a/test/form/samples/namespace-object-import/_expected/umd.js
+++ b/test/form/samples/namespace-object-import/_expected/umd.js
@@ -1,0 +1,14 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+}(function () { 'use strict';
+
+	var dep = "default";
+
+	var dep$1 = /*#__PURE__*/Object.freeze({
+		'default': dep
+	});
+
+	console.log(dep$1);
+
+}));

--- a/test/form/samples/namespace-object-import/dep.js
+++ b/test/form/samples/namespace-object-import/dep.js
@@ -1,0 +1,1 @@
+export default "default"

--- a/test/form/samples/namespace-object-import/main.js
+++ b/test/form/samples/namespace-object-import/main.js
@@ -1,0 +1,3 @@
+import * as dep from './dep.js';
+
+console.log(dep);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

#2591

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Add ES3 support for namespace import. All other es3 compatibility issues I'm aware of could be fixed with polyfills and babel.
