### PR TITLE
Fix resolved external id normalization bug

### DIFF
--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -459,13 +459,13 @@ export class ModuleLoader {
 		let moduleSideEffects = null;
 		if (resolveIdResult) {
 			if (typeof resolveIdResult === 'object') {
-				id = resolveIdResult.id;
 				if (resolveIdResult.external) {
 					external = true;
 				}
 				if (typeof resolveIdResult.moduleSideEffects === 'boolean') {
 					moduleSideEffects = resolveIdResult.moduleSideEffects;
 				}
+				id = external ? normalizeRelativeExternalId(importer, resolveIdResult.id) : resolveIdResult.id;
 			} else {
 				if (this.isExternal(resolveIdResult, importer, true)) {
 					external = true;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
When plugins return an object result for `resolveId` (like here: https://github.com/rollup/rollup-plugin-node-resolve/blob/master/src/index.js#L301) external ids should be be normalized.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
