### PR TITLE
Better try statement tree shaking

### DIFF
--- a/src/ast/nodes/SwitchCase.ts
+++ b/src/ast/nodes/SwitchCase.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
 import {
 	findFirstOccurrenceOutsideComment,
+	NodeRenderOptions,
 	RenderOptions,
 	renderStatementList
 } from '../../utils/renderHelpers';
@@ -31,14 +32,20 @@ export default class SwitchCase extends NodeBase {
 		}
 	}
 
-	render(code: MagicString, options: RenderOptions) {
+	render(code: MagicString, options: RenderOptions, nodeRenderOptions?: NodeRenderOptions) {
 		if (this.consequent.length) {
 			this.test && this.test.render(code, options);
 			const testEnd = this.test
 				? this.test.end
 				: findFirstOccurrenceOutsideComment(code.original, 'default', this.start) + 7;
 			const consequentStart = findFirstOccurrenceOutsideComment(code.original, ':', testEnd) + 1;
-			renderStatementList(this.consequent, code, consequentStart, this.end, options);
+			renderStatementList(
+				this.consequent,
+				code,
+				consequentStart,
+				nodeRenderOptions!.end || this.end,
+				options
+			);
 		} else {
 			super.render(code, options);
 		}

--- a/src/ast/nodes/SwitchStatement.ts
+++ b/src/ast/nodes/SwitchStatement.ts
@@ -1,3 +1,5 @@
+import MagicString from 'magic-string';
+import { RenderOptions } from '../../utils/renderHelpers';
 import {
 	BreakFlow,
 	BREAKFLOW_ERROR_RETURN,
@@ -74,6 +76,15 @@ export default class SwitchStatement extends StatementBase {
 		}
 		if (hasDefault && !(minBreakFlow instanceof Set && minBreakFlow.has(null))) {
 			context.breakFlow = minBreakFlow;
+		}
+	}
+
+	render(code: MagicString, options: RenderOptions) {
+		this.discriminant.render(code, options);
+		for (let caseIndex = 0; caseIndex < this.cases.length; caseIndex++) {
+			this.cases[caseIndex].render(code, options, {
+				end: caseIndex + 1 < this.cases.length ? this.cases[caseIndex + 1].start : this.end - 1
+			});
 		}
 	}
 }

--- a/src/ast/nodes/TryStatement.ts
+++ b/src/ast/nodes/TryStatement.ts
@@ -14,8 +14,9 @@ export default class TryStatement extends StatementBase {
 
 	hasEffects(context: HasEffectsContext): boolean {
 		return (
-			this.block.body.length > 0 ||
-			(this.handler !== null && this.handler.hasEffects(context)) ||
+			(this.context.tryCatchDeoptimization
+				? this.block.body.length > 0
+				: this.block.hasEffects(context)) ||
 			(this.finalizer !== null && this.finalizer.hasEffects(context))
 		);
 	}

--- a/test/form/samples/break-control-flow/break-statement-labels-switch/_expected.js
+++ b/test/form/samples/break-control-flow/break-statement-labels-switch/_expected.js
@@ -3,15 +3,12 @@ function returnAll() {
 		case 1:
 			console.log('retained');
 			return;
-
 		case 2:
 			console.log('retained');
 			return;
-
 		default:
 			console.log('retained');
 			return;
-
 	}
 }
 
@@ -25,10 +22,8 @@ function returnNoDefault() {
 	switch (globalThis.unknown) {
 		case 1:
 			return;
-
 		case 2:
 			return;
-
 	}
 	console.log('retained');
 }
@@ -39,13 +34,10 @@ function returnSomeBreak() {
 	switch (globalThis.unknown) {
 		case 1:
 			return;
-
 		case 2:
 			break;
-
 		default:
 			return;
-
 	}
 	console.log('retained');
 }
@@ -64,13 +56,10 @@ function returnBreakDifferentLabels() {
 			switch (globalThis.unknown) {
 				case 1:
 					break outer;
-
 				case 2:
 					break inner;
-
 				default:
 					break outer;
-
 			}
 		}
 		console.log('retained');

--- a/test/form/samples/break-control-flow/switch-errors/_expected.js
+++ b/test/form/samples/break-control-flow/switch-errors/_expected.js
@@ -1,10 +1,8 @@
 switch (globalThis.unknown) {
 	case 1:
 		throw new Error();
-
 	case 2:
 		throw new Error();
-
 	case 3:
 		console.log('retained');
 	default:
@@ -22,5 +20,4 @@ switch (globalThis.unknown) {
 	case 3:
 		var hoisted3;
 	default:
-
 }

--- a/test/form/samples/render-removed-statements/_expected.js
+++ b/test/form/samples/render-removed-statements/_expected.js
@@ -46,7 +46,6 @@ switch (globalThis.unknown) {
  case 3: // retained
 		// lead retained
 		console.log(2); // trail retained
-
 	case 4: /* lead retained */ console.log('3'); // trail retained
 	default: // retained
 		/* lead retained */

--- a/test/form/samples/side-effects-switch-statements/_expected.js
+++ b/test/form/samples/side-effects-switch-statements/_expected.js
@@ -12,7 +12,6 @@ switch ( globalThis.unknown ) {
 	case 'baz':
 		effect();
 	default:
-
 }
 
 switch ( globalThis.unknown ) {

--- a/test/form/samples/try-statement-deoptimization/deactivate-via-option/_expected.js
+++ b/test/form/samples/try-statement-deoptimization/deactivate-via-option/_expected.js
@@ -14,4 +14,8 @@ function test(callback) {
 test(() => {
 });
 
+try {} finally {
+	console.log('retained');
+}
+
 export { mutated };

--- a/test/form/samples/try-statement-deoptimization/deactivate-via-option/main.js
+++ b/test/form/samples/try-statement-deoptimization/deactivate-via-option/main.js
@@ -20,3 +20,13 @@ function test(callback) {
 test(() => {
 	Object.create(null);
 });
+
+try {
+	const x = 1;
+} catch {
+	console.log('removed');
+}
+
+try {} finally {
+	console.log('retained');
+}

--- a/test/form/samples/try-statement-deoptimization/direct-inclusion/_expected.js
+++ b/test/form/samples/try-statement-deoptimization/direct-inclusion/_expected.js
@@ -1,11 +1,7 @@
-try {} catch {
-	console.log('retained');
-}
-
 try {} catch {} finally {
 	console.log('retained');
-}
+} // this will be retained
 
 try {
-	Object.create(null);
+	Object.create(null); // this will be retained
 } catch {}

--- a/test/form/samples/try-statement-deoptimization/direct-inclusion/main.js
+++ b/test/form/samples/try-statement-deoptimization/direct-inclusion/main.js
@@ -1,17 +1,16 @@
 Object.create(null); // this will be removed
 
-try {} catch {} // this will be removed
+try {} catch {} finally {} // this will be removed
 
 try {} catch {
-	Object.create(null); // this will be removed
-	console.log('retained');
-}
+	console.log('removed');
+} // this will be removed
 
 try {} catch {} finally {
 	Object.create(null); // this will be removed
 	console.log('retained');
-}
+} // this will be retained
 
 try {
-	Object.create(null);
+	Object.create(null); // this will be retained
 } catch {}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3161  
Resolves #3162 
Resolves #3163 

### Description
This will no longer ignore a try-statement if the only side-effect can be found in the catch block. Also it will properly consider `treeshake.tryCatchDeoptimization` when checking for side-effects in the try block: If the optimization is off, the block is checked for side-effects, otherwise we check if it is non-empty.

Lastly, this improves the switch statement rendering logic to prevent trailing empty lines.