### PR TITLE
Do not tree-shake arguments with side-effects

### DIFF
--- a/src/ast/scopes/ParameterScope.ts
+++ b/src/ast/scopes/ParameterScope.ts
@@ -58,7 +58,8 @@ export default class ParameterScope extends ChildScope {
 						calledFromTryStatement = true;
 					}
 				}
-			} else if (!argIncluded && arg.shouldBeIncluded()) {
+			}
+			if (!argIncluded && arg.shouldBeIncluded()) {
 				argIncluded = true;
 			}
 			if (argIncluded) {

--- a/test/form/samples/treeshake-excess-arguments/argument-side-effects/_config.js
+++ b/test/form/samples/treeshake-excess-arguments/argument-side-effects/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'retains arguments that have side-effects'
+};

--- a/test/form/samples/treeshake-excess-arguments/argument-side-effects/_expected.js
+++ b/test/form/samples/treeshake-excess-arguments/argument-side-effects/_expected.js
@@ -1,0 +1,10 @@
+function sideEffects() {
+	console.log('print message');
+	return true;
+}
+
+function hola(a, b) {
+	console.log(a);
+}
+
+hola(1, sideEffects());

--- a/test/form/samples/treeshake-excess-arguments/argument-side-effects/main.js
+++ b/test/form/samples/treeshake-excess-arguments/argument-side-effects/main.js
@@ -1,0 +1,10 @@
+function sideEffects() {
+	console.log('print message');
+	return true;
+}
+
+function hola(a, b) {
+	console.log(a);
+}
+
+hola(1, sideEffects());


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2922

### Description
A simple case that was not covered by a test. Arguments should not be dropped if they have side-effects, independent of if there is a corresponding parameter or not.