### PR TITLE
Do not truncate after switch-statement with removed case

### DIFF
--- a/src/ast/nodes/SwitchStatement.ts
+++ b/src/ast/nodes/SwitchStatement.ts
@@ -65,6 +65,8 @@ export default class SwitchStatement extends StatementBase {
 				switchCase.include(context, includeChildrenRecursively);
 				minBrokenFlow = minBrokenFlow < context.brokenFlow ? minBrokenFlow : context.brokenFlow;
 				context.brokenFlow = brokenFlow;
+			} else {
+				minBrokenFlow = brokenFlow;
 			}
 		}
 		if (

--- a/test/function/samples/switch-statements-removed-default/_config.js
+++ b/test/function/samples/switch-statements-removed-default/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not remove code after a switch statement that should be retained'
+};

--- a/test/function/samples/switch-statements-removed-default/main.js
+++ b/test/function/samples/switch-statements-removed-default/main.js
@@ -1,0 +1,10 @@
+function performSwitch(value) {
+	switch (value) {
+		case 'foo':
+			return false;
+		default:
+	}
+	return true;
+}
+
+assert.ok(performSwitch('baz'));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3236 

### Description
When switch cases were removed, the logic to determine if ALL switch cases contained a return ignored the removed cases. This is fixed now.