### PR TITLE
Allow transformers to return an empty string

### DIFF
--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -76,21 +76,21 @@ export default function transform(
 			}
 		}
 
-		if (!result) return code;
-
 		if (typeof result === 'string') {
 			result = {
 				ast: undefined,
 				code: result,
 				map: undefined
 			};
-		} else {
+		} else if (result && typeof result === 'object') {
 			if (typeof result.map === 'string') {
 				result.map = JSON.parse(result.map);
 			}
 			if (typeof result.moduleSideEffects === 'boolean') {
 				moduleSideEffects = result.moduleSideEffects;
 			}
+		} else {
+			return code;
 		}
 
 		if (result.map && typeof (result.map as ExistingRawSourceMap).mappings === 'string') {

--- a/test/function/samples/transform-empty-string/_config.js
+++ b/test/function/samples/transform-empty-string/_config.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+
+const sideEffects = [];
+
+module.exports = {
+	description: 'allows transformers to transform code to an empty string',
+	context: { sideEffects },
+	exports() {
+		assert.deepStrictEqual(sideEffects, ['this happens']);
+	},
+	options: {
+		plugins: {
+			name: 'test-plugin',
+			transform(code, id) {
+				if (id.endsWith('transformed.js')) {
+					return '';
+				}
+			}
+		}
+	}
+};

--- a/test/function/samples/transform-empty-string/main.js
+++ b/test/function/samples/transform-empty-string/main.js
@@ -1,0 +1,3 @@
+import './transformed.js';
+
+sideEffects.push('this happens');

--- a/test/function/samples/transform-empty-string/transformed.js
+++ b/test/function/samples/transform-empty-string/transformed.js
@@ -1,0 +1,1 @@
+sideEffects.push('should not happen');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2859 

### Description
As a regression of the latest release, transformers returning an empty string were treated as if they returned `null` and were therefore ignored. This broke Sapper.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
