### PR TITLE
Fix reference url in error messages

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -156,7 +156,7 @@ const deferredHandlers: {
 	MISSING_EXPORT: {
 		fn: warnings => {
 			title('Missing exports');
-			info('https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-');
+			info('https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module');
 
 			warnings.forEach(warning => {
 				stderr(tc.bold(warning.importer as string));

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -156,7 +156,7 @@ function handleMissingExport(
 		{
 			code: 'MISSING_EXPORT',
 			message: `'${exportName}' is not exported by ${relativeId(importedModule)}`,
-			url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-`
+			url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
 		},
 		importerStart as number
 	);

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -303,7 +303,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 					importer: relativeId(this.context.fileName),
 					message: `'${exportName}' is not exported by '${relativeId(fileName)}'`,
 					missing: exportName,
-					url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-`
+					url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
 				},
 				path[0].pos
 			);

--- a/test/function/samples/default-not-reexported/_config.js
+++ b/test/function/samples/default-not-reexported/_config.js
@@ -17,6 +17,6 @@ module.exports = {
 			2:
 			3: console.log( def );
 		`,
-		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-`
+		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
 	}
 };

--- a/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
+++ b/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
@@ -33,6 +33,6 @@ module.exports = {
 			2:
 			3: Object.assign({}, a);
 		`,
-		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-`
+		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
 	}
 };

--- a/test/function/samples/import-of-unexported-fails/_config.js
+++ b/test/function/samples/import-of-unexported-fails/_config.js
@@ -17,6 +17,6 @@ module.exports = {
 			2:
 			3: a();
 		`,
-		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-`
+		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
 	}
 };

--- a/test/function/samples/namespace-missing-export/_config.js
+++ b/test/function/samples/namespace-missing-export/_config.js
@@ -22,7 +22,7 @@ module.exports = {
 				3: assert.equal( typeof mod.foo, 'undefined' );
 				                            ^
 			`,
-			url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-`
+			url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
 		}
 	]
 };

--- a/test/function/samples/reexport-missing-error/_config.js
+++ b/test/function/samples/reexport-missing-error/_config.js
@@ -15,6 +15,6 @@ module.exports = {
 			1: export { foo as bar } from './empty.js';
 			            ^
 		`,
-		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-'
+		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module'
 	}
 };


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Update existing tests.

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

### Description

Remove an unneeded trailing hyphen (`-`) from reference url in error messages.

Before: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module-`
After:    `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`


