### PR TITLE
Keep nested exports with preserveModules (#2854)

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -338,6 +338,7 @@ export default class Chunk {
 		const dynamicDependencies: Set<Chunk | ExternalModule> = new Set();
 		for (const module of this.orderedModules) {
 			this.addChunksFromDependencies(module.dependencies, dependencies);
+			this.addChunksFromDependencies(module.getReexportModules(), dependencies);
 			this.addChunksFromDependencies(module.dynamicDependencies, dynamicDependencies);
 			this.setUpModuleImports(module);
 		}

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -311,6 +311,10 @@ export default class Module {
 		);
 	}
 
+	getReexportModules() {
+		return this.getReexports().map(exportName => this.getVariableForExportName(exportName).module);
+	}
+
 	getReexports(walkedModuleIds = new Set<string>()) {
 		// avoid infinite recursion when using circular `export * from X`
 		if (walkedModuleIds.has(this.id)) {

--- a/test/chunking-form/samples/preserve-modules-nested-export/_config.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'confirm exports are preserved when exporting a module',
+	options: {
+		input: ['main1.js', 'main2.js'],
+		preserveModules: true
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/amd/dep.js
@@ -1,0 +1,7 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = 1;
+
+	exports.foo = foo;
+
+});

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/amd/main1.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/amd/main1.js
@@ -1,0 +1,9 @@
+define(['exports', './dep'], function (exports, __chunk_1) { 'use strict';
+
+
+
+	exports.foo = __chunk_1.foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/amd/main2.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/amd/main2.js
@@ -1,0 +1,9 @@
+define(['exports', './dep'], function (exports, __chunk_1) { 'use strict';
+
+
+
+	exports.foo = __chunk_1.foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/cjs/dep.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const foo = 1;
+
+exports.foo = foo;

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/cjs/main1.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __chunk_1 = require('./dep.js');
+
+
+
+exports.foo = __chunk_1.foo;

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/cjs/main2.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var __chunk_1 = require('./dep.js');
+
+
+
+exports.foo = __chunk_1.foo;

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/es/dep.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/es/dep.js
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export { foo };

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/es/main1.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/es/main1.js
@@ -1,0 +1,1 @@
+export { foo } from './dep.js';

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/es/main2.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/es/main2.js
@@ -1,0 +1,1 @@
+export { foo } from './dep.js';

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/dep.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/dep.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = exports('foo', 1);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/main1.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/main1.js
@@ -1,0 +1,13 @@
+System.register(['./dep.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('foo', module.foo);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/main2.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/main2.js
@@ -1,0 +1,13 @@
+System.register(['./dep.js'], function (exports, module) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('foo', module.foo);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-nested-export/dep.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/dep.js
@@ -1,0 +1,3 @@
+const foo = 1;
+
+export { foo  };

--- a/test/chunking-form/samples/preserve-modules-nested-export/main1.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/main1.js
@@ -1,0 +1,1 @@
+export { foo } from './dep';

--- a/test/chunking-form/samples/preserve-modules-nested-export/main2.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/main2.js
@@ -1,0 +1,1 @@
+export { foo } from './main1.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#2854

### Description

This hopefully fixes the issue described in #2854 essentially ensuring that entry file exports are preserved when using `preserveModules`. 

This fix seemed a little too basic and I'm new to the codebase so theres a near certainty I've missed something important here or done something in an incorrect way.