### PR TITLE
getInteropBlock() to work with null prototype objects

### DIFF
--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -20,7 +20,7 @@ export default function getInteropBlock(
 			}
 
 			return (
-				`${name}${_}=${_}${name}${_}&&${_}${name}.hasOwnProperty('default')${_}?` +
+				`${name}${_}=${_}${name}${_}&&${_}Object.prototype.hasOwnProperty.call(${name},${_}'default')${_}?` +
 				`${_}${name}['default']${_}:${_}${name};`
 			);
 		})

--- a/test/chunking-form/samples/avoid-chunk-import-hoisting/_expected/amd/generated-dep.js
+++ b/test/chunking-form/samples/avoid-chunk-import-hoisting/_expected/amd/generated-dep.js
@@ -1,6 +1,6 @@
 define(['exports', 'lib'], function (exports, value) { 'use strict';
 
-	value = value && value.hasOwnProperty('default') ? value['default'] : value;
+	value = value && Object.prototype.hasOwnProperty.call(value, 'default') ? value['default'] : value;
 
 	var dep = 2 * value;
 

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/_virtual/_external_commonjs-external
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/_virtual/_external_commonjs-external
@@ -1,6 +1,6 @@
 define(['external'], function (external) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 
 

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/commonjs.js
@@ -1,6 +1,6 @@
 define(['exports', 'external', './other', './_virtual/_external_commonjs-external', './_virtual/other.js_commonjs-proxy'], function (exports, external, other, _external_commonjsExternal, other$1) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	const { value } = other$1;
 

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/main.js
@@ -1,6 +1,6 @@
 define(['external', './commonjs'], function (external, commonjs) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	console.log(commonjs.default, external);
 

--- a/test/form/samples/compact/_expected/amd.js
+++ b/test/form/samples/compact/_expected/amd.js
@@ -1,4 +1,4 @@
-define(['external'],function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',__proto__:null,get default(){return foo}});console.log(self);
+define(['external'],function(x){'use strict';x=x&&Object.prototype.hasOwnProperty.call(x,'default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',__proto__:null,get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/iife.js
+++ b/test/form/samples/compact/_expected/iife.js
@@ -1,4 +1,4 @@
-var foo=(function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',__proto__:null,get default(){return foo}});console.log(self);
+var foo=(function(x){'use strict';x=x&&Object.prototype.hasOwnProperty.call(x,'default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',__proto__:null,get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/compact/_expected/umd.js
+++ b/test/form/samples/compact/_expected/umd.js
@@ -1,4 +1,4 @@
-(function(g,f){typeof exports==='object'&&typeof module!=='undefined'?module.exports=f(require('external')):typeof define==='function'&&define.amd?define(['external'],f):(g=g||self,g.foo=f(g.x));}(this,(function(x){'use strict';x=x&&x.hasOwnProperty('default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',__proto__:null,get default(){return foo}});console.log(self);
+(function(g,f){typeof exports==='object'&&typeof module!=='undefined'?module.exports=f(require('external')):typeof define==='function'&&define.amd?define(['external'],f):(g=g||self,g.foo=f(g.x));}(this,(function(x){'use strict';x=x&&Object.prototype.hasOwnProperty.call(x,'default')?x['default']:x;var self=/*#__PURE__*/Object.freeze({[Symbol.toStringTag]:'Module',__proto__:null,get default(){return foo}});console.log(self);
 function foo () {
 	console.log( x );
 }

--- a/test/form/samples/deconflict-format-specific-globals/_expected/amd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/amd.js
@@ -19,7 +19,7 @@ define(['module', 'require', 'external'], function (module, require, external) {
 		}
 	}
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	console.log(external);
 

--- a/test/form/samples/deconflict-format-specific-globals/_expected/iife.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/iife.js
@@ -1,7 +1,7 @@
 var bundle = (function (external) {
 	'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	console.log(external);
 

--- a/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, global.bundle = factory(global.external));
 }(this, (function (external) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	console.log(external);
 

--- a/test/form/samples/export-default-import/_expected/amd.js
+++ b/test/form/samples/export-default-import/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['exports', 'x'], function (exports, x) { 'use strict';
 
-	x = x && x.hasOwnProperty('default') ? x['default'] : x;
+	x = x && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 
 
 

--- a/test/form/samples/export-default-import/_expected/iife.js
+++ b/test/form/samples/export-default-import/_expected/iife.js
@@ -1,7 +1,7 @@
 var myBundle = (function (exports, x) {
 	'use strict';
 
-	x = x && x.hasOwnProperty('default') ? x['default'] : x;
+	x = x && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 
 
 

--- a/test/form/samples/export-default-import/_expected/umd.js
+++ b/test/form/samples/export-default-import/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.myBundle = {}, global.x));
 }(this, (function (exports, x) { 'use strict';
 
-	x = x && x.hasOwnProperty('default') ? x['default'] : x;
+	x = x && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 
 
 

--- a/test/form/samples/external-deshadowing/_expected/amd.js
+++ b/test/form/samples/external-deshadowing/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['exports', 'a', 'b'], function (exports, a, Test$1) { 'use strict';
 
-  Test$1 = Test$1 && Test$1.hasOwnProperty('default') ? Test$1['default'] : Test$1;
+  Test$1 = Test$1 && Object.prototype.hasOwnProperty.call(Test$1, 'default') ? Test$1['default'] : Test$1;
 
   const Test = () => {
     console.log(a.Test);

--- a/test/form/samples/external-deshadowing/_expected/iife.js
+++ b/test/form/samples/external-deshadowing/_expected/iife.js
@@ -1,7 +1,7 @@
 var myBundle = (function (exports, a, Test$1) {
   'use strict';
 
-  Test$1 = Test$1 && Test$1.hasOwnProperty('default') ? Test$1['default'] : Test$1;
+  Test$1 = Test$1 && Object.prototype.hasOwnProperty.call(Test$1, 'default') ? Test$1['default'] : Test$1;
 
   const Test = () => {
     console.log(a.Test);

--- a/test/form/samples/external-deshadowing/_expected/umd.js
+++ b/test/form/samples/external-deshadowing/_expected/umd.js
@@ -4,7 +4,7 @@
   (global = global || self, factory(global.myBundle = {}, global.a, global.b));
 }(this, (function (exports, a, Test$1) { 'use strict';
 
-  Test$1 = Test$1 && Test$1.hasOwnProperty('default') ? Test$1['default'] : Test$1;
+  Test$1 = Test$1 && Object.prototype.hasOwnProperty.call(Test$1, 'default') ? Test$1['default'] : Test$1;
 
   const Test = () => {
     console.log(a.Test);

--- a/test/form/samples/external-imports-custom-names/_expected/amd.js
+++ b/test/form/samples/external-imports-custom-names/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['jquery'], function ($) { 'use strict';
 
-	$ = $ && $.hasOwnProperty('default') ? $['default'] : $;
+	$ = $ && Object.prototype.hasOwnProperty.call($, 'default') ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/samples/external-imports-custom-names/_expected/iife.js
+++ b/test/form/samples/external-imports-custom-names/_expected/iife.js
@@ -1,7 +1,7 @@
 (function ($) {
 	'use strict';
 
-	$ = $ && $.hasOwnProperty('default') ? $['default'] : $;
+	$ = $ && Object.prototype.hasOwnProperty.call($, 'default') ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/samples/external-imports-custom-names/_expected/umd.js
+++ b/test/form/samples/external-imports-custom-names/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.jQuery));
 }(this, (function ($) { 'use strict';
 
-	$ = $ && $.hasOwnProperty('default') ? $['default'] : $;
+	$ = $ && Object.prototype.hasOwnProperty.call($, 'default') ? $['default'] : $;
 
 	$( function () {
 		$( 'body' ).html( '<h1>hello world!</h1>' );

--- a/test/form/samples/external-imports/_expected/amd.js
+++ b/test/form/samples/external-imports/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['factory', 'baz', 'shipping-port', 'alphabet'], function (factory, baz, containers, alphabet) { 'use strict';
 
-	factory = factory && factory.hasOwnProperty('default') ? factory['default'] : factory;
+	factory = factory && Object.prototype.hasOwnProperty.call(factory, 'default') ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/samples/external-imports/_expected/iife.js
+++ b/test/form/samples/external-imports/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (factory, baz, containers, alphabet) {
 	'use strict';
 
-	factory = factory && factory.hasOwnProperty('default') ? factory['default'] : factory;
+	factory = factory && Object.prototype.hasOwnProperty.call(factory, 'default') ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/samples/external-imports/_expected/umd.js
+++ b/test/form/samples/external-imports/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.factory, global.baz, global.containers, global.alphabet));
 }(this, (function (factory, baz, containers, alphabet) { 'use strict';
 
-	factory = factory && factory.hasOwnProperty('default') ? factory['default'] : factory;
+	factory = factory && Object.prototype.hasOwnProperty.call(factory, 'default') ? factory['default'] : factory;
 	var alphabet__default = 'default' in alphabet ? alphabet['default'] : alphabet;
 
 	factory( null );

--- a/test/form/samples/guessed-global-names/_expected/amd.js
+++ b/test/form/samples/guessed-global-names/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['unchanged', 'changed', 'special-character', 'with/slash', './relative'], function (unchanged, changedName, specialCharacter, slash, relative_js) { 'use strict';
 
-	changedName = changedName && changedName.hasOwnProperty('default') ? changedName['default'] : changedName;
+	changedName = changedName && Object.prototype.hasOwnProperty.call(changedName, 'default') ? changedName['default'] : changedName;
 
 	console.log(unchanged.foo, changedName, specialCharacter.bar, slash.baz, relative_js.quux);
 

--- a/test/form/samples/guessed-global-names/_expected/iife.js
+++ b/test/form/samples/guessed-global-names/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (unchanged, changedName, specialCharacter, slash, relative_js) {
 	'use strict';
 
-	changedName = changedName && changedName.hasOwnProperty('default') ? changedName['default'] : changedName;
+	changedName = changedName && Object.prototype.hasOwnProperty.call(changedName, 'default') ? changedName['default'] : changedName;
 
 	console.log(unchanged.foo, changedName, specialCharacter.bar, slash.baz, relative_js.quux);
 

--- a/test/form/samples/guessed-global-names/_expected/umd.js
+++ b/test/form/samples/guessed-global-names/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.unchanged, global.changedName, global.specialCharacter, global.slash, global.relative_js));
 }(this, (function (unchanged, changedName, specialCharacter, slash, relative_js) { 'use strict';
 
-	changedName = changedName && changedName.hasOwnProperty('default') ? changedName['default'] : changedName;
+	changedName = changedName && Object.prototype.hasOwnProperty.call(changedName, 'default') ? changedName['default'] : changedName;
 
 	console.log(unchanged.foo, changedName, specialCharacter.bar, slash.baz, relative_js.quux);
 

--- a/test/form/samples/paths-function/_expected/amd.js
+++ b/test/form/samples/paths-function/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['https://unpkg.com/foo'], function (foo) { 'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths-function/_expected/iife.js
+++ b/test/form/samples/paths-function/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths-function/_expected/umd.js
+++ b/test/form/samples/paths-function/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths-relative/_expected/amd.js
+++ b/test/form/samples/paths-relative/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['../foo'], function (foo) { 'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths-relative/_expected/iife.js
+++ b/test/form/samples/paths-relative/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths-relative/_expected/umd.js
+++ b/test/form/samples/paths-relative/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths/_expected/amd.js
+++ b/test/form/samples/paths/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['https://unpkg.com/foo'], function (foo) { 'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths/_expected/iife.js
+++ b/test/form/samples/paths/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (foo) {
 	'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/paths/_expected/umd.js
+++ b/test/form/samples/paths/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.foo));
 }(this, (function (foo) { 'use strict';
 
-	foo = foo && foo.hasOwnProperty('default') ? foo['default'] : foo;
+	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
 	assert.equal( foo, 42 );
 

--- a/test/form/samples/reexport-external-default-and-name/_expected/amd.js
+++ b/test/form/samples/reexport-external-default-and-name/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['exports', 'external'], function (exports, external) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	const value = 42;
 

--- a/test/form/samples/reexport-external-default-and-name/_expected/iife.js
+++ b/test/form/samples/reexport-external-default-and-name/_expected/iife.js
@@ -1,7 +1,7 @@
 var bundle = (function (exports, external) {
 	'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	const value = 42;
 

--- a/test/form/samples/reexport-external-default-and-name/_expected/umd.js
+++ b/test/form/samples/reexport-external-default-and-name/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.bundle = {}, global.external));
 }(this, (function (exports, external) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	const value = 42;
 

--- a/test/form/samples/reexport-external-default/_expected/amd.js
+++ b/test/form/samples/reexport-external-default/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['external1', 'external2'], function (external1, external2) { 'use strict';
 
-	external2 = external2 && external2.hasOwnProperty('default') ? external2['default'] : external2;
+	external2 = external2 && Object.prototype.hasOwnProperty.call(external2, 'default') ? external2['default'] : external2;
 
 	console.log(external1.foo);
 

--- a/test/form/samples/reexport-external-default/_expected/iife.js
+++ b/test/form/samples/reexport-external-default/_expected/iife.js
@@ -1,7 +1,7 @@
 var bundle = (function (external1, external2) {
 	'use strict';
 
-	external2 = external2 && external2.hasOwnProperty('default') ? external2['default'] : external2;
+	external2 = external2 && Object.prototype.hasOwnProperty.call(external2, 'default') ? external2['default'] : external2;
 
 	console.log(external1.foo);
 

--- a/test/form/samples/reexport-external-default/_expected/umd.js
+++ b/test/form/samples/reexport-external-default/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, global.bundle = factory(global.external1, global.external2));
 }(this, (function (external1, external2) { 'use strict';
 
-	external2 = external2 && external2.hasOwnProperty('default') ? external2['default'] : external2;
+	external2 = external2 && Object.prototype.hasOwnProperty.call(external2, 'default') ? external2['default'] : external2;
 
 	console.log(external1.foo);
 

--- a/test/form/samples/relative-external-with-global/_expected/amd.js
+++ b/test/form/samples/relative-external-with-global/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['./lib/throttle'], function (throttle) { 'use strict';
 
-	throttle = throttle && throttle.hasOwnProperty('default') ? throttle['default'] : throttle;
+	throttle = throttle && Object.prototype.hasOwnProperty.call(throttle, 'default') ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );

--- a/test/form/samples/relative-external-with-global/_expected/iife.js
+++ b/test/form/samples/relative-external-with-global/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (throttle) {
 	'use strict';
 
-	throttle = throttle && throttle.hasOwnProperty('default') ? throttle['default'] : throttle;
+	throttle = throttle && Object.prototype.hasOwnProperty.call(throttle, 'default') ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );

--- a/test/form/samples/relative-external-with-global/_expected/umd.js
+++ b/test/form/samples/relative-external-with-global/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.Lib.throttle));
 }(this, (function (throttle) { 'use strict';
 
-	throttle = throttle && throttle.hasOwnProperty('default') ? throttle['default'] : throttle;
+	throttle = throttle && Object.prototype.hasOwnProperty.call(throttle, 'default') ? throttle['default'] : throttle;
 
 	const fn = throttle( () => {
 		console.log( '.' );

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/amd.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/amd.js
@@ -19,7 +19,7 @@ define(['require', 'exports', 'external'], function (require, exports, myExterna
 		}
 	}
 
-	myExternal = myExternal && myExternal.hasOwnProperty('default') ? myExternal['default'] : myExternal;
+	myExternal = myExternal && Object.prototype.hasOwnProperty.call(myExternal, 'default') ? myExternal['default'] : myExternal;
 
 	const test = () => myExternal;
 

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/iife.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/iife.js
@@ -1,7 +1,7 @@
 var bundle = (function (exports, myExternal) {
 	'use strict';
 
-	myExternal = myExternal && myExternal.hasOwnProperty('default') ? myExternal['default'] : myExternal;
+	myExternal = myExternal && Object.prototype.hasOwnProperty.call(myExternal, 'default') ? myExternal['default'] : myExternal;
 
 	const test = () => myExternal;
 

--- a/test/form/samples/resolve-external-dynamic-imports/_expected/umd.js
+++ b/test/form/samples/resolve-external-dynamic-imports/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.bundle = {}, global.myExternal));
 }(this, (function (exports, myExternal) { 'use strict';
 
-	myExternal = myExternal && myExternal.hasOwnProperty('default') ? myExternal['default'] : myExternal;
+	myExternal = myExternal && Object.prototype.hasOwnProperty.call(myExternal, 'default') ? myExternal['default'] : myExternal;
 
 	const test = () => myExternal;
 

--- a/test/form/samples/url-external/_expected/amd.js
+++ b/test/form/samples/url-external/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['https://external.com/external.js'], function (external) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	console.log(external);
 

--- a/test/form/samples/url-external/_expected/iife.js
+++ b/test/form/samples/url-external/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (external) {
 	'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	console.log(external);
 

--- a/test/form/samples/url-external/_expected/umd.js
+++ b/test/form/samples/url-external/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.external));
 }(this, (function (external) { 'use strict';
 
-	external = external && external.hasOwnProperty('default') ? external['default'] : external;
+	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
 	console.log(external);
 

--- a/test/form/samples/use-global-map-for-export-name/_expected/amd.js
+++ b/test/form/samples/use-global-map-for-export-name/_expected/amd.js
@@ -1,6 +1,6 @@
 define(['leaflet'], function (L) { 'use strict';
 
-	L = L && L.hasOwnProperty('default') ? L['default'] : L;
+	L = L && Object.prototype.hasOwnProperty.call(L, 'default') ? L['default'] : L;
 
 	L.terminator = function(options) {
 	};

--- a/test/form/samples/use-global-map-for-export-name/_expected/iife.js
+++ b/test/form/samples/use-global-map-for-export-name/_expected/iife.js
@@ -1,7 +1,7 @@
 (function (L) {
 	'use strict';
 
-	L = L && L.hasOwnProperty('default') ? L['default'] : L;
+	L = L && Object.prototype.hasOwnProperty.call(L, 'default') ? L['default'] : L;
 
 	L.terminator = function(options) {
 	};

--- a/test/form/samples/use-global-map-for-export-name/_expected/umd.js
+++ b/test/form/samples/use-global-map-for-export-name/_expected/umd.js
@@ -4,7 +4,7 @@
 	(global = global || self, factory(global.L));
 }(this, (function (L) { 'use strict';
 
-	L = L && L.hasOwnProperty('default') ? L['default'] : L;
+	L = L && Object.prototype.hasOwnProperty.call(L, 'default') ? L['default'] : L;
 
 	L.terminator = function(options) {
 	};

--- a/test/function/samples/default-export-with-null-prototype/_config.js
+++ b/test/function/samples/default-export-with-null-prototype/_config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	description: 'default exports of objects with null prototypes are supported',
+	options: {
+		external: ['foo'],
+		output: {
+			format: 'iife',
+			globals: { foo: 'foo' }
+		},
+		plugins: [
+			{
+				renderChunk: code => `
+					const foo = { __proto__: null, bar: 42 };
+					${code}
+				`
+			}
+		]
+	}
+};

--- a/test/function/samples/default-export-with-null-prototype/main.js
+++ b/test/function/samples/default-export-with-null-prototype/main.js
@@ -1,0 +1,3 @@
+import foo from 'foo';
+
+assert.equal(foo.bar, 42);


### PR DESCRIPTION
…e objects

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Currently, rollup attempts to detect how exports should be generated based on the exported values from the module entry.

1. If there is a [default export](https://rollupjs.org/repl/?version=1.32.0&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGRlZmF1bHQlMjAnZGVmYXVsdC1leHBvcnQnJTNCJTIyJTJDJTIyaXNFbnRyeSUyMiUzQXRydWUlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyZm9ybWF0JTIyJTNBJTIyYW1kJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlMkMlMjJnbG9iYWxzJTIyJTNBJTdCJTdEJTdEJTJDJTIyZXhhbXBsZSUyMiUzQW51bGwlN0Q=), export the default property as-is.
2. If there is a [named export (`named`)](https://rollupjs.org/repl/?version=1.32.0&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGNvbnN0JTIwbmFtZWQlMjAlM0QlMjAnbmFtZWQtZXhwb3J0JyUzQiU1Q24lMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlMjJmb3JtYXQlMjIlM0ElMjJhbWQlMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlMkMlMjJhbWQlMjIlM0ElN0IlMjJpZCUyMiUzQSUyMiUyMiU3RCUyQyUyMmdsb2JhbHMlMjIlM0ElN0IlN0QlN0QlMkMlMjJleGFtcGxlJTIyJTNBbnVsbCU3RA==), rollup returns an object with the `named` property.
3. If there are both [a default export and a named export (`named`)](https://rollupjs.org/repl/?version=1.32.0&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGNvbnN0JTIwbmFtZWQlMjAlM0QlMjAnbmFtZWQtZXhwb3J0JyUzQiU1Q25leHBvcnQlMjBkZWZhdWx0JTIwJ2RlZmF1bHQtZXhwb3J0JyUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmFtZCUyMiUyQyUyMm5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmFtZCUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyJTIyJTdEJTJDJTIyZ2xvYmFscyUyMiUzQSU3QiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE), rollup returns an object with the `default` and the `named` property. It's important to note that if no `output.exports` property is set, rollup warns in this case.

On the other hand, when importing the default value from an external module, rollup injects [some interop](https://rollupjs.org/repl/?version=1.32.0&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMGZvbyUyMGZyb20lMjAnbW9kdWxlJTJGZm9vJyUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmFtZCUyMiUyQyUyMm5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmFtZCUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyJTIyJTdEJTJDJTIyZ2xvYmFscyUyMiUzQSU3QiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE) code extract the code right default value. This interop checks the presence of the `default` property on the exported object using `module.hasOwnProperty('default')`.

I recently ran into a case where the interop code throws an error because `hasOwnProperty` is not defined on the external module. This happens because the module (`module/a`) has a single default export and the default export value has no prototype. In this case, if another module (`module/b`) imports the default export the interop code will throw because `hasOwnProperty` is not defined on the object.

```js
/* `module/a` original code */
export default { __proto__: null, name: 'a' };

/* `module/a` generated code */
define('module/a', function () { 'use strict';
  var main = { __proto__: null, name: 'a' };
  return main;
});
```

```js
/* `module/b` original code */
import a from 'module/a';
console.log(a.name);

/* `module/b` generated code */
define('module/b', ['module/a'], function (a) { 'use strict';
  a = a && a.hasOwnProperty('default') ? a['default'] : a;
  //              ^ throws here because a does inherit from object!
  console.log(a.name);
});
```