### PR TITLE
Properly handle removing arguments when there are extra parentheses

### DIFF
--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -248,7 +248,14 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 					for (let index = 0; index <= lastIncludedIndex; index++) {
 						this.arguments[index].render(code, options);
 					}
-					code.remove(this.arguments[lastIncludedIndex].end, this.end - 1);
+					code.remove(
+						findFirstOccurrenceOutsideComment(
+							code.original,
+							',',
+							this.arguments[lastIncludedIndex].end
+						),
+						this.end - 1
+					);
 				} else {
 					code.remove(
 						findFirstOccurrenceOutsideComment(code.original, '(', this.callee.end) + 1,

--- a/test/form/samples/treeshake-excess-arguments/function-arguments/_expected.js
+++ b/test/form/samples/treeshake-excess-arguments/function-arguments/_expected.js
@@ -38,4 +38,10 @@ const needed63 = 3;
 
 (function(p1, p2, p3) {
 	console.log(p1, p3);
-} (needed61, needed62, needed63));
+})(needed61, needed62, needed63);
+
+const needed7 = 1;
+
+(function(p1) {
+	console.log(p1);
+}((((needed7)))));

--- a/test/form/samples/treeshake-excess-arguments/function-arguments/main.js
+++ b/test/form/samples/treeshake-excess-arguments/function-arguments/main.js
@@ -48,4 +48,11 @@ const needed63 = 3;
 
 (function(p1, p2, p3) {
 	console.log(p1, p3);
-} (needed61, needed62, needed63, unneeded6));
+})(needed61, needed62, needed63, unneeded6);
+
+const needed7 = 1;
+const unneeded7 = 1;
+
+(function(p1) {
+	console.log(p1);
+}((((needed7))), unneeded7));


### PR DESCRIPTION
surrounding the arguments

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2909

### Description
This changes the logic that removes unneeded arguments to actually scan for `,` to determine where to remove code instead of relying on acorn, which does not include parentheses with arguments in their range.