### PR TITLE
Cache dynamic ids

### DIFF
--- a/test/incremental/index.js
+++ b/test/incremental/index.js
@@ -35,7 +35,7 @@ describe('incremental', () => {
 		};
 	});
 
-	it('does not resolves id and transforms in the second time', () => {
+	it('does not resolve ids and transforms in the second time', () => {
 		return rollup
 			.rollup({
 				input: 'entry',
@@ -58,6 +58,31 @@ describe('incremental', () => {
 			})
 			.then(result => {
 				assert.equal(result, 42);
+			});
+	});
+
+	it('does not resolve dynamic ids and transforms in the second time', () => {
+		modules = {
+			entry: `export default import('foo');`,
+			foo: `export default 42`
+		};
+		return rollup
+			.rollup({
+				input: 'entry',
+				plugins: [plugin]
+			})
+			.then(bundle => {
+				assert.equal(resolveIdCalls, 2);
+				assert.equal(transformCalls, 2);
+				return rollup.rollup({
+					input: 'entry',
+					plugins: [plugin],
+					cache: bundle
+				});
+			})
+			.then(bundle => {
+				assert.equal(resolveIdCalls, 3); // +1 for entry point which is resolved every time
+				assert.equal(transformCalls, 2);
 			});
 	});
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2903 

### Description
As it turns out, id resolution is REALLY expensive and while the ids of static imports were cached between builds, the ids of dynamic imports were not cached. This is fixed now for statically resolvable dynamic imports. This should also speed up watch mode.