### PR TITLE
Properly handle circular reexports

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "spec": "test/test.js"
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -112,7 +112,7 @@ Repository: https://github.com/acornjs/acorn.git
 ## braces
 License: MIT
 By: Jon Schlinkert, Brian Woodward, Elan Shanker, Eugene Sharygin, hemanth.hm
-Repository: git+https://github.com/micromatch/braces.git
+Repository: micromatch/braces
 
 > The MIT License (MIT)
 > 
@@ -148,7 +148,7 @@ Repository: sindresorhus/date-time
 ## fill-range
 License: MIT
 By: Jon Schlinkert, Edo Rivai, Paul Miller, Rouven Weßling
-Repository: git+https://github.com/jonschlinkert/fill-range.git
+Repository: jonschlinkert/fill-range
 
 > The MIT License (MIT)
 > 
@@ -206,7 +206,7 @@ Repository: git://github.com/isaacs/inherits
 ## is-number
 License: MIT
 By: Jon Schlinkert, Olsten Larck, Rouven Weßling
-Repository: git+https://github.com/jonschlinkert/is-number.git
+Repository: jonschlinkert/is-number
 
 > The MIT License (MIT)
 > 
@@ -249,7 +249,7 @@ Repository: Rich-Harris/locate-character
 ## magic-string
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/rich-harris/magic-string.git
+Repository: https://github.com/rich-harris/magic-string
 
 > Copyright 2018 Rich Harris
 > 
@@ -427,7 +427,7 @@ Repository: https://github.com/tapjs/signal-exit.git
 ## sourcemap-codec
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/Rich-Harris/sourcemap-codec.git
+Repository: https://github.com/Rich-Harris/sourcemap-codec
 
 > The MIT License
 > 
@@ -463,7 +463,7 @@ Repository: sindresorhus/time-zone
 ## to-regex-range
 License: MIT
 By: Jon Schlinkert, Rouven Weßling
-Repository: git+https://github.com/micromatch/to-regex-range.git
+Repository: micromatch/to-regex-range
 
 > The MIT License (MIT)
 > 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -693,7 +693,7 @@ export default class Chunk {
 		}
 
 		if (usesTopLevelAwait && format !== 'es' && format !== 'system') {
-			error({
+			return error({
 				code: 'INVALID_TLA_FORMAT',
 				message: `Module format ${format} does not support top-level await. Use the "es" or "system" output formats rather.`
 			});

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -61,21 +61,21 @@ export interface CommentDescription {
 	text: string;
 }
 
-export interface ImportDescription {
-	module: Module | ExternalModule | null;
+interface ImportDescription {
+	module: Module | ExternalModule;
 	name: string;
 	source: string;
 	start: number;
 }
 
-export interface ExportDescription {
+interface ExportDescription {
 	identifier: string | null;
 	localName: string;
 }
 
-export interface ReexportDescription {
+interface ReexportDescription {
 	localName: string;
-	module: Module;
+	module: Module | ExternalModule;
 	source: string;
 	start: number;
 }
@@ -709,7 +709,7 @@ export default class Module {
 
 		if (name in this.importDescriptions) {
 			const importDeclaration = this.importDescriptions[name];
-			const otherModule = importDeclaration.module!;
+			const otherModule = importDeclaration.module;
 
 			if (otherModule instanceof Module && importDeclaration.name === '*') {
 				return otherModule.getOrCreateNamespace();
@@ -828,7 +828,12 @@ export default class Module {
 				: isNamespace
 				? '*'
 				: (specifier as ImportSpecifier).imported.name;
-			this.importDescriptions[localName] = { source, start: specifier.start, name, module: null };
+			this.importDescriptions[localName] = {
+				module: null as any, // filled in later
+				name,
+				source,
+				start: specifier.start
+			};
 		}
 	}
 
@@ -842,7 +847,7 @@ export default class Module {
 		for (const name of Object.keys(importDescription)) {
 			const specifier = importDescription[name];
 			const id = this.resolvedIds[specifier.source].id;
-			specifier.module = this.graph.moduleById.get(id) as Module | ExternalModule | null;
+			specifier.module = this.graph.moduleById.get(id) as Module | ExternalModule;
 		}
 	}
 

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -209,7 +209,7 @@ export class ModuleLoader {
 
 	private addModuleToManualChunk(alias: string, module: Module) {
 		if (module.manualChunkAlias !== null && module.manualChunkAlias !== alias) {
-			error(errCannotAssignModuleToChunk(module.id, alias, module.manualChunkAlias));
+			return error(errCannotAssignModuleToChunk(module.id, alias, module.manualChunkAlias));
 		}
 		module.manualChunkAlias = alias;
 		if (!this.manualChunkModules[alias]) {
@@ -398,7 +398,7 @@ export class ModuleLoader {
 	): ResolvedId {
 		if (resolvedId === null) {
 			if (isRelative(source)) {
-				error(errUnresolvedImport(source, importer));
+				return error(errUnresolvedImport(source, importer));
 			}
 			this.graph.warn(errUnresolvedImportTreatedAsExternal(source, importer));
 			return {

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -40,7 +40,7 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 			const variable = this.scope.findVariable(this.callee.name);
 
 			if (variable.isNamespace) {
-				this.context.error(
+				return this.context.error(
 					{
 						code: 'CANNOT_CALL_NAMESPACE',
 						message: `Cannot call a namespace ('${this.callee.name}')`

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -165,7 +165,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 	}
 
 	private disallowImportReassignment() {
-		this.context.error(
+		return this.context.error(
 			{
 				code: 'ILLEGAL_REASSIGNMENT',
 				message: `Illegal reassignment to import '${this.name}'`

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -259,7 +259,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			this.object instanceof Identifier &&
 			this.scope.findVariable(this.object.name).isNamespace
 		) {
-			this.context.error(
+			return this.context.error(
 				{
 					code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
 					message: `Illegal reassignment to import '${this.object.name}'`

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -20,7 +20,7 @@ export default class TaggedTemplateExpression extends NodeBase {
 			const variable = this.scope.findVariable(name);
 
 			if (variable.isNamespace) {
-				this.context.error(
+				return this.context.error(
 					{
 						code: 'CANNOT_CALL_NAMESPACE',
 						message: `Cannot call a namespace ('${name}')`

--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -42,14 +42,11 @@ export default class NamespaceVariable extends Variable {
 	include(context: InclusionContext) {
 		if (!this.included) {
 			if (this.containsExternalNamespace) {
-				this.context.error(
-					{
-						code: 'NAMESPACE_CANNOT_CONTAIN_EXTERNAL',
-						id: this.module.id,
-						message: `Cannot create an explicit namespace object for module "${this.context.getModuleName()}" because it contains a reexported external namespace`
-					},
-					undefined as any
-				);
+				return this.context.error({
+					code: 'NAMESPACE_CANNOT_CONTAIN_EXTERNAL',
+					id: this.module.id,
+					message: `Cannot create an explicit namespace object for module "${this.context.getModuleName()}" because it contains a reexported external namespace`
+				});
 			}
 			this.included = true;
 			for (const identifier of this.references) {

--- a/src/finalisers/iife.ts
+++ b/src/finalisers/iife.ts
@@ -35,7 +35,7 @@ export default function iife(
 	const useVariableAssignment = !extend && !isNamespaced;
 
 	if (name && useVariableAssignment && !isLegal(name)) {
-		error({
+		return error({
 			code: 'ILLEGAL_IDENTIFIER_AS_NAME',
 			message: `Given name "${name}" is not a legal JS identifier. If you need this, you can try "output.extend: true".`
 		});

--- a/src/finalisers/umd.ts
+++ b/src/finalisers/umd.ts
@@ -43,7 +43,7 @@ export default function umd(
 	const globalVar = options.compact ? 'g' : 'global';
 
 	if (hasExports && !options.name) {
-		error({
+		return error({
 			code: 'INVALID_OPTION',
 			message: 'You must supply "output.name" for UMD bundles.'
 		});

--- a/src/rollup/index.ts
+++ b/src/rollup/index.ts
@@ -35,7 +35,7 @@ import {
 
 function checkOutputOptions(options: OutputOptions) {
 	if ((options.format as string) === 'es6') {
-		error(
+		return error(
 			errDeprecation({
 				message: 'The "es6" output format is deprecated – use "esm" instead',
 				url: `https://rollupjs.org/guide/en/#output-format`
@@ -44,14 +44,14 @@ function checkOutputOptions(options: OutputOptions) {
 	}
 
 	if (['amd', 'cjs', 'system', 'es', 'iife', 'umd'].indexOf(options.format as string) < 0) {
-		error({
+		return error({
 			message: `You must specify "output.format", which can be one of "amd", "cjs", "system", "esm", "iife" or "umd".`,
 			url: `https://rollupjs.org/guide/en/#output-format`
 		});
 	}
 
 	if (options.exports && !['default', 'named', 'none', 'auto'].includes(options.exports)) {
-		error(errInvalidExportOptionValue(options.exports));
+		return error(errInvalidExportOptionValue(options.exports));
 	}
 }
 
@@ -107,18 +107,18 @@ function getInputOptions(rawInputOptions: GenericConfigObject): InputOptions {
 
 	if (inputOptions.inlineDynamicImports) {
 		if (inputOptions.preserveModules)
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: `"preserveModules" does not support the "inlineDynamicImports" option.`
 			});
 		if (inputOptions.manualChunks)
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: '"manualChunks" option is not supported for "inlineDynamicImports".'
 			});
 
 		if (inputOptions.experimentalOptimizeChunks)
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: '"experimentalOptimizeChunks" option is not supported for "inlineDynamicImports".'
 			});
@@ -126,18 +126,18 @@ function getInputOptions(rawInputOptions: GenericConfigObject): InputOptions {
 			(inputOptions.input instanceof Array && inputOptions.input.length > 1) ||
 			(typeof inputOptions.input === 'object' && Object.keys(inputOptions.input).length > 1)
 		)
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: 'Multiple inputs are not supported for "inlineDynamicImports".'
 			});
 	} else if (inputOptions.preserveModules) {
 		if (inputOptions.manualChunks)
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: '"preserveModules" does not support the "manualChunks" option.'
 			});
 		if (inputOptions.experimentalOptimizeChunks)
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: '"preserveModules" does not support the "experimentalOptimizeChunks" option.'
 			});
@@ -335,7 +335,7 @@ export default async function rollup(rawInputOptions: GenericConfigObject): Prom
 				rawOutputOptions
 			);
 			if (!outputOptions.dir && !outputOptions.file) {
-				error({
+				return error({
 					code: 'MISSING_OPTION',
 					message: 'You must specify "output.file" or "output.dir" for the build.'
 				});
@@ -350,12 +350,12 @@ export default async function rollup(rawInputOptions: GenericConfigObject): Prom
 				}
 				if (chunkCount > 1) {
 					if (outputOptions.sourcemapFile)
-						error({
+						return error({
 							code: 'INVALID_OPTION',
 							message: '"output.sourcemapFile" is only supported for single-file builds.'
 						});
 					if (typeof outputOptions.file === 'string')
-						error({
+						return error({
 							code: 'INVALID_OPTION',
 							message:
 								'When building multiple chunks, the "output.dir" option must be used, not "output.file".' +
@@ -494,20 +494,20 @@ function normalizeOutputOptions(
 
 	if (typeof outputOptions.file === 'string') {
 		if (typeof outputOptions.dir === 'string')
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message:
 					'You must set either "output.file" for a single-file build or "output.dir" when generating multiple chunks.'
 			});
 		if (inputOptions.preserveModules) {
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message:
 					'You must set "output.dir" instead of "output.file" when using the "preserveModules" option.'
 			});
 		}
 		if (typeof inputOptions.input === 'object' && !Array.isArray(inputOptions.input))
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: 'You must set "output.dir" instead of "output.file" when providing named inputs.'
 			});
@@ -515,12 +515,12 @@ function normalizeOutputOptions(
 
 	if (hasMultipleChunks) {
 		if (outputOptions.format === 'umd' || outputOptions.format === 'iife')
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message: 'UMD and IIFE output formats are not supported for code-splitting builds.'
 			});
 		if (typeof outputOptions.file === 'string')
-			error({
+			return error({
 				code: 'INVALID_OPTION',
 				message:
 					'You must set "output.dir" instead of "output.file" when generating multiple chunks.'

--- a/src/utils/FileEmitter.ts
+++ b/src/utils/FileEmitter.ts
@@ -151,7 +151,7 @@ export class FileEmitter {
 	public assertAssetsFinalized = (): void => {
 		for (const [referenceId, emittedFile] of this.filesByReferenceId.entries()) {
 			if (emittedFile.type === 'asset' && typeof emittedFile.fileName !== 'string')
-				error(errNoAssetSourceSet(emittedFile.name || referenceId));
+				return error(errNoAssetSourceSet(emittedFile.name || referenceId));
 		}
 	};
 
@@ -273,7 +273,7 @@ export class FileEmitter {
 
 	private emitChunk(emittedChunk: EmittedFile): string {
 		if (this.graph.phase > BuildPhase.LOAD_AND_PARSE) {
-			error(errInvalidRollupPhaseForChunkEmission());
+			return error(errInvalidRollupPhaseForChunkEmission());
 		}
 		if (typeof emittedChunk.id !== 'string') {
 			return error(

--- a/src/utils/PluginContext.ts
+++ b/src/utils/PluginContext.ts
@@ -80,7 +80,9 @@ export function getPluginContexts(
 
 		const context: PluginContext = {
 			addWatchFile(id) {
-				if (graph.phase >= BuildPhase.GENERATE) this.error(errInvalidRollupPhaseForAddWatchFile());
+				if (graph.phase >= BuildPhase.GENERATE) {
+					return this.error(errInvalidRollupPhaseForAddWatchFile());
+				}
 				graph.watchFiles[id] = true;
 			},
 			cache: cacheInstance,

--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -246,7 +246,7 @@ export class PluginDriver {
 				// permit values allows values to be returned instead of a functional hook
 				if (typeof hook !== 'function') {
 					if (permitValues) return hook;
-					error({
+					return error({
 						code: 'INVALID_PLUGIN_HOOK',
 						message: `Error running plugin hook ${hookName} for ${plugin.name}, expected a function hook.`
 					});
@@ -274,7 +274,7 @@ export class PluginDriver {
 		try {
 			// permit values allows values to be returned instead of a functional hook
 			if (typeof hook !== 'function') {
-				error({
+				return error({
 					code: 'INVALID_PLUGIN_HOOK',
 					message: `Error running plugin hook ${hookName} for ${plugin.name}, expected a function hook.`
 				});

--- a/src/utils/addons.ts
+++ b/src/utils/addons.ts
@@ -44,7 +44,7 @@ export function createAddons(
 			return { intro, outro, banner, footer };
 		})
 		.catch((err): any => {
-			error({
+			return error({
 				code: 'ADDON_ERROR',
 				message: `Could not retrieve ${err.hook}. Check configuration of plugin ${err.plugin}.
 \tError Message: ${err.message}`

--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -81,7 +81,7 @@ class Link {
 						traced.source.content != null &&
 						sourcesContent[sourceIndex] !== traced.source.content
 					) {
-						error({
+						return error({
 							message: `Multiple conflicting contents for sourcemap source ${traced.source.filename}`
 						});
 					}

--- a/src/utils/defaultPlugin.ts
+++ b/src/utils/defaultPlugin.ts
@@ -51,7 +51,7 @@ function addJsExtensionIfNecessary(file: string, preserveSymlinks: boolean) {
 function createResolveId(preserveSymlinks: boolean) {
 	return function(source: string, importer: string) {
 		if (typeof process === 'undefined') {
-			error({
+			return error({
 				code: 'MISSING_PROCESS',
 				message: `It looks like you're using Rollup in a non-Node.js environment. This means you must supply a plugin with custom resolveId and load functions`,
 				url: 'https://rollupjs.org/guide/en/#a-simple-example'

--- a/src/utils/getExportMode.ts
+++ b/src/utils/getExportMode.ts
@@ -11,10 +11,10 @@ export default function getExportMode(
 
 	if (exportMode === 'default') {
 		if (exportKeys.length !== 1 || exportKeys[0] !== 'default') {
-			error(errIncompatibleExportOptionValue('default', exportKeys, facadeModuleId));
+			return error(errIncompatibleExportOptionValue('default', exportKeys, facadeModuleId));
 		}
 	} else if (exportMode === 'none' && exportKeys.length) {
-		error(errIncompatibleExportOptionValue('none', exportKeys, facadeModuleId));
+		return error(errIncompatibleExportOptionValue('none', exportKeys, facadeModuleId));
 	}
 
 	if (!exportMode || exportMode === 'auto') {

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -151,7 +151,7 @@ export default function transform(
 						pluginContext.setAssetSource(assetReferenceId, source);
 						if (!customTransformCache && !setAssetSourceErr) {
 							try {
-								this.error({
+								return this.error({
 									code: 'INVALID_SETASSETSOURCE',
 									message: `setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.`
 								});

--- a/test/function/samples/circular-missed-reexports-2/_config.js
+++ b/test/function/samples/circular-missed-reexports-2/_config.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const path = require('path');
+
+module.exports = {
+	description: 'handles circular reexports',
+	exports(exports) {
+		assert.strictEqual(exports.exists, 42);
+	},
+	error: {
+		code: 'MISSING_EXPORT',
+		frame: `
+1: export { doesNotExist } from './dep1.js';
+            ^`,
+		loc: {
+			column: 9,
+			file: path.resolve(__dirname, 'dep2.js'),
+			line: 1
+		},
+		message: "'doesNotExist' is not exported by dep1.js",
+		pos: 9,
+		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
+		watchFiles: [
+			path.resolve(__dirname, 'main.js'),
+			path.resolve(__dirname, 'dep1.js'),
+			path.resolve(__dirname, 'dep2.js')
+		]
+	}
+};

--- a/test/function/samples/circular-missed-reexports-2/dep1.js
+++ b/test/function/samples/circular-missed-reexports-2/dep1.js
@@ -1,0 +1,1 @@
+export { doesNotExist } from './dep2.js';

--- a/test/function/samples/circular-missed-reexports-2/dep2.js
+++ b/test/function/samples/circular-missed-reexports-2/dep2.js
@@ -1,0 +1,1 @@
+export { doesNotExist } from './dep1.js';

--- a/test/function/samples/circular-missed-reexports-2/main.js
+++ b/test/function/samples/circular-missed-reexports-2/main.js
@@ -1,0 +1,1 @@
+export { doesNotExist } from './dep1.js';

--- a/test/function/samples/circular-missed-reexports/_config.js
+++ b/test/function/samples/circular-missed-reexports/_config.js
@@ -21,9 +21,10 @@ module.exports = {
 		},
 		{
 			code: 'NON_EXISTENT_EXPORT',
-			frame:
-				" 1: import { exists, doesNotExist } from './dep1.js';\n" +
-				'                    ^\n2: export { exists };',
+			frame: `
+1: import { exists, doesNotExist } from './dep1.js';
+                    ^
+2: export { exists };`,
 			id: path.resolve(__dirname, 'main.js'),
 			loc: {
 				column: 17,

--- a/test/function/samples/circular-missed-reexports/_config.js
+++ b/test/function/samples/circular-missed-reexports/_config.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const path = require('path');
+
+module.exports = {
+	description: 'handles circular reexports',
+	exports(exports) {
+		assert.strictEqual(exports.exists, 42);
+	},
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			cycle: ['dep1.js', 'dep2.js', 'dep1.js'],
+			importer: 'dep1.js',
+			message: 'Circular dependency: dep1.js -> dep2.js -> dep1.js'
+		},
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			cycle: ['dep1.js', 'dep1.js'],
+			importer: 'dep1.js',
+			message: 'Circular dependency: dep1.js -> dep1.js'
+		},
+		{
+			code: 'NON_EXISTENT_EXPORT',
+			frame:
+				" 1: import { exists, doesNotExist } from './dep1.js';\n" +
+				'                    ^\n2: export { exists };',
+			id: path.resolve(__dirname, 'main.js'),
+			loc: {
+				column: 17,
+				file: path.resolve(__dirname, 'main.js'),
+				line: 1
+			},
+			message: "Non-existent export 'doesNotExist' is imported from dep1.js",
+			name: 'doesNotExist',
+			pos: 17,
+			source: path.resolve(__dirname, 'dep1.js')
+		}
+	]
+};

--- a/test/function/samples/circular-missed-reexports/dep1.js
+++ b/test/function/samples/circular-missed-reexports/dep1.js
@@ -1,0 +1,5 @@
+export * from './dep2.js';
+export { exists1 as exists } from './dep2.js';
+export { exists3 as exists2 } from './dep1.js';
+export { exists4 as exists3 } from './dep2.js';
+export const exists4 = 42;

--- a/test/function/samples/circular-missed-reexports/dep2.js
+++ b/test/function/samples/circular-missed-reexports/dep2.js
@@ -1,0 +1,2 @@
+export * from './dep1.js';
+export { exists2 as exists1 } from './dep1.js';

--- a/test/function/samples/circular-missed-reexports/main.js
+++ b/test/function/samples/circular-missed-reexports/main.js
@@ -1,0 +1,2 @@
+import { exists, doesNotExist } from './dep1.js';
+export { exists };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---require buble/register
-test/test.js


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3348 

### Description
This adds a break-off condition when searching variables for export names. It prevents maximum callstack exceeded errors for both named and namespace circular reexports.