### PR TITLE
Fix `removedExports` to correctly track the exported item

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -66,7 +66,6 @@ export interface ImportDescription {
 export interface ExportDescription {
 	identifier?: string;
 	localName: string;
-	node?: Node;
 }
 
 export interface ReexportDescription {
@@ -334,8 +333,8 @@ export default class Module {
 		const renderedExports: string[] = [];
 		const removedExports: string[] = [];
 		for (const exportName in this.exports) {
-			const expt = this.exports[exportName];
-			(expt.node && expt.node.included ? renderedExports : removedExports).push(exportName);
+			const variable = this.getVariableForExportName(exportName);
+			(variable && variable.included ? renderedExports : removedExports).push(exportName);
 		}
 		return { renderedExports, removedExports };
 	}
@@ -666,8 +665,7 @@ export default class Module {
 
 			this.exports.default = {
 				identifier: node.variable.getOriginalVariableName(),
-				localName: 'default',
-				node
+				localName: 'default'
 			};
 		} else if ((<ExportNamedDeclaration>node).declaration) {
 			// export var { foo, bar } = ...
@@ -679,13 +677,13 @@ export default class Module {
 			if (declaration.type === NodeType.VariableDeclaration) {
 				for (const decl of declaration.declarations) {
 					for (const localName of extractAssignedNames(decl.id)) {
-						this.exports[localName] = { localName, node };
+						this.exports[localName] = { localName };
 					}
 				}
 			} else {
 				// export function foo () {}
 				const localName = declaration.id.name;
-				this.exports[localName] = { localName, node };
+				this.exports[localName] = { localName };
 			}
 		} else {
 			// export { foo, bar, baz }
@@ -703,7 +701,7 @@ export default class Module {
 					);
 				}
 
-				this.exports[exportedName] = { localName, node };
+				this.exports[exportedName] = { localName };
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

closes #2834

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The `RenderedModule.removedExports/renderedExports` now correctly track the *item* being exported, and not the export declaration itself.