### PR TITLE
Make chunking consistent when emitting files

### DIFF
--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_config.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_config.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+
+module.exports = {
+	description:
+		'creates a consistent chunking order (needs to be consistent with the other test of this kind)',
+	options: {
+		input: 'main',
+		plugins: {
+			resolveId(id) {
+				if (id === 'emitted') {
+					return id;
+				}
+			},
+			load(id) {
+				if (id === 'emitted') {
+					return `import value from './dep.js';
+export const id = 'emitted';
+console.log(id, value);
+`;
+				}
+			},
+			buildStart() {
+				this.emitFile({
+					type: 'chunk',
+					id: 'emitted'
+				});
+			},
+			generateBundle(options, bundle) {
+				assert.deepStrictEqual(Object.keys(bundle).map(key => bundle[key].name), [
+					'main',
+					'dep',
+					'emitted'
+				]);
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/amd/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/amd/generated-dep.js
@@ -1,0 +1,7 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var value = 42;
+
+	exports.value = value;
+
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/amd/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/amd/generated-emitted.js
@@ -1,0 +1,10 @@
+define(['exports', './generated-dep'], function (exports, dep) { 'use strict';
+
+	const id = 'emitted';
+	console.log(id, dep.value);
+
+	exports.id = id;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/amd/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/amd/main.js
@@ -1,0 +1,7 @@
+define(['./generated-dep', './generated-emitted'], function (dep, emitted) { 'use strict';
+
+	console.log(emitted.id);
+
+	console.log('main', dep.value);
+
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/cjs/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/cjs/generated-dep.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var value = 42;
+
+exports.value = value;

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/cjs/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/cjs/generated-emitted.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var dep = require('./generated-dep.js');
+
+const id = 'emitted';
+console.log(id, dep.value);
+
+exports.id = id;

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/cjs/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/cjs/main.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+var emitted = require('./generated-emitted.js');
+
+console.log(emitted.id);
+
+console.log('main', dep.value);

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/es/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/es/generated-dep.js
@@ -1,0 +1,3 @@
+var value = 42;
+
+export { value as v };

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/es/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/es/generated-emitted.js
@@ -1,0 +1,6 @@
+import { v as value } from './generated-dep.js';
+
+const id = 'emitted';
+console.log(id, value);
+
+export { id };

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/es/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/es/main.js
@@ -1,0 +1,6 @@
+import { v as value } from './generated-dep.js';
+import { id } from './generated-emitted.js';
+
+console.log(id);
+
+console.log('main', value);

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/system/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/system/generated-dep.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var value = exports('v', 42);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/system/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/system/generated-emitted.js
@@ -1,0 +1,15 @@
+System.register(['./generated-dep.js'], function (exports) {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: function () {
+
+			const id = exports('id', 'emitted');
+			console.log(id, value);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/system/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/_expected/system/main.js
@@ -1,0 +1,18 @@
+System.register(['./generated-dep.js', './generated-emitted.js'], function () {
+	'use strict';
+	var value, id;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}, function (module) {
+			id = module.id;
+		}],
+		execute: function () {
+
+			console.log(id);
+
+			console.log('main', value);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/dep.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/dep2.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/dep2.js
@@ -1,0 +1,3 @@
+import { id } from 'emitted';
+
+console.log(id);

--- a/test/chunking-form/samples/emit-file/emit-chunk-order1/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order1/main.js
@@ -1,0 +1,3 @@
+import value from './dep.js';
+import './dep2.js';
+console.log('main', value);

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_config.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_config.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+
+module.exports = {
+	description:
+		'creates a consistent chunking order (needs to be consistent with the other test of this kind)',
+	options: {
+		input: 'main',
+		plugins: {
+			resolveId(id) {
+				if (id === 'emitted') {
+					return id;
+				}
+			},
+			load(id) {
+				if (id === 'emitted') {
+					return new Promise(resolve =>
+						setTimeout(
+							() =>
+								resolve(`import value from './dep.js';
+export const id = 'emitted';
+console.log(id, value);
+`),
+							200
+						)
+					);
+				}
+			},
+			buildStart() {
+				this.emitFile({
+					type: 'chunk',
+					id: 'emitted'
+				});
+			},
+			generateBundle(options, bundle) {
+				assert.deepStrictEqual(Object.keys(bundle).map(key => bundle[key].name), [
+					'main',
+					'dep',
+					'emitted'
+				]);
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/amd/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/amd/generated-dep.js
@@ -1,0 +1,7 @@
+define(['exports'], function (exports) { 'use strict';
+
+	var value = 42;
+
+	exports.value = value;
+
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/amd/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/amd/generated-emitted.js
@@ -1,0 +1,10 @@
+define(['exports', './generated-dep'], function (exports, dep) { 'use strict';
+
+	const id = 'emitted';
+	console.log(id, dep.value);
+
+	exports.id = id;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/amd/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/amd/main.js
@@ -1,0 +1,7 @@
+define(['./generated-dep', './generated-emitted'], function (dep, emitted) { 'use strict';
+
+	console.log(emitted.id);
+
+	console.log('main', dep.value);
+
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/cjs/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/cjs/generated-dep.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var value = 42;
+
+exports.value = value;

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/cjs/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/cjs/generated-emitted.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var dep = require('./generated-dep.js');
+
+const id = 'emitted';
+console.log(id, dep.value);
+
+exports.id = id;

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/cjs/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/cjs/main.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+var emitted = require('./generated-emitted.js');
+
+console.log(emitted.id);
+
+console.log('main', dep.value);

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/es/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/es/generated-dep.js
@@ -1,0 +1,3 @@
+var value = 42;
+
+export { value as v };

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/es/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/es/generated-emitted.js
@@ -1,0 +1,6 @@
+import { v as value } from './generated-dep.js';
+
+const id = 'emitted';
+console.log(id, value);
+
+export { id };

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/es/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/es/main.js
@@ -1,0 +1,6 @@
+import { v as value } from './generated-dep.js';
+import { id } from './generated-emitted.js';
+
+console.log(id);
+
+console.log('main', value);

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/system/generated-dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/system/generated-dep.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var value = exports('v', 42);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/system/generated-emitted.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/system/generated-emitted.js
@@ -1,0 +1,15 @@
+System.register(['./generated-dep.js'], function (exports) {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: function () {
+
+			const id = exports('id', 'emitted');
+			console.log(id, value);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/system/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/_expected/system/main.js
@@ -1,0 +1,18 @@
+System.register(['./generated-dep.js', './generated-emitted.js'], function () {
+	'use strict';
+	var value, id;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}, function (module) {
+			id = module.id;
+		}],
+		execute: function () {
+
+			console.log(id);
+
+			console.log('main', value);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/dep.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/dep.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/dep2.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/dep2.js
@@ -1,0 +1,3 @@
+import { id } from 'emitted';
+
+console.log(id);

--- a/test/chunking-form/samples/emit-file/emit-chunk-order2/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-order2/main.js
@@ -1,0 +1,3 @@
+import value from './dep.js';
+import './dep2.js';
+console.log('main', value);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This makes the chunking reproducible when additional chunks are emitted and the loading speed varies. This is done by enforcing the entry modules to always retain the order in which the chunks were emitted. This should fix a blinking test.


