### PR TITLE
Fix module id conflict on a case insensitive OS

### DIFF
--- a/src/utils/renderNamePattern.ts
+++ b/src/utils/renderNamePattern.ts
@@ -31,12 +31,13 @@ export function renderNamePattern(
 }
 
 export function makeUnique(name: string, existingNames: Record<string, any>) {
-	if (name in existingNames === false) return name;
+	const existingNamesLowercase = new Set(Object.keys(existingNames).map(key => key.toLowerCase()));
+	if (!existingNamesLowercase.has(name.toLocaleLowerCase())) return name;
 
 	const ext = extname(name);
 	name = name.substr(0, name.length - ext.length);
 	let uniqueName,
 		uniqueIndex = 1;
-	while (existingNames[(uniqueName = name + ++uniqueIndex + ext)]);
+	while (existingNamesLowercase.has((uniqueName = name + ++uniqueIndex + ext).toLowerCase()));
 	return uniqueName;
 }

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_config.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	description: 'Preserve modules id case sensitive',
+	options: {
+		input: 'main.js',
+		preserveModules: true,
+		plugins: [
+			{
+				resolveId(id) {
+					if (id.toLowerCase().includes('one')) {
+						return id;
+					}
+				},
+				load(id) {
+					if (id.toLowerCase().includes('one')) {
+						return `export default '${id.replace('\0', '')}'`;
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/_virtual/_One1.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/_virtual/_One1.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var c = 'One1.js';
+
+	return c;
+
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/_virtual/_One2.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/_virtual/_One2.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var b = 'One.js';
+
+	return b;
+
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/_virtual/_one.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/_virtual/_one.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var a = 'one.js';
+
+	return a;
+
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(['./_virtual/_one', './_virtual/_One2', './_virtual/_One1'], function (_one, _One, _One1) { 'use strict';
+
+	window.APP = { a: _one, b: _One, c: _One1 };
+
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/_virtual/_One1.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/_virtual/_One1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var c = 'One1.js';
+
+module.exports = c;

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/_virtual/_One2.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/_virtual/_One2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var b = 'One.js';
+
+module.exports = b;

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/_virtual/_one.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/_virtual/_one.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var a = 'one.js';
+
+module.exports = a;

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var _one = require('./_virtual/_one.js');
+var _One = require('./_virtual/_One2.js');
+var _One1 = require('./_virtual/_One1.js');
+
+window.APP = { a: _one, b: _One, c: _One1 };

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/_virtual/_One1.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/_virtual/_One1.js
@@ -1,0 +1,3 @@
+var c = 'One1.js';
+
+export default c;

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/_virtual/_One2.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/_virtual/_One2.js
@@ -1,0 +1,3 @@
+var b = 'One.js';
+
+export default b;

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/_virtual/_one.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/_virtual/_one.js
@@ -1,0 +1,3 @@
+var a = 'one.js';
+
+export default a;

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/es/main.js
@@ -1,0 +1,5 @@
+import a from './_virtual/_one.js';
+import b from './_virtual/_One2.js';
+import c from './_virtual/_One1.js';
+
+window.APP = { a, b, c };

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/_virtual/_One1.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/_virtual/_One1.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var c = exports('default', 'One1.js');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/_virtual/_One2.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/_virtual/_One2.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var b = exports('default', 'One.js');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/_virtual/_one.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/_virtual/_one.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var a = exports('default', 'one.js');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/_expected/system/main.js
@@ -1,0 +1,18 @@
+System.register(['./_virtual/_one.js', './_virtual/_One2.js', './_virtual/_One1.js'], function () {
+	'use strict';
+	var a, b, c;
+	return {
+		setters: [function (module) {
+			a = module.default;
+		}, function (module) {
+			b = module.default;
+		}, function (module) {
+			c = module.default;
+		}],
+		execute: function () {
+
+			window.APP = { a, b, c };
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-id-case-sensitive/main.js
+++ b/test/chunking-form/samples/preserve-modules-id-case-sensitive/main.js
@@ -1,0 +1,5 @@
+import a from '\0one.js';
+import b from '\0One.js';
+import c from '\0One1.js';
+
+window.APP = { a, b, c };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Suppose we have to files named `date.js` and `Date.js`, `makeUnique` treats these two files are different currently. But on a case insensitive OS, they are the same file. This commit try to fix the
problem.

