### PR TITLE
Do not resolve relative external ids when using the object form

### DIFF
--- a/docs/05-plugins.md
+++ b/docs/05-plugins.md
@@ -231,18 +231,20 @@ resolveFileUrl({fileName}) {
 Type: `(source: string, importer: string) => string | false | null | {id: string, external?: boolean, moduleSideEffects?: boolean | null}`<br>
 Kind: `async, first`
 
-Defines a custom resolver. A resolver can be useful for e.g. locating third-party dependencies. Returning `null` defers to other `resolveId` functions and eventually the default resolution behavior; returning `false` signals that `source` should be treated as an external module and not included in the bundle.
+Defines a custom resolver. A resolver can be useful for e.g. locating third-party dependencies. Returning `null` defers to other `resolveId` functions and eventually the default resolution behavior; returning `false` signals that `source` should be treated as an external module and not included in the bundle. If this happens for a relative import, the id will be renormalized the same way as when the `external` option is used.
 
 If you return an object, then it is possible to resolve an import to a different id while excluding it from the bundle at the same time. This allows you to replace dependencies with external dependencies without the need for the user to mark them as "external" manually via the `external` option:
 
 ```js
 resolveId(source) {
   if (source === 'my-dependency') {
-    return {source: 'my-dependency-develop', external: true};
+    return {id: 'my-dependency-develop', external: true};
   }
   return null;
 }
 ```
+
+Relative ids, i.e. starting with `./` or `../`, will **not** be renormalized when returning an object. If you want this behaviour, return an absolute file system location as `id` instead.
 
 If `false` is returned for `moduleSideEffects` in the first hook that resolves a module id and no other module imports anything from this module, then this module will not be included without checking for actual side-effects inside the module. If `true` is returned, Rollup will use its default algorithm to include all statements in the module that have side-effects (such as modifying a global or exported variable). If `null` is returned or the flag is omitted, then `moduleSideEffects` will be determined by the `treeshake.moduleSideEffects` option or default to `true`. The `load` and `transform` hooks can override this.
 

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -40,6 +40,31 @@ When providing a function, it is actually called with three parameters `(id, par
 
 When creating an `iife` or `umd` bundle, you will need to provide global variable names to replace your external imports via the `output.globals` option.
 
+If a relative import, i.e. starting with `./` or `../`, is marked as "external", rollup will internally resolve the id to an absolute file system location so that different imports of the external module can be merged. When the resulting bundle is written, the import will again be converted to a relative import. Example:
+
+```js
+// input
+// src/main.js (entry point)
+import x from '../external.js';
+import './nested/nested.js';
+console.log(x);
+
+// src/nested/nested.js
+// the import would point to the same file if it existed
+import x from '../../external.js';
+console.log(x);
+
+// output
+// the different imports are merged
+import x from '../external.js';
+
+console.log(x);
+
+console.log(x);
+```
+
+The conversion back to a relative import is done as if `output.file` or `output.dir` were in the same location as the entry point or the common base directory of all entry points if there is more than one.
+
 #### input
 Type: `string | string [] | { [entryName: string]: string }`<br>
 CLI: `-i`/`--input <filename>`

--- a/src/utils/pluginDriver.ts
+++ b/src/utils/pluginDriver.ts
@@ -34,7 +34,7 @@ export interface PluginDriver {
 		hook: H,
 		args: Args<PluginHooks[H]>,
 		hookContext?: HookContext | null,
-		skip?: number
+		skip?: number | null
 	): EnsurePromise<R>;
 	hookFirstSync<H extends keyof PluginHooks, R = ReturnType<PluginHooks[H]>>(
 		hook: H,

--- a/test/form/samples/relative-external-ids/_expected.js
+++ b/test/form/samples/relative-external-ids/_expected.js
@@ -5,4 +5,4 @@ import './resolved.js';
 import './nested/optionDirectNested.js';
 import './nested/optionIndirectNested.js';
 import './nested/hookNested.js';
-import './nested/resolvedNested.js';
+import './resolvedNested.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:
Resolves #2867

### Description
This change will improve the behaviour of the resolveId hook so that the user has the option to specify external ids that will appear in the generated bundle unmodified even in the case of relative imports. This also contains a documentation update that explains this.

The logic is now:
- if a relative import is marked as external via user option or by returning "false" from the "resolveId" hook, Rollup will internally resolve the import to an absolute file system location to be able to merge different relative imports of the same external file. When the bundle is written, the absolute location will be converted to a relative import again as if the "output.file" or "output.dir" option were in the same location as the entry point (or the common base directory of all entry points) (existing behaviour).
- if "resolveId" returns an object with an absolute id and "external: true", this id will be resolved to a relative import in the generated bundle (existing behaviour).
- if "resolveId" returns an object with a relative id and "external: true", this id will **not** be resolved but used in the generated bundle unmodified (**new behaviour**)