### PR TITLE
Update deprecated references to the node-resolve plugin in the docs

### DIFF
--- a/docs/07-tools.md
+++ b/docs/07-tools.md
@@ -43,17 +43,17 @@ The resulting `bundle.js` will still work in Node.js, because the `import` decla
 
 #### rollup-plugin-node-resolve
 
-The [rollup-plugin-node-resolve](https://github.com/rollup/rollup-plugin-node-resolve) plugin teaches Rollup how to find external modules. Install it…
+The [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve) plugin teaches Rollup how to find external modules. Install it…
 
 ```
-npm install --save-dev rollup-plugin-node-resolve
+npm install --save-dev @rollup/plugin-node-resolve
 ```
 
 …and add it to your config file:
 
 ```js
 // rollup.config.js
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 
 export default {
   input: 'src/main.js',


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no