### PR TITLE
Correctly handle early bind for member expressions

### DIFF
--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -136,6 +136,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		recursionTracker: ImmutableEntityPathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown {
+		if (!this.bound) this.bind();
 		if (this.variable !== null) {
 			return this.variable.getLiteralValueAtPath(path, recursionTracker, origin);
 		}
@@ -153,6 +154,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		recursionTracker: ImmutableEntityPathTracker,
 		origin: DeoptimizableEntity
 	) {
+		if (!this.bound) this.bind();
 		if (this.variable !== null) {
 			return this.variable.getReturnExpressionWhenCalledAtPath(path, recursionTracker, origin);
 		}

--- a/test/form/samples/early-bind-member-expressions/_config.js
+++ b/test/form/samples/early-bind-member-expressions/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'correctly resolves namespace members when accessed early (#2895)',
+	options: { external: 'external' }
+};

--- a/test/form/samples/early-bind-member-expressions/_expected.js
+++ b/test/form/samples/early-bind-member-expressions/_expected.js
@@ -1,0 +1,3 @@
+import { y } from 'external';
+
+const {x} = y();

--- a/test/form/samples/early-bind-member-expressions/main.js
+++ b/test/form/samples/early-bind-member-expressions/main.js
@@ -1,0 +1,3 @@
+import * as stuff from 'external'
+
+const {x} = stuff.y();


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2895 

### Description
When binding namespace members, it could happen that the base variable was bound to a variable before the member expression which could lead to the namespace being needlessly included later.