### PR TITLE
Fix incomplete computed property deoptimization

### DIFF
--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -36,11 +36,12 @@ interface PropertyMap {
 	};
 }
 
-export default class ObjectExpression extends NodeBase {
+export default class ObjectExpression extends NodeBase implements DeoptimizableEntity {
 	properties!: (Property | SpreadElement)[];
 	type!: NodeType.tObjectExpression;
 
 	private deoptimizedPaths = new Set<string>();
+
 	// We collect deoptimization information if we can resolve a computed property access
 	private expressionsToBeDeoptimized = new Map<string, DeoptimizableEntity[]>();
 	private hasUnknownDeoptimizedProperty = false;

--- a/test/function/samples/deoptimize-cached-prop/_config.js
+++ b/test/function/samples/deoptimize-cached-prop/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimizes cached properties and return values if necessary (#3264)'
+};

--- a/test/function/samples/deoptimize-cached-prop/main.js
+++ b/test/function/samples/deoptimize-cached-prop/main.js
@@ -1,0 +1,24 @@
+const obj1 = {};
+let prop = 'x';
+
+updateProp();
+
+obj1[prop] = true;
+
+assert.strictEqual(obj1.y ? 'WORKING' : 'BUG', 'WORKING');
+
+function updateProp() {
+	prop = 'y';
+}
+
+const obj2 = {};
+obj2[getResult().prop] = 1;
+
+assert.equal(obj2.foo ? 'WORKING' : 'BUG', 'WORKING');
+
+function getResult() {
+	const result = {};
+	result.prop = 'foo';
+	return result;
+}
+


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3264 

### Description
I am aware that #3266 already provides a fix for #3264 and I hope there is no ill thought from the author (the other fix in the PR is still welcome), but this PR will actually fix the root cause of the issue, which is that when the key of a computed property is later deoptimized, and the involved member expression had a deoptimized path, then ALL paths of the member expression need to be deoptimized (I know this may sound VERY confusing. I really hope to find some time soon to improve the names of the concepts around this).

So the result is that

```js
const obj1 = {};
let prop = 'x';

updateProp();

obj1[prop] = true;

assert.strictEqual(obj1.y ? 'WORKING' : 'BUG', 'WORKING');

function updateProp() {
	prop = 'y';
}
```

is completely retained, while

```js
const obj1 = {};
let prop = 'x';

obj1[prop] = true;

assert.strictEqual(obj1.y ? 'BUG' : 'WORKING', 'WORKING');
```

is correctly optimized to

```js
assert.strictEqual( 'WORKING', 'WORKING');
```