### PR TITLE
Align TS types, docs and implementation for this.warn and this.error

### DIFF
--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -343,7 +343,7 @@ Emitted chunks will follow the [`output.chunkFileNames`](guide/en/#outputchunkfi
 
 The generated code that replaces `import.meta.ROLLUP_CHUNK_URL_chunkReferenceId` can be customized via the [`resolveFileUrl`](guide/en/#resolvefileurl) plugin hook. Once the chunk has been rendered during `generate`, you can also use [`this.getChunkFileName(chunkReferenceId)`](guide/en/#thisgetchunkfilenamechunkreferenceid-string--string) to determine the file name.
 
-#### `this.error(error: string | Error, position?: number) => void`
+#### `this.error(error: string | Error, position?: number | { column: number; line: number }) => never`
 
 Structurally equivalent to `this.warn`, except that it will also abort the bundling process.
 
@@ -398,7 +398,7 @@ If you pass `skipSelf: true`, then the `resolveId` hook of the plugin from which
 
 Set the deferred source of an asset.
 
-#### `this.warn(warning: string | RollupWarning, position?: number )`
+#### `this.warn(warning: string | RollupWarning, position?: number | { column: number; line: number }) => void`
 
 Using this method will queue warnings for a build. These warnings will be printed by the CLI just like internally-generated warnings (except with the plugin name), or captured by custom `onwarn` handlers.
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -122,7 +122,7 @@ export interface PluginContext extends MinimalPluginContext {
 	cache: PluginCache;
 	emitAsset: EmitAsset;
 	emitChunk: EmitChunk;
-	error: (err: RollupError | string, pos?: { column: number; line: number }) => never;
+	error: (err: RollupError | string, pos?: number | { column: number; line: number }) => never;
 	getAssetFileName: (assetReferenceId: string) => string;
 	getChunkFileName: (chunkReferenceId: string) => string;
 	getModuleInfo: (
@@ -146,7 +146,7 @@ export interface PluginContext extends MinimalPluginContext {
 	/** @deprecated Use `this.resolve` instead */
 	resolveId: (source: string, importer: string) => Promise<string | null>;
 	setAssetSource: (assetReferenceId: string, source: string | Buffer) => void;
-	warn: (warning: RollupWarning | string, pos?: { column: number; line: number }) => void;
+	warn: (warning: RollupWarning | string, pos?: number | { column: number; line: number }) => void;
 	/** @deprecated Use `this.addWatchFile` and the `watchChange` hook instead  */
 	watcher: EventEmitter;
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -12,15 +12,15 @@ export function error(base: Error | RollupError, props?: RollupError): never {
 
 export function augmentCodeLocation(
 	object: RollupError | RollupWarning,
-	pos: { column: number; line: number },
+	pos: number | { column: number; line: number },
 	source: string,
 	id: string
 ): void {
-	if (pos.line !== undefined && pos.column !== undefined) {
+	if (typeof pos === 'object') {
 		const { line, column } = pos;
 		object.loc = { file: id, line, column };
 	} else {
-		object.pos = pos as any;
+		object.pos = pos;
 		const { line, column } = locate(source, pos, { offsetLine: 1 });
 		object.loc = { file: id, line, column };
 	}

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -134,14 +134,14 @@ export default function transform(
 				return {
 					...pluginContext,
 					cache: trackedPluginCache ? trackedPluginCache.cache : pluginContext.cache,
-					warn(warning: RollupWarning | string, pos?: { column: number; line: number }) {
+					warn(warning: RollupWarning | string, pos?: number | { column: number; line: number }) {
 						if (typeof warning === 'string') warning = { message: warning } as RollupWarning;
 						if (pos) augmentCodeLocation(warning, pos, curSource, id);
 						warning.id = id;
 						warning.hook = 'transform';
 						pluginContext.warn(warning);
 					},
-					error(err: RollupError | string, pos?: { column: number; line: number }): never {
+					error(err: RollupError | string, pos?: number | { column: number; line: number }): never {
 						if (typeof err === 'string') err = { message: err };
 						if (pos) augmentCodeLocation(err, pos, curSource, id);
 						err.id = id;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2974 

### Description
This makes sure that both ways of supplying a position/location are supported and work.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
