### PR TITLE
Adjust bug template to mention REPL.it

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -28,7 +28,7 @@ about: Something went awry and you'd like to tell us about it.
 <!--
   Issues without minimal reproductions will be closed! Please provide a link to one by:
   1. Using the REPL at https://rollupjs.org/repl/, or
-  2. Using the REPL.it reproduction template at https://repl.it/@rollup/rollup-plugin-repro
+  2. Using the REPL.it reproduction template at https://repl.it/@rollup/rollup-repro
      (allows full use of all rollup options and plugins), or
   3. Provide a minimal repository link (Read https://git.io/fNzHA for instructions).
      These may take more time to triage than the other options.

--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -13,6 +13,8 @@ about: Something went awry and you'd like to tell us about it.
 
   👉🏽 Need help or tech support? Please don't open an issue!
   Head to https://gitter.im/rollup/rollup or https://stackoverflow.com/questions/tagged/rollupjs
+  
+  👉🏽 Is this issue related to an official plugin? Please do not open an issue here, go to the plugins repository instead: https://github.com/rollup/plugins/issues
 
   ❤️ Rollup? Please consider supporting our collective:
   👉 https://opencollective.com/rollup/donate
@@ -20,16 +22,21 @@ about: Something went awry and you'd like to tell us about it.
 
 - Rollup Version:
 - Operating System (or Browser):
-- Node Version:
-
-### How Do We Reproduce?
+- Node Version (if applicable):
+- Link to reproduction (IMPORTANT, read below):
 
 <!--
-  Issues without minimal reproductions will be closed! Please provide one by:
+  Issues without minimal reproductions will be closed! Please provide a link to one by:
   1. Using the REPL at https://rollupjs.org/repl/, or
-  2. Work to isolate the problem and provide the exact steps in this issue, or
+  2. Using the REPL.it reproduction template at https://repl.it/@rollup/rollup-plugin-repro
+     (allows full use of all rollup options and plugins), or
   3. Provide a minimal repository link (Read https://git.io/fNzHA for instructions).
      These may take more time to triage than the other options.
+     
+  For some bugs it this may seem like overkill but believe us, very often what seems like a
+  "clear issue" is actually specific to some details of your setup. Having a runnable
+  reproduction not only "proves" your bug to us but also allows us to spend all our effort
+  fixing the bug instead of struggling to understand your issue.
 -->
 
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This will adjust the BUG issue template in two ways:
- It mentions the REPL.it template used by the plugins repo as it is also valuable for Rollup core as it allows all options to be used
- It requires a "reproduction link" as I believe ALL reproductions should be possible to be provided as some link. Would like to experiment how users react to that and if it improves provided reproductions.

Opinions?