### PR TITLE
Use correct file names when writing sourcemaps for multiple outputs using the "dir" option

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -509,6 +509,7 @@ export default class Chunk {
 	) {
 		timeStart('render format', 3);
 
+		const chunkId = this.id!;
 		const format = options.format as string;
 		const finalise = finalisers[format];
 		if (options.dynamicImportFunction && format !== 'es') {
@@ -602,12 +603,12 @@ export default class Chunk {
 
 				let file: string;
 				if (options.file) file = resolve(options.sourcemapFile || options.file);
-				else if (options.dir) file = resolve(options.dir, this.id!);
-				else file = resolve(this.id!);
+				else if (options.dir) file = resolve(options.dir, chunkId);
+				else file = resolve(chunkId);
 
 				const decodedMap = magicString.generateDecodedMap({});
 				map = collapseSourcemaps(
-					this,
+					this.graph,
 					file,
 					decodedMap,
 					this.usedModules,

--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -1,5 +1,4 @@
 import { DecodedSourceMap, SourceMap } from 'magic-string';
-import Chunk from '../Chunk';
 import Graph from '../Graph';
 import Module from '../Module';
 import {
@@ -200,14 +199,14 @@ function getCollapsedSourcemap(
 }
 
 export function collapseSourcemaps(
-	bundle: Chunk,
+	graph: Graph,
 	file: string,
 	map: DecodedSourceMap,
 	modules: Module[],
 	bundleSourcemapChain: DecodedSourceMapOrMissing[],
 	excludeContent: boolean | undefined
 ) {
-	const linkMap = getLinkMap(bundle.graph);
+	const linkMap = getLinkMap(graph);
 	const moduleSources = modules
 		.filter(module => !module.excludeFromSourcemap)
 		.map(module =>

--- a/test/cli/samples/config-multiple-source-maps/_config.js
+++ b/test/cli/samples/config-multiple-source-maps/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'correctly generates sourcemaps for multiple outputs',
+	command: 'rollup -c'
+};

--- a/test/cli/samples/config-multiple-source-maps/_expected/main-cjs.js
+++ b/test/cli/samples/config-multiple-source-maps/_expected/main-cjs.js
@@ -1,0 +1,4 @@
+'use strict';
+
+assert.equal( ANSWER, 42 );
+//# sourceMappingURL=main-cjs.js.map

--- a/test/cli/samples/config-multiple-source-maps/_expected/main-cjs.js.map
+++ b/test/cli/samples/config-multiple-source-maps/_expected/main-cjs.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"main-cjs.js","sources":["../main.js"],"sourcesContent":["assert.equal( ANSWER, 42 );\n"],"names":[],"mappings":";;AAAA,MAAM,CAAC,KAAK,EAAE,MAAM,EAAE,EAAE,EAAE"}

--- a/test/cli/samples/config-multiple-source-maps/_expected/main-es.js
+++ b/test/cli/samples/config-multiple-source-maps/_expected/main-es.js
@@ -1,0 +1,2 @@
+assert.equal( ANSWER, 42 );
+//# sourceMappingURL=main-es.js.map

--- a/test/cli/samples/config-multiple-source-maps/_expected/main-es.js.map
+++ b/test/cli/samples/config-multiple-source-maps/_expected/main-es.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"main-es.js","sources":["../main.js"],"sourcesContent":["assert.equal( ANSWER, 42 );\n"],"names":[],"mappings":"AAAA,MAAM,CAAC,KAAK,EAAE,MAAM,EAAE,EAAE,EAAE"}

--- a/test/cli/samples/config-multiple-source-maps/main.js
+++ b/test/cli/samples/config-multiple-source-maps/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/samples/config-multiple-source-maps/rollup.config.js
+++ b/test/cli/samples/config-multiple-source-maps/rollup.config.js
@@ -1,0 +1,17 @@
+export default {
+	input: 'main.js',
+	output: [
+		{
+			format: 'cjs',
+			dir: '_actual',
+			entryFileNames: '[name]-[format].js',
+			sourcemap: true,
+		},
+		{
+			format: 'es',
+			dir: '_actual',
+			entryFileNames: '[name]-[format].js',
+			sourcemap: true
+		}
+	]
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3439

### Description
The issue was that Rollup mutates the generated chunk objects when writing multiple outputs, overwriting the chunk ids in the process. When using a config file, writing multiple outputs is interleaved. As the sourcemapfile is using the chunk id and is generated at the end, an overwritten chunk id is used. This is fixed for now by storing the chunk id in a local variable.