### PR TITLE
[v2.0.0] Remove @types dependencies

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,7 +31,7 @@ MIT, ISC
 ## acorn
 License: MIT
 By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
-Repository: https://github.com/acornjs/acorn.git
+Repository: git+https://github.com/acornjs/acorn.git
 
 > Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 > 
@@ -58,7 +58,7 @@ Repository: https://github.com/acornjs/acorn.git
 ## acorn-export-ns-from
 License: MIT
 By: Adrian Heine
-Repository: https://github.com/acornjs/acorn-export-ns-from
+Repository: git+https://github.com/acornjs/acorn-export-ns-from.git
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -85,7 +85,7 @@ Repository: https://github.com/acornjs/acorn-export-ns-from
 ## acorn-import-meta
 License: MIT
 By: Adrian Heine
-Repository: https://github.com/adrianheine/acorn-import-meta
+Repository: git+https://github.com/adrianheine/acorn-import-meta.git
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -112,7 +112,7 @@ Repository: https://github.com/adrianheine/acorn-import-meta
 ## acorn-walk
 License: MIT
 By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
-Repository: https://github.com/acornjs/acorn.git
+Repository: git+https://github.com/acornjs/acorn.git
 
 > Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 > 
@@ -139,7 +139,7 @@ Repository: https://github.com/acornjs/acorn.git
 ## anymatch
 License: ISC
 By: Elan Shanker
-Repository: https://github.com/micromatch/anymatch
+Repository: git+https://github.com/micromatch/anymatch.git
 
 > The ISC License
 > 
@@ -162,14 +162,14 @@ Repository: https://github.com/micromatch/anymatch
 ## binary-extensions
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/binary-extensions
+Repository: git+https://github.com/sindresorhus/binary-extensions.git
 
 ---------------------------------------
 
 ## braces
 License: MIT
 By: Jon Schlinkert, Brian Woodward, Elan Shanker, Eugene Sharygin, hemanth.hm
-Repository: micromatch/braces
+Repository: git+https://github.com/micromatch/braces.git
 
 > The MIT License (MIT)
 > 
@@ -227,7 +227,7 @@ Repository: git+https://github.com/paulmillr/chokidar.git
 ## colorette
 License: MIT
 By: Jorge Bucaran
-Repository: jorgebucaran/colorette
+Repository: git+https://github.com/jorgebucaran/colorette.git
 
 > Copyright © Jorge Bucaran <<https://jorgebucaran.com>>
 > 
@@ -242,14 +242,14 @@ Repository: jorgebucaran/colorette
 ## date-time
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/date-time
+Repository: git+https://github.com/sindresorhus/date-time.git
 
 ---------------------------------------
 
 ## fill-range
 License: MIT
 By: Jon Schlinkert, Edo Rivai, Paul Miller, Rouven Weßling
-Repository: jonschlinkert/fill-range
+Repository: git+https://github.com/jonschlinkert/fill-range.git
 
 > The MIT License (MIT)
 > 
@@ -278,7 +278,7 @@ Repository: jonschlinkert/fill-range
 ## glob-parent
 License: ISC
 By: Gulp Team, Elan Shanker, Blaine Bublitz
-Repository: gulpjs/glob-parent
+Repository: git+https://github.com/gulpjs/glob-parent.git
 
 > The ISC License
 > 
@@ -301,13 +301,13 @@ Repository: gulpjs/glob-parent
 ## hash.js
 License: MIT
 By: Fedor Indutny
-Repository: git@github.com:indutny/hash.js
+Repository: git+ssh://git@github.com/indutny/hash.js.git
 
 ---------------------------------------
 
 ## inherits
 License: ISC
-Repository: git://github.com/isaacs/inherits
+Repository: git://github.com/isaacs/inherits.git
 
 > The ISC License
 > 
@@ -330,14 +330,14 @@ Repository: git://github.com/isaacs/inherits
 ## is-binary-path
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/is-binary-path
+Repository: git+https://github.com/sindresorhus/is-binary-path.git
 
 ---------------------------------------
 
 ## is-extglob
 License: MIT
 By: Jon Schlinkert
-Repository: jonschlinkert/is-extglob
+Repository: git+https://github.com/jonschlinkert/is-extglob.git
 
 > The MIT License (MIT)
 > 
@@ -366,7 +366,7 @@ Repository: jonschlinkert/is-extglob
 ## is-glob
 License: MIT
 By: Jon Schlinkert, Brian Woodward, Daniel Perez
-Repository: micromatch/is-glob
+Repository: git+https://github.com/micromatch/is-glob.git
 
 > The MIT License (MIT)
 > 
@@ -395,7 +395,7 @@ Repository: micromatch/is-glob
 ## is-number
 License: MIT
 By: Jon Schlinkert, Olsten Larck, Rouven Weßling
-Repository: jonschlinkert/is-number
+Repository: git+https://github.com/jonschlinkert/is-number.git
 
 > The MIT License (MIT)
 > 
@@ -431,14 +431,14 @@ Repository: git+https://github.com/Rich-Harris/is-reference.git
 ## locate-character
 License: MIT
 By: Rich Harris
-Repository: Rich-Harris/locate-character
+Repository: git+https://github.com/Rich-Harris/locate-character.git
 
 ---------------------------------------
 
 ## magic-string
 License: MIT
 By: Rich Harris
-Repository: https://github.com/rich-harris/magic-string
+Repository: git+https://github.com/rich-harris/magic-string.git
 
 > Copyright 2018 Rich Harris
 > 
@@ -453,7 +453,7 @@ Repository: https://github.com/rich-harris/magic-string
 ## micromatch
 License: MIT
 By: Jon Schlinkert, Amila Welihinda, Bogdan Chadkin, Brian Woodward, Devon Govett, Elan Shanker, Fabrício Matté, Martin Kolárik, Olsten Larck, Paul Miller, Tom Byrer, Tyler Akins, Peter Bright
-Repository: micromatch/micromatch
+Repository: git+https://github.com/micromatch/micromatch.git
 
 > The MIT License (MIT)
 > 
@@ -481,7 +481,7 @@ Repository: micromatch/micromatch
 
 ## minimalistic-assert
 License: ISC
-Repository: https://github.com/calvinmetcalf/minimalistic-assert.git
+Repository: git+https://github.com/calvinmetcalf/minimalistic-assert.git
 
 > Copyright 2015 Calvin Metcalf
 > 
@@ -528,7 +528,7 @@ Repository: git://github.com/substack/minimist.git
 ## normalize-path
 License: MIT
 By: Jon Schlinkert, Blaine Bublitz
-Repository: jonschlinkert/normalize-path
+Repository: git+https://github.com/jonschlinkert/normalize-path.git
 
 > The MIT License (MIT)
 > 
@@ -557,14 +557,14 @@ Repository: jonschlinkert/normalize-path
 ## parse-ms
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/parse-ms
+Repository: git+https://github.com/sindresorhus/parse-ms.git
 
 ---------------------------------------
 
 ## picomatch
 License: MIT
 By: Jon Schlinkert
-Repository: micromatch/picomatch
+Repository: git+https://github.com/micromatch/picomatch.git
 
 > The MIT License (MIT)
 > 
@@ -593,14 +593,14 @@ Repository: micromatch/picomatch
 ## pretty-bytes
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/pretty-bytes
+Repository: git+https://github.com/sindresorhus/pretty-bytes.git
 
 ---------------------------------------
 
 ## pretty-ms
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/pretty-ms
+Repository: git+https://github.com/sindresorhus/pretty-ms.git
 
 ---------------------------------------
 
@@ -643,14 +643,14 @@ Repository: git://github.com/kamicane/require-relative.git
 ## rollup-pluginutils
 License: MIT
 By: Rich Harris
-Repository: rollup/rollup-pluginutils
+Repository: git+https://github.com/rollup/rollup-pluginutils.git
 
 ---------------------------------------
 
 ## signal-exit
 License: ISC
 By: Ben Coe
-Repository: https://github.com/tapjs/signal-exit.git
+Repository: git+https://github.com/tapjs/signal-exit.git
 
 > The ISC License
 > 
@@ -674,7 +674,7 @@ Repository: https://github.com/tapjs/signal-exit.git
 ## sourcemap-codec
 License: MIT
 By: Rich Harris
-Repository: https://github.com/Rich-Harris/sourcemap-codec
+Repository: git+https://github.com/Rich-Harris/sourcemap-codec.git
 
 > The MIT License
 > 
@@ -703,14 +703,14 @@ Repository: https://github.com/Rich-Harris/sourcemap-codec
 ## time-zone
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/time-zone
+Repository: git+https://github.com/sindresorhus/time-zone.git
 
 ---------------------------------------
 
 ## to-regex-range
 License: MIT
 By: Jon Schlinkert, Rouven Weßling
-Repository: micromatch/to-regex-range
+Repository: git+https://github.com/micromatch/to-regex-range.git
 
 > The MIT License (MIT)
 > 

--- a/cli/run/build.ts
+++ b/cli/run/build.ts
@@ -48,7 +48,7 @@ export default function build(
 
 				return bundle.generate(output).then(({ output: outputs }) => {
 					for (const file of outputs) {
-						let source: string | Buffer;
+						let source: string | Uint8Array;
 						if (file.type === 'asset') {
 							source = file.source;
 						} else {

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -29,7 +29,7 @@ async function build() {
       // For assets, this contains
       // {
       //   fileName: string,              // the asset file name
-      //   source: string | Buffer        // the asset source
+      //   source: string | UInt8Array    // the asset source
       //   type: 'asset'                  // signifies that this is an asset
       // }
       console.log('Asset', chunkOrAsset);

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -131,7 +131,7 @@ Called at the end of `bundle.generate()` or immediately before the files are wri
 // AssetInfo
 {
   fileName: string,
-  source: string | Buffer,
+  source: string | UInt8Array,
   type: 'asset',
 }
 
@@ -429,7 +429,7 @@ Emits a new file that is included in the build output and returns a `referenceId
 // EmittedAsset
 {
   type: 'asset',
-  source?: string | Buffer,
+  source?: string | UInt8Array,
   name?: string,
   fileName?: string
 }
@@ -443,7 +443,7 @@ The generated code that replaces `import.meta.ROLLUP_FILE_URL_referenceId` can b
 
 If the `type` is *`chunk`*, then this emits a new chunk with the given module id as entry point. This will not result in duplicate modules in the graph, instead if necessary, existing chunks will be split or a facade chunk with reexports will be created. Chunks with a specified `fileName` will always generate separate chunks while other emitted chunks may be deduplicated with existing chunks even if the `name` does not match. If such a chunk is not deduplicated, the [`output.chunkFileNames`](guide/en/#outputchunkfilenames) name pattern will be used.
 
-If the `type` is *`asset`*, then this emits an arbitrary new file with the given `source` as content. It is possible to defer setting the `source` via [`this.setAssetSource(assetReferenceId, source)`](guide/en/#thissetassetsourceassetreferenceid-string-source-string--buffer--void) to a later time to be able to reference a file during the build phase while setting the source separately for each output during the generate phase. Assets with a specified `fileName` will always generate separate files while other emitted assets may be deduplicated with existing assets if they have the same source even if the `name` does not match. If such an asset is not deduplicated, the [`output.assetFileNames`](guide/en/#outputassetfilenames) name pattern will be used.
+If the `type` is *`asset`*, then this emits an arbitrary new file with the given `source` as content. It is possible to defer setting the `source` via [`this.setAssetSource(assetReferenceId, source)`](guide/en/#thissetassetsourceassetreferenceid-string-source-string--uint8array--void) to a later time to be able to reference a file during the build phase while setting the source separately for each output during the generate phase. Assets with a specified `fileName` will always generate separate files while other emitted assets may be deduplicated with existing assets if they have the same source even if the `name` does not match. If such an asset is not deduplicated, the [`output.assetFileNames`](guide/en/#outputassetfilenames) name pattern will be used.
 
 #### `this.error(error: string | Error, position?: number | { column: number; line: number }) => never`
 
@@ -496,9 +496,9 @@ Resolve imports to module ids (i.e. file names) using the same plugins that Roll
 
 If you pass `skipSelf: true`, then the `resolveId` hook of the plugin from which `this.resolve` is called will be skipped when resolving.
 
-#### `this.setAssetSource(assetReferenceId: string, source: string | Buffer) => void`
+#### `this.setAssetSource(assetReferenceId: string, source: string | UInt8Array) => void`
 
-Set the deferred source of an asset.
+Set the deferred source of an asset. Note that you can also pass a Node `Buffer` as `source` as it is a sub-class of `UInt8Array`.
 
 #### `this.warn(warning: string | RollupWarning, position?: number | { column: number; line: number }) => void`
 
@@ -520,7 +520,7 @@ The `position` argument is a character index where the warning was raised. If pr
 
 ☢️ These context utility functions have been deprecated and may be removed in a future Rollup version.
 
-- `this.emitAsset(assetName: string, source: string) => string` - _**Use [`this.emitFile`](guide/en/#thisemitfileemittedfile-emittedchunk--emittedasset--string)**_ - Emits a custom file that is included in the build output, returning an `assetReferenceId` that can be used to reference the emitted file. You can defer setting the source if you provide it later via [`this.setAssetSource(assetReferenceId, source)`](guide/en/#thissetassetsourceassetreferenceid-string-source-string--buffer--void). A string or Buffer source must be set for each asset through either method or an error will be thrown on generate completion.
+- `this.emitAsset(assetName: string, source: string) => string` - _**Use [`this.emitFile`](guide/en/#thisemitfileemittedfile-emittedchunk--emittedasset--string)**_ - Emits a custom file that is included in the build output, returning an `assetReferenceId` that can be used to reference the emitted file. You can defer setting the source if you provide it later via [`this.setAssetSource(assetReferenceId, source)`](guide/en/#thissetassetsourceassetreferenceid-string-source-string--uint8array--void). A string or `UInt8Array`/`Buffer` source must be set for each asset through either method or an error will be thrown on generate completion.
 
   Emitted assets will follow the [`output.assetFileNames`](guide/en/#outputassetfilenames) naming scheme. You can reference the URL of the file in any code returned by a [`load`](guide/en/#load) or [`transform`](guide/en/#transform) plugin hook via `import.meta.ROLLUP_ASSET_URL_assetReferenceId`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -427,9 +427,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.1.tgz",
-      "integrity": "sha512-Zq8gcQGmn4txQEJeiXo/KiLpon8TzAl0kmKH4zdWctPj05nWwp1ClMdAVEloqrQKfaC48PNLdgN/aVaLqUrluA=="
+      "version": "13.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
+      "integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -530,12 +531,6 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
-    },
-    "ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -375,9 +375,10 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.42.tgz",
-      "integrity": "sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ=="
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
@@ -531,6 +532,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.0",
@@ -2307,14 +2314,6 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-          "dev": true
-        }
       }
     },
     "is-regex": {
@@ -3253,12 +3252,6 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
-        "ansi-colors": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-          "dev": true
-        },
         "chokidar": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
@@ -4809,9 +4802,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+      "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
       "dev": true
     },
     "tslint": {
@@ -4895,9 +4888,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,6 @@
     "url": "https://github.com/rollup/rollup/issues"
   },
   "homepage": "https://rollupjs.org/",
-  "dependencies": {
-    "@types/estree": "*"
-  },
   "optionalDependencies": {
     "fsevents": "~2.1.2"
   },
@@ -125,9 +122,9 @@
     "sourcemap-codec": "^1.4.8",
     "systemjs": "^6.2.3",
     "terser": "^4.6.3",
-    "tslib": "^1.10.0",
+    "tslib": "^1.11.0",
     "tslint": "^6.0.0",
-    "typescript": "^3.7.5",
+    "typescript": "^3.8.2",
     "url-parse": "^1.4.7"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
   },
   "homepage": "https://rollupjs.org/",
   "dependencies": {
-    "@types/estree": "*",
-    "@types/node": "*"
+    "@types/estree": "*"
   },
   "optionalDependencies": {
     "fsevents": "~2.1.2"
@@ -75,6 +74,7 @@
     "@rollup/plugin-replace": "^2.3.1",
     "@types/micromatch": "^4.0.1",
     "@types/minimist": "^1.2.0",
+    "@types/node": "^13.7.4",
     "acorn": "^7.1.0",
     "acorn-export-ns-from": "^0.1.0",
     "acorn-import-meta": "^1.0.0",

--- a/scripts/test-package.js
+++ b/scripts/test-package.js
@@ -1,15 +1,5 @@
 const pkg = require('../package.json');
 
-function checkTypes() {
-	for (const key of Object.keys(pkg.dependencies)) {
-		if (key.startsWith('@types') && pkg.dependencies[key] !== '*') {
-			throw new Error(
-				`The dependency ${key} should have version range "*" but it has "${pkg.dependencies[key]}".`
-			);
-		}
-	}
-}
-
 function checkChokidar() {
 	const chokidarPkg = require('../node_modules/chokidar/package.json');
 	const chokidarFsevents = chokidarPkg.dependencies.fsevents;
@@ -22,5 +12,4 @@ function checkChokidar() {
 	}
 }
 
-checkTypes();
 checkChokidar();

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -1,7 +1,6 @@
 import * as acorn from 'acorn';
 import injectExportNsFrom from 'acorn-export-ns-from';
 import injectImportMeta from 'acorn-import-meta';
-import * as ESTree from 'estree';
 import GlobalScope from './ast/scopes/GlobalScope';
 import { PathTracker } from './ast/utils/PathTracker';
 import Chunk from './Chunk';
@@ -49,7 +48,7 @@ export default class Graph {
 	acornOptions: acorn.Options;
 	acornParser: typeof acorn.Parser;
 	cachedModules: Map<string, ModuleJSON>;
-	contextParse: (code: string, acornOptions?: acorn.Options) => ESTree.Program;
+	contextParse: (code: string, acornOptions?: acorn.Options) => acorn.Node;
 	deoptimizationTracker: PathTracker;
 	getModuleContext: (id: string) => string;
 	moduleById = new Map<string, Module | ExternalModule>();
@@ -124,7 +123,7 @@ export default class Graph {
 				...defaultAcornOptions,
 				...options,
 				...this.acornOptions
-			}) as any;
+			});
 
 		this.pluginDriver = new PluginDriver(
 			this,

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1,5 +1,4 @@
 import * as acorn from 'acorn';
-import * as ESTree from 'estree';
 import { locate } from 'locate-character';
 import MagicString from 'magic-string';
 import extractAssignedNames from 'rollup-pluginutils/src/extractAssignedNames';
@@ -121,7 +120,7 @@ export interface AstContext {
 }
 
 export const defaultAcornOptions: acorn.Options = {
-	ecmaVersion: 2020 as any,
+	ecmaVersion: 2020,
 	preserveParens: false,
 	sourceType: 'module'
 };
@@ -239,7 +238,7 @@ export default class Module {
 	private astContext!: AstContext;
 	private context: string;
 	private defaultExport: ExportDefaultVariable | null | undefined = null;
-	private esTreeAst!: ESTree.Program;
+	private esTreeAst!: acorn.Node;
 	private graph: Graph;
 	private magicString!: MagicString;
 	private namespaceVariable: NamespaceVariable | null = null;

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -331,7 +331,7 @@ function writeOutputFile(
 ): Promise<unknown> {
 	const fileName = resolve(outputOptions.dir || dirname(outputOptions.file!), outputFile.fileName);
 	let writeSourceMapPromise: Promise<void> | undefined;
-	let source: string | Buffer;
+	let source: string | Uint8Array;
 	if (outputFile.type === 'asset') {
 		source = outputFile.source;
 	} else {

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -1,5 +1,3 @@
-import * as ESTree from 'estree';
-
 export const VERSION: string;
 
 export interface RollupError extends RollupLogProps {
@@ -88,7 +86,7 @@ export interface SourceMap {
 export type SourceMapInput = ExistingRawSourceMap | string | null | { mappings: '' };
 
 export interface SourceDescription {
-	ast?: ESTree.Program;
+	ast?: AcornNode;
 	code: string;
 	map?: SourceMapInput;
 	moduleSideEffects?: boolean | null;
@@ -96,7 +94,7 @@ export interface SourceDescription {
 }
 
 export interface TransformModuleJSON {
-	ast: ESTree.Program;
+	ast: AcornNode;
 	code: string;
 	// note if plugins use new this.cache to opt-out auto transform cache
 	customTransformCache: boolean;
@@ -174,7 +172,7 @@ export interface PluginContext extends MinimalPluginContext {
 	/** @deprecated Use `this.resolve` instead */
 	isExternal: IsExternal;
 	moduleIds: IterableIterator<string>;
-	parse: (input: string, options: any) => ESTree.Program;
+	parse: (input: string, options: any) => AcornNode;
 	resolve: (
 		source: string,
 		importer: string,
@@ -251,7 +249,7 @@ export type RenderChunkHook = (
 
 export type ResolveDynamicImportHook = (
 	this: PluginContext,
-	specifier: string | ESTree.Node,
+	specifier: string | AcornNode,
 	importer: string
 ) => Promise<ResolveIdResult> | ResolveIdResult;
 
@@ -616,3 +614,9 @@ export interface RollupWatcher
 }
 
 export function watch(configs: RollupWatchOptions[]): RollupWatcher;
+
+interface AcornNode {
+	end: number;
+	start: number;
+	type: string;
+}

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -129,7 +129,7 @@ export interface MinimalPluginContext {
 export interface EmittedAsset {
 	fileName?: string;
 	name?: string;
-	source?: string | Buffer;
+	source?: string | Uint8Array;
 	type: 'asset';
 }
 
@@ -142,7 +142,7 @@ export interface EmittedChunk {
 
 export type EmittedFile = EmittedAsset | EmittedChunk;
 
-export type EmitAsset = (name: string, source?: string | Buffer) => string;
+export type EmitAsset = (name: string, source?: string | Uint8Array) => string;
 
 export type EmitChunk = (id: string, options?: { name?: string }) => string;
 
@@ -182,7 +182,7 @@ export interface PluginContext extends MinimalPluginContext {
 	) => Promise<ResolvedId | null>;
 	/** @deprecated Use `this.resolve` instead */
 	resolveId: (source: string, importer: string) => Promise<string | null>;
-	setAssetSource: (assetReferenceId: string, source: string | Buffer) => void;
+	setAssetSource: (assetReferenceId: string, source: string | Uint8Array) => void;
 	warn: (warning: RollupWarning | string, pos?: number | { column: number; line: number }) => void;
 }
 
@@ -478,7 +478,7 @@ export interface OutputAsset {
 	fileName: string;
 	/** @deprecated Accessing "isAsset" on files in the bundle is deprecated, please use "type === \'asset\'" instead */
 	isAsset: true;
-	source: string | Buffer;
+	source: string | Uint8Array;
 	type: 'asset';
 }
 

--- a/src/utils/PluginContext.ts
+++ b/src/utils/PluginContext.ts
@@ -84,7 +84,7 @@ export function getPluginContexts(
 			},
 			cache: cacheInstance,
 			emitAsset: getDeprecatedContextHandler(
-				(name: string, source?: string | Buffer) =>
+				(name: string, source?: string | Uint8Array) =>
 					fileEmitter.emitFile({ type: 'asset', name, source }),
 				'emitAsset',
 				'emitFile',

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -24,7 +24,7 @@ function mkdirpath(path: string) {
 	}
 }
 
-export function writeFile(dest: string, data: string | Buffer) {
+export function writeFile(dest: string, data: string | Uint8Array) {
 	return new Promise<void>((fulfil, reject) => {
 		mkdirpath(dest);
 

--- a/src/utils/pureComments.ts
+++ b/src/utils/pureComments.ts
@@ -1,11 +1,10 @@
 import * as acorn from 'acorn';
 // @ts-ignore
 import { base as basicWalker } from 'acorn-walk';
-import * as ESTree from 'estree';
 import { CommentDescription } from '../Module';
 
 function handlePureAnnotationsOfNode(
-	node: ESTree.Node & acorn.Node,
+	node: acorn.Node,
 	state: { commentIndex: number; commentNodes: CommentDescription[] },
 	type: string = node.type
 ) {
@@ -20,7 +19,7 @@ function handlePureAnnotationsOfNode(
 }
 
 function markPureNode(
-	node: ESTree.Node & { annotations?: CommentDescription[] },
+	node: acorn.Node & { annotations?: CommentDescription[] },
 	comment: CommentDescription
 ) {
 	if (node.annotations) {
@@ -29,7 +28,7 @@ function markPureNode(
 		node.annotations = [comment];
 	}
 	if (node.type === 'ExpressionStatement') {
-		node = node.expression;
+		node = (node as any).expression;
 	}
 	if (node.type === 'CallExpression' || node.type === 'NewExpression') {
 		(node as any).annotatedPure = true;
@@ -39,8 +38,8 @@ function markPureNode(
 const pureCommentRegex = /[@#]__PURE__/;
 const isPureComment = (comment: CommentDescription) => pureCommentRegex.test(comment.text);
 
-export function markPureCallExpressions(comments: CommentDescription[], esTreeAst: ESTree.Program) {
-	handlePureAnnotationsOfNode(esTreeAst as any, {
+export function markPureCallExpressions(comments: CommentDescription[], esTreeAst: acorn.Node) {
+	handlePureAnnotationsOfNode(esTreeAst, {
 		commentIndex: 0,
 		commentNodes: comments.filter(isPureComment)
 	});

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -102,7 +102,7 @@ export default function transform(
 						err.hook = 'transform';
 						return pluginContext.error(err);
 					},
-					emitAsset(name: string, source?: string | Buffer) {
+					emitAsset(name: string, source?: string | Uint8Array) {
 						const emittedFile = { type: 'asset' as const, name, source };
 						emittedFiles.push({ ...emittedFile });
 						return graph.pluginDriver.emitFile(emittedFile);

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -3,7 +3,8 @@
 		"noEmit": true,
 		"strict": true,
 		"pretty": true,
-		"lib": ["es2015"]
+		"lib": ["es2015"],
+		"types": []
 	},
 	"include": ["./dist", "./typings"],
 	"files": ["./index.ts"]


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:
Resolves #3108, #2142

### Description
I hope this is the last change that is going into 2.0.0.
One problem that was reported repeatedly is that Rollup's dependency on `@types/node` was causing issues for users that were not targeting Node but had conflicting types such as AMD or browser types. Moreover it was not clear why non-TypeScript-users would need to have external type dependencies.

One suggestion was to make the types a peerDependency but in our opinion this would have caused unnecessary friction for TypeScript users. This PR finally fixes this by getting rid of the @types dependencies the following way:

- The only Node type we needed for our external interface was `Buffer`. A Node `Buffer` however is a sub-class of `UInt8Array`, which is a standard JS type and still very powerful. So this replaces `Buffer` everywhere with `UInt8Array`.
- Even though we had `ESTree` types in our public interface, we only had `acorn.Node` as a type internally. This PR replaces all `ESTree.Node` types with a simplified, copied version of `acorn.Node` that reflects the properties present on all nodes. Note that you will need type casts if you need to access properties of specific node types.

I also made sure that the typings test for the public interface that we have in place will ignore all `@types` packages that come from our dev dependencies and will thus ensure that we do not accidentally add a dependency on `@types/node` to the published artefact.