### PR TITLE
Deoptimize typeof for regular expression literals to better support es6-shim

### DIFF
--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -26,9 +26,11 @@ export default class Literal<T = LiteralValue> extends NodeBase {
 	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
 		if (
 			path.length > 0 ||
-			// unknown literals such as bigints can also be null but do not start with an "n"
+			// unknown literals can also be null but do not start with an "n"
 			(this.value === null && this.context.code.charCodeAt(this.start) !== 110) ||
-			typeof this.value === 'bigint'
+			typeof this.value === 'bigint' ||
+			// to support shims for regular expressions
+			this.context.code.charCodeAt(this.start) === 47
 		) {
 			return UNKNOWN_VALUE;
 		}

--- a/test/form/samples/deopt-regexp-type/_config.js
+++ b/test/form/samples/deopt-regexp-type/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimizes typeof for regular expressions to better support es6-sim'
+};

--- a/test/form/samples/deopt-regexp-type/_expected.js
+++ b/test/form/samples/deopt-regexp-type/_expected.js
@@ -1,0 +1,10 @@
+const isCallable =
+	typeof /abc/ === 'function'
+		? function IsCallableSlow(x) {
+				return typeof x === 'function' && _toString(x) === '[object Function]';
+		  }
+		: function IsCallableFast(x) {
+				return typeof x === 'function';
+		  };
+
+console.log(isCallable(/x/));

--- a/test/form/samples/deopt-regexp-type/main.js
+++ b/test/form/samples/deopt-regexp-type/main.js
@@ -1,0 +1,10 @@
+const isCallable =
+	typeof /abc/ === 'function'
+		? function IsCallableSlow(x) {
+				return typeof x === 'function' && _toString(x) === '[object Function]';
+		  }
+		: function IsCallableFast(x) {
+				return typeof x === 'function';
+		  };
+
+console.log(isCallable(/x/));


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
As stated in the title, es6-shim scans if regular expressions have type `function`. This will deoptimize this check as I do not think this is a huge loss in treeshakeability.