### PR TITLE
Fix support for async functions as config

### DIFF
--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -9,7 +9,6 @@ const {
 } = require('../utils.js');
 
 const cwd = process.cwd();
-
 sander.rimrafSync(__dirname, 'node_modules');
 sander.copydirSync(__dirname, 'node_modules_rename_me').to(__dirname, 'node_modules');
 

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -9,6 +9,7 @@ const {
 } = require('../utils.js');
 
 const cwd = process.cwd();
+
 sander.rimrafSync(__dirname, 'node_modules');
 sander.copydirSync(__dirname, 'node_modules_rename_me').to(__dirname, 'node_modules');
 

--- a/test/cli/samples/config-async-function/_config.js
+++ b/test/cli/samples/config-async-function/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'supports using an async function as config',
+	command: 'rollup -c',
+};

--- a/test/cli/samples/config-async-function/_expected.js
+++ b/test/cli/samples/config-async-function/_expected.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var main = 42;
+
+module.exports = main;

--- a/test/cli/samples/config-async-function/main.js
+++ b/test/cli/samples/config-async-function/main.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/cli/samples/config-async-function/rollup.config.js
+++ b/test/cli/samples/config-async-function/rollup.config.js
@@ -1,0 +1,6 @@
+export default async () => ({
+	input: 'main.js',
+	output: {
+		format: 'cjs',
+	},
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3470 

### Description
Don't know how this could slip past the radar. We had tests for configs as Promises and configs as functions, but functions that return promises...
Now async functions are supported again.
