### PR TITLE
Add missing spaces in certain statements and expressions to avoid invalid code

### DIFF
--- a/src/ast/nodes/ForInStatement.ts
+++ b/src/ast/nodes/ForInStatement.ts
@@ -60,6 +60,10 @@ export default class ForInStatement extends StatementBase {
 	render(code: MagicString, options: RenderOptions) {
 		this.left.render(code, options, NO_SEMICOLON);
 		this.right.render(code, options, NO_SEMICOLON);
+		// handle no space between "in" and the right side
+		if (code.original.charCodeAt(this.right.start - 1) === 110 /* n */) {
+			code.prependLeft(this.right.start, ' ');
+		}
 		this.body.render(code, options);
 	}
 }

--- a/src/ast/nodes/ForOfStatement.ts
+++ b/src/ast/nodes/ForOfStatement.ts
@@ -45,6 +45,10 @@ export default class ForOfStatement extends StatementBase {
 	render(code: MagicString, options: RenderOptions) {
 		this.left.render(code, options, NO_SEMICOLON);
 		this.right.render(code, options, NO_SEMICOLON);
+		// handle no space between "of" and the right side
+		if (code.original.charCodeAt(this.right.start - 1) === 102 /* f */) {
+			code.prependLeft(this.right.start, ' ');
+		}
 		this.body.render(code, options);
 	}
 }

--- a/src/ast/nodes/ThrowStatement.ts
+++ b/src/ast/nodes/ThrowStatement.ts
@@ -20,5 +20,8 @@ export default class ThrowStatement extends StatementBase {
 
 	render(code: MagicString, options: RenderOptions) {
 		this.argument.render(code, options, { preventASI: true });
+		if (this.argument.start === this.start + 5 /* 'throw'.length */) {
+			code.prependLeft(this.start + 5, ' ');
+		}
 	}
 }

--- a/test/form/samples/side-effects-await/_config.js
+++ b/test/form/samples/side-effects-await/_config.js
@@ -1,5 +1,4 @@
 module.exports = {
 	description:
-		'await statements should never be dropped if a function has other side-effects (#1584)',
-	options: { output: { name: 'myBundle' } }
+		'await statements should never be dropped if a function has other side-effects (#1584)'
 };

--- a/test/form/samples/top-level-await/_expected/es.js
+++ b/test/form/samples/top-level-await/_expected/es.js
@@ -1,1 +1,3 @@
 await operation();
+
+await retainedOperation();

--- a/test/form/samples/top-level-await/_expected/system.js
+++ b/test/form/samples/top-level-await/_expected/system.js
@@ -5,6 +5,8 @@ System.register([], function () {
 
 			await operation();
 
+			await retainedOperation();
+
 		}
 	};
 });

--- a/test/form/samples/top-level-await/main.js
+++ b/test/form/samples/top-level-await/main.js
@@ -1,4 +1,4 @@
 await operation();
 
-if (false)
-	await treeshakenOperation();
+if (false) await treeshakenOperation();
+else await retainedOperation();

--- a/test/function/samples/missing-spaces-after-simplification/_config.js
+++ b/test/function/samples/missing-spaces-after-simplification/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description:
+		'handle situations where the simplification of an expression can lead to issues due to missing white-space',
+	options: { treeshake: { tryCatchDeoptimization: false } }
+};

--- a/test/function/samples/missing-spaces-after-simplification/main.js
+++ b/test/function/samples/missing-spaces-after-simplification/main.js
@@ -1,0 +1,28 @@
+let result = '';
+
+const a = { a: true };
+for (const key in!0?a:a) result += key;
+
+const b = ['b'];
+for (const value of!0?b:b) result += value;
+
+const c = 'c';
+function testReturn() {
+	return!0?c:c;
+}
+result += testReturn();
+
+const d = 'd';
+function* testYield() {
+	yield!0?d:d;
+}
+for (const value of testYield()) result += value;
+
+const e = 'e';
+try {
+	throw!0?e:e;
+} catch (err) {
+	result += err;
+}
+
+assert.strictEqual(result, 'abcde');


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3158 

### Description
This resolves some cases where missing white-space could lead to invalid code when an expression is simplified so that after simplification, it starts with a word character while before, it started with some punctuation.

This affects for..in loops , for..of loops and throw statements. The fix is the same as is already in place for return statements and yield expressions in that a space is inserted at the right position if there is none in the original code.

Examples of the broken code: https://rollupjs.org/repl/?version=1.23.1&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMCUyMyUyMGRpZmZlcmVudCUyMHNpbXBsaWZpZWQlMjBleHByZXNzaW9ucyU1Q24lNUNuJTJGJTJGJTIwc2VxdWVuY2UlNUNuZm9yKGNvbnN0JTIwd2F0JTIwaW4hMCUyQ2ZhbHNlKWNvbnNvbGUubG9nKCd3YXQnKSU1Q24lMkYlMkYlMjBjb25kaXRpb25hbCU1Q25mb3IoY29uc3QlMjB3YXQlMjBpbiEwJTNGZmFsc2UlM0FmYWxzZSljb25zb2xlLmxvZygnd2F0JyklNUNuJTJGJTJGJTIwbG9naWNhbCU1Q25mb3IoY29uc3QlMjB3YXQlMjBpbiEwJTI2JTI2ZmFsc2UpY29uc29sZS5sb2coJ3dhdCcpJTVDbiU1Q24lMkYlMkYlMjAlMjMlMjBkaWZmZXJlbnQlMjBzdXJyb3VuZGluZyUyMGV4cHJlc3Npb25zJTVDbiU1Q24lMkYlMkYlMjBmb3IlMjBvZiUyMGV4cHJlc3Npb24lNUNuZm9yKGNvbnN0JTIwd2F0JTIwb2YhMCUyNiUyNmZhbHNlKWNvbnNvbGUubG9nKCd3YXQnKSU1Q24lNUNuJTJGJTJGJTIwcmV0dXJuJTIwZXhwcmVzc2lvbiUyQyUyMGFscmVhZHklMjB3b3JraW5nJTVDbmZ1bmN0aW9uJTIwdGVzdCgpJTdCJTVDbiUyMCUyMHJldHVybiEwJTNGZmFsc2UlM0FmYWxzZSUzQiU1Q24lN0QlNUNuY29uc29sZS5sb2codGVzdCgpKSU1Q24lNUNuJTJGJTJGJTIweWllbGQlMjBzdGF0ZW1lbnQlMkMlMjBhbHJlYWR5JTIwd29ya2luZyU1Q25mdW5jdGlvbiUyMCp0ZXN0MigpJTdCJTVDbiU1Q3R5aWVsZCEwJTNGZmFsc2UlM0FmYWxzZSU1Q24lN0QlNUNuY29uc29sZS5sb2codGVzdDIoKSklNUNuJTVDbiUyRiUyRiUyMHRocm93JTIwc3RhdGVtZW50JTVDbmZ1bmN0aW9uJTIwdGVzdDMoKSU3QiU1Q24lMjAlMjB0aHJvdyEwJTNGZmFsc2UlM0FmYWxzZSUzQiU1Q24lN0QlNUNuY29uc29sZS5sb2codGVzdDMoKSklNUNuJTVDbiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmVzbSUyMiUyQyUyMm5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmFtZCUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyJTIyJTdEJTJDJTIyZ2xvYmFscyUyMiUzQSU3QiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE