### PR TITLE
feat: per module inlineDynamicImport

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -194,6 +194,7 @@ export default class Module {
 	importDescriptions: { [name: string]: ImportDescription } = Object.create(null);
 	importMetas: MetaProperty[] = [];
 	imports = new Set<Variable>();
+	inlineDynamicImport = false;
 	isEntryPoint: boolean;
 	isExecuted = false;
 	isUserDefinedEntryPoint = false;
@@ -221,12 +222,19 @@ export default class Module {
 	private transformDependencies: string[] = [];
 	private transitiveReexports: string[] | null = null;
 
-	constructor(graph: Graph, id: string, moduleSideEffects: boolean, isEntry: boolean) {
+	constructor(
+		graph: Graph,
+		id: string,
+		moduleSideEffects: boolean,
+		inlineDynamicImport: boolean,
+		isEntry: boolean
+	) {
 		this.id = id;
 		this.graph = graph;
 		this.excludeFromSourcemap = /\0/.test(id);
 		this.context = graph.getModuleContext(id);
 		this.moduleSideEffects = moduleSideEffects;
+		this.inlineDynamicImport = inlineDynamicImport;
 		this.isEntryPoint = isEntry;
 	}
 
@@ -534,6 +542,7 @@ export default class Module {
 		originalSourcemap,
 		resolvedIds,
 		sourcemapChain,
+		inlineDynamicImport,
 		transformDependencies,
 		transformFiles
 	}: TransformModuleJSON & {
@@ -550,6 +559,10 @@ export default class Module {
 		this.customTransformCache = customTransformCache;
 		if (typeof moduleSideEffects === 'boolean') {
 			this.moduleSideEffects = moduleSideEffects;
+		}
+		if (typeof inlineDynamicImport === 'boolean') {
+			this.inlineDynamicImport = inlineDynamicImport;
+			console.log(this.id, inlineDynamicImport);
 		}
 
 		timeStart('generate ast', 3);

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -91,6 +91,7 @@ export type SourceMapInput = ExistingRawSourceMap | string | null | { mappings: 
 export interface SourceDescription {
 	ast?: ESTree.Program;
 	code: string;
+	inlineDynamicImport?: boolean | null;
 	map?: SourceMapInput;
 	moduleSideEffects?: boolean | null;
 }
@@ -104,6 +105,7 @@ export interface TransformModuleJSON {
 	code: string;
 	// note if plugins use new this.cache to opt-out auto transform cache
 	customTransformCache: boolean;
+	inlineDynamicImport: boolean | null;
 	moduleSideEffects: boolean | null;
 	originalCode: string;
 	originalSourcemap: ExistingDecodedSourceMap | null;
@@ -198,6 +200,7 @@ export interface PluginContextMeta {
 export interface ResolvedId {
 	external: boolean;
 	id: string;
+	inlineDynamicImport: boolean;
 	moduleSideEffects: boolean;
 }
 
@@ -208,6 +211,7 @@ export interface ResolvedIdMap {
 interface PartialResolvedId {
 	external?: boolean;
 	id: string;
+	inlineDynamicImport?: boolean | null;
 	moduleSideEffects?: boolean | null;
 }
 

--- a/src/utils/chunkColouring.ts
+++ b/src/utils/chunkColouring.ts
@@ -19,6 +19,11 @@ export function assignChunkColouringHashes(
 			Uint8ArrayXor(module.entryPointsHash, currentEntryHash);
 		}
 
+		for (const { resolution } of module.dynamicImports) {
+			if (resolution instanceof Module && resolution.inlineDynamicImport) {
+				module.dependencies.push(resolution);
+			}
+		}
 		for (const dependency of module.dependencies) {
 			if (
 				dependency instanceof ExternalModule ||
@@ -35,6 +40,7 @@ export function assignChunkColouringHashes(
 		for (const { resolution } of module.dynamicImports) {
 			if (
 				resolution instanceof Module &&
+				!resolution.inlineDynamicImport &&
 				resolution.dynamicallyImportedBy.length > 0 &&
 				!resolution.manualChunkAlias
 			) {

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -35,6 +35,7 @@ export default function transform(
 	const emittedFiles: EmittedFile[] = [];
 	let customTransformCache = false;
 	let moduleSideEffects: boolean | null = null;
+	let inlineDynamicImport: boolean | null = null;
 	let trackedPluginCache: { cache: PluginCache; used: boolean };
 	let curPlugin: Plugin;
 	const curSource: string = source.code;
@@ -81,6 +82,9 @@ export default function transform(
 			}
 			if (typeof result.moduleSideEffects === 'boolean') {
 				moduleSideEffects = result.moduleSideEffects;
+			}
+			if (typeof result.inlineDynamicImport === 'boolean') {
+				inlineDynamicImport = result.inlineDynamicImport;
 			}
 		} else {
 			return code;
@@ -189,6 +193,7 @@ export default function transform(
 				ast: ast as any,
 				code,
 				customTransformCache,
+				inlineDynamicImport,
 				moduleSideEffects,
 				originalCode,
 				originalSourcemap,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no (YET)

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

This PR allows to specify if a dynamically imported module should be inlined or not. 

This allows rollup to:
- Create a plugin that only inlines small bundles
- Dynamic import of WebAssembly chunks without creating an extra JS

The WASM use case is interesting, since in order to load WASM eficiently, async is a must, a dynamic import covers the use case perfectly:
```js
const {foo} = await import('./file.wasm');
```
The problem is that currently this import() will create two files (and meaning one extra round-trip):
- The `file.wasm.js` chunk (the js code that loads the WASM):

```js
const createAsyncWasm = (src) => {
  return WebAssembly.instantiateStreaming(fetch(src)).then(obj => obj.instance.exports);
};
const wasmPath = /*@__PURE__*/new URL('rust.rs-87ce7a05.wasm', import.meta.url).href;
const wasmExports = /*@__PURE__*/createAsyncWasm(wasmPath);
const then = wasmExports.then.bind(wasmExports);
```

and the `file.wasm` asset.

This new features allows to inline the JS, since the WASM is already loaded from a different asset