### PR TITLE
Support implicit type coercion errors in es5-shim

### DIFF
--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -2,6 +2,7 @@ import { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker';
 import { EMPTY_PATH, LiteralValueOrUnknown, ObjectPath, UNKNOWN_VALUE } from '../values';
+import ExpressionStatement from './ExpressionStatement';
 import { LiteralValue } from './Literal';
 import * as NodeType from './NodeType';
 import { ExpressionNode, NodeBase } from './shared/Node';
@@ -58,6 +59,14 @@ export default class BinaryExpression extends NodeBase {
 		if (!operatorFn) return UNKNOWN_VALUE;
 
 		return operatorFn(leftValue as LiteralValue, rightValue as LiteralValue);
+	}
+
+	hasEffects(options: ExecutionPathOptions): boolean {
+		// support some implicit type coercion runtime errors
+		if (this.operator === '+' && this.parent instanceof ExpressionStatement) {
+			return true;
+		}
+		return super.hasEffects(options);
 	}
 
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, _options: ExecutionPathOptions) {

--- a/test/form/samples/deopt-string-concatenation/_config.js
+++ b/test/form/samples/deopt-string-concatenation/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description:
+		'deoptimize concatenation when used as an expression statement to better support es5-shim'
+};

--- a/test/form/samples/deopt-string-concatenation/_expected.js
+++ b/test/form/samples/deopt-string-concatenation/_expected.js
@@ -1,0 +1,11 @@
+function parseInt(str, radix) {
+	if (typeof str === 'symbol') {
+		'' + str;
+	}
+
+	var string = trim(String(str));
+	var defaultedRadix = $Number(radix) || (hexRegex.test(string) ? 16 : 10);
+	return origParseInt(string, defaultedRadix);
+}
+
+console.log(parseInt('1'));

--- a/test/form/samples/deopt-string-concatenation/main.js
+++ b/test/form/samples/deopt-string-concatenation/main.js
@@ -1,0 +1,11 @@
+function parseInt(str, radix) {
+	if (typeof str === 'symbol') {
+		'' + str;
+	}
+
+	var string = trim(String(str));
+	var defaultedRadix = $Number(radix) || (hexRegex.test(string) ? 16 : 10);
+	return origParseInt(string, defaultedRadix);
+}
+
+console.log(parseInt('1'));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This will deoptimize `'' + something` type conversion when used as an expression statement to better support es5-shim