### PR TITLE
remove acorn-bigint and acorn-dynamic-import devDenpendencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -245,9 +245,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+      "version": "12.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+      "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -282,15 +282,9 @@
       "optional": true
     },
     "acorn": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
-    },
-    "acorn-bigint": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/acorn-bigint/-/acorn-bigint-0.4.0.tgz",
-      "integrity": "sha512-W9iaqWzqFo7ZBLmI9dMjHYGrN0Nm/ZgToqhvd3RELJux7RsX6k1/80h+bD9TtTpeKky/kYNbr3+vHWqI3hdyfA==",
-      "dev": true
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -2538,9 +2532,9 @@
       }
     },
     "husky": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.2.tgz",
-      "integrity": "sha512-WXCtaME2x0o4PJlKY4ap8BzLA+D0zlvefqAvLCPriOOu+x0dpO5uc5tlB7CY6/0SE2EESmoZsj4jW5D09KrJoA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.3.tgz",
+      "integrity": "sha512-DBBMPSiBYEMx7EVUTRE/ymXJa/lOL+WplcsV/lZu+/HHGt0gzD+5BIz9EJnCrWyUa7hkMuBh7/9OZ04qDkM+Nw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -2550,7 +2544,7 @@
         "is-ci": "^2.0.0",
         "opencollective-postinstall": "^2.0.2",
         "pkg-dir": "^4.2.0",
-        "please-upgrade-node": "^3.1.1",
+        "please-upgrade-node": "^3.2.0",
         "read-pkg": "^5.1.1",
         "run-node": "^1.0.0",
         "slash": "^3.0.0"
@@ -2680,6 +2674,15 @@
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
+          }
+        },
+        "please-upgrade-node": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+          "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+          "dev": true,
+          "requires": {
+            "semver-compare": "^1.0.0"
           }
         },
         "read-pkg": {
@@ -5072,14 +5075,14 @@
       }
     },
     "rollup": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.18.0.tgz",
-      "integrity": "sha512-MBAWr6ectF948gW/bs/yfi0jW7DzwI8n0tEYG/ZMQutmK+blF/Oazyhg3oPqtScCGV8bzCtL9KzlzPtTriEOJA==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.19.4.tgz",
+      "integrity": "sha512-G24w409GNj7i/Yam2cQla6qV2k6Nug8bD2DZg9v63QX/cH/dEdbNJg8H4lUm5M1bRpPKRUC465Rm9H51JTKOfQ==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.6.3",
-        "acorn": "^6.2.0"
+        "@types/node": "^12.6.9",
+        "acorn": "^6.2.1"
       }
     },
     "rollup-plugin-alias": {
@@ -5102,9 +5105,9 @@
       }
     },
     "rollup-plugin-commonjs": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.1.tgz",
-      "integrity": "sha512-x0PcCVdEc4J8igv1qe2vttz8JKAKcTs3wfIA3L8xEty3VzxgORLrzZrNWaVMc+pBC4U3aDOb9BnWLAQ8J11vkA==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.2.tgz",
+      "integrity": "sha512-DxeR4QXTgTOFseYls1V7vgKbrSJmPYNdEMOs0OvH+7+89C3GiIonU9gFrE0u39Vv1KWm3wepq8KAvKugtoM2Zw==",
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1",
@@ -5115,9 +5118,9 @@
       },
       "dependencies": {
         "resolve": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-          "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -5790,9 +5793,9 @@
       }
     },
     "terser": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
-      "integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.4.tgz",
+      "integrity": "sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   "homepage": "https://github.com/rollup/rollup",
   "dependencies": {
     "@types/estree": "0.0.39",
-    "@types/node": "^12.6.9",
-    "acorn": "^6.2.1"
+    "@types/node": "^12.7.1",
+    "acorn": "^6.3.0"
   },
   "devDependencies": {
     "@types/chokidar": "^2.1.3",
@@ -81,7 +81,7 @@
     "execa": "^2.0.3",
     "fixturify": "^1.2.0",
     "hash.js": "^1.1.7",
-    "husky": "^3.0.2",
+    "husky": "^3.0.3",
     "immutable": "^4.0.0-rc.12",
     "is-reference": "^1.1.3",
     "lint-staged": "^9.2.1",
@@ -97,10 +97,10 @@
     "pretty-ms": "^5.0.0",
     "require-relative": "^0.8.7",
     "requirejs": "^2.3.6",
-    "rollup": "^1.18.0",
+    "rollup": "^1.19.4",
     "rollup-plugin-alias": "^1.5.2",
     "rollup-plugin-buble": "^0.19.8",
-    "rollup-plugin-commonjs": "^10.0.1",
+    "rollup-plugin-commonjs": "^10.0.2",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-replace": "^2.2.0",
@@ -115,7 +115,7 @@
     "source-map-support": "^0.5.13",
     "sourcemap-codec": "^1.4.6",
     "systemjs": "^5.0.0",
-    "terser": "^4.1.2",
+    "terser": "^4.1.4",
     "tslib": "^1.10.0",
     "tslint": "^5.18.0",
     "turbocolor": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,6 @@
     "@types/chokidar": "^2.1.3",
     "@types/micromatch": "^3.1.0",
     "@types/minimist": "^1.2.0",
-    "acorn-bigint": "^0.4.0",
-    "acorn-dynamic-import": "^4.0.0",
     "acorn-import-meta": "^1.0.0",
     "acorn-jsx": "^5.0.1",
     "acorn-walk": "^6.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,6 +81,7 @@ function fixAcornEsmImport() {
 
 const moduleAliases = {
 	resolve: ['.js', '.json', '.md'],
+	'acorn-dynamic-import': path.resolve('node_modules/acorn-dynamic-import/src/index.js'),
 	'help.md': path.resolve('cli/help.md'),
 	'package.json': path.resolve('package.json')
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,7 +81,6 @@ function fixAcornEsmImport() {
 
 const moduleAliases = {
 	resolve: ['.js', '.json', '.md'],
-	'acorn-dynamic-import': path.resolve('node_modules/acorn-dynamic-import/src/index.js'),
 	'help.md': path.resolve('cli/help.md'),
 	'package.json': path.resolve('package.json')
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -54,9 +54,9 @@ function addSheBang() {
 	};
 }
 
-const expectedAcornImport = "import acorn__default, { tokTypes, Parser } from 'acorn';";
+const expectedAcornImport = "import acorn__default, { Parser } from 'acorn';";
 const newAcornImport =
-	"import * as acorn__default from 'acorn';\nimport { tokTypes, Parser } from 'acorn';";
+	"import * as acorn__default from 'acorn';\nimport { Parser } from 'acorn';";
 
 // by default, rollup-plugin-commonjs will translate require statements as default imports
 // which can cause issues for secondary tools that use the ESM version of acorn

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -1,6 +1,4 @@
 import * as acorn from 'acorn';
-import injectBigInt from 'acorn-bigint';
-import injectDynamicImportPlugin from 'acorn-dynamic-import';
 import injectImportMeta from 'acorn-import-meta';
 import * as ESTree from 'estree';
 import GlobalScope from './ast/scopes/GlobalScope';
@@ -171,9 +169,7 @@ export default class Graph {
 		this.acornOptions = options.acorn || {};
 		const acornPluginsToInject = [];
 
-		acornPluginsToInject.push(injectDynamicImportPlugin);
 		acornPluginsToInject.push(injectImportMeta);
-		acornPluginsToInject.push(injectBigInt);
 
 		if (options.experimentalTopLevelAwait) {
 			(this.acornOptions as any).allowAwaitOutsideFunction = true;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -116,7 +116,7 @@ export interface AstContext {
 }
 
 export const defaultAcornOptions: acorn.Options = {
-	ecmaVersion: 2019,
+	ecmaVersion: 2020 as any,
 	preserveParens: false,
 	sourceType: 'module'
 };

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -13,6 +13,4 @@ declare module 'date-time';
 declare module 'locate-character';
 declare module 'is-reference';
 declare module 'require-relative';
-declare module 'acorn-dynamic-import';
 declare module 'acorn-import-meta';
-declare module 'acorn-bigint';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

acorn built with bigint and dynamic import internal since 6.2.0 (while rollup depending on acorn ^6.2.1): https://github.com/acornjs/acorn/blob/master/acorn/CHANGELOG.md

(Note: don't update dependency acorn version to 7.0.0 for the moment, until most plugins compatible with that (at least waiting for acorn offcial stage3 plugins), and notice that `import()` has updated to `ImportExpression` in 7.0.0, which maybe need to update in rollup source.)
