### PR TITLE
Make tests run on Node 12, fix watcher cleanup issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,15 @@ unit_tests: &unit_tests
         name: Run unit tests.
         command: npm run ci:test
 
+unit_tests_12: &unit_tests_12
+  steps:
+    - checkout
+    - restore_cache:
+        key: dependency-cache-{{ checksum "package-lock.json" }}
+    - run:
+        name: Run unit tests.
+        command: npm run ci:test_12
+
 jobs:
   analysis:
     docker:
@@ -45,7 +54,7 @@ jobs:
   node-v12-latest:
     docker:
       - image: rollupcabal/circleci-node-v12:latest
-    <<: *unit_tests
+    <<: *unit_tests_12
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ jobs:
     docker:
       - image: rollupcabal/circleci-node-v10:latest
     <<: *unit_tests
+  node-v12-latest:
+    docker:
+      - image: rollupcabal/circleci-node-v12:latest
+    <<: *unit_tests
 
 workflows:
   version: 2
@@ -64,6 +68,12 @@ workflows:
             tags:
               only: /.*/
       - node-v10-latest:
+          requires:
+            - analysis
+          filters:
+            tags:
+              only: /.*/
+      - node-v12-latest:
           requires:
             - analysis
           filters:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ci:coverage": "npm run test:coverage",
     "ci:lint": "npm run lint:nofix && npm run security",
     "ci:test": "npm run build:test && npm run build:bootstrap && npm run test:all",
+    "ci:test_12": "npm run build:test && npm run build:bootstrap && npm run test:only && npm run test:typescript",
     "lint": "npm run lint:ts -- --fix && npm run lint:js -- --fix && npm run lint:markdown",
     "lint:nofix": "npm run lint:ts && npm run lint:js && npm run lint:markdown",
     "lint:ts": "tslint --project .",

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -211,26 +211,26 @@ export class Task {
 		return rollup(options)
 			.then(result => {
 				if (this.closed) return undefined as any;
-
+				const previouslyWatched = this.watched;
 				const watched = (this.watched = new Set());
 
 				this.cache = result.cache;
 				this.watchFiles = result.watchFiles;
-				(this.cache.modules as ModuleJSON[]).forEach(module => {
+				for (const module of this.cache.modules as ModuleJSON[]) {
 					if (module.transformDependencies) {
 						module.transformDependencies.forEach(depId => {
 							watched.add(depId);
 							this.watchFile(depId, true);
 						});
 					}
-				});
-				this.watchFiles.forEach(id => {
+				}
+				for (const id of this.watchFiles) {
 					watched.add(id);
 					this.watchFile(id);
-				});
-				this.watched.forEach(id => {
+				}
+				for (const id of previouslyWatched) {
 					if (!watched.has(id)) deleteTask(id, this, this.chokidarOptionsHash);
-				});
+				}
 
 				return Promise.all(this.outputs.map(output => result.write(output))).then(() => result);
 			})

--- a/test/function/samples/catch-dynamic-import-failure/_config.js
+++ b/test/function/samples/catch-dynamic-import-failure/_config.js
@@ -10,7 +10,8 @@ module.exports = {
 		return exports.then(result => {
 			assert.strictEqual(result[0].message, 'exists-named');
 			assert.strictEqual(result[1].message, 'exists-default');
-			assert.strictEqual(result[2].message, "Cannot find module 'does-not-exist'");
+			const expectedError = "Cannot find module 'does-not-exist'";
+			assert.strictEqual(result[2].message.slice(0, expectedError.length), expectedError);
 		});
 	}
 };

--- a/test/function/samples/dynamic-import-expression/_config.js
+++ b/test/function/samples/dynamic-import-expression/_config.js
@@ -24,6 +24,9 @@ module.exports = {
 		]
 	},
 	exports(exports) {
-		return exports.catch(err => assert.strictEqual(err.message, "Cannot find module 'x/y'"));
+		const expectedError = "Cannot find module 'x/y'";
+		return exports.catch(err =>
+			assert.strictEqual(err.message.slice(0, expectedError.length), expectedError)
+		);
 	}
 };

--- a/test/function/samples/dynamic-import-rewriting/_config.js
+++ b/test/function/samples/dynamic-import-rewriting/_config.js
@@ -13,6 +13,9 @@ module.exports = {
 		]
 	},
 	exports(exports) {
-		return exports.promise.catch(err => assert.equal(err.message, "Cannot find module 'asdf'"));
+		const expectedError = "Cannot find module 'asdf'";
+		return exports.promise.catch(err =>
+			assert.strictEqual(err.message.slice(0, expectedError.length), expectedError)
+		);
 	}
 };

--- a/test/leak/index.js
+++ b/test/leak/index.js
@@ -2,13 +2,6 @@ const path = require('path');
 const rollup = require('../..');
 const weak = require('weak');
 
-if (process.version.startsWith('v12')) {
-	console.log(
-		'Skipping leak test on Node 12, see https://github.com/TooTallNate/node-weak/issues/99'
-	);
-	return;
-}
-
 var shouldCollect = false;
 var isCollected = false;
 

--- a/test/leak/index.js
+++ b/test/leak/index.js
@@ -2,6 +2,13 @@ const path = require('path');
 const rollup = require('../..');
 const weak = require('weak');
 
+if (process.version.startsWith('v12')) {
+	console.log(
+		'Skipping leak test on Node 12, see https://github.com/TooTallNate/node-weak/issues/99'
+	);
+	return;
+}
+
 var shouldCollect = false;
 var isCollected = false;
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This adds Node 12 to the test setup. It also improves cleanup of watchers as there was an issue that prevented the test run from finishing on Node 12.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
