### PR TITLE
Protect all module globals for CJS output from being redefined

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1058,10 +1058,12 @@ export default class Chunk {
 		if (options.format !== 'es') {
 			usedNames.add('exports');
 			if (options.format === 'cjs') {
-				usedNames.add(INTEROP_DEFAULT_VARIABLE);
-				if (this.exportMode === 'default') {
-					usedNames.add('module');
-				}
+				usedNames
+					.add(INTEROP_DEFAULT_VARIABLE)
+					.add('require')
+					.add('module')
+					.add('__filename')
+					.add('__dirname');
 			}
 		}
 

--- a/test/form/samples/protect-cjs-globals/_config.js
+++ b/test/form/samples/protect-cjs-globals/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'prevent conflicts with cjs module globals',
+	options: {
+		output: { name: 'bundle' }
+	}
+};

--- a/test/form/samples/protect-cjs-globals/_expected/amd.js
+++ b/test/form/samples/protect-cjs-globals/_expected/amd.js
@@ -1,0 +1,17 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const exports$1 = 1;
+	const require = 2;
+	const module = 3;
+	const __filename = 4;
+	const __dirname = 5;
+
+	exports.__dirname = __dirname;
+	exports.__filename = __filename;
+	exports.exports = exports$1;
+	exports.module = module;
+	exports.require = require;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/form/samples/protect-cjs-globals/_expected/cjs.js
+++ b/test/form/samples/protect-cjs-globals/_expected/cjs.js
@@ -1,0 +1,15 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const exports$1 = 1;
+const require$1 = 2;
+const module$1 = 3;
+const __filename$1 = 4;
+const __dirname$1 = 5;
+
+exports.__dirname = __dirname$1;
+exports.__filename = __filename$1;
+exports.exports = exports$1;
+exports.module = module$1;
+exports.require = require$1;

--- a/test/form/samples/protect-cjs-globals/_expected/es.js
+++ b/test/form/samples/protect-cjs-globals/_expected/es.js
@@ -1,0 +1,7 @@
+const exports = 1;
+const require = 2;
+const module = 3;
+const __filename = 4;
+const __dirname = 5;
+
+export { __dirname, __filename, exports, module, require };

--- a/test/form/samples/protect-cjs-globals/_expected/iife.js
+++ b/test/form/samples/protect-cjs-globals/_expected/iife.js
@@ -1,0 +1,18 @@
+var bundle = (function (exports) {
+	'use strict';
+
+	const exports$1 = 1;
+	const require = 2;
+	const module = 3;
+	const __filename = 4;
+	const __dirname = 5;
+
+	exports.__dirname = __dirname;
+	exports.__filename = __filename;
+	exports.exports = exports$1;
+	exports.module = module;
+	exports.require = require;
+
+	return exports;
+
+}({}));

--- a/test/form/samples/protect-cjs-globals/_expected/system.js
+++ b/test/form/samples/protect-cjs-globals/_expected/system.js
@@ -1,0 +1,14 @@
+System.register('bundle', [], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const exports$1 = exports('exports', 1);
+			const require = exports('require', 2);
+			const module = exports('module', 3);
+			const __filename = exports('__filename', 4);
+			const __dirname = exports('__dirname', 5);
+
+		}
+	};
+});

--- a/test/form/samples/protect-cjs-globals/_expected/umd.js
+++ b/test/form/samples/protect-cjs-globals/_expected/umd.js
@@ -1,0 +1,21 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(global = global || self, factory(global.bundle = {}));
+}(this, function (exports) { 'use strict';
+
+	const exports$1 = 1;
+	const require = 2;
+	const module = 3;
+	const __filename = 4;
+	const __dirname = 5;
+
+	exports.__dirname = __dirname;
+	exports.__filename = __filename;
+	exports.exports = exports$1;
+	exports.module = module;
+	exports.require = require;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+}));

--- a/test/form/samples/protect-cjs-globals/main.js
+++ b/test/form/samples/protect-cjs-globals/main.js
@@ -1,0 +1,5 @@
+export const exports = 1;
+export const require = 2;
+export const module = 3;
+export const __filename = 4;
+export const __dirname = 5;

--- a/test/form/samples/sequence-expression/_expected/cjs.js
+++ b/test/form/samples/sequence-expression/_expected/cjs.js
@@ -20,6 +20,6 @@ var e = (foo$1());
 var g = ((() => {console.log(foo$1());})(), 1);
 
 // should maintain this context
-var module = {};
-module.bar = function () { console.log( 'bar' );};
-var h = (0, module.bar)();
+var module$1 = {};
+module$1.bar = function () { console.log( 'bar' );};
+var h = (0, module$1.bar)();

--- a/test/function/samples/protect-cjs-globals/_config.js
+++ b/test/function/samples/protect-cjs-globals/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'prevent conflicts with cjs module globals'
+};

--- a/test/function/samples/protect-cjs-globals/main.js
+++ b/test/function/samples/protect-cjs-globals/main.js
@@ -1,0 +1,5 @@
+export const exports = 1;
+export const require = 2;
+export const module = 3;
+export const __filename = 4;
+export const __dirname = 5;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2886 

### Description
This PR makes sure that Rollup does not produce invalid CJS modules when `module`, `require`, `__filename` or `__dirname` are defined as top-level variables in modules.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
