### PR TITLE
Use browser relative path algorithm for chunks

### DIFF
--- a/browser/path.ts
+++ b/browser/path.ts
@@ -37,16 +37,17 @@ export function relative(from: string, to: string) {
 	const fromParts = from.split(/[/\\]/).filter(Boolean);
 	const toParts = to.split(/[/\\]/).filter(Boolean);
 
+	if (fromParts[0] === '.') fromParts.shift();
+	if (toParts[0] === '.') toParts.shift();
+
 	while (fromParts[0] && toParts[0] && fromParts[0] === toParts[0]) {
 		fromParts.shift();
 		toParts.shift();
 	}
 
-	while (toParts[0] === '.' || toParts[0] === '..') {
-		const toPart = toParts.shift();
-		if (toPart === '..') {
-			fromParts.pop();
-		}
+	while (toParts[0] === '..' && fromParts.length > 0) {
+		toParts.shift();
+		fromParts.pop();
 	}
 
 	while (fromParts.pop()) {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1,5 +1,6 @@
 import sha256 from 'hash.js/lib/hash/sha/256';
 import MagicString, { Bundle as MagicStringBundle, SourceMap } from 'magic-string';
+import { relative } from '../browser/path';
 import ExportDefaultDeclaration from './ast/nodes/ExportDefaultDeclaration';
 import FunctionDeclaration from './ast/nodes/FunctionDeclaration';
 import { UNDEFINED_EXPRESSION } from './ast/values';
@@ -28,7 +29,7 @@ import { error } from './utils/error';
 import { sortByExecutionOrder } from './utils/executionOrder';
 import getIndentString from './utils/getIndentString';
 import { makeLegal } from './utils/identifierHelpers';
-import { basename, dirname, isAbsolute, normalize, relative, resolve } from './utils/path';
+import { basename, dirname, isAbsolute, normalize, resolve } from './utils/path';
 import relativeId, { getAliasName } from './utils/relativeId';
 import renderChunk from './utils/renderChunk';
 import { RenderOptions } from './utils/renderHelpers';

--- a/test/function/index.js
+++ b/test/function/index.js
@@ -51,6 +51,7 @@ runTestSuiteWithSamples('function', path.resolve(__dirname, 'samples'), (dir, co
 		path.basename(dir) + ': ' + config.description,
 		() => {
 			if (config.show) console.group(path.basename(dir));
+			if (config.before) config.before();
 
 			process.chdir(dir);
 			const warnings = [];

--- a/test/function/samples/relative-outside-external/_config.js
+++ b/test/function/samples/relative-outside-external/_config.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const cwd = process.cwd;
+
+module.exports = {
+	description: 'correctly resolves relative external imports from outside directories',
+	options: {
+		external() {
+			return true;
+		}
+	},
+	before() {
+		process.cwd = () => '/';
+	},
+	context: {
+		require(id) {
+			return id;
+		}
+	},
+	exports(exports) {
+		process.cwd = cwd;
+		assert.strictEqual(exports.value, '../../../test.js');
+	}
+};

--- a/test/function/samples/relative-outside-external/main.js
+++ b/test/function/samples/relative-outside-external/main.js
@@ -1,0 +1,1 @@
+export {default as value} from '../../../test.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2901 

### Description
This will fix an issue where a relative external dependency of a chunk was outside `dir` in a way that was no longer covered by the current working directory. We do this by using and adjusting our browser polyfill for path.relative for chunks.
