### PR TITLE
Properly include try statements for each pass when deoptimization is deactivated

### DIFF
--- a/src/ast/nodes/TryStatement.ts
+++ b/src/ast/nodes/TryStatement.ts
@@ -21,7 +21,7 @@ export default class TryStatement extends StatementBase {
 	}
 
 	include(includeChildrenRecursively: IncludeChildren) {
-		if (!this.directlyIncluded) {
+		if (!this.directlyIncluded || !this.context.tryCatchDeoptimization) {
 			this.included = true;
 			this.directlyIncluded = true;
 			this.block.include(

--- a/test/form/samples/try-statement-deoptimization/deactivate-via-option/_expected.js
+++ b/test/form/samples/try-statement-deoptimization/deactivate-via-option/_expected.js
@@ -1,8 +1,17 @@
+function mutate(foo) {
+	foo.bar = 1;
+}
+
+const mutated = {};
+
 function test(callback) {
 	try {
 		callback();
+		mutate(mutated);
 	} catch {}
 }
 
 test(() => {
 });
+
+export { mutated };

--- a/test/form/samples/try-statement-deoptimization/deactivate-via-option/main.js
+++ b/test/form/samples/try-statement-deoptimization/deactivate-via-option/main.js
@@ -2,11 +2,18 @@ function callGlobal() {
 	Object.create(null);
 }
 
+function mutate(foo) {
+	foo.bar = 1;
+}
+
+export const mutated = {};
+
 function test(callback) {
 	try {
 		Object.create(null);
 		callback();
 		callGlobal();
+		mutate(mutated);
 	} catch {}
 }
 


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2913 

### Description
When tryCatchDeoptimization is deactivated, we need to run `include` on all children of the try statement for each tree-shaking pass, not only for the first (this is how it works for all other nodes). This caused e.g. call parameters to vanish but other effects could have been caused by this as well.
