### PR TITLE
Make sure circular `export * from X` does not stack overflow

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -308,7 +308,13 @@ export default class Module {
 		);
 	}
 
-	getReexports() {
+	getReexports(walkedModuleIds = new Set<string>()) {
+		// avoid infinite recursion when using circular `export * from X`
+		if (walkedModuleIds.has(this.id)) {
+			return [];
+		}
+		walkedModuleIds.add(this.id);
+
 		const reexports = Object.create(null);
 
 		for (const name in this.reexports) {
@@ -321,7 +327,9 @@ export default class Module {
 				return;
 			}
 
-			for (const name of (<Module>module).getExports().concat((<Module>module).getReexports())) {
+			for (const name of (<Module>module)
+				.getExports()
+				.concat((<Module>module).getReexports(walkedModuleIds))) {
 				if (name !== 'default') reexports[name] = true;
 			}
 		});

--- a/test/function/samples/cycles-export-star/_config.js
+++ b/test/function/samples/cycles-export-star/_config.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'does not stack overflow on `export * from X` cycles',
+	code(code) {
+		assert.equal(
+			code,
+			`'use strict';\n\nfunction b() {\n\treturn 'b';\n}\n\nassert.equal(b(), 'b');\n`
+		);
+	},
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			importer: 'a.js',
+			message: 'Circular dependency: a.js -> b.js -> a.js'
+		}
+	]
+};

--- a/test/function/samples/cycles-export-star/a.js
+++ b/test/function/samples/cycles-export-star/a.js
@@ -1,0 +1,5 @@
+export * from './b.js';
+
+export function a() {
+	return 'a';
+}

--- a/test/function/samples/cycles-export-star/b.js
+++ b/test/function/samples/cycles-export-star/b.js
@@ -1,0 +1,5 @@
+export * from './a.js';
+
+export function b() {
+	return 'b';
+}

--- a/test/function/samples/cycles-export-star/main.js
+++ b/test/function/samples/cycles-export-star/main.js
@@ -1,0 +1,3 @@
+import { b } from './a.js';
+
+assert.equal(b(), 'b');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

closes #2815

### Description

Circular `export * from X` used to lead to a stack overflow. This Fix avoids that by keeping track of already walked modules. Not sure if this is the right place for such a fix?

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
