### PR TITLE
remove @types/node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,8 @@
     "@types/node": {
       "version": "12.12.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
+      "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   "homepage": "https://github.com/rollup/rollup",
   "dependencies": {
     "@types/estree": "*",
-    "@types/node": "*",
     "acorn": "^7.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no (open to suggestions on how to test this)

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
- #3224

### Description

Remove @types/node dependency because this is causing the node types to be included by default for any consumer of rollup.

Note "@types/node" is still brought in for development as it's a dev dependency of "@types/fs-extra", "@types/resolve", "@types/rimraf" and "rollup"(!)

fixes #3224

[Here is an updated version of the repro which now correctly fails on an `npm run build`](https://github.com/tjenkinson/typescript-rollup-repro/tree/fixed/packages/with-rollup)
