### PR TITLE
Adds type definitions for RollupWatcher events.

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -584,7 +584,16 @@ export interface RollupWatchOptions extends InputOptions {
 	watch?: WatcherOptions;
 }
 
+type RollupWatcherEvent =
+	{code:'START'}
+	| {code: 'BUNDLE_START', input: InputOption, output: string | undefined}
+	| {code: 'BUNDLE_END', duration: number, input: InputOption, output: string | undefined, result: RollupBuild}
+	| {code:'END'}
+	| {code:'ERROR', error:Error}
+	| {code:'FATAL', error:Error}
+
 export interface RollupWatcher extends EventEmitter {
+	on(event: 'event', listener: (event: RollupWatcherEvent) => void): void;
 	close(): void;
 }
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -593,7 +593,7 @@ type RollupWatcherEvent =
 	| {code:'FATAL', error:Error}
 
 export interface RollupWatcher extends EventEmitter {
-	on(event: 'event', listener: (event: RollupWatcherEvent) => void): void;
+	on(event: 'event', listener: (event: RollupWatcherEvent) => void): this;
 	close(): void;
 }
 


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

### Description

The type information is extracted from https://github.com/rollup/rollup/blob/master/src/watch/index.ts, someone should double check that I got it all right.  I'm new to rollup and have never actually used any of this stuff, but when I tried to I ran into the problem of there being no useful type information which caused me to have to read source code.  Rather than having everyone suffer like I did, I decided to create a PR to resolve the issue.