### PR TITLE
clean up rest then by async/await

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -700,7 +700,7 @@ export default class Chunk {
 		const chunkSourcemapChain: DecodedSourceMapOrMissing[] = [];
 
 		return (async () => {
-			const code: string = await renderChunk({
+			let code: string = await renderChunk({
 				chunk: this,
 				code: prevCode,
 				graph: this.graph,
@@ -726,7 +726,7 @@ export default class Chunk {
 					chunkSourcemapChain,
 					options.sourcemapExcludeSources as boolean
 				);
-				map.sources = map.sources.map(sourcePath =>
+				map.sources = map.sources.map((sourcePath: string) =>
 					normalize(
 						options.sourcemapPathTransform ? options.sourcemapPathTransform(sourcePath) : sourcePath
 					)

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -708,15 +708,15 @@ export default class Chunk {
 				renderChunk: outputChunk,
 				sourcemapChain: chunkSourcemapChain
 			});
-			
+
 			if (options.sourcemap) {
 				timeStart('sourcemap', 3);
-				
+
 				let file: string;
 				if (options.file) file = resolve(options.sourcemapFile || options.file);
 				else if (options.dir) file = resolve(options.dir, this.id as string);
 				else file = resolve(this.id as string);
-				
+
 				const decodedMap = magicString.generateDecodedMap({});
 				map = collapseSourcemaps(
 					this,
@@ -731,12 +731,12 @@ export default class Chunk {
 						options.sourcemapPathTransform ? options.sourcemapPathTransform(sourcePath) : sourcePath
 					)
 				);
-				
+
 				timeEnd('sourcemap', 3);
 			}
-			
+
 			if (options.compact !== true && code[code.length - 1] !== '\n') code += '\n';
-			
+
 			return { code, map };
 		})();
 	}

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -699,22 +699,24 @@ export default class Chunk {
 		let map: SourceMap = null as any;
 		const chunkSourcemapChain: DecodedSourceMapOrMissing[] = [];
 
-		return renderChunk({
-			chunk: this,
-			code: prevCode,
-			graph: this.graph,
-			options,
-			renderChunk: outputChunk,
-			sourcemapChain: chunkSourcemapChain
-		}).then((code: string) => {
+		return (async () => {
+			const code: string = await renderChunk({
+				chunk: this,
+				code: prevCode,
+				graph: this.graph,
+				options,
+				renderChunk: outputChunk,
+				sourcemapChain: chunkSourcemapChain
+			});
+			
 			if (options.sourcemap) {
 				timeStart('sourcemap', 3);
-
+				
 				let file: string;
 				if (options.file) file = resolve(options.sourcemapFile || options.file);
 				else if (options.dir) file = resolve(options.dir, this.id as string);
 				else file = resolve(this.id as string);
-
+				
 				const decodedMap = magicString.generateDecodedMap({});
 				map = collapseSourcemaps(
 					this,
@@ -729,14 +731,14 @@ export default class Chunk {
 						options.sourcemapPathTransform ? options.sourcemapPathTransform(sourcePath) : sourcePath
 					)
 				);
-
+				
 				timeEnd('sourcemap', 3);
 			}
-
+			
 			if (options.compact !== true && code[code.length - 1] !== '\n') code += '\n';
-
+			
 			return { code, map };
-		});
+		})();
 	}
 
 	visitDependencies(handleDependency: (dependency: Chunk | ExternalModule) => void) {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -699,15 +699,16 @@ export default class Chunk {
 		let map: SourceMap = null as any;
 		const chunkSourcemapChain: DecodedSourceMapOrMissing[] = [];
 
+		const _ = renderChunk({
+			chunk: this,
+			code: prevCode,
+			graph: this.graph,
+			options,
+			renderChunk: outputChunk,
+			sourcemapChain: chunkSourcemapChain
+		});
 		return (async () => {
-			let code: string = await renderChunk({
-				chunk: this,
-				code: prevCode,
-				graph: this.graph,
-				options,
-				renderChunk: outputChunk,
-				sourcemapChain: chunkSourcemapChain
-			});
+			let code: string = await _;
 
 			if (options.sourcemap) {
 				timeStart('sourcemap', 3);

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -230,20 +230,20 @@ export default class Graph {
 				}
 			}
 			timeEnd('parse modules', 2);
-			
+
 			this.phase = BuildPhase.ANALYSE;
-			
+
 			// Phase 2 - linking. We populate the module dependency links and
 			// determine the topological execution order for the bundle
 			timeStart('analyse dependency graph', 2);
-			
+
 			this.link(entryModules);
-			
+
 			timeEnd('analyse dependency graph', 2);
-			
+
 			// Phase 3 – marking. We include all statements that should be included
 			timeStart('mark included statements', 2);
-			
+
 			if (inlineDynamicImports) {
 				if (entryModules.length > 1) {
 					throw new Error(
@@ -255,20 +255,20 @@ export default class Graph {
 				module.includeAllExports();
 			}
 			this.includeMarked(this.modules);
-			
+
 			// check for unused external imports
 			for (const externalModule of this.externalModules) externalModule.warnUnusedImports();
-			
+
 			timeEnd('mark included statements', 2);
-			
+
 			// Phase 4 – we construct the chunks, working out the optimal chunking using
 			// entry point graph colouring, before generating the import and export facades
 			timeStart('generate chunks', 2);
-			
+
 			if (!this.preserveModules && !inlineDynamicImports) {
 				assignChunkColouringHashes(entryModules, manualChunkModulesByAlias);
 			}
-			
+
 			// TODO: there is one special edge case unhandled here and that is that any module
 			//       exposed as an unresolvable export * (to a graph external export *,
 			//       either as a namespace import reexported or top-level export *)
@@ -293,7 +293,7 @@ export default class Graph {
 						chunkModules[entryPointsHashStr] = [module];
 					}
 				}
-				
+
 				for (const entryHashSum in chunkModules) {
 					const chunkModulesOrdered = chunkModules[entryHashSum];
 					sortByExecutionOrder(chunkModulesOrdered);
@@ -301,7 +301,7 @@ export default class Graph {
 					chunks.push(chunk);
 				}
 			}
-			
+
 			for (const chunk of chunks) {
 				chunk.link();
 			}
@@ -310,9 +310,9 @@ export default class Graph {
 			for (const chunk of chunks) {
 				facades.push(...chunk.generateFacades());
 			}
-			
+
 			timeEnd('generate chunks', 2);
-			
+
 			this.phase = BuildPhase.GENERATE;
 			return chunks.concat(facades);
 		})();

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -182,10 +182,9 @@ export class ModuleLoader {
 				unresolvedManualChunks.push({ id, alias });
 			}
 		}
+		const _ = unresolvedManualChunks.map(({ id }) => this.loadEntryModule(id, false));
 		const loadNewManualChunkModulesPromise = (async () => {
-			const manualChunkModules = await Promise.all(
-				unresolvedManualChunks.map(({ id }) => this.loadEntryModule(id, false))
-			);
+			const manualChunkModules = await Promise.all(_);
 			for (let index = 0; index < manualChunkModules.length; index++) {
 				this.addModuleToManualChunk(unresolvedManualChunks[index].alias, manualChunkModules[index]);
 			}
@@ -251,7 +250,7 @@ export class ModuleLoader {
 				);
 			})
 		);
-		if (fetchDynamicImportsPromise as unknown instanceof Promise) {
+		if (typeof fetchDynamicImportsPromise.catch === 'function') {
 			fetchDynamicImportsPromise.catch(() => {});
 		}
 		await Promise.all(

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -314,7 +314,7 @@ export class ModuleLoader {
 						}
 						return cachedModule;
 					}
-					
+
 					if (typeof sourceDescription.moduleSideEffects === 'boolean') {
 						module.moduleSideEffects = sourceDescription.moduleSideEffects;
 					}
@@ -332,7 +332,7 @@ export class ModuleLoader {
 					const id = module.resolvedIds[source].id;
 					const exportAllModule = this.modulesById.get(id);
 					if (exportAllModule instanceof ExternalModule) return;
-					
+
 					for (const name in (exportAllModule as Module).exportsAll) {
 						if (name in module.exportsAll) {
 							this.graph.warn(errNamespaceConflict(name, module, exportAllModule as Module));

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -280,8 +280,9 @@ export default async function rollup(rawInputOptions: GenericConfigObject): Prom
 	const result: RollupBuild = {
 		cache: cache as RollupCache,
 		generate: ((rawOutputOptions: GenericConfigObject) => {
+			const _ = generate(getOutputOptions(rawOutputOptions), false);
 			const promise = (async () => {
-				const result = await generate(getOutputOptions(rawOutputOptions), false);
+				const result = await _;
 				return createOutput(result);
 			})();
 			if (promise as unknown instanceof Promise) {
@@ -299,8 +300,9 @@ export default async function rollup(rawInputOptions: GenericConfigObject): Prom
 					message: 'You must specify "output.file" or "output.dir" for the build.'
 				});
 			}
+			const _ = generate(outputOptions, true);
 			return (async () => {
-				const bundle = await generate(outputOptions, true);
+				const bundle = await _;
 				let chunkCnt = 0;
 				for (const fileName of Object.keys(bundle)) {
 					const file = bundle[fileName];

--- a/src/utils/FileEmitter.ts
+++ b/src/utils/FileEmitter.ts
@@ -267,18 +267,19 @@ export class FileEmitter {
 			name: emittedChunk.name || emittedChunk.id,
 			type: 'chunk'
 		};
+		const _ = this.graph.moduleLoader.addEntryModules(
+			[
+				{
+					fileName: emittedChunk.fileName || null,
+					id: emittedChunk.id as string,
+					name: emittedChunk.name || null
+				}
+			],
+			false
+		);
 		(async () => {
 			try {
-				const { newEntryModules: [module] } = await this.graph.moduleLoader.addEntryModules(
-					[
-						{
-							fileName: emittedChunk.fileName || null,
-							id: emittedChunk.id as string,
-							name: emittedChunk.name || null
-						}
-					],
-					false
-				);
+				const { newEntryModules: [module] } = await _;
 				consumedChunk.module = module;
 			} catch (error) {
 				// Avoid unhandled Promise rejection as the error will be thrown later

--- a/src/utils/FileEmitter.ts
+++ b/src/utils/FileEmitter.ts
@@ -267,25 +267,24 @@ export class FileEmitter {
 			name: emittedChunk.name || emittedChunk.id,
 			type: 'chunk'
 		};
-		this.graph.moduleLoader
-			.addEntryModules(
-				[
-					{
-						fileName: emittedChunk.fileName || null,
-						id: emittedChunk.id,
-						name: emittedChunk.name || null
-					}
-				],
-				false
-			)
-			.then(({ newEntryModules: [module] }) => {
+		(async () => {
+			try {
+				const { newEntryModules: [module] } = await this.graph.moduleLoader.addEntryModules(
+					[
+						{
+							fileName: emittedChunk.fileName || null,
+							id: emittedChunk.id as string,
+							name: emittedChunk.name || null
+						}
+					],
+					false
+				);
 				consumedChunk.module = module;
-			})
-			.catch(() => {
+			} catch (error) {
 				// Avoid unhandled Promise rejection as the error will be thrown later
 				// once module loading has finished
-			});
-
+			}
+		})();
 		return this.assignReferenceId(consumedChunk, emittedChunk.id);
 	}
 

--- a/src/utils/addons.ts
+++ b/src/utils/addons.ts
@@ -33,14 +33,14 @@ export function createAddons(graph: Graph, options: OutputOptions): Promise<Addo
 		pluginDriver.hookReduceValue('intro', evalIfFn(options.intro), [], concatDblSep),
 		pluginDriver.hookReduceValue('outro', evalIfFn(options.outro), [], concatDblSep)
 	];
-	return (async () :Promise<any> => {
+	return (async () => {
 		try {
 			let [banner, footer, intro, outro] = await Promise.all(_);
 			if (intro) intro += '\n\n';
 			if (outro) outro = `\n\n${outro}`;
 			if (banner.length) banner += '\n';
 			if (footer.length) footer = '\n' + footer;
-			return { intro, outro, banner, footer };
+			return { intro, outro, banner, footer } as any;
 		} catch (err) {
 			error({
 				code: 'ADDON_ERROR',

--- a/src/utils/addons.ts
+++ b/src/utils/addons.ts
@@ -27,25 +27,26 @@ const concatDblSep = (out: string, next: string) => (next ? `${out}\n\n${next}` 
 
 export function createAddons(graph: Graph, options: OutputOptions): Promise<Addons> {
 	const pluginDriver = graph.pluginDriver;
-	return Promise.all([
+	const _ = [
 		pluginDriver.hookReduceValue('banner', evalIfFn(options.banner), [], concatSep),
 		pluginDriver.hookReduceValue('footer', evalIfFn(options.footer), [], concatSep),
 		pluginDriver.hookReduceValue('intro', evalIfFn(options.intro), [], concatDblSep),
 		pluginDriver.hookReduceValue('outro', evalIfFn(options.outro), [], concatDblSep)
-	])
-		.then(([banner, footer, intro, outro]) => {
+	];
+	return (async () :Promise<any> => {
+		try {
+			let [banner, footer, intro, outro] = await Promise.all(_);
 			if (intro) intro += '\n\n';
 			if (outro) outro = `\n\n${outro}`;
 			if (banner.length) banner += '\n';
 			if (footer.length) footer = '\n' + footer;
-
 			return { intro, outro, banner, footer };
-		})
-		.catch((err): any => {
+		} catch (err) {
 			error({
 				code: 'ADDON_ERROR',
 				message: `Could not retrieve ${err.hook}. Check configuration of plugin ${err.plugin}.
 \tError Message: ${err.message}`
 			});
-		});
+		}
+	})();
 }

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -98,101 +98,103 @@ export default function transform(
 
 	let setAssetSourceErr: any;
 
-	return graph.pluginDriver
-		.hookReduceArg0<any, string>(
-			'transform',
-			[curSource, id],
-			transformReducer,
-			(pluginContext, plugin) => {
-				curPlugin = plugin;
-				if (curPlugin.cacheKey) customTransformCache = true;
-				else trackedPluginCache = trackPluginCache(pluginContext.cache);
-				return {
-					...pluginContext,
-					cache: trackedPluginCache ? trackedPluginCache.cache : pluginContext.cache,
-					warn(warning: RollupWarning | string, pos?: number | { column: number; line: number }) {
-						if (typeof warning === 'string') warning = { message: warning } as RollupWarning;
-						if (pos) augmentCodeLocation(warning, pos, curSource, id);
-						warning.id = id;
-						warning.hook = 'transform';
-						pluginContext.warn(warning);
-					},
-					error(err: RollupError | string, pos?: number | { column: number; line: number }): never {
-						if (typeof err === 'string') err = { message: err };
-						if (pos) augmentCodeLocation(err, pos, curSource, id);
-						err.id = id;
-						err.hook = 'transform';
-						return pluginContext.error(err);
-					},
-					emitAsset(name: string, source?: string | Buffer) {
-						const emittedFile = { type: 'asset' as 'asset', name, source };
-						emittedFiles.push({ ...emittedFile });
-						return graph.pluginDriver.emitFile(emittedFile);
-					},
-					emitChunk(id, options) {
-						const emittedFile = { type: 'chunk' as 'chunk', id, name: options && options.name };
-						emittedFiles.push({ ...emittedFile });
-						return graph.pluginDriver.emitFile(emittedFile);
-					},
-					emitFile(emittedFile: EmittedFile) {
-						emittedFiles.push(emittedFile);
-						return graph.pluginDriver.emitFile(emittedFile);
-					},
-					addWatchFile(id: string) {
-						transformDependencies.push(id);
-						pluginContext.addWatchFile(id);
-					},
-					setAssetSource(assetReferenceId, source) {
-						pluginContext.setAssetSource(assetReferenceId, source);
-						if (!customTransformCache && !setAssetSourceErr) {
-							try {
-								this.error({
-									code: 'INVALID_SETASSETSOURCE',
-									message: `setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.`
-								});
-							} catch (err) {
-								setAssetSourceErr = err;
+	return (async () => {
+		let code;
+		try {
+			code = await graph.pluginDriver.hookReduceArg0<any, string>(
+				'transform',
+				[curSource, id],
+				transformReducer,
+				(pluginContext, plugin) => {
+					curPlugin = plugin;
+					if (curPlugin.cacheKey) customTransformCache = true;
+					else trackedPluginCache = trackPluginCache(pluginContext.cache);
+					return {
+						...pluginContext,
+						cache: trackedPluginCache ? trackedPluginCache.cache : pluginContext.cache,
+						warn(warning: RollupWarning | string, pos?: number | { column: number; line: number }) {
+							if (typeof warning === 'string') warning = { message: warning } as RollupWarning;
+							if (pos) augmentCodeLocation(warning, pos, curSource, id);
+							warning.id = id;
+							warning.hook = 'transform';
+							pluginContext.warn(warning);
+						},
+						error(err: RollupError | string, pos?: number | { column: number; line: number }): never {
+							if (typeof err === 'string') err = { message: err };
+							if (pos) augmentCodeLocation(err, pos, curSource, id);
+							err.id = id;
+							err.hook = 'transform';
+							return pluginContext.error(err);
+						},
+						emitAsset(name: string, source?: string | Buffer) {
+							const emittedFile = { type: 'asset' as 'asset', name, source };
+							emittedFiles.push({ ...emittedFile });
+							return graph.pluginDriver.emitFile(emittedFile);
+						},
+						emitChunk(id, options) {
+							const emittedFile = { type: 'chunk' as 'chunk', id, name: options && options.name };
+							emittedFiles.push({ ...emittedFile });
+							return graph.pluginDriver.emitFile(emittedFile);
+						},
+						emitFile(emittedFile: EmittedFile) {
+							emittedFiles.push(emittedFile);
+							return graph.pluginDriver.emitFile(emittedFile);
+						},
+						addWatchFile(id: string) {
+							transformDependencies.push(id);
+							pluginContext.addWatchFile(id);
+						},
+						setAssetSource(assetReferenceId, source) {
+							pluginContext.setAssetSource(assetReferenceId, source);
+							if (!customTransformCache && !setAssetSourceErr) {
+								try {
+									this.error({
+										code: 'INVALID_SETASSETSOURCE',
+										message: `setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.`
+									});
+								} catch (err) {
+									setAssetSourceErr = err;
+								}
 							}
+						},
+						getCombinedSourcemap() {
+							const combinedMap = collapseSourcemap(
+								graph,
+								id,
+								originalCode,
+								originalSourcemap,
+								sourcemapChain
+							);
+							if (!combinedMap) {
+								const magicString = new MagicString(originalCode);
+								return magicString.generateMap({ includeContent: true, hires: true, source: id });
+							}
+							if (originalSourcemap !== combinedMap) {
+								originalSourcemap = combinedMap;
+								sourcemapChain.length = 0;
+							}
+							return new SourceMap({
+								...combinedMap,
+								file: null as any,
+								sourcesContent: combinedMap.sourcesContent as string[]
+							});
 						}
-					},
-					getCombinedSourcemap() {
-						const combinedMap = collapseSourcemap(
-							graph,
-							id,
-							originalCode,
-							originalSourcemap,
-							sourcemapChain
-						);
-						if (!combinedMap) {
-							const magicString = new MagicString(originalCode);
-							return magicString.generateMap({ includeContent: true, hires: true, source: id });
-						}
-						if (originalSourcemap !== combinedMap) {
-							originalSourcemap = combinedMap;
-							sourcemapChain.length = 0;
-						}
-						return new SourceMap({
-							...combinedMap,
-							file: null as any,
-							sourcesContent: combinedMap.sourcesContent as string[]
-						});
-					}
-				};
-			}
-		)
-		.catch(err => throwPluginError(err, curPlugin.name, { hook: 'transform', id }))
-		.then(code => {
-			if (!customTransformCache && setAssetSourceErr) throw setAssetSourceErr;
-
-			return {
-				ast: ast as any,
-				code,
-				customTransformCache,
-				moduleSideEffects,
-				originalCode,
-				originalSourcemap,
-				sourcemapChain,
-				transformDependencies
-			};
-		});
+					};
+				}
+			);
+		} catch (err) {
+			code = await throwPluginError(err, curPlugin!.name, { hook: 'transform', id });
+		}
+		if (!customTransformCache && setAssetSourceErr) throw setAssetSourceErr;
+		return {
+			ast: ast as any,
+			code,
+			customTransformCache,
+			moduleSideEffects,
+			originalCode,
+			originalSourcemap,
+			sourcemapChain,
+			transformDependencies
+		};
+	})();
 }

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -88,10 +88,10 @@ export class Watcher {
 
 		try {
 			for (const task of this.tasks) await task.run();
-			
+
 			this.succeeded = true;
 			this.running = false;
-			
+
 			this.emit('event', {
 				code: 'END'
 			});
@@ -102,7 +102,7 @@ export class Watcher {
 				error
 			});
 		}
-		
+
 		if (this.rerun) {
 			this.rerun = false;
 			this.invalidate();
@@ -211,7 +211,7 @@ export class Task {
 				if (this.closed) return undefined as any;
 				const previouslyWatched = this.watched;
 				const watched = (this.watched = new Set());
-				
+
 				this.cache = result.cache;
 				this.watchFiles = result.watchFiles;
 				for (const module of this.cache.modules as ModuleJSON[]) {
@@ -229,9 +229,9 @@ export class Task {
 				for (const id of previouslyWatched) {
 					if (!watched.has(id)) deleteTask(id, this, this.chokidarOptionsHash);
 				}
-				
+
 				await Promise.all(this.outputs.map(output => result.write(output)))
-				
+
 				this.watcher.emit('event', {
 					code: 'BUNDLE_END',
 					duration: Date.now() - start,
@@ -241,7 +241,7 @@ export class Task {
 				});
 			} catch (error) {
 				if (this.closed) return;
-				
+
 				if (this.cache) {
 					// this is necessary to ensure that any 'renamed' files
 					// continue to be watched following an error

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -207,7 +207,7 @@ export class Task {
 		setWatcher(this.watcher.emitter);
 		return (async () => {
 			try {
-				const result :RollupBuild = await rollup(options);
+				const result: RollupBuild = await rollup(options);
 				if (this.closed) return undefined as any;
 				const previouslyWatched = this.watched;
 				const watched = (this.watched = new Set());


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

## 4 places may be mistake in /src/utils/pluginDriver.ts <kbd>important</kbd>

These seem like typical closure mistake for variable `i`, so I left them as-is. But I'm not sure @lukastaegert . If it is, I will recorrect them. Some of them seem to be the reason why checks failed. I just wonder how PR before passed.

https://github.com/rollup/rollup/blob/9879cbcf86ed9dad04691cf4f3a23bacd87e1863/src/utils/pluginDriver.ts#L394

https://github.com/rollup/rollup/blob/9879cbcf86ed9dad04691cf4f3a23bacd87e1863/src/utils/pluginDriver.ts#L411

https://github.com/rollup/rollup/blob/9879cbcf86ed9dad04691cf4f3a23bacd87e1863/src/utils/pluginDriver.ts#L442
(and several lines below)

https://github.com/rollup/rollup/blob/9879cbcf86ed9dad04691cf4f3a23bacd87e1863/src/utils/pluginDriver.ts#L466
(and several lines below)

## one kind of case may be improvable

codes like:

```js
function f () {
  return g().then(() => { /* thing */ });
}
```

are refactored to:

```js
function f () {
  const _ = g();
  return (async () => {
    await _;
    /* thing */
  })();
}
```

rather than:

```js
async function f () {
  await g();
  /* thing */
}
```

because sync error may be thrown by `g()`. My priority is to ensure semantic consistency.

If they are not intended, the code could be more beautiful.
