### PR TITLE
Always make "module" available for SystemJS and AMD formats if `import.meta` is accessed directly

### DIFF
--- a/src/ast/nodes/MetaProperty.ts
+++ b/src/ast/nodes/MetaProperty.ts
@@ -35,16 +35,15 @@ export default class MetaProperty extends NodeBase {
 				parent instanceof MemberExpression && typeof parent.propertyKey === 'string'
 					? parent.propertyKey
 					: null);
-			if (metaProperty) {
-				if (
-					metaProperty.startsWith(FILE_PREFIX) ||
+			if (
+				metaProperty &&
+				(metaProperty.startsWith(FILE_PREFIX) ||
 					metaProperty.startsWith(ASSET_PREFIX) ||
-					metaProperty.startsWith(CHUNK_PREFIX)
-				) {
-					this.scope.addAccessedGlobalsByFormat(accessedFileUrlGlobals);
-				} else {
-					this.scope.addAccessedGlobalsByFormat(accessedMetaUrlGlobals);
-				}
+					metaProperty.startsWith(CHUNK_PREFIX))
+			) {
+				this.scope.addAccessedGlobalsByFormat(accessedFileUrlGlobals);
+			} else {
+				this.scope.addAccessedGlobalsByFormat(accessedMetaUrlGlobals);
 			}
 		}
 	}

--- a/test/form/samples/import-meta/_config.js
+++ b/test/form/samples/import-meta/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'supports directly accessing import.meta'
+};

--- a/test/form/samples/import-meta/_expected/amd.js
+++ b/test/form/samples/import-meta/_expected/amd.js
@@ -1,0 +1,5 @@
+define(['module'], function (module) { 'use strict';
+
+	console.log(({ url: new URL(module.uri, document.baseURI).href }));
+
+});

--- a/test/form/samples/import-meta/_expected/cjs.js
+++ b/test/form/samples/import-meta/_expected/cjs.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(({ url: (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('cjs.js', document.baseURI).href)) }));

--- a/test/form/samples/import-meta/_expected/es.js
+++ b/test/form/samples/import-meta/_expected/es.js
@@ -1,0 +1,1 @@
+console.log(import.meta);

--- a/test/form/samples/import-meta/_expected/iife.js
+++ b/test/form/samples/import-meta/_expected/iife.js
@@ -1,0 +1,6 @@
+(function () {
+	'use strict';
+
+	console.log(({ url: (document.currentScript && document.currentScript.src || new URL('iife.js', document.baseURI).href) }));
+
+}());

--- a/test/form/samples/import-meta/_expected/system.js
+++ b/test/form/samples/import-meta/_expected/system.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			console.log(module.meta);
+
+		}
+	};
+});

--- a/test/form/samples/import-meta/_expected/umd.js
+++ b/test/form/samples/import-meta/_expected/umd.js
@@ -1,0 +1,8 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+}((function () { 'use strict';
+
+	console.log(({ url: (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
+
+})));

--- a/test/form/samples/import-meta/main.js
+++ b/test/form/samples/import-meta/main.js
@@ -1,0 +1,1 @@
+console.log(import.meta);

--- a/test/form/samples/resolve-import-meta-url-export/resolved.js
+++ b/test/form/samples/resolve-import-meta-url-export/resolved.js
@@ -1,3 +1,0 @@
-console.log(import.meta.url);
-console.log(import.meta.privateProp);
-console.log(import.meta);

--- a/test/form/samples/resolve-import-meta-url-export/unresolved.js
+++ b/test/form/samples/resolve-import-meta-url-export/unresolved.js
@@ -1,3 +1,0 @@
-console.log(import.meta.url);
-console.log(import.meta.privateProp);
-console.log(import.meta);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
https://github.com/rollup/rollup/issues/3151#issuecomment-564697539

### Description
When `import.meta` is accessed directly, Rollup would render a polyfill object that accesses `module` for AMD and SystemJS formats without importing it. This is fixed here.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
