### PR TITLE
feature:  use disk file cache

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -139,6 +139,10 @@ export class Task {
 		});
 		this.inputOptions = inputOptions;
 
+		if (config && config.cache) {
+			this.cache = config.cache as RollupCache;
+		}
+
 		this.outputs = outputOptions;
 		this.outputFiles = this.outputs.map(output => {
 			if (output.file || output.dir) return path.resolve(output.file || (output.dir as string));


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
can use disk file cache when  rollup watch

