### PR TITLE
Fixes type definition on watch and Watcher constructor.

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -28,7 +28,7 @@ export class Watcher {
 	private succeeded = false;
 	private tasks: Task[];
 
-	constructor(configs: GenericConfigObject[]) {
+	constructor(configs: GenericConfigObject[] | GenericConfigObject) {
 		this.emitter = new (class extends EventEmitter implements RollupWatcher {
 			close: () => void;
 			constructor(close: () => void) {
@@ -279,6 +279,6 @@ export class Task {
 	}
 }
 
-export default function watch(configs: GenericConfigObject[]): RollupWatcher {
+export default function watch(configs: GenericConfigObject[] | GenericConfigObject): RollupWatcher {
 	return new Watcher(configs).emitter;
 }


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no - This is a bug in the type definitions, not in the runtime code.

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

### Description
As seen on line 42, this function actually accepts either a `GenericConfigObject[]` or a `GenericConfigObject`.  The documentation uses the non-array form, which results in a user following the documentation in TypeScript getting a type checker error.