### PR TITLE
Prevent ASI errors for conditional expressions

### DIFF
--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -1,9 +1,9 @@
 import MagicString from 'magic-string';
 import { BLANK } from '../../utils/blank';
 import {
-	findFirstLineBreakOutsideComment,
 	findFirstOccurrenceOutsideComment,
 	NodeRenderOptions,
+	removeLineBreaks,
 	RenderOptions
 } from '../../utils/renderHelpers';
 import { removeAnnotations } from '../../utils/treeshakeNode';
@@ -161,17 +161,7 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 					? findFirstOccurrenceOutsideComment(code.original, '?', this.test.end)
 					: colonPos) + 1;
 			if (preventASI) {
-				const branchStart = (this.usedBranch as ExpressionNode).start;
-				let lineBreakPos = inclusionStart;
-				do {
-					lineBreakPos = findFirstLineBreakOutsideComment(code.original, lineBreakPos);
-					if (lineBreakPos >= 0 && lineBreakPos < branchStart) {
-						code.remove(lineBreakPos, lineBreakPos + 1);
-						lineBreakPos++;
-					} else {
-						lineBreakPos = -1;
-					}
-				} while (lineBreakPos >= 0);
+				removeLineBreaks(code, inclusionStart, (this.usedBranch as ExpressionNode).start);
 			}
 			code.remove(this.start, inclusionStart);
 			if (this.consequent.included) {

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -3,6 +3,7 @@ import { BLANK } from '../../utils/blank';
 import {
 	findFirstOccurrenceOutsideComment,
 	NodeRenderOptions,
+	removeLineBreaks,
 	RenderOptions
 } from '../../utils/renderHelpers';
 import { removeAnnotations } from '../../utils/treeshakeNode';
@@ -155,7 +156,7 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ renderedParentType, isCalleeOfRenderedParent }: NodeRenderOptions = BLANK
+		{ renderedParentType, isCalleeOfRenderedParent, preventASI }: NodeRenderOptions = BLANK
 	) {
 		if (!this.left.included || !this.right.included) {
 			const operatorPos = findFirstOccurrenceOutsideComment(
@@ -165,6 +166,9 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 			);
 			if (this.right.included) {
 				code.remove(this.start, operatorPos + 2);
+				if (preventASI) {
+					removeLineBreaks(code, operatorPos + 2, this.right.start);
+				}
 			} else {
 				code.remove(operatorPos, this.end);
 			}

--- a/src/ast/nodes/ReturnStatement.ts
+++ b/src/ast/nodes/ReturnStatement.ts
@@ -22,7 +22,7 @@ export default class ReturnStatement extends StatementBase {
 
 	render(code: MagicString, options: RenderOptions) {
 		if (this.argument) {
-			this.argument.render(code, options);
+			this.argument.render(code, options, { preventASI: true });
 			if (this.argument.start === this.start + 6 /* 'return'.length */) {
 				code.prependLeft(this.start + 6, ' ');
 			}

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -3,6 +3,7 @@ import { BLANK } from '../../utils/blank';
 import {
 	getCommaSeparatedNodesWithBoundaries,
 	NodeRenderOptions,
+	removeLineBreaks,
 	RenderOptions
 } from '../../utils/renderHelpers';
 import { treeshakeNode } from '../../utils/treeshakeNode';
@@ -81,10 +82,9 @@ export default class SequenceExpression extends NodeBase {
 	render(
 		code: MagicString,
 		options: RenderOptions,
-		{ renderedParentType, isCalleeOfRenderedParent }: NodeRenderOptions = BLANK
+		{ renderedParentType, isCalleeOfRenderedParent, preventASI }: NodeRenderOptions = BLANK
 	) {
-		let firstStart = 0,
-			includedNodes = 0;
+		let includedNodes = 0;
 		for (const { node, start, end } of getCommaSeparatedNodesWithBoundaries(
 			this.expressions,
 			code,
@@ -96,7 +96,9 @@ export default class SequenceExpression extends NodeBase {
 				continue;
 			}
 			includedNodes++;
-			if (firstStart === 0) firstStart = start;
+			if (includedNodes === 1 && preventASI) {
+				removeLineBreaks(code, start, node.start);
+			}
 			if (node === this.expressions[this.expressions.length - 1] && includedNodes === 1) {
 				node.render(code, options, {
 					isCalleeOfRenderedParent: renderedParentType

--- a/src/ast/nodes/ThrowStatement.ts
+++ b/src/ast/nodes/ThrowStatement.ts
@@ -1,3 +1,5 @@
+import MagicString from 'magic-string';
+import { RenderOptions } from '../../utils/renderHelpers';
 import { ExecutionPathOptions } from '../ExecutionPathOptions';
 import * as NodeType from './NodeType';
 import { ExpressionNode, StatementBase } from './shared/Node';
@@ -8,5 +10,9 @@ export default class ThrowStatement extends StatementBase {
 
 	hasEffects(_options: ExecutionPathOptions) {
 		return true;
+	}
+
+	render(code: MagicString, options: RenderOptions) {
+		this.argument.render(code, options, { preventASI: true });
 	}
 }

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -165,3 +165,15 @@ export function getCommaSeparatedNodesWithBoundaries<N extends Node>(
 	});
 	return splitUpNodes;
 }
+
+export function removeLineBreaks(code: MagicString, start: number, end: number) {
+	let lineBreakPos = start;
+	while (true) {
+		lineBreakPos = findFirstLineBreakOutsideComment(code.original, lineBreakPos);
+		if (lineBreakPos === -1 || lineBreakPos >= end) {
+			break;
+		}
+		code.remove(lineBreakPos, lineBreakPos + 1);
+		lineBreakPos++;
+	}
+}

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -17,6 +17,7 @@ export interface NodeRenderOptions {
 	isCalleeOfRenderedParent?: boolean;
 	isNoStatement?: boolean;
 	isShorthandProperty?: boolean;
+	preventASI?: boolean;
 	renderedParentType?: string; // also serves as a flag if the rendered parent is different from the actual parent
 	start?: number;
 }

--- a/test/form/samples/keep-tree-shaking-comments-no-asi/_config.js
+++ b/test/form/samples/keep-tree-shaking-comments-no-asi/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description:
+		'always keep leading comments when tree-shaking and no automatic semicolons are inserted'
+};

--- a/test/form/samples/keep-tree-shaking-comments-no-asi/_expected.js
+++ b/test/form/samples/keep-tree-shaking-comments-no-asi/_expected.js
@@ -1,0 +1,7 @@
+console.log(
+	/* keep me */
+	'expected');
+
+console.log(
+	/* keep me */
+	'expected' );

--- a/test/form/samples/keep-tree-shaking-comments-no-asi/_expected.js
+++ b/test/form/samples/keep-tree-shaking-comments-no-asi/_expected.js
@@ -5,3 +5,10 @@ console.log(
 console.log(
 	/* keep me */
 	'expected' );
+
+console.log(
+	/* keep me */
+	'expected');
+
+console.log((/* keep me */
+	'expected'));

--- a/test/form/samples/keep-tree-shaking-comments-no-asi/main.js
+++ b/test/form/samples/keep-tree-shaking-comments-no-asi/main.js
@@ -7,3 +7,11 @@ console.log(true ?
 	/* keep me */
 	'expected' :
 	'unexpected');
+
+console.log(true &&
+	/* keep me */
+	'expected');
+
+console.log((true,
+	/* keep me */
+	'expected'));

--- a/test/form/samples/keep-tree-shaking-comments-no-asi/main.js
+++ b/test/form/samples/keep-tree-shaking-comments-no-asi/main.js
@@ -1,0 +1,9 @@
+console.log(false ?
+	'unexpected' :
+	/* keep me */
+	'expected');
+
+console.log(true ?
+	/* keep me */
+	'expected' :
+	'unexpected');

--- a/test/function/samples/prevent-tree-shaking-asi/_config.js
+++ b/test/function/samples/prevent-tree-shaking-asi/_config.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'prevent automatic semicolon insertion from changing behaviour when tree-shaking',
+	exports(exports) {
+		assert.strictEqual(exports.test1(), 'expected');
+		assert.strictEqual(exports.test2(), 'expected');
+	}
+};

--- a/test/function/samples/prevent-tree-shaking-asi/_config.js
+++ b/test/function/samples/prevent-tree-shaking-asi/_config.js
@@ -1,9 +1,6 @@
-const assert = require('assert');
-
 module.exports = {
 	description: 'prevent automatic semicolon insertion from changing behaviour when tree-shaking',
-	exports(exports) {
-		assert.strictEqual(exports.test1(), 'expected');
-		assert.strictEqual(exports.test2(), 'expected');
+	options: {
+		treeshake: { tryCatchDeoptimization: false }
 	}
 };

--- a/test/function/samples/prevent-tree-shaking-asi/main.js
+++ b/test/function/samples/prevent-tree-shaking-asi/main.js
@@ -1,0 +1,15 @@
+export function test1() {
+	return true ?
+
+
+		'expected' :
+		'unexpected';
+}
+
+export function test2() {
+	return false ?
+		'unexpected' :
+
+
+		'expected';
+}

--- a/test/function/samples/prevent-tree-shaking-asi/main.js
+++ b/test/function/samples/prevent-tree-shaking-asi/main.js
@@ -1,15 +1,42 @@
-export function test1() {
+function test1() {
 	return true ?
-
+		/* kept */
 
 		'expected' :
 		'unexpected';
 }
+assert.strictEqual(test1(), 'expected');
 
-export function test2() {
+function test2() {
 	return false ?
 		'unexpected' :
-
+		/* kept */
 
 		'expected';
+}
+assert.strictEqual(test2(), 'expected');
+
+function test3() {
+	return true &&
+		/* kept */
+
+		'expected';
+}
+assert.strictEqual(test3(), 'expected');
+
+function test4() {
+	return 'removed',
+		/* kept */
+
+		'expected';
+}
+assert.strictEqual(test4(), 'expected');
+
+try {
+  throw true ?
+
+    new Error('expected') :
+    null;
+} catch (err) {
+	assert.strictEqual(err.message, 'expected');
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:
Resolves #3019 

### Description
This will remove linebreaks before simplified statements if this would lead to an erroneous automatic semicolon insertion. The logic is in place for both return and break statements and checks for simplifications in conditional, logical and sequence expressions.

The logic only removes line-breaks but does not touch other non-code characters to retain (annotation?) comments in the best possible way.
