### PR TITLE
Run transform hooks again in watch mode on files that errored

### DIFF
--- a/src/watch/index.ts
+++ b/src/watch/index.ts
@@ -229,6 +229,9 @@ export class Task {
 						this.watchFile(id);
 					}
 				}
+				if (error.id) {
+					this.cache.modules = this.cache.modules.filter(module => module.id !== error.id);
+				}
 				throw error;
 			});
 	}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3386 
Resolves rollup/plugins#186

### Description
This is a very simple fix that will make sure that after changing an errored file back to its previous state in watch mode, transform hooks will run again on this file. The diagnostics of @rollup/plugin-typescript depends on this and it is really a sensible approach IMO. This fix is solely in `rollup.watch` and works by checking if a thrown error has an id property. This id is then removed from the cache before the next run.