### PR TITLE
Avoid invalid code when "else" branch is simplified

### DIFF
--- a/src/ast/nodes/IfStatement.ts
+++ b/src/ast/nodes/IfStatement.ts
@@ -82,6 +82,9 @@ export default class IfStatement extends StatementBase implements DeoptimizableE
 			}
 			if (this.alternate !== null) {
 				if (this.alternate.included) {
+					if (code.original.charCodeAt(this.alternate.start - 1) === 101 /* f */) {
+						code.prependLeft(this.alternate.start, ' ');
+					}
 					this.alternate.render(code, options);
 				} else {
 					code.remove(this.consequent.end, this.alternate.end);

--- a/src/ast/nodes/IfStatement.ts
+++ b/src/ast/nodes/IfStatement.ts
@@ -82,7 +82,7 @@ export default class IfStatement extends StatementBase implements DeoptimizableE
 			}
 			if (this.alternate !== null) {
 				if (this.alternate.included) {
-					if (code.original.charCodeAt(this.alternate.start - 1) === 101 /* f */) {
+					if (code.original.charCodeAt(this.alternate.start - 1) === 101 /* e */) {
 						code.prependLeft(this.alternate.start, ' ');
 					}
 					this.alternate.render(code, options);

--- a/test/function/samples/if-statement-insert-whitespace/_config.js
+++ b/test/function/samples/if-statement-insert-whitespace/_config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	description: 'inserts necessary white-space when simplifying if-statements (#3419)',
+	options: {
+		external: 'external'
+	},
+	context: {
+		require(required) {
+			return false;
+		}
+	}
+};

--- a/test/function/samples/if-statement-insert-whitespace/main.js
+++ b/test/function/samples/if-statement-insert-whitespace/main.js
@@ -1,0 +1,8 @@
+let works = false;
+const makeItWork = () => works = true;
+
+import value from 'external';
+
+if (value) {} else"production"!=="local"?makeItWork():void 0;
+
+assert.ok(works);


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3419

### Description
This ensures that in a situation such as #3419, there is always whitespace or a similar separator between the "else" keyword and the following branch so that the expression can be transformed freely. This is a similar fix as was previously implemented for for..in and for..of statements.