### PR TITLE
Do no fail if the source attribute is `undefined` in an unused named export

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -703,7 +703,7 @@ export default class Module {
 			const source = node.source.value;
 			this.sources.add(source);
 			this.exportAllSources.add(source);
-		} else if (node.source !== null) {
+		} else if (node.source instanceof Literal) {
 			// export { name } from './other'
 
 			const source = node.source.value;

--- a/test/function/samples/handle-missing-export-source/_config.js
+++ b/test/function/samples/handle-missing-export-source/_config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	description:
+		'does not fail if a pre-generated AST is omitting the source property of an unused named export (#3210)',
+	options: {
+		plugins: {
+			transform(code, id) {
+				if (id.endsWith('foo.js')) {
+					const ast = this.parse(code);
+					delete ast.body.find(node => node.type === 'ExportNamedDeclaration').source;
+					return { code, ast };
+				}
+			}
+		}
+	}
+};

--- a/test/function/samples/handle-missing-export-source/foo.js
+++ b/test/function/samples/handle-missing-export-source/foo.js
@@ -1,0 +1,1 @@
+export const unused = 42;

--- a/test/function/samples/handle-missing-export-source/main.js
+++ b/test/function/samples/handle-missing-export-source/main.js
@@ -1,0 +1,3 @@
+import './foo.js';
+
+export const foo = 42;


### PR DESCRIPTION


This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3210 

### Description
This is a quick fix by changing how Rollup checks for named re-exports, but it is recommended that rollup-plugin-dts improves the ESTree compliance of their generated ASTs.