### PR TITLE
[v2.0.0] Change writeBundle signature to match generateBundle

### DIFF
--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -316,7 +316,7 @@ export async function rollupInternal(
 				await Promise.all(
 					Object.keys(bundle).map(chunkId => writeOutputFile(bundle[chunkId], outputOptions))
 				);
-				await outputPluginDriver.hookParallel('writeBundle', [bundle]);
+				await outputPluginDriver.hookParallel('writeBundle', [outputOptions, bundle]);
 				return createOutput(bundle);
 			});
 		}

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -332,7 +332,11 @@ interface OutputPluginHooks {
 	resolveAssetUrl: ResolveAssetUrlHook;
 	resolveDynamicImport: ResolveDynamicImportHook;
 	resolveFileUrl: ResolveFileUrlHook;
-	writeBundle: (this: PluginContext, bundle: OutputBundle) => void | Promise<void>;
+	writeBundle: (
+		this: PluginContext,
+		options: OutputOptions,
+		bundle: OutputBundle
+	) => void | Promise<void>;
 }
 
 export interface PluginHooks extends OutputPluginHooks {

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -620,7 +620,8 @@ describe('hooks', () => {
 						}
 					},
 					{
-						writeBundle(outputBundle) {
+						writeBundle(options, outputBundle) {
+							assert.deepStrictEqual(options.file, file);
 							assert.deepStrictEqual(outputBundle, bundle);
 							callCount++;
 						}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:
Resolves #2717 

### Description
This is one of the few truly breaking changes in this release as there is no two-step deprecation; but to be honest, I could not think of another good name for this hook and well, writing a downward compatible plugin is not that difficult because you can do this:

```js
{
  writeBundle(options, bundle = options) {
    // now bundle is always the bundle, both in 1.x and 2.x
  }
}
```

So you can detect the signature of the hook by checking if the second parameter is used; in that case, it is the bundle, otherwise the first is the bundle.