### PR TITLE
Fix a warning of unresolved dependencies in an interop test

### DIFF
--- a/test/cli/samples/interop/_config.js
+++ b/test/cli/samples/interop/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'does not include the interop block',
-	command: 'rollup -i main.js -f cjs --no-interop'
+	command: 'rollup -i main.js -f cjs --no-interop --external turbocolor'
 };


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

I fixed a test to suppress a warning.

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
Fix a warning of unresolved dependencies in an interop test. Following are before and after test results.

Before
```
main.js → stdout...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
turbocolor (imported by main.js)
created stdout in 23ms

✓ interop: does not include the interop block (354ms)

```

After
```
main.js → stdout...
created stdout in 26ms

✓ interop: does not include the interop block (371ms)
```