### PR TITLE
Allow environment variables to contain colons

### DIFF
--- a/cli/run/index.ts
+++ b/cli/run/index.ts
@@ -47,9 +47,9 @@ export default function runRollup(command: any) {
 
 		environment.forEach((arg: string) => {
 			arg.split(',').forEach((pair: string) => {
-				const [key, value] = pair.split(':');
+				const [key, ...value] = pair.split(':');
 				if (value) {
-					process.env[key] = value;
+					process.env[key] = value.join(':');
 				} else {
 					process.env[key] = String(true);
 				}

--- a/cli/run/index.ts
+++ b/cli/run/index.ts
@@ -9,7 +9,7 @@ import build from './build';
 import loadConfigFile from './loadConfigFile';
 import watch from './watch';
 
-export default function runRollup(command: any) {
+export default function runRollup (command: any) {
 	let inputSource;
 	if (command._.length > 0) {
 		if (command.input) {
@@ -48,7 +48,7 @@ export default function runRollup(command: any) {
 		environment.forEach((arg: string) => {
 			arg.split(',').forEach((pair: string) => {
 				const [key, ...value] = pair.split(':');
-				if (value && value.length) {
+				if (value.length) {
 					process.env[key] = value.join(':');
 				} else {
 					process.env[key] = String(true);
@@ -93,7 +93,7 @@ export default function runRollup(command: any) {
 	}
 }
 
-function execute(configFile: string, configs: GenericConfigObject[], command: any) {
+function execute (configFile: string, configs: GenericConfigObject[], command: any) {
 	if (command.watch) {
 		watch(configFile, configs, command, command.silent);
 	} else {

--- a/cli/run/index.ts
+++ b/cli/run/index.ts
@@ -48,7 +48,7 @@ export default function runRollup(command: any) {
 		environment.forEach((arg: string) => {
 			arg.split(',').forEach((pair: string) => {
 				const [key, ...value] = pair.split(':');
-				if (value) {
+				if (value && value.length) {
 					process.env[key] = value.join(':');
 				} else {
 					process.env[key] = String(true);

--- a/test/cli/samples/config-env/_config.js
+++ b/test/cli/samples/config-env/_config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	description: 'passes environment variables to config file',
-	command: 'rollup --config --environment PRODUCTION,FOO:bar',
+	command: 'rollup --config --environment PRODUCTION,FOO:bar,HOST:http://localhost:4000',
 	execute: true
 };

--- a/test/cli/samples/config-env/main.js
+++ b/test/cli/samples/config-env/main.js
@@ -1,2 +1,3 @@
 assert.equal( '__ENVIRONMENT__', 'production' );
 assert.equal( '__FOO__', 'bar' );
+assert.equal( '__HOST__', 'http://localhost:4000' );

--- a/test/cli/samples/config-env/rollup.config.js
+++ b/test/cli/samples/config-env/rollup.config.js
@@ -8,7 +8,8 @@ module.exports = {
 	plugins: [
 		replace( {
 			__ENVIRONMENT__: process.env.PRODUCTION ? 'production' : 'development',
-			__FOO__: process.env.FOO
+			__FOO__: process.env.FOO,
+			__HOST__: process.env.HOST
 		} )
 	]
 };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [X] bugfix
- [ ] feature
- [X] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [X] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [X] no

List any relevant issue numbers:

### Description
Environment variables may include colons. Currently if one does they are removed along with any text following.

**Before:**
```
URL:http://localhost:4200 =  ['URL', 'http']
```

**After:**
```
URL:http://localhost:4200 =  ['URL', 'http://localhost:4200']
```

**Example:**
https://jsbin.com/zizexetuqu/edit?js,console

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
