### PR TITLE
Properly include try-catch-statements even if they have already been included in some way

### DIFF
--- a/src/ast/nodes/TryStatement.ts
+++ b/src/ast/nodes/TryStatement.ts
@@ -10,6 +10,8 @@ export default class TryStatement extends StatementBase {
 	handler!: CatchClause | null;
 	type!: NodeType.tTryStatement;
 
+	private directlyIncluded = false;
+
 	hasEffects(options: ExecutionPathOptions): boolean {
 		return (
 			this.block.body.length > 0 ||
@@ -19,8 +21,9 @@ export default class TryStatement extends StatementBase {
 	}
 
 	include(includeChildrenRecursively: IncludeChildren) {
-		if (!this.included) {
+		if (!this.directlyIncluded) {
 			this.included = true;
+			this.directlyIncluded = true;
 			this.block.include(
 				this.context.tryCatchDeoptimization ? INCLUDE_VARIABLES : includeChildrenRecursively
 			);

--- a/test/form/samples/try-statement-deoptimization/include-via-outside-variable/_config.js
+++ b/test/form/samples/try-statement-deoptimization/include-via-outside-variable/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'works when the try-statement is included via an outside variable'
+};

--- a/test/form/samples/try-statement-deoptimization/include-via-outside-variable/_expected.js
+++ b/test/form/samples/try-statement-deoptimization/include-via-outside-variable/_expected.js
@@ -1,0 +1,6 @@
+console.log(myVar);
+
+try {
+	var myVar = 3;
+	console.log(myVar);
+} catch {}

--- a/test/form/samples/try-statement-deoptimization/include-via-outside-variable/main.js
+++ b/test/form/samples/try-statement-deoptimization/include-via-outside-variable/main.js
@@ -1,0 +1,6 @@
+console.log(myVar);
+
+try {
+	var myVar = 3;
+	console.log(myVar);
+} catch {}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2894 

### Description

There was an overzealous performance optimization that prevented try statements from being included if they have already been included in a different way, e.g. because they contain a variable delaration that was included.