### PR TITLE
Also remove export-all declarations when not tree-shaking

### DIFF
--- a/src/ast/nodes/ExportAllDeclaration.ts
+++ b/src/ast/nodes/ExportAllDeclaration.ts
@@ -1,8 +1,11 @@
+import MagicString from 'magic-string';
+import { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import Literal from './Literal';
 import * as NodeType from './NodeType';
 import { NodeBase } from './shared/Node';
 
 export default class ExportAllDeclaration extends NodeBase {
+	needsBoundaries!: true;
 	source!: Literal<string>;
 	type!: NodeType.tExportAllDeclaration;
 
@@ -13,4 +16,13 @@ export default class ExportAllDeclaration extends NodeBase {
 	initialise() {
 		this.context.addExport(this);
 	}
+
+	render(code: MagicString, _options: RenderOptions, nodeRenderOptions?: NodeRenderOptions) {
+		code.remove(
+			(nodeRenderOptions as NodeRenderOptions).start as number,
+			(nodeRenderOptions as NodeRenderOptions).end as number
+		);
+	}
 }
+
+ExportAllDeclaration.prototype.needsBoundaries = true;

--- a/test/form/samples/no-treeshake/_expected/amd.js
+++ b/test/form/samples/no-treeshake/_expected/amd.js
@@ -47,6 +47,7 @@ define(['exports', 'external'], function (exports, external) { 'use strict';
 
 	exports.create = create;
 	exports.getPrototypeOf = getPrototypeOf;
+	exports.quux = quux;
 	exports.strange = quux;
 
 	Object.defineProperty(exports, '__esModule', { value: true });

--- a/test/form/samples/no-treeshake/_expected/cjs.js
+++ b/test/form/samples/no-treeshake/_expected/cjs.js
@@ -51,4 +51,5 @@ test({
 
 exports.create = create;
 exports.getPrototypeOf = getPrototypeOf;
+exports.quux = quux;
 exports.strange = quux;

--- a/test/form/samples/no-treeshake/_expected/es.js
+++ b/test/form/samples/no-treeshake/_expected/es.js
@@ -45,4 +45,4 @@ test({
 	}
 });
 
-export { create, getPrototypeOf, quux as strange };
+export { create, getPrototypeOf, quux, quux as strange };

--- a/test/form/samples/no-treeshake/_expected/iife.js
+++ b/test/form/samples/no-treeshake/_expected/iife.js
@@ -48,6 +48,7 @@ var stirred = (function (exports, external) {
 
 	exports.create = create;
 	exports.getPrototypeOf = getPrototypeOf;
+	exports.quux = quux;
 	exports.strange = quux;
 
 	return exports;

--- a/test/form/samples/no-treeshake/_expected/umd.js
+++ b/test/form/samples/no-treeshake/_expected/umd.js
@@ -51,6 +51,7 @@
 
 	exports.create = create;
 	exports.getPrototypeOf = getPrototypeOf;
+	exports.quux = quux;
 	exports.strange = quux;
 
 	Object.defineProperty(exports, '__esModule', { value: true });

--- a/test/form/samples/no-treeshake/main.js
+++ b/test/form/samples/no-treeshake/main.js
@@ -1,6 +1,8 @@
 import * as external from 'external';
 import foo from './foo.js';
+
 export { quux as strange } from './quux.js';
+export * from './quux.js';
 
 function baz() {
 	return foo + external.value;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3196 

### Description
As exports are always re-rendering in the wrapper, export all declaration should always be removed completely. This basically emulates how it is done for import declarations to work also when tree-shaking is disabled.