### PR TITLE
change error mssg from deprecated name to rollup-plugin-json

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -133,7 +133,7 @@ function tryParse(module: Module, Parser: typeof acorn.Parser, acornOptions: aco
 	} catch (err) {
 		let message = err.message.replace(/ \(\d+:\d+\)$/, '');
 		if (module.id.endsWith('.json')) {
-			message += ' (Note that you need @rollup/plugin-json to import JSON files)';
+			message += ' (Note that you need rollup-plugin-json to import JSON files)';
 		} else if (!module.id.endsWith('.js')) {
 			message += ' (Note that you need plugins to import files that are not JavaScript)';
 		}

--- a/test/function/samples/error-parse-json/_config.js
+++ b/test/function/samples/error-parse-json/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 		'throws with an extended error message when failing to parse a file with ".json" extension',
 	error: {
 		code: 'PARSE_ERROR',
-		message: 'Unexpected token (Note that you need @rollup/plugin-json to import JSON files)',
+		message: 'Unexpected token (Note that you need rollup-plugin-json to import JSON files)',
 		parserError: {
 			loc: {
 				column: 8,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [X] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [X] no

List any relevant issue numbers:

### Description

I was debugging and just noticed the error message refers to a deprecated package. Just want to save others one link to click 😆 
