### PR TITLE
Make sure external re-exports are included for moduleSideEffects: false

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -456,7 +456,6 @@ export default class Module {
 
 		for (const exportName of this.getExports()) {
 			const variable = this.getVariableForExportName(exportName);
-
 			variable.deoptimizePath(UNKNOWN_PATH);
 			if (!variable.included) {
 				variable.include();
@@ -466,13 +465,13 @@ export default class Module {
 
 		for (const name of this.getReexports()) {
 			const variable = this.getVariableForExportName(name);
-
-			if (variable instanceof ExternalVariable) {
-				variable.reexported = variable.module.reexported = true;
-			} else if (!variable.included) {
+			variable.deoptimizePath(UNKNOWN_PATH);
+			if (!variable.included) {
 				variable.include();
-				variable.deoptimizePath(UNKNOWN_PATH);
 				this.graph.needsTreeshakingPass = true;
+			}
+			if (variable instanceof ExternalVariable) {
+				variable.module.reexported = true;
 			}
 		}
 	}

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -398,7 +398,11 @@ export class ModuleLoader {
 				error(errUnresolvedImport(source, importer));
 			}
 			this.graph.warn(errUnresolvedImportTreatedAsExternal(source, importer));
-			return { id: source, external: true, moduleSideEffects: true };
+			return {
+				external: true,
+				id: source,
+				moduleSideEffects: this.hasModuleSideEffects(source, true)
+			};
 		}
 		return resolvedId;
 	}

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -18,7 +18,6 @@ export default class Variable implements ExpressionEntity {
 	isReassigned = false;
 	module?: Module | ExternalModule;
 	name: string;
-	reexported = false;
 	renderBaseName: string | null = null;
 	renderName: string | null = null;
 	safeExportName: string | null = null;

--- a/test/function/samples/module-side-effects/external-false/_config.js
+++ b/test/function/samples/module-side-effects/external-false/_config.js
@@ -25,6 +25,9 @@ module.exports = {
 					if (id === 'internal') {
 						return id;
 					}
+					if (id === 'implicit-external') {
+						return null;
+					}
 					const moduleSideEffects = JSON.parse(id.split('-')[1]);
 					if (moduleSideEffects) {
 						return { id, moduleSideEffects, external: true };
@@ -38,5 +41,15 @@ module.exports = {
 				}
 			}
 		}
-	}
+	},
+	warnings: [
+		{
+			code: 'UNRESOLVED_IMPORT',
+			importer: 'main.js',
+			message:
+				"'implicit-external' is imported by main.js, but could not be resolved – treating it as an external dependency",
+			source: 'implicit-external',
+			url: 'https://rollupjs.org/guide/en#warning-treating-module-as-external-dependency'
+		}
+	]
 };

--- a/test/function/samples/module-side-effects/external-false/main.js
+++ b/test/function/samples/module-side-effects/external-false/main.js
@@ -1,3 +1,4 @@
 import 'pluginsideeffects-false';
 import 'pluginsideeffects-true';
 import 'internal';
+import 'implicit-external';

--- a/test/function/samples/module-side-effects/reexport-from-external/_config.js
+++ b/test/function/samples/module-side-effects/reexport-from-external/_config.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'handles reexporting external values when module side-effects are false',
+	context: {
+		require(id) {
+			return { value: id };
+		}
+	},
+	exports(exports) {
+		assert.deepStrictEqual(exports, {
+			external: 'external',
+			value: 'externalStar'
+		});
+	},
+	options: {
+		external() {
+			return true;
+		},
+		treeshake: {
+			moduleSideEffects: false
+		}
+	}
+};

--- a/test/function/samples/module-side-effects/reexport-from-external/main.js
+++ b/test/function/samples/module-side-effects/reexport-from-external/main.js
@@ -1,0 +1,2 @@
+export { value as external } from 'external';
+export * from 'externalStar';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2904 

### Description
This fixes two things:
- If an external variable is re-exported, the external variable is always properly included
- If a module is only implicitly external (i.e. not found), it should still be marked as side-effect free if this configuration holds for external modules.