### PR TITLE
Avoid name conflicts when inlining dynamic imports nested in functions

### DIFF
--- a/src/ast/nodes/ImportExpression.ts
+++ b/src/ast/nodes/ImportExpression.ts
@@ -12,11 +12,11 @@ interface DynamicImportMechanism {
 }
 
 export default class Import extends NodeBase {
+	inlineNamespace?: NamespaceVariable;
 	source!: ExpressionNode;
 	type!: NodeType.tImportExpression;
 
 	private exportMode: 'none' | 'named' | 'default' | 'auto' = 'auto';
-	private inlineNamespace?: NamespaceVariable;
 
 	hasEffects(): boolean {
 		return true;
@@ -26,6 +26,7 @@ export default class Import extends NodeBase {
 		if (!this.included) {
 			this.included = true;
 			this.context.includeDynamicImport(this);
+			this.scope.addAccessedDynamicImport(this);
 		}
 		this.source.include(context, includeChildrenRecursively);
 	}

--- a/src/ast/scopes/ChildScope.ts
+++ b/src/ast/scopes/ChildScope.ts
@@ -54,12 +54,7 @@ export default class ChildScope extends Scope {
 		this.parent instanceof ChildScope && this.parent.addReturnExpression(expression);
 	}
 
-	contains(name: string): boolean {
-		return this.variables.has(name) || this.parent.contains(name);
-	}
-
-	deconflict(format: string) {
-		const usedNames = new Set<string>();
+	addUsedOutsideNames(usedNames: Set<string>, format: string): void {
 		for (const variable of this.accessedOutsideVariables.values()) {
 			if (variable.included) {
 				usedNames.add(variable.getBaseVariableName());
@@ -75,6 +70,15 @@ export default class ChildScope extends Scope {
 				usedNames.add(name);
 			}
 		}
+	}
+
+	contains(name: string): boolean {
+		return this.variables.has(name) || this.parent.contains(name);
+	}
+
+	deconflict(format: string) {
+		const usedNames = new Set<string>();
+		this.addUsedOutsideNames(usedNames, format);
 		if (this.accessedDynamicImports) {
 			for (const importExpression of this.accessedDynamicImports) {
 				if (importExpression.inlineNamespace) {

--- a/src/ast/scopes/ChildScope.ts
+++ b/src/ast/scopes/ChildScope.ts
@@ -45,9 +45,7 @@ export default class ChildScope extends Scope {
 
 	addNamespaceMemberAccess(name: string, variable: Variable) {
 		this.accessedOutsideVariables.set(name, variable);
-		if (this.parent instanceof ChildScope) {
-			this.parent.addNamespaceMemberAccess(name, variable);
-		}
+		(this.parent as ChildScope).addNamespaceMemberAccess(name, variable);
 	}
 
 	addReturnExpression(expression: ExpressionEntity) {
@@ -97,7 +95,7 @@ export default class ChildScope extends Scope {
 	}
 
 	findLexicalBoundary(): ChildScope {
-		return this.parent instanceof ChildScope ? this.parent.findLexicalBoundary() : this;
+		return (this.parent as ChildScope).findLexicalBoundary();
 	}
 
 	findVariable(name: string): Variable {

--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -49,9 +49,9 @@ export function deconflictChunk(
 function addUsedGlobalNames(usedNames: Set<string>, modules: Module[], format: string) {
 	for (const module of modules) {
 		const moduleScope = module.scope;
-		for (const [name, variable] of moduleScope.accessedOutsideVariables) {
+		for (const variable of moduleScope.accessedOutsideVariables.values()) {
 			if (variable.included) {
-				usedNames.add(name);
+				usedNames.add(variable.getBaseVariableName());
 			}
 		}
 		const accessedGlobalVariables =
@@ -114,9 +114,10 @@ function deconflictImportsOther(
 			if (chunk.exportMode === 'default' || (preserveModules && variable.isNamespace)) {
 				variable.setRenderNames(null, chunk.variableName);
 			} else {
-				variable.setRenderNames(chunk.variableName, chunk.getVariableExportName(variable) as
-					| string
-					| null);
+				variable.setRenderNames(
+					chunk.variableName,
+					chunk.getVariableExportName(variable) as string | null
+				);
 			}
 		}
 	}

--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -31,7 +31,9 @@ export function deconflictChunk(
 	interop: boolean,
 	preserveModules: boolean
 ) {
-	addUsedGlobalNames(usedNames, modules, format);
+	for (const module of modules) {
+		module.scope.addUsedOutsideNames(usedNames, format);
+	}
 	deconflictTopLevelVariables(usedNames, modules);
 	DECONFLICT_IMPORTED_VARIABLES_BY_FORMAT[format](
 		usedNames,
@@ -43,25 +45,6 @@ export function deconflictChunk(
 
 	for (const module of modules) {
 		module.scope.deconflict(format);
-	}
-}
-
-function addUsedGlobalNames(usedNames: Set<string>, modules: Module[], format: string) {
-	for (const module of modules) {
-		const moduleScope = module.scope;
-		for (const variable of moduleScope.accessedOutsideVariables.values()) {
-			if (variable.included) {
-				usedNames.add(variable.getBaseVariableName());
-			}
-		}
-		const accessedGlobalVariables =
-			moduleScope.accessedGlobalVariablesByFormat &&
-			moduleScope.accessedGlobalVariablesByFormat.get(format);
-		if (accessedGlobalVariables) {
-			for (const name of accessedGlobalVariables) {
-				usedNames.add(name);
-			}
-		}
 	}
 }
 

--- a/test/form/samples/nested-inlined-dynamic-import/_config.js
+++ b/test/form/samples/nested-inlined-dynamic-import/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'deconflicts variables when nested dynamic imports are inlined',
+	options: {
+		inlineDynamicImports: true
+	}
+};

--- a/test/form/samples/nested-inlined-dynamic-import/_expected/amd.js
+++ b/test/form/samples/nested-inlined-dynamic-import/_expected/amd.js
@@ -1,0 +1,18 @@
+define(function () { 'use strict';
+
+	async function main() {
+		const foo$1 = 1;
+		const ns = await Promise.resolve().then(function () { return foo; });
+		console.log(ns.value + foo$1);
+	}
+
+	main();
+
+	const value = 42;
+
+	var foo = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		value: value
+	});
+
+});

--- a/test/form/samples/nested-inlined-dynamic-import/_expected/cjs.js
+++ b/test/form/samples/nested-inlined-dynamic-import/_expected/cjs.js
@@ -1,0 +1,16 @@
+'use strict';
+
+async function main() {
+	const foo$1 = 1;
+	const ns = await Promise.resolve().then(function () { return foo; });
+	console.log(ns.value + foo$1);
+}
+
+main();
+
+const value = 42;
+
+var foo = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	value: value
+});

--- a/test/form/samples/nested-inlined-dynamic-import/_expected/es.js
+++ b/test/form/samples/nested-inlined-dynamic-import/_expected/es.js
@@ -1,0 +1,14 @@
+async function main() {
+	const foo$1 = 1;
+	const ns = await Promise.resolve().then(function () { return foo; });
+	console.log(ns.value + foo$1);
+}
+
+main();
+
+const value = 42;
+
+var foo = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	value: value
+});

--- a/test/form/samples/nested-inlined-dynamic-import/_expected/iife.js
+++ b/test/form/samples/nested-inlined-dynamic-import/_expected/iife.js
@@ -1,0 +1,19 @@
+(function () {
+	'use strict';
+
+	async function main() {
+		const foo$1 = 1;
+		const ns = await Promise.resolve().then(function () { return foo; });
+		console.log(ns.value + foo$1);
+	}
+
+	main();
+
+	const value = 42;
+
+	var foo = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		value: value
+	});
+
+}());

--- a/test/form/samples/nested-inlined-dynamic-import/_expected/system.js
+++ b/test/form/samples/nested-inlined-dynamic-import/_expected/system.js
@@ -1,0 +1,23 @@
+System.register([], function () {
+	'use strict';
+	return {
+		execute: function () {
+
+			async function main() {
+				const foo$1 = 1;
+				const ns = await Promise.resolve().then(function () { return foo; });
+				console.log(ns.value + foo$1);
+			}
+
+			main();
+
+			const value = 42;
+
+			var foo = /*#__PURE__*/Object.freeze({
+				__proto__: null,
+				value: value
+			});
+
+		}
+	};
+});

--- a/test/form/samples/nested-inlined-dynamic-import/_expected/umd.js
+++ b/test/form/samples/nested-inlined-dynamic-import/_expected/umd.js
@@ -1,0 +1,21 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+}((function () { 'use strict';
+
+	async function main() {
+		const foo$1 = 1;
+		const ns = await Promise.resolve().then(function () { return foo; });
+		console.log(ns.value + foo$1);
+	}
+
+	main();
+
+	const value = 42;
+
+	var foo = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		value: value
+	});
+
+})));

--- a/test/form/samples/nested-inlined-dynamic-import/foo.js
+++ b/test/form/samples/nested-inlined-dynamic-import/foo.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/form/samples/nested-inlined-dynamic-import/main.js
+++ b/test/form/samples/nested-inlined-dynamic-import/main.js
@@ -1,0 +1,7 @@
+async function main() {
+	const foo = 1;
+	const ns = await import('./foo.js');
+	console.log(ns.value + foo);
+}
+
+main();

--- a/test/function/samples/nested-inlined-dynamic-import-1/_config.js
+++ b/test/function/samples/nested-inlined-dynamic-import-1/_config.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+module.exports = {
+	description:
+		'deconflicts variables when nested dynamic imports are inlined via inlineDynamicImports',
+	options: {
+		inlineDynamicImports: true
+	},
+	exports(exports) {
+		return exports().then(result => assert.strictEqual(result, 43));
+	}
+};

--- a/test/function/samples/nested-inlined-dynamic-import-1/foo.js
+++ b/test/function/samples/nested-inlined-dynamic-import-1/foo.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/function/samples/nested-inlined-dynamic-import-1/main.js
+++ b/test/function/samples/nested-inlined-dynamic-import-1/main.js
@@ -1,0 +1,4 @@
+export default () => {
+	const foo = 1;
+	return import('./foo.js').then(ns => ns.value + foo);
+};

--- a/test/function/samples/nested-inlined-dynamic-import-2/_config.js
+++ b/test/function/samples/nested-inlined-dynamic-import-2/_config.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'deconflicts variables when nested dynamic imports are inlined',
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			cycle: ['lib1.js', 'lib2.js', 'lib1.js'],
+			importer: 'lib1.js',
+			message: 'Circular dependency: lib1.js -> lib2.js -> lib1.js'
+		}
+	],
+	exports(exports) {
+		return exports().then(result => assert.strictEqual(result, 43));
+	}
+};

--- a/test/function/samples/nested-inlined-dynamic-import-2/lib1.js
+++ b/test/function/samples/nested-inlined-dynamic-import-2/lib1.js
@@ -1,0 +1,6 @@
+import './lib2.js';
+
+export default () => {
+	const lib2 = 1;
+	return import('./lib2.js').then(ns => ns.foo + lib2);
+};

--- a/test/function/samples/nested-inlined-dynamic-import-2/lib2.js
+++ b/test/function/samples/nested-inlined-dynamic-import-2/lib2.js
@@ -1,0 +1,3 @@
+import './lib1.js';
+
+export const foo = 42;

--- a/test/function/samples/nested-inlined-dynamic-import-2/main.js
+++ b/test/function/samples/nested-inlined-dynamic-import-2/main.js
@@ -1,0 +1,1 @@
+export {default} from './lib1.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
resolves #3245 

### Description
This makes sure that when a dynamic import is used inside a function, variables inside this function are deconflicted with respect to the inlined namespace.