### PR TITLE
Always forward AST nodes for unresolvable dynamic imports

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -302,18 +302,17 @@ export default class Module {
 	getDynamicImportExpressions(): (string | Node)[] {
 		return this.dynamicImports.map(({ node }) => {
 			const importArgument = node.parent.arguments[0];
-			if (importArgument instanceof TemplateLiteral) {
-				if (importArgument.expressions.length === 0 && importArgument.quasis.length === 1) {
-					return importArgument.quasis[0].value.cooked;
-				}
-			} else if (importArgument instanceof Literal) {
-				if (typeof importArgument.value === 'string') {
-					return importArgument.value;
-				}
-			} else {
-				return importArgument;
+			if (
+				importArgument instanceof TemplateLiteral &&
+				importArgument.quasis.length === 1 &&
+				importArgument.quasis[0].value.cooked
+			) {
+				return importArgument.quasis[0].value.cooked;
 			}
-			return undefined as any;
+			if (importArgument instanceof Literal && typeof importArgument.value === 'string') {
+				return importArgument.value;
+			}
+			return importArgument;
 		});
 	}
 

--- a/test/form/samples/dynamic-import-unresolvable/_config.js
+++ b/test/form/samples/dynamic-import-unresolvable/_config.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+
+module.exports = {
+	solo: true,
+	description: 'Returns the raw AST nodes for unresolvable dynamic imports',
+	options: {
+		plugins: [
+			{
+				resolveDynamicImport(specifier) {
+					assert.ok(specifier);
+					assert.strictEqual(typeof specifier, 'object');
+					if (specifier.type !== 'TemplateLiteral' && specifier.type !== 'Literal') {
+						throw new Error(`Unexpected specifier type ${specifier.type}.`);
+					}
+					return false;
+				}
+			}
+		]
+	}
+};

--- a/test/form/samples/dynamic-import-unresolvable/_expected.js
+++ b/test/form/samples/dynamic-import-unresolvable/_expected.js
@@ -1,0 +1,3 @@
+import(`${globalVar}`);
+import(`My ${globalVar}`);
+import(7);

--- a/test/form/samples/dynamic-import-unresolvable/main.js
+++ b/test/form/samples/dynamic-import-unresolvable/main.js
@@ -1,0 +1,3 @@
+import(`${globalVar}`);
+import(`My ${globalVar}`);
+import(7);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:
Resolves #2980 

### Description
This makes sure that whenever a dynamic import does not contain a string or template string without inserted expressions, the raw AST nodes will be forwarded. Previously, the specifier would be null for template literals with expressions or literals that are not string.