### PR TITLE
Permit plugins to add assets directly to the bundle in Rollup 1.x

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -272,6 +272,16 @@ export default async function rollup(rawInputOptions: GenericConfigObject): Prom
 			throw error;
 		}
 		await graph.pluginDriver.hookSeq('generateBundle', [outputOptions, outputBundle, isWrite]);
+		for (const key of Object.keys(outputBundle)) {
+			const file = outputBundle[key] as any;
+			if (!file.type) {
+				graph.warnDeprecation(
+					'A plugin is directly adding properties to the bundle object in the "generateBundle" hook. This is deprecated and will be removed in a future Rollup version, please use "this.emitAsset" instead.',
+					false
+				);
+				file.type = 'asset';
+			}
+		}
 		graph.pluginDriver.finaliseAssets();
 
 		timeEnd('GENERATE', 1);

--- a/test/form/samples/deprecated/emit-asset-hacky/_config.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/_config.js
@@ -1,0 +1,16 @@
+module.exports = {
+	description: 'supports emitting assets in a hacky way by editing the bundle object',
+	options: {
+		strictDeprecations: false,
+		plugins: {
+			generateBundle(options, outputBundle) {
+				const file = {
+					fileName: 'my-hacky-asset.txt',
+					isAsset: true,
+					source: 'My Hacky Source'
+				};
+				outputBundle[file.fileName] = file;
+			}
+		}
+	}
+};

--- a/test/form/samples/deprecated/emit-asset-hacky/_expected/amd.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/_expected/amd.js
@@ -1,0 +1,5 @@
+define(function () { 'use strict';
+
+	console.log('main');
+
+});

--- a/test/form/samples/deprecated/emit-asset-hacky/_expected/cjs.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/_expected/cjs.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('main');

--- a/test/form/samples/deprecated/emit-asset-hacky/_expected/es.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/_expected/es.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/test/form/samples/deprecated/emit-asset-hacky/_expected/iife.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/_expected/iife.js
@@ -1,0 +1,6 @@
+(function () {
+	'use strict';
+
+	console.log('main');
+
+}());

--- a/test/form/samples/deprecated/emit-asset-hacky/_expected/my-hacky-asset.txt
+++ b/test/form/samples/deprecated/emit-asset-hacky/_expected/my-hacky-asset.txt
@@ -1,0 +1,1 @@
+My Hacky Source

--- a/test/form/samples/deprecated/emit-asset-hacky/_expected/system.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/_expected/system.js
@@ -1,0 +1,10 @@
+System.register([], function () {
+	'use strict';
+	return {
+		execute: function () {
+
+			console.log('main');
+
+		}
+	};
+});

--- a/test/form/samples/deprecated/emit-asset-hacky/_expected/umd.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/_expected/umd.js
@@ -1,0 +1,8 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+}(function () { 'use strict';
+
+	console.log('main');
+
+}));

--- a/test/form/samples/deprecated/emit-asset-hacky/main.js
+++ b/test/form/samples/deprecated/emit-asset-hacky/main.js
@@ -1,0 +1,1 @@
+console.log('main');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3104

### Description
Apparently some plugins heavily depend on the ability to directly add assets to the bundle object. This will permit this workflow again but add a deprecation message that will show when using `strictDeprecations`.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
