### PR TITLE
Handle deoptimizations while a node is being included.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -249,7 +249,7 @@ Repository: Rich-Harris/locate-character
 ## magic-string
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/rich-harris/magic-string.git
+Repository: https://github.com/rich-harris/magic-string
 
 > Copyright 2018 Rich Harris
 > 
@@ -427,7 +427,7 @@ Repository: https://github.com/tapjs/signal-exit.git
 ## sourcemap-codec
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/Rich-Harris/sourcemap-codec.git
+Repository: https://github.com/Rich-Harris/sourcemap-codec
 
 > The MIT License
 > 

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -143,8 +143,8 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 		this.included = true;
 		if (
 			includeChildrenRecursively ||
-			this.usedBranch === null ||
-			this.test.shouldBeIncluded(context)
+			this.test.shouldBeIncluded(context) ||
+			this.usedBranch === null
 		) {
 			this.test.include(context, includeChildrenRecursively);
 			this.consequent.include(context, includeChildrenRecursively);

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -143,8 +143,8 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 		this.included = true;
 		if (
 			includeChildrenRecursively ||
-			this.usedBranch === null ||
-			this.unusedBranch!.shouldBeIncluded(context)
+			(this.usedBranch === this.right && this.left.shouldBeIncluded(context)) ||
+			this.usedBranch === null
 		) {
 			this.left.include(context, includeChildrenRecursively);
 			this.right.include(context, includeChildrenRecursively);

--- a/test/form/samples/conditional-expression-deopzimize-while-included/_config.js
+++ b/test/form/samples/conditional-expression-deopzimize-while-included/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles deoptimizations of logical expression while they are inlcuded (#3324)'
+};

--- a/test/form/samples/conditional-expression-deopzimize-while-included/_expected.js
+++ b/test/form/samples/conditional-expression-deopzimize-while-included/_expected.js
@@ -1,0 +1,9 @@
+let isReassigned = false;
+
+const result = (foo(), reassign() ? first() : second());
+console.log(result);
+
+function reassign() {
+	isReassigned = true;
+	return isReassigned;
+}

--- a/test/form/samples/conditional-expression-deopzimize-while-included/main.js
+++ b/test/form/samples/conditional-expression-deopzimize-while-included/main.js
@@ -1,0 +1,9 @@
+let isReassigned = false;
+
+const result = (foo(), reassign() ? first() : second());
+console.log(result);
+
+function reassign() {
+	isReassigned = true;
+	return isReassigned;
+}

--- a/test/form/samples/logical-expression/deopzimize-while-included/_config.js
+++ b/test/form/samples/logical-expression/deopzimize-while-included/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles deoptimizations of logical expression while they are inlcuded (#3324)'
+};

--- a/test/form/samples/logical-expression/deopzimize-while-included/_expected.js
+++ b/test/form/samples/logical-expression/deopzimize-while-included/_expected.js
@@ -1,0 +1,15 @@
+let isFirstReassigned = false;
+
+const result1 = (foo(), isFirstReassigned );
+console.log(result1);
+
+let isSecondReassigned = false;
+
+const result2 = (foo(), reassign2() || foo());
+console.log(result1);
+
+function reassign2() {
+	// this needs to be included
+	isSecondReassigned = true;
+	return isSecondReassigned;
+}

--- a/test/form/samples/logical-expression/deopzimize-while-included/main.js
+++ b/test/form/samples/logical-expression/deopzimize-while-included/main.js
@@ -1,0 +1,20 @@
+let isFirstReassigned = false;
+
+const result1 = (foo(), isFirstReassigned && reassign1());
+console.log(result1);
+
+function reassign1() {
+	// this should never be triggered
+	isFirstReassigned = true;
+}
+
+let isSecondReassigned = false;
+
+const result2 = (foo(), reassign2() || foo());
+console.log(result1);
+
+function reassign2() {
+	// this needs to be included
+	isSecondReassigned = true;
+	return isSecondReassigned;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3324 

### Description
This fixes an issue with logical and conditional expressions that can arise when an expression that contains a variable reassignment is automatically included without a preceding `hasEffects` check.

The issue is quite complicated to trigger (see #3324) while the fix was in essence to switch the order of two lines.