### PR TITLE
Use asterisk for @types/* dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
   },
   "homepage": "https://github.com/rollup/rollup",
   "dependencies": {
-    "@types/estree": "0.0.39",
-    "@types/node": "^12.7.5",
+    "@types/estree": "*",
+    "@types/node": "*",
     "acorn": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no
- [x] not sure

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Could we use asterisk instead of fixed version for `@types/node` and possible other `@types/*` dependencies?

This is how [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped) publish their packages with dependencies to other typings (for example see [`@types/react/package.json`](https://unpkg.com/browse/@types/react/package.json)). It allows users to instal a single version of package with necessary typings.

I believe that it may reduce the size of `node_modules` folder.
