### PR TITLE
Wire up --context CLI flag

### DIFF
--- a/src/utils/mergeOptions.ts
+++ b/src/utils/mergeOptions.ts
@@ -213,7 +213,7 @@ function getInputOptions(
 		acornInjectPlugins: config.acornInjectPlugins as any,
 		cache: getOption('cache'),
 		chunkGroupingSize: getOption('chunkGroupingSize', 5000),
-		context: config.context as any,
+		context: getOption('context'),
 		experimentalCacheExpiry: getOption('experimentalCacheExpiry', 10),
 		experimentalOptimizeChunks: getOption('experimentalOptimizeChunks'),
 		experimentalTopLevelAwait: getOption('experimentalTopLevelAwait'),

--- a/test/cli/samples/context/_config.js
+++ b/test/cli/samples/context/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'Uses --context to set `this` value',
+	command: 'rollup main.js --format commonjs --context window'
+};

--- a/test/cli/samples/context/_expected.js
+++ b/test/cli/samples/context/_expected.js
@@ -1,0 +1,6 @@
+'use strict';
+
+console.log(window);
+var main = 42;
+
+module.exports = main;

--- a/test/cli/samples/context/main.js
+++ b/test/cli/samples/context/main.js
@@ -1,0 +1,2 @@
+console.log(this);
+export default 42;


### PR DESCRIPTION
Fixes #3121

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

#3121

### Description

It looks like --context was not wired up in mergeOptions. Using the `createGetOption` helper to check both the config and command line options.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
