### PR TITLE
Also recover from plugin errors during the initial build in watch mode

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -272,8 +272,6 @@ export default class Module {
 			props.frame = getCodeFrame(this.originalCode, location.line, location.column);
 		}
 
-		props.watchFiles = Object.keys(this.graph.watchFiles);
-
 		error(props);
 	}
 

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -199,6 +199,10 @@ export default async function rollup(rawInputOptions: GenericConfigObject): Prom
 			inputOptions.inlineDynamicImports as boolean
 		);
 	} catch (err) {
+		const watchFiles = Object.keys(graph.watchFiles);
+		if (watchFiles.length > 0) {
+			err.watchFiles = watchFiles;
+		}
 		await graph.pluginDriver.hookParallel('buildEnd', [err]);
 		throw err;
 	}

--- a/test/function/samples/deprecated/emit-asset/set-asset-source-transform/_config.js
+++ b/test/function/samples/deprecated/emit-asset/set-asset-source-transform/_config.js
@@ -20,6 +20,7 @@ module.exports = {
 		message:
 			'setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.',
 		plugin: 'test-plugin',
-		pluginCode: 'INVALID_SETASSETSOURCE'
+		pluginCode: 'INVALID_SETASSETSOURCE',
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/deprecated/emit-chunk/chunk-not-found/_config.js
+++ b/test/function/samples/deprecated/emit-chunk/chunk-not-found/_config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
 	description: 'Throws if an emitted entry chunk cannot be resolved',
 	options: {
@@ -11,6 +13,7 @@ module.exports = {
 	},
 	error: {
 		code: 'UNRESOLVED_ENTRY',
-		message: 'Could not resolve entry module (not-found.js).'
+		message: 'Could not resolve entry module (not-found.js).',
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/deprecations/transform-dependencies/_config.js
+++ b/test/function/samples/deprecations/transform-dependencies/_config.js
@@ -16,6 +16,7 @@ module.exports = {
 		message:
 			'Returning "dependencies" from the "transform" hook as done by plugin at position 1 is deprecated. The "this.addWatchFile" plugin context function should be used instead.',
 		plugin: 'at position 1',
-		pluginCode: 'DEPRECATED_FEATURE'
+		pluginCode: 'DEPRECATED_FEATURE',
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/dynamic-import-relative-not-found/_config.js
+++ b/test/function/samples/dynamic-import-relative-not-found/_config.js
@@ -1,7 +1,10 @@
+const path = require('path');
+
 module.exports = {
 	description: 'throws if a dynamic relative import is not found',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './mod' from main.js`
+		message: `Could not resolve './mod' from main.js`,
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/emit-file/chunk-not-found/_config.js
+++ b/test/function/samples/emit-file/chunk-not-found/_config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
 	description: 'Throws if an emitted entry chunk cannot be resolved',
 	options: {
@@ -10,6 +12,7 @@ module.exports = {
 	},
 	error: {
 		code: 'UNRESOLVED_ENTRY',
-		message: 'Could not resolve entry module (not-found.js).'
+		message: 'Could not resolve entry module (not-found.js).',
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/emit-file/set-asset-source-transform/_config.js
+++ b/test/function/samples/emit-file/set-asset-source-transform/_config.js
@@ -19,6 +19,7 @@ module.exports = {
 		message:
 			'setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.',
 		plugin: 'test-plugin',
-		pluginCode: 'INVALID_SETASSETSOURCE'
+		pluginCode: 'INVALID_SETASSETSOURCE',
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/external-conflict/_config.js
+++ b/test/function/samples/external-conflict/_config.js
@@ -1,22 +1,24 @@
+const path = require('path');
+
 module.exports = {
 	description: 'external paths from custom resolver remain external (#633)',
 	options: {
 		external: (_id, parent) => parent === 'dep',
 		plugins: [
 			{
-				resolveId (id, parent) {
-					if (id === 'dep')
-						return id;
+				resolveId(id, parent) {
+					if (id === 'dep') return id;
 				},
-				load (id) {
-					if (id === 'dep')
-						return `import 'dep'`;
+				load(id) {
+					if (id === 'dep') return `import 'dep'`;
 				}
 			}
 		]
 	},
 	error: {
-		code: "INVALID_EXTERNAL_ID",
-		message: "'dep' is imported as an external by dep, but is already an existing non-external module id."
+		code: 'INVALID_EXTERNAL_ID',
+		message:
+			"'dep' is imported as an external by dep, but is already an existing non-external module id.",
+		watchFiles: [path.resolve(__dirname, 'main.js'), 'dep']
 	}
 };

--- a/test/function/samples/load-returns-string-or-null/_config.js
+++ b/test/function/samples/load-returns-string-or-null/_config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
 	description: 'throws error if load returns something wacky',
 	options: {
@@ -12,6 +14,7 @@ module.exports = {
 	},
 	error: {
 		code: 'BAD_LOADER',
-		message: `Error loading main.js: plugin load hook should return a string, a { code, map } object, or nothing/null`
+		message: `Error loading main.js: plugin load hook should return a string, a { code, map } object, or nothing/null`,
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/manual-chunks-conflict/_config.js
+++ b/test/function/samples/manual-chunks-conflict/_config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
 	description: 'Throws for conflicts between manual chunks',
 	options: {
@@ -9,6 +11,7 @@ module.exports = {
 	},
 	error: {
 		code: 'INVALID_CHUNK',
-		message: `Cannot assign dep.js to the "dep2" chunk as it is already in the "dep1" chunk.`
+		message: `Cannot assign dep.js to the "dep2" chunk as it is already in the "dep1" chunk.`,
+		watchFiles: [path.resolve(__dirname, 'main.js'), path.resolve(__dirname, 'dep.js')]
 	}
 };

--- a/test/function/samples/no-relative-external/_config.js
+++ b/test/function/samples/no-relative-external/_config.js
@@ -1,7 +1,10 @@
+const path = require('path');
+
 module.exports = {
 	description: 'missing relative imports are an error, not a warning',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './missing.js' from main.js`
+		message: `Could not resolve './missing.js' from main.js`,
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/paths-are-case-sensitive/_config.js
+++ b/test/function/samples/paths-are-case-sensitive/_config.js
@@ -1,7 +1,10 @@
+const path = require('path');
+
 module.exports = {
 	description: 'insists on correct casing for imports',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './foo.js' from main.js`
+		message: `Could not resolve './foo.js' from main.js`,
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/plugin-error-loc-instead-pos/_config.js
+++ b/test/function/samples/plugin-error-loc-instead-pos/_config.js
@@ -18,6 +18,7 @@ module.exports = {
 		message: 'nope',
 		hook: 'transform',
 		id: path.resolve(__dirname, 'main.js'),
+		watchFiles: [path.resolve(__dirname, 'main.js')],
 		loc: {
 			file: path.resolve(__dirname, 'main.js'),
 			line: 1,

--- a/test/function/samples/plugin-error-only-first-transform/_config.js
+++ b/test/function/samples/plugin-error-only-first-transform/_config.js
@@ -23,6 +23,7 @@ module.exports = {
 		message: `Something happened 1`,
 		plugin: 'plugin1',
 		hook: 'transform',
-		id: path.resolve(__dirname, 'main.js')
+		id: path.resolve(__dirname, 'main.js'),
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/plugin-error/load/_config.js
+++ b/test/function/samples/plugin-error/load/_config.js
@@ -16,6 +16,7 @@ module.exports = {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: `Could not load ${path.resolve(__dirname, 'main.js')}: nope`,
-		hook: 'load'
+		hook: 'load',
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };

--- a/test/function/samples/plugin-error/transform/_config.js
+++ b/test/function/samples/plugin-error/transform/_config.js
@@ -18,6 +18,7 @@ module.exports = {
 		message: 'nope',
 		hook: 'transform',
 		id: path.resolve(__dirname, 'main.js'),
+		watchFiles: [path.resolve(__dirname, 'main.js')],
 		pos: 22,
 		loc: {
 			file: path.resolve(__dirname, 'main.js'),

--- a/test/function/samples/throws-not-found-module/_config.js
+++ b/test/function/samples/throws-not-found-module/_config.js
@@ -1,7 +1,10 @@
+const path = require('path');
+
 module.exports = {
 	description: 'throws error if module is not found',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './mod' from main.js`
+		message: `Could not resolve './mod' from main.js`,
+		watchFiles: [path.resolve(__dirname, 'main.js')]
 	}
 };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3215
Resolves #2534 

### Description
This is a follow-up of the #3081. The approach is still the same, but instead of attaching the necessary watch information to parse errors, it will be attached to *any* error during the build phase. This includes any errors thrown by plugins, but also many other obscure errors that can be encountered during that phase. Hopefully, watch mode is now more enjoyable for everyone.