### PR TITLE
fix(types): watch accepts single or array config

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -664,7 +664,7 @@ export interface RollupWatcher
 	close(): void;
 }
 
-export function watch(configs: RollupWatchOptions[]): RollupWatcher;
+export function watch(config: RollupWatchOptions | RollupWatchOptions[]): RollupWatcher;
 
 interface AcornNode {
 	end: number;


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

The `rollup.watch` API accepts a single config object or an array of config objects. This is correct everywhere else ([one](https://github.com/rollup/rollup/blob/master/src/watch/watch-proxy.ts#L17), [two](https://github.com/rollup/rollup/blob/master/src/watch/watch.ts#L27), and [three](https://rollupjs.org/guide/en/#watchoptions)) except the shipped types.