### PR TITLE
Allow passing input options to output

### DIFF
--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -439,7 +439,11 @@ function normalizeOutputOptions(
 	}
 	const mergedOptions = mergeOptions({
 		config: {
-			output: { ...rawOutputOptions, ...(inputOptions.output as Object) }
+			output: {
+				...rawOutputOptions,
+				...(rawOutputOptions.output as Object),
+				...(inputOptions.output as Object)
+			}
 		}
 	});
 

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -3,7 +3,7 @@ const rollup = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 
 describe('misc', () => {
-	it('throw modification of options or its property', () => {
+	it('avoids modification of options or their properties', () => {
 		const { freeze } = Object;
 		return rollup.rollup(
 			freeze({
@@ -118,12 +118,11 @@ describe('misc', () => {
 			});
 	});
 
-	it('ignores falsy plugins', () => {
-		return rollup.rollup({
+	it('ignores falsy plugins', () =>
+		rollup.rollup({
 			input: 'x',
 			plugins: [loader({ x: `console.log( 42 );` }), null, false, undefined]
-		});
-	});
+		}));
 
 	it('handles different import paths for different outputs', () => {
 		return rollup
@@ -154,6 +153,27 @@ describe('misc', () => {
 							assert.equal(generated.output[0].code, "import 'the-answer';\n", 'no render path 2')
 						)
 				])
+			);
+	});
+
+	it('allows passing the same object to `rollup` and `generate`', () => {
+		const options = {
+			input: 'input',
+			plugins: [
+				loader({
+					input: 'export default 42;'
+				})
+			],
+			output: {
+				format: 'esm'
+			}
+		};
+
+		return rollup
+			.rollup(options)
+			.then(bundle => bundle.generate(options))
+			.then(output =>
+				assert.strictEqual(output.output[0].code, 'var input = 42;\n\nexport default input;\n')
 			);
 	});
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3222

### Description
This fixes a regression where it is no longer possible to pass an object with an `output` key to bundle.generate.