### PR TITLE
Explicitly allow null as return value for various hooks

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -199,7 +199,7 @@ export default class Module {
 	manualChunkAlias: string = null as any;
 	moduleSideEffects: boolean;
 	originalCode!: string;
-	originalSourcemap!: RawSourceMap | void;
+	originalSourcemap!: RawSourceMap | null;
 	reexports: { [name: string]: ReexportDescription } = Object.create(null);
 	resolvedIds!: ResolvedIdMap;
 	scope!: ModuleScope;

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -49,18 +49,19 @@ function normalizeRelativeExternalId(importer: string, source: string) {
 }
 
 function getIdMatcher<T extends Array<any>>(
-	option: boolean | string[] | ((id: string, ...args: T) => boolean | void)
+	option: boolean | string[] | ((id: string, ...args: T) => boolean | null | undefined)
 ): (id: string, ...args: T) => boolean {
 	if (option === true) {
 		return () => true;
-	} else if (typeof option === 'function') {
+	}
+	if (typeof option === 'function') {
 		return (id, ...args) => (!id.startsWith('\0') && option(id, ...args)) || false;
-	} else if (option) {
+	}
+	if (option) {
 		const ids = new Set(Array.isArray(option) ? option : option ? [option] : []);
 		return (id => ids.has(id)) as (id: string, ...args: T) => boolean;
-	} else {
-		return () => false;
 	}
+	return () => false;
 }
 
 function getHasModuleSideEffects(
@@ -127,8 +128,7 @@ export class ModuleLoader {
 			pureExternalModules,
 			graph
 		);
-		this.getManualChunk =
-			typeof getManualChunk === 'function' ? getManualChunk : () => (null as unknown) as void;
+		this.getManualChunk = typeof getManualChunk === 'function' ? getManualChunk : () => null;
 	}
 
 	addEntryModuleAndGetReferenceId(unresolvedEntryModule: UnresolvedModuleWithAlias): string {

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -79,7 +79,7 @@ export interface TransformModuleJSON {
 	customTransformCache: boolean;
 	moduleSideEffects: boolean | null;
 	originalCode: string;
-	originalSourcemap: RawSourceMap | void;
+	originalSourcemap: RawSourceMap | null;
 	resolvedIds?: ResolvedIdMap;
 	sourcemapChain: (RawSourceMap | { missing: true; plugin: string })[];
 	transformDependencies: string[] | null;
@@ -171,7 +171,7 @@ interface PartialResolvedId {
 	moduleSideEffects?: boolean | null;
 }
 
-export type ResolveIdResult = string | false | void | PartialResolvedId;
+export type ResolveIdResult = string | false | null | undefined | PartialResolvedId;
 
 export type ResolveIdHook = (
 	this: PluginContext,
@@ -179,9 +179,13 @@ export type ResolveIdHook = (
 	importer: string | undefined
 ) => Promise<ResolveIdResult> | ResolveIdResult;
 
-export type IsExternal = (source: string, importer: string, isResolved: boolean) => boolean | void;
+export type IsExternal = (
+	source: string,
+	importer: string,
+	isResolved: boolean
+) => boolean | null | undefined;
 
-export type IsPureModule = (id: string) => boolean | void;
+export type IsPureModule = (id: string) => boolean | null | undefined;
 
 export type HasModuleSideEffects = (id: string, external: boolean) => boolean;
 
@@ -190,7 +194,7 @@ export type LoadHook = (
 	id: string
 ) => Promise<SourceDescription | string | null> | SourceDescription | string | null;
 
-export type TransformResult = string | void | TransformSourceDescription;
+export type TransformResult = string | null | undefined | TransformSourceDescription;
 
 export type TransformHook = (
 	this: PluginContext,
@@ -203,10 +207,10 @@ export type TransformChunkHook = (
 	code: string,
 	options: OutputOptions
 ) =>
-	| Promise<{ code: string; map: RawSourceMap } | void>
+	| Promise<{ code: string; map: RawSourceMap } | null | undefined>
 	| { code: string; map: RawSourceMap }
-	| void
-	| null;
+	| null
+	| undefined;
 
 export type RenderChunkHook = (
 	this: PluginContext,
@@ -229,7 +233,7 @@ export type ResolveImportMetaHook = (
 	this: PluginContext,
 	prop: string | null,
 	options: { chunkId: string; format: string; moduleId: string }
-) => string | void;
+) => string | null | undefined;
 
 export type ResolveAssetUrlHook = (
 	this: PluginContext,
@@ -240,7 +244,7 @@ export type ResolveAssetUrlHook = (
 		moduleId: string;
 		relativeAssetPath: string;
 	}
-) => string | void;
+) => string | null | undefined;
 
 export type ResolveFileUrlHook = (
 	this: PluginContext,
@@ -253,7 +257,7 @@ export type ResolveFileUrlHook = (
 		moduleId: string;
 		relativePath: string;
 	}
-) => string | void;
+) => string | null | undefined;
 
 export type AddonHook = string | ((this: PluginContext) => string | Promise<string>);
 
@@ -303,8 +307,8 @@ export interface PluginHooks {
 		options: OnWriteOptions,
 		chunk: OutputChunk
 	) => void | Promise<void>;
-	options: (this: MinimalPluginContext, options: InputOptions) => InputOptions | void | null;
-	outputOptions: (this: PluginContext, options: OutputOptions) => OutputOptions | void | null;
+	options: (this: MinimalPluginContext, options: InputOptions) => InputOptions | null | undefined;
+	outputOptions: (this: PluginContext, options: OutputOptions) => OutputOptions | null | undefined;
 	renderChunk: RenderChunkHook;
 	renderError: (this: PluginContext, err?: Error) => Promise<void> | void;
 	renderStart: (this: PluginContext) => Promise<void> | void;
@@ -341,7 +345,7 @@ export interface TreeshakingOptions {
 	tryCatchDeoptimization?: boolean;
 }
 
-export type GetManualChunk = (id: string) => string | void;
+export type GetManualChunk = (id: string) => string | null | undefined;
 
 export type ExternalOption = string[] | IsExternal;
 export type PureModulesOption = boolean | string[] | IsPureModule;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2939 

### Description
Apparently, `void` is not the same as `null | undefined`. This PR changes the types to explicitly list `null | undefined` in various plugin hooks where it makes sense.