### PR TITLE
Make sure logical expressions always check the left argument for side effects

### DIFF
--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -97,10 +97,13 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {
-		if (this.usedBranch === null) {
-			return this.left.hasEffects(context) || this.right.hasEffects(context);
+		if (this.left.hasEffects(context)) {
+			return true;
 		}
-		return this.usedBranch.hasEffects(context);
+		if (this.usedBranch !== this.left) {
+			return this.right.hasEffects(context);
+		}
+		return false;
 	}
 
 	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {

--- a/test/function/samples/reassigned-return-expression/_config.js
+++ b/test/function/samples/reassigned-return-expression/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not bind return expressions before assignments are bound (#3382)'
+};

--- a/test/function/samples/reassigned-return-expression/main.js
+++ b/test/function/samples/reassigned-return-expression/main.js
@@ -1,0 +1,17 @@
+function getIcon() {
+	var icon = undefined;
+	icon = { code: true };
+	return icon;
+}
+
+function main() {
+	var a = getIcon() || {
+		code: undefined
+	};
+	if (!a.code) {
+		return 'broken';
+	}
+	return 'works';
+}
+
+assert.strictEqual(main(), 'works');


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3382 

### Description
There is a bug in logical expressions in that it would only check one of the arguments for side-effects if the value can be resolved at some point. However, checking for side-effects has the "side-effect" of binding new assignments, which in the linked issue was necessary to trigger some deoptimizations. The fix here is rather small even though tracking it was quite intricate.