### PR TITLE
Do not skip onwarn handler when --silent is used

### DIFF
--- a/bin/src/run/batchWarnings.ts
+++ b/bin/src/run/batchWarnings.ts
@@ -253,7 +253,7 @@ const deferredHandlers: {
 				let lastUrl: string;
 
 				nestedByMessage.forEach(({ key: message, items }) => {
-					title(`${plugin} plugin: ${message}`);
+					title(`Plugin ${plugin}: ${message}`);
 					items.forEach(warning => {
 						if (warning.url !== lastUrl) info((lastUrl = warning.url as string));
 

--- a/bin/src/run/build.ts
+++ b/bin/src/run/build.ts
@@ -77,13 +77,14 @@ export default function build(
 			);
 		})
 		.then((bundle?: RollupBuild) => {
-			warnings.flush();
-			if (!silent)
+			if (!silent) {
+				warnings.flush();
 				stderr(
 					tc.green(`created ${tc.bold(files.join(', '))} in ${tc.bold(ms(Date.now() - start))}`)
 				);
-			if (bundle && bundle.getTimings) {
-				printTimings(bundle.getTimings());
+				if (bundle && bundle.getTimings) {
+					printTimings(bundle.getTimings());
+				}
 			}
 		})
 		.catch((err: any) => {

--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -165,7 +165,7 @@ $ rollup --config
 $ rollup --config my.config.js
 ```
 
-You can also export a function that returns any of the above configuration formats. This function will be passed the current command line arguments so that you can dynamically adapt your configuration to respect e.g. `--silent`. You can even define your own command line options if you prefix them with `config`:
+You can also export a function that returns any of the above configuration formats. This function will be passed the current command line arguments so that you can dynamically adapt your configuration to respect e.g. [`--silent`](guide/en/#--silent). You can even define your own command line options if you prefix them with `config`:
 
 ```javascript
 // rollup.config.js
@@ -254,7 +254,7 @@ Rebuild the bundle when its source files change on disk.
 
 #### `--silent`
 
-Don't print warnings to the console.
+Don't print warnings to the console. If your configuration file contains an `onwarn` handler, this handler will still be called. To manually prevent that, you can access the command line options in your configuration file as described at the end of [Configuration Files](guide/en/#configuration-files).
 
 #### `--environment <values>`
 

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -317,7 +317,7 @@ Be aware that manual chunks can change the behaviour of the application if side-
 #### onwarn
 Type: `(warning: RollupWarning, defaultHandler: (warning: string | RollupWarning) => void) => void;`
 
-A function that will intercept warning messages. If not supplied, warnings will be deduplicated and printed to the console.
+A function that will intercept warning messages. If not supplied, warnings will be deduplicated and printed to the console. When using the [`--silent`](guide/en/#--silent) CLI option, this handler is the only way to get notified about warnings.
 
 The function receives two arguments: the warning object and the default handler. Warnings objects have, at a minimum, a `code` and a `message` property, allowing you to control how different kinds of warnings are handled. Other properties are added depending on the type of warning.
 

--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -58,12 +58,9 @@ const defaultOnWarn: WarningHandler = warning => {
 
 const getOnWarn = (
 	config: GenericConfigObject,
-	command: CommandConfigObject,
 	defaultOnWarnHandler: WarningHandler = defaultOnWarn
 ): WarningHandler =>
-	command.silent
-		? () => {}
-		: config.onwarn
+	config.onwarn
 		? warning => (config.onwarn as WarningHandlerWithDefault)(warning, defaultOnWarnHandler)
 		: defaultOnWarnHandler;
 
@@ -225,7 +222,7 @@ function getInputOptions(
 		input: getOption('input', []),
 		manualChunks: getOption('manualChunks'),
 		moduleContext: config.moduleContext as any,
-		onwarn: getOnWarn(config, command, defaultOnWarnHandler),
+		onwarn: getOnWarn(config, defaultOnWarnHandler),
 		perf: getOption('perf', false),
 		plugins: config.plugins as any,
 		preserveModules: getOption('preserveModules'),

--- a/test/cli/samples/silent-onwarn/_config.js
+++ b/test/cli/samples/silent-onwarn/_config.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'triggers onwarn with --silent',
+	command: 'rollup -c --silent',
+	stderr: stderr => {
+		assert.equal(stderr, '');
+		return true;
+	}
+};

--- a/test/cli/samples/silent-onwarn/_expected.js
+++ b/test/cli/samples/silent-onwarn/_expected.js
@@ -1,0 +1,5 @@
+var doIt = () => console.log('main');
+
+doIt();
+
+export default doIt;

--- a/test/cli/samples/silent-onwarn/main.js
+++ b/test/cli/samples/silent-onwarn/main.js
@@ -1,0 +1,5 @@
+import doIt from './main.js';
+
+export default () => console.log('main');
+
+doIt();

--- a/test/cli/samples/silent-onwarn/rollup.config.js
+++ b/test/cli/samples/silent-onwarn/rollup.config.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+
+const warnings = [];
+
+export default {
+	input: 'main.js',
+	output: {
+		format: 'esm'
+	},
+	onwarn(warning) {
+		warnings.push(warning);
+	},
+	plugins: {
+		generateBundle(bundle) {
+			assert.strictEqual(warnings.length, 1);
+			assert.strictEqual(warnings[0].code, 'CIRCULAR_DEPENDENCY');
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #2686 

### Description
This decouples the `onwarn` handler from the `--silent` option so that the handler is called even when the flag is used. The documentation is also updated to reflect this.

@filipesilva sorry this has taken so long considering it was a rather straightforward fix and had been on my mind for some time.