### PR TITLE
Fix wrong variable name in import expression

### DIFF
--- a/src/ast/nodes/ImportExpression.ts
+++ b/src/ast/nodes/ImportExpression.ts
@@ -54,6 +54,7 @@ export default class Import extends NodeBase {
 			);
 			code.overwrite(this.end - 1, this.end, importMechanism.right);
 		}
+		this.source.render(code, options);
 	}
 
 	renderFinalResolution(code: MagicString, resolution: string, format: string) {

--- a/test/form/samples/import-expression/_config.js
+++ b/test/form/samples/import-expression/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	solo: true,
+	description: 'correctly transforms variables in imported expressions',
+	options: {
+		external: 'external'
+	}
+};

--- a/test/form/samples/import-expression/_config.js
+++ b/test/form/samples/import-expression/_config.js
@@ -1,5 +1,4 @@
 module.exports = {
-	solo: true,
 	description: 'correctly transforms variables in imported expressions',
 	options: {
 		external: 'external'

--- a/test/form/samples/import-expression/_expected/amd.js
+++ b/test/form/samples/import-expression/_expected/amd.js
@@ -1,0 +1,25 @@
+define(['require', 'external'], function (require, external) { 'use strict';
+
+	function _interopNamespace(e) {
+		if (e && e.__esModule) { return e; } else {
+			var n = {};
+			if (e) {
+				Object.keys(e).forEach(function (k) {
+					var d = Object.getOwnPropertyDescriptor(e, k);
+					Object.defineProperty(n, k, d.get ? d : {
+						enumerable: true,
+						get: function () {
+							return e[k];
+						}
+					});
+				});
+			}
+			n['default'] = e;
+			return n;
+		}
+	}
+
+	new Promise(function (resolve, reject) { require([external.join('a', 'b')], function (m) { resolve(_interopNamespace(m)); }, reject) });
+	console.log(external.join);
+
+});

--- a/test/form/samples/import-expression/_expected/cjs.js
+++ b/test/form/samples/import-expression/_expected/cjs.js
@@ -1,0 +1,25 @@
+'use strict';
+
+function _interopNamespace(e) {
+	if (e && e.__esModule) { return e; } else {
+		var n = {};
+		if (e) {
+			Object.keys(e).forEach(function (k) {
+				var d = Object.getOwnPropertyDescriptor(e, k);
+				Object.defineProperty(n, k, d.get ? d : {
+					enumerable: true,
+					get: function () {
+						return e[k];
+					}
+				});
+			});
+		}
+		n['default'] = e;
+		return n;
+	}
+}
+
+var external = require('external');
+
+new Promise(function (resolve) { resolve(_interopNamespace(require(external.join('a', 'b')))); });
+console.log(external.join);

--- a/test/form/samples/import-expression/_expected/es.js
+++ b/test/form/samples/import-expression/_expected/es.js
@@ -1,0 +1,4 @@
+import { join } from 'external';
+
+import(join('a', 'b'));
+console.log(join);

--- a/test/form/samples/import-expression/_expected/iife.js
+++ b/test/form/samples/import-expression/_expected/iife.js
@@ -1,0 +1,7 @@
+(function (external) {
+	'use strict';
+
+	import(external.join('a', 'b'));
+	console.log(external.join);
+
+}(external));

--- a/test/form/samples/import-expression/_expected/system.js
+++ b/test/form/samples/import-expression/_expected/system.js
@@ -1,0 +1,15 @@
+System.register(['external'], function (exports, module) {
+	'use strict';
+	var join;
+	return {
+		setters: [function (module) {
+			join = module.join;
+		}],
+		execute: function () {
+
+			module.import(join('a', 'b'));
+			console.log(join);
+
+		}
+	};
+});

--- a/test/form/samples/import-expression/_expected/umd.js
+++ b/test/form/samples/import-expression/_expected/umd.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
+	typeof define === 'function' && define.amd ? define(['external'], factory) :
+	(global = global || self, factory(global.external));
+}(this, function (external) { 'use strict';
+
+	import(external.join('a', 'b'));
+	console.log(external.join);
+
+}));

--- a/test/form/samples/import-expression/main.js
+++ b/test/form/samples/import-expression/main.js
@@ -1,0 +1,4 @@
+import { join as pathJoin } from 'external';
+
+import(pathJoin('a', 'b'));
+console.log(pathJoin);


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3072 

### Description
Import expressions did not properly render their source, which meant that variable name changes could be lost.