### PR TITLE
Use exported methods instead of accessing files directly from rollup-pluginutils

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -2,7 +2,7 @@ import * as acorn from 'acorn';
 import * as ESTree from 'estree';
 import { locate } from 'locate-character';
 import MagicString from 'magic-string';
-import extractAssignedNames from 'rollup-pluginutils/src/extractAssignedNames';
+import { extractAssignedNames } from 'rollup-pluginutils';
 import { createInclusionContext, InclusionContext } from './ast/ExecutionContext';
 import ClassDeclaration from './ast/nodes/ClassDeclaration';
 import ExportAllDeclaration from './ast/nodes/ExportAllDeclaration';

--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -1,7 +1,7 @@
 import { WatchOptions } from 'chokidar';
 import { EventEmitter } from 'events';
 import path from 'path';
-import createFilter from 'rollup-pluginutils/src/createFilter';
+import { createFilter } from 'rollup-pluginutils';
 import rollup, { setWatcher } from '../rollup/index';
 import {
 	InputOptions,


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

If you want to use rollup built directly with tsc (to avoid self build dependency on rollup, for example in debian), rollup-pluginutils only provides cjs and es files with exports and src directory only contains ts files which cannot be used from js output generated by tsc.

The build command used in debian is https://salsa.debian.org/js-team/node-rollup/blob/master/debian/nodejs/build

We also use the following patches https://salsa.debian.org/js-team/node-rollup/tree/master/debian/patches to avoid using other rollup plugins during build.

We have tested rebuilding all the node modules packaged in debian which uses rollup to build and it works great. If this patch is merged, we have one less patch to maintain in debian and also I think it is consistent with the rest of the code base.