### PR TITLE
Fix URL resolution to work when the current script contains query parameters

### DIFF
--- a/src/utils/defaultPlugin.ts
+++ b/src/utils/defaultPlugin.ts
@@ -108,7 +108,7 @@ const importMetaMechanisms: Record<string, (prop: string | null, chunkId: string
 
 const getRelativeUrlFromDocument = (relativePath: string) =>
 	getResolveUrl(
-		`(document.currentScript && document.currentScript.src || document.baseURI) + '/../${relativePath}'`
+		`'${relativePath}', document.currentScript && document.currentScript.src || document.baseURI`
 	);
 
 const relativeUrlMechanisms: Record<string, (relativePath: string) => string> = {

--- a/test/chunking-form/samples/asset-emission/_expected/cjs/main.js
+++ b/test/chunking-form/samples/asset-emission/_expected/cjs/main.js
@@ -2,7 +2,7 @@
 
 var __chunk_1 = require('./nested/chunk.js');
 
-var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo1-25253976.svg').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/logo1-25253976.svg').href);
+var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo1-25253976.svg').href : new URL('assets/logo1-25253976.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 __chunk_1.showImage(logo);
 Promise.resolve(require('./nested/chunk2.js'));

--- a/test/chunking-form/samples/asset-emission/_expected/cjs/nested/chunk2.js
+++ b/test/chunking-form/samples/asset-emission/_expected/cjs/nested/chunk2.js
@@ -2,6 +2,6 @@
 
 var __chunk_1 = require('./chunk.js');
 
-var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/../assets/logo2-25253976.svg').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../../assets/logo2-25253976.svg').href);
+var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/../assets/logo2-25253976.svg').href : new URL('../assets/logo2-25253976.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 __chunk_1.showImage(logo);

--- a/test/chunking-form/samples/configure-asset-url/_expected/cjs/main.js
+++ b/test/chunking-form/samples/configure-asset-url/_expected/cjs/main.js
@@ -2,6 +2,6 @@
 
 var asset2 = 'resolved';
 
-var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href);
+var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 Promise.resolve(require('./nested/chunk.js')).then(result => console.log(result, asset2, asset3));

--- a/test/chunking-form/samples/configure-file-url/_expected/cjs/main.js
+++ b/test/chunking-form/samples/configure-file-url/_expected/cjs/main.js
@@ -3,7 +3,7 @@
 const asset = 'resolved';
 const chunk = 'resolved';
 
-const asset$1 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href);
-const chunk$1 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/nested/chunk.js').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../nested/chunk.js').href);
+const asset$1 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
+const chunk$1 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/nested/chunk.js').href : new URL('nested/chunk.js', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 Promise.resolve(require('./nested/chunk2.js')).then(result => console.log(result, chunk, chunk$1, asset, asset$1));

--- a/test/chunking-form/samples/emit-chunk-worker/_expected/cjs/chunks/nested.js
+++ b/test/chunking-form/samples/emit-chunk-worker/_expected/cjs/chunks/nested.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const getWorkerMessage = () => new Promise(resolve => {
-  const worker = new Worker((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/worker-proxy.js').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../worker-proxy.js').href));
+  const worker = new Worker((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/worker-proxy.js').href : new URL('worker-proxy.js', document.currentScript && document.currentScript.src || document.baseURI).href));
   worker.onmessage = resolve;
 });
 

--- a/test/chunking-form/samples/emit-chunk-worker/_expected/cjs/chunks/worker-proxy.js
+++ b/test/chunking-form/samples/emit-chunk-worker/_expected/cjs/chunks/worker-proxy.js
@@ -1,3 +1,3 @@
 'use strict';
 
-PLACEHOLDER((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/worker.js').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../worker.js').href));
+PLACEHOLDER((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/worker.js').href : new URL('worker.js', document.currentScript && document.currentScript.src || document.baseURI).href));

--- a/test/chunking-form/samples/emit-chunk-worker/_expected/cjs/main.js
+++ b/test/chunking-form/samples/emit-chunk-worker/_expected/cjs/main.js
@@ -3,7 +3,7 @@
 var __chunk_1 = require('./chunks/chunk.js');
 
 const getWorkerMessage = () => new Promise(resolve => {
-  const worker = new Worker((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/chunks/worker-proxy.js').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../chunks/worker-proxy.js').href));
+  const worker = new Worker((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/chunks/worker-proxy.js').href : new URL('chunks/worker-proxy.js', document.currentScript && document.currentScript.src || document.baseURI).href));
   worker.onmessage = resolve;
 });
 

--- a/test/chunking-form/samples/emit-chunk-worklet/_expected/cjs/main.js
+++ b/test/chunking-form/samples/emit-chunk-worklet/_expected/cjs/main.js
@@ -2,6 +2,6 @@
 
 var __chunk_1 = require('./chunks/chunk.js');
 
-CSS.paintWorklet.addModule((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/chunks/worklet.js').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../chunks/worklet.js').href));
+CSS.paintWorklet.addModule((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/chunks/worklet.js').href : new URL('chunks/worklet.js', document.currentScript && document.currentScript.src || document.baseURI).href));
 
 document.body.innerHTML += `<h1 style="background-image: paint(vertical-lines);">color: ${__chunk_1.color}, size: ${__chunk_1.size}</h1>`;

--- a/test/form/samples/asset-emission/_expected/cjs.js
+++ b/test/form/samples/asset-emission/_expected/cjs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25253976.svg').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/logo-25253976.svg').href);
+var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25253976.svg').href : new URL('assets/logo-25253976.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 function showImage(url) {
 	console.log(url);

--- a/test/form/samples/asset-emission/_expected/iife.js
+++ b/test/form/samples/asset-emission/_expected/iife.js
@@ -1,7 +1,7 @@
 (function () {
 	'use strict';
 
-	var logo = new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/logo-25253976.svg').href;
+	var logo = new URL('assets/logo-25253976.svg', document.currentScript && document.currentScript.src || document.baseURI).href;
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/asset-emission/_expected/umd.js
+++ b/test/form/samples/asset-emission/_expected/umd.js
@@ -3,7 +3,7 @@
 	factory();
 }(function () { 'use strict';
 
-	var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25253976.svg').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/logo-25253976.svg').href);
+	var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25253976.svg').href : new URL('assets/logo-25253976.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/asset-emission/index-umd-iife-queryparam.html
+++ b/test/form/samples/asset-emission/index-umd-iife-queryparam.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>UMD (IIFE) + query parameter</title>
+</head>
+<body>
+    <script src="_actual/umd.js?test=1"></script>
+</body>
+</html>

--- a/test/form/samples/configure-asset-url/_expected/cjs.js
+++ b/test/form/samples/configure-asset-url/_expected/cjs.js
@@ -4,6 +4,6 @@ var asset1 = 'cjs.js:solved:assets/asset-solved-9b321da2.txt:assets/asset-solved
 
 var asset2 = 'resolved';
 
-var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href);
+var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 console.log(asset1, asset2, asset3);

--- a/test/form/samples/configure-asset-url/_expected/iife.js
+++ b/test/form/samples/configure-asset-url/_expected/iife.js
@@ -5,7 +5,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href;
+	var asset3 = new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href;
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/configure-asset-url/_expected/umd.js
+++ b/test/form/samples/configure-asset-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href);
+	var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/configure-file-url/_expected/cjs.js
+++ b/test/form/samples/configure-file-url/_expected/cjs.js
@@ -4,6 +4,6 @@ var asset1 = 'chunkId=cjs.js:moduleId=solved:fileName=assets/asset-solved-9b321d
 
 var asset2 = 'resolved';
 
-var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href);
+var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 console.log(asset1, asset2, asset3);

--- a/test/form/samples/configure-file-url/_expected/iife.js
+++ b/test/form/samples/configure-file-url/_expected/iife.js
@@ -5,7 +5,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href;
+	var asset3 = new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href;
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/configure-file-url/_expected/umd.js
+++ b/test/form/samples/configure-file-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/asset-unresolved-9548436d.txt').href);
+	var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-9548436d.txt').href : new URL('assets/asset-unresolved-9548436d.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -615,7 +615,7 @@ describe('hooks', () => {
 					code,
 					`'use strict';
 
-var input = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/test-19916f7d.ext').href : new URL((document.currentScript && document.currentScript.src || document.baseURI) + '/../assets/test-19916f7d.ext').href);
+var input = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/test-19916f7d.ext').href : new URL('assets/test-19916f7d.ext', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 module.exports = input;
 `


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2603 

### Description
Fixes URL resolution by not just concatenating strings but using the URL constructor to its full potential, i.e. `new URL('test/file.png', 'http://server.js/index.js?test=1').href === 'http://server.js/test/file.png')`

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
