### PR TITLE
Deconflict unused parameters

### DIFF
--- a/src/ast/scopes/ChildScope.ts
+++ b/src/ast/scopes/ChildScope.ts
@@ -67,7 +67,7 @@ export default class ChildScope extends Scope {
 			}
 		}
 		for (const [name, variable] of this.variables) {
-			if (variable.included) {
+			if (variable.included || variable.alwaysRendered) {
 				variable.setSafeName(getSafeName(name, usedNames));
 			}
 		}

--- a/src/ast/scopes/ParameterScope.ts
+++ b/src/ast/scopes/ParameterScope.ts
@@ -38,6 +38,11 @@ export default class ParameterScope extends ChildScope {
 
 	addParameterVariables(parameters: LocalVariable[][], hasRest: boolean) {
 		this.parameters = parameters;
+		for (const parameterList of parameters) {
+			for (const parameter of parameterList) {
+				parameter.alwaysRendered = true;
+			}
+		}
 		this.hasRest = hasRest;
 	}
 

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -11,6 +11,7 @@ import { ImmutableEntityPathTracker } from '../utils/ImmutableEntityPathTracker'
 import { LiteralValueOrUnknown, ObjectPath, UNKNOWN_EXPRESSION, UNKNOWN_VALUE } from '../values';
 
 export default class Variable implements ExpressionEntity {
+	alwaysRendered = false;
 	exportName: string | null = null;
 	included = false;
 	isId = false;

--- a/test/function/samples/argument-treeshaking-parameter-conflict/_config.js
+++ b/test/function/samples/argument-treeshaking-parameter-conflict/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	solo: true,
+	description: 'does not cause conflicts when deconflicting non-included parameters'
+};

--- a/test/function/samples/argument-treeshaking-parameter-conflict/dep.js
+++ b/test/function/samples/argument-treeshaking-parameter-conflict/dep.js
@@ -1,0 +1,2 @@
+export let value = 0;
+export const mutate = () => value++;

--- a/test/function/samples/argument-treeshaking-parameter-conflict/main.js
+++ b/test/function/samples/argument-treeshaking-parameter-conflict/main.js
@@ -1,0 +1,9 @@
+import * as dep from './dep';
+
+function test(mutate) {
+	dep.mutate('hello');
+}
+
+test();
+
+assert.strictEqual(dep.value, 1);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2970 

### Description
As treeshaken parameters were still rendered, this could cause conflicts with other variables. This PR fixes this.
