### PR TITLE
Remove Symbol polyfill in module namespaces

### DIFF
--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -98,10 +98,8 @@ export default class NamespaceVariable extends Variable {
 		const name = this.getName();
 
 		const callee = options.freeze ? `/*#__PURE__*/Object.freeze` : '';
-
-		let output = `${options.varOrConst} ${name} = ${`${callee}({${n}${members.join(
-			`,${n}`
-		)}${n}});`}`;
+		const membersStr = members.join(`,${n}`);
+		let output = `${options.varOrConst} ${name}${_}=${_}${callee}({${n}${membersStr}${n}});`;
 
 		if (options.format === 'system' && this.exportName) {
 			output += `${n}exports('${this.exportName}',${_}${name});`;

--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -91,25 +91,17 @@ export default class NamespaceVariable extends Variable {
 			return `${t}${safeName}: ${original.getName()}`;
 		});
 
+		if (options.namespaceToStringTag) {
+			members.unshift(`${t}[Symbol.toStringTag]:${_}'Module'`);
+		}
+
 		const name = this.getName();
 
 		const callee = options.freeze ? `/*#__PURE__*/Object.freeze` : '';
 
-		let output = `${options.varOrConst} ${name} = ${
-			options.namespaceToStringTag
-				? `{${n}${members.join(`,${n}`)}${n}};`
-				: `${callee}({${n}${members.join(`,${n}`)}${n}});`
-		}`;
-
-		if (options.namespaceToStringTag) {
-			output += `${n}if${_}(typeof Symbol${_}!==${_}'undefined'${_}&&${_}Symbol.toStringTag)${n}`;
-			output += `${t}Object.defineProperty(${name},${_}Symbol.toStringTag,${_}{${_}value:${_}'Module'${_}});${n}`;
-			output += `else${n || ' '}`;
-			output += `${t}Object.defineProperty(${name},${_}'toString',${_}{${_}value:${_}function${_}()${_}{${_}return${_}'[object Module]'${
-				options.compact ? ';' : ''
-			}${_}}${_}});${n}`;
-			output += `${callee}(${name});`;
-		}
+		let output = `${options.varOrConst} ${name} = ${`${callee}({${n}${members.join(
+			`,${n}`
+		)}${n}});`}`;
 
 		if (options.format === 'system' && this.exportName) {
 			output += `${n}exports('${this.exportName}',${_}${name});`;

--- a/test/form/samples/compact/_expected/amd.js
+++ b/test/form/samples/compact/_expected/amd.js
@@ -1,4 +1,4 @@
-define(['external'],function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
+define(['external'],function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/amd.js
+++ b/test/form/samples/compact/_expected/amd.js
@@ -1,4 +1,4 @@
-define(['external'],function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = {get default(){return foo}};if(typeof Symbol!=='undefined'&&Symbol.toStringTag)Object.defineProperty(self,Symbol.toStringTag,{value:'Module'});else Object.defineProperty(self,'toString',{value:function(){return'[object Module]';}});/*#__PURE__*/Object.freeze(self);console.log(self);
+define(['external'],function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/cjs.js
+++ b/test/form/samples/compact/_expected/cjs.js
@@ -1,4 +1,4 @@
-'use strict';function _interopDefault(e){return(e&&(typeof e==='object')&&'default'in e)?e['default']:e}var x=_interopDefault(require('external'));var self = {get default(){return foo}};if(typeof Symbol!=='undefined'&&Symbol.toStringTag)Object.defineProperty(self,Symbol.toStringTag,{value:'Module'});else Object.defineProperty(self,'toString',{value:function(){return'[object Module]';}});/*#__PURE__*/Object.freeze(self);console.log(self);
+'use strict';function _interopDefault(e){return(e&&(typeof e==='object')&&'default'in e)?e['default']:e}var x=_interopDefault(require('external'));var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/cjs.js
+++ b/test/form/samples/compact/_expected/cjs.js
@@ -1,4 +1,4 @@
-'use strict';function _interopDefault(e){return(e&&(typeof e==='object')&&'default'in e)?e['default']:e}var x=_interopDefault(require('external'));var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
+'use strict';function _interopDefault(e){return(e&&(typeof e==='object')&&'default'in e)?e['default']:e}var x=_interopDefault(require('external'));var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/es.js
+++ b/test/form/samples/compact/_expected/es.js
@@ -1,4 +1,4 @@
-import x from'external';var self = {get default(){return foo}};if(typeof Symbol!=='undefined'&&Symbol.toStringTag)Object.defineProperty(self,Symbol.toStringTag,{value:'Module'});else Object.defineProperty(self,'toString',{value:function(){return'[object Module]';}});/*#__PURE__*/Object.freeze(self);console.log(self);
+import x from'external';var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/es.js
+++ b/test/form/samples/compact/_expected/es.js
@@ -1,4 +1,4 @@
-import x from'external';var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
+import x from'external';var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/iife.js
+++ b/test/form/samples/compact/_expected/iife.js
@@ -1,4 +1,4 @@
-var foo=(function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = {get default(){return foo}};if(typeof Symbol!=='undefined'&&Symbol.toStringTag)Object.defineProperty(self,Symbol.toStringTag,{value:'Module'});else Object.defineProperty(self,'toString',{value:function(){return'[object Module]';}});/*#__PURE__*/Object.freeze(self);console.log(self);
+var foo=(function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/iife.js
+++ b/test/form/samples/compact/_expected/iife.js
@@ -1,4 +1,4 @@
-var foo=(function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
+var foo=(function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/system.js
+++ b/test/form/samples/compact/_expected/system.js
@@ -1,4 +1,4 @@
-System.register('foo',['external'],function(exports){'use strict';var x;return{setters:[function(module){x=module.default;}],execute:function(){exports('default',foo);var self = {get default(){return foo}};if(typeof Symbol!=='undefined'&&Symbol.toStringTag)Object.defineProperty(self,Symbol.toStringTag,{value:'Module'});else Object.defineProperty(self,'toString',{value:function(){return'[object Module]';}});/*#__PURE__*/Object.freeze(self);console.log(self);
+System.register('foo',['external'],function(exports){'use strict';var x;return{setters:[function(module){x=module.default;}],execute:function(){exports('default',foo);var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/system.js
+++ b/test/form/samples/compact/_expected/system.js
@@ -1,4 +1,4 @@
-System.register('foo',['external'],function(exports){'use strict';var x;return{setters:[function(module){x=module.default;}],execute:function(){exports('default',foo);var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
+System.register('foo',['external'],function(exports){'use strict';var x;return{setters:[function(module){x=module.default;}],execute:function(){exports('default',foo);var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/umd.js
+++ b/test/form/samples/compact/_expected/umd.js
@@ -1,4 +1,4 @@
-(function(g,f){typeof exports==='object'&&typeof module!=='undefined'?module.exports=f(require('external')):typeof define==='function'&&define.amd?define(['external'],f):(g=g||self,g.foo=f(g.x));}(this,function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
+(function(g,f){typeof exports==='object'&&typeof module!=='undefined'?module.exports=f(require('external')):typeof define==='function'&&define.amd?define(['external'],f):(g=g||self,g.foo=f(g.x));}(this,function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/umd.js
+++ b/test/form/samples/compact/_expected/umd.js
@@ -1,4 +1,4 @@
-(function(g,f){typeof exports==='object'&&typeof module!=='undefined'?module.exports=f(require('external')):typeof define==='function'&&define.amd?define(['external'],f):(g=g||self,g.foo=f(g.x));}(this,function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = {get default(){return foo}};if(typeof Symbol!=='undefined'&&Symbol.toStringTag)Object.defineProperty(self,Symbol.toStringTag,{value:'Module'});else Object.defineProperty(self,'toString',{value:function(){return'[object Module]';}});/*#__PURE__*/Object.freeze(self);console.log(self);
+(function(g,f){typeof exports==='object'&&typeof module!=='undefined'?module.exports=f(require('external')):typeof define==='function'&&define.amd?define(['external'],f):(g=g||self,g.foo=f(g.x));}(this,function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self = /*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/namespace-tostringtag/_expected/amd.js
+++ b/test/form/samples/namespace-tostringtag/_expected/amd.js
@@ -1,13 +1,9 @@
 define(['exports'], function (exports) { 'use strict';
 
-	var self = {
+	var self = /*#__PURE__*/Object.freeze({
+		[Symbol.toStringTag]: 'Module',
 		get p () { return p; }
-	};
-	if (typeof Symbol !== 'undefined' && Symbol.toStringTag)
-		Object.defineProperty(self, Symbol.toStringTag, { value: 'Module' });
-	else
-		Object.defineProperty(self, 'toString', { value: function () { return '[object Module]' } });
-	/*#__PURE__*/Object.freeze(self);
+	});
 
 	console.log(Object.keys(self));
 

--- a/test/form/samples/namespace-tostringtag/_expected/cjs.js
+++ b/test/form/samples/namespace-tostringtag/_expected/cjs.js
@@ -2,14 +2,10 @@
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
-var self = {
+var self = /*#__PURE__*/Object.freeze({
+	[Symbol.toStringTag]: 'Module',
 	get p () { return p; }
-};
-if (typeof Symbol !== 'undefined' && Symbol.toStringTag)
-	Object.defineProperty(self, Symbol.toStringTag, { value: 'Module' });
-else
-	Object.defineProperty(self, 'toString', { value: function () { return '[object Module]' } });
-/*#__PURE__*/Object.freeze(self);
+});
 
 console.log(Object.keys(self));
 

--- a/test/form/samples/namespace-tostringtag/_expected/es.js
+++ b/test/form/samples/namespace-tostringtag/_expected/es.js
@@ -1,11 +1,7 @@
-var self = {
+var self = /*#__PURE__*/Object.freeze({
+	[Symbol.toStringTag]: 'Module',
 	get p () { return p; }
-};
-if (typeof Symbol !== 'undefined' && Symbol.toStringTag)
-	Object.defineProperty(self, Symbol.toStringTag, { value: 'Module' });
-else
-	Object.defineProperty(self, 'toString', { value: function () { return '[object Module]' } });
-/*#__PURE__*/Object.freeze(self);
+});
 
 console.log(Object.keys(self));
 

--- a/test/form/samples/namespace-tostringtag/_expected/iife.js
+++ b/test/form/samples/namespace-tostringtag/_expected/iife.js
@@ -1,14 +1,10 @@
 var iife = (function (exports) {
 	'use strict';
 
-	var self = {
+	var self = /*#__PURE__*/Object.freeze({
+		[Symbol.toStringTag]: 'Module',
 		get p () { return p; }
-	};
-	if (typeof Symbol !== 'undefined' && Symbol.toStringTag)
-		Object.defineProperty(self, Symbol.toStringTag, { value: 'Module' });
-	else
-		Object.defineProperty(self, 'toString', { value: function () { return '[object Module]' } });
-	/*#__PURE__*/Object.freeze(self);
+	});
 
 	console.log(Object.keys(self));
 

--- a/test/form/samples/namespace-tostringtag/_expected/system.js
+++ b/test/form/samples/namespace-tostringtag/_expected/system.js
@@ -3,14 +3,10 @@ System.register('iife', [], function (exports) {
 	return {
 		execute: function () {
 
-			var self = {
+			var self = /*#__PURE__*/Object.freeze({
+				[Symbol.toStringTag]: 'Module',
 				get p () { return p; }
-			};
-			if (typeof Symbol !== 'undefined' && Symbol.toStringTag)
-				Object.defineProperty(self, Symbol.toStringTag, { value: 'Module' });
-			else
-				Object.defineProperty(self, 'toString', { value: function () { return '[object Module]' } });
-			/*#__PURE__*/Object.freeze(self);
+			});
 
 			console.log(Object.keys(self));
 

--- a/test/form/samples/namespace-tostringtag/_expected/umd.js
+++ b/test/form/samples/namespace-tostringtag/_expected/umd.js
@@ -4,14 +4,10 @@
 	(global = global || self, factory(global.iife = {}));
 }(this, function (exports) { 'use strict';
 
-	var self = {
+	var self = /*#__PURE__*/Object.freeze({
+		[Symbol.toStringTag]: 'Module',
 		get p () { return p; }
-	};
-	if (typeof Symbol !== 'undefined' && Symbol.toStringTag)
-		Object.defineProperty(self, Symbol.toStringTag, { value: 'Module' });
-	else
-		Object.defineProperty(self, 'toString', { value: function () { return '[object Module]' } });
-	/*#__PURE__*/Object.freeze(self);
+	});
 
 	console.log(Object.keys(self));
 

--- a/test/function/samples/namespace-tostring/_config.js
+++ b/test/function/samples/namespace-tostring/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'creates Symbol.toStringTag property',
+	options: {
+		output: {
+			namespaceToStringTag: true
+		}
+	}
+};

--- a/test/function/samples/namespace-tostring/foo.js
+++ b/test/function/samples/namespace-tostring/foo.js
@@ -1,0 +1,1 @@
+export const bar = 42;

--- a/test/function/samples/namespace-tostring/main.js
+++ b/test/function/samples/namespace-tostring/main.js
@@ -1,0 +1,4 @@
+import * as foo from './foo';
+
+assert.equal("" + foo, "[object Module]");
+assert.equal(foo.bar, 42);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:

Fixes #3097.

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This simplifies generated code for module namespaces by removing the `Symbol` polyfill. It is technically a breaking change but it was agreed in https://github.com/rollup/rollup/issues/3097#issuecomment-533856451. 