### PR TITLE
feat: Call namespace error as a warning

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
+	"arrowParens": "avoid",
+	"printWidth": 100,
 	"singleQuote": true,
-	"useTabs": true,
-	"printWidth": 100
+	"trailingComma": "none",
+	"useTabs": true
 }

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -3,7 +3,7 @@ import { BLANK } from '../../utils/blank';
 import {
 	findFirstOccurrenceOutsideComment,
 	NodeRenderOptions,
-	RenderOptions
+	RenderOptions,
 } from '../../utils/renderHelpers';
 import { CallOptions } from '../CallOptions';
 import { DeoptimizableEntity } from '../DeoptimizableEntity';
@@ -13,7 +13,7 @@ import {
 	ObjectPath,
 	PathTracker,
 	SHARED_RECURSION_TRACKER,
-	UNKNOWN_PATH
+	UNKNOWN_PATH,
 } from '../utils/PathTracker';
 import { LiteralValueOrUnknown, UnknownValue, UNKNOWN_EXPRESSION } from '../values';
 import Identifier from './Identifier';
@@ -40,10 +40,10 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 			const variable = this.scope.findVariable(this.callee.name);
 
 			if (variable.isNamespace) {
-				return this.context.error(
+				this.context.warn(
 					{
 						code: 'CANNOT_CALL_NAMESPACE',
-						message: `Cannot call a namespace ('${this.callee.name}')`
+						message: `Cannot call a namespace ('${this.callee.name}')`,
 					},
 					this.start
 				);
@@ -54,7 +54,7 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 					{
 						code: 'EVAL',
 						message: `Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification`,
-						url: 'https://rollupjs.org/guide/en/#avoiding-eval'
+						url: 'https://rollupjs.org/guide/en/#avoiding-eval',
 					},
 					this.start
 				);
@@ -212,7 +212,7 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 	initialise() {
 		this.callOptions = {
 			args: this.arguments,
-			withNew: false
+			withNew: false,
 		};
 	}
 

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -20,10 +20,10 @@ export default class TaggedTemplateExpression extends NodeBase {
 			const variable = this.scope.findVariable(name);
 
 			if (variable.isNamespace) {
-				return this.context.error(
+				this.context.warn(
 					{
 						code: 'CANNOT_CALL_NAMESPACE',
-						message: `Cannot call a namespace ('${name}')`
+						message: `Cannot call a namespace ('${name}')`,
 					},
 					this.start
 				);
@@ -34,7 +34,7 @@ export default class TaggedTemplateExpression extends NodeBase {
 					{
 						code: 'EVAL',
 						message: `Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification`,
-						url: 'https://rollupjs.org/guide/en/#avoiding-eval'
+						url: 'https://rollupjs.org/guide/en/#avoiding-eval',
 					},
 					this.start
 				);
@@ -52,7 +52,7 @@ export default class TaggedTemplateExpression extends NodeBase {
 	initialise() {
 		this.callOptions = {
 			args: NO_ARGS,
-			withNew: false
+			withNew: false,
 		};
 	}
 }

--- a/test/function/samples/cannot-call-external-namespace/_config.js
+++ b/test/function/samples/cannot-call-external-namespace/_config.js
@@ -1,21 +1,11 @@
-const path = require('path');
+const assert = require('assert');
 
 module.exports = {
-	description: 'errors if code calls an external namespace',
-	error: {
-		code: 'CANNOT_CALL_NAMESPACE',
-		message: `Cannot call a namespace ('foo')`,
-		pos: 28,
-		watchFiles: [path.resolve(__dirname, 'main.js')],
-		loc: {
-			file: path.resolve(__dirname, 'main.js'),
-			line: 2,
-			column: 0
-		},
-		frame: `
-			1: import * as foo from 'foo';
-			2: foo();
-			   ^
-		`
-	}
+	description: 'warns if code calls an external namespace',
+	options: {
+		external: ['fs'],
+	},
+	warnings(warnings) {
+		assert.deepStrictEqual(warnings.map(String), ["main.js (3:2) Cannot call a namespace ('foo')"]);
+	},
 };

--- a/test/function/samples/cannot-call-external-namespace/_config.js
+++ b/test/function/samples/cannot-call-external-namespace/_config.js
@@ -3,9 +3,12 @@ const assert = require('assert');
 module.exports = {
 	description: 'warns if code calls an external namespace',
 	options: {
-		external: ['fs'],
+		external: ['fs']
 	},
 	warnings(warnings) {
-		assert.deepStrictEqual(warnings.map(String), ["main.js (3:2) Cannot call a namespace ('foo')"]);
-	},
+		assert.deepStrictEqual(warnings.map(String), [
+			"main.js (4:1) Cannot call a namespace ('foo')",
+			"main.js (8:1) Cannot call a namespace ('foo')"
+		]);
+	}
 };

--- a/test/function/samples/cannot-call-external-namespace/main.js
+++ b/test/function/samples/cannot-call-external-namespace/main.js
@@ -1,2 +1,6 @@
-import * as foo from 'foo';
-foo();
+import * as foo from 'fs';
+try {
+  foo();
+}
+catch (e) {
+}

--- a/test/function/samples/cannot-call-external-namespace/main.js
+++ b/test/function/samples/cannot-call-external-namespace/main.js
@@ -1,6 +1,9 @@
 import * as foo from 'fs';
+
 try {
-  foo();
-}
-catch (e) {
-}
+	foo();
+} catch (e) {}
+
+try {
+	foo``;
+} catch (e) {}

--- a/test/function/samples/cannot-call-internal-namespace/_config.js
+++ b/test/function/samples/cannot-call-internal-namespace/_config.js
@@ -1,8 +1,11 @@
 const assert = require('assert');
 
 module.exports = {
-	description: 'errors if code calls an internal namespace',
+	description: 'warns if code calls an internal namespace',
 	warnings(warnings) {
-		assert.deepStrictEqual(warnings.map(String), ["main.js (3:2) Cannot call a namespace ('foo')"]);
-	},
+		assert.deepStrictEqual(warnings.map(String), [
+			"main.js (4:1) Cannot call a namespace ('foo')",
+			"main.js (8:1) Cannot call a namespace ('foo')"
+		]);
+	}
 };

--- a/test/function/samples/cannot-call-internal-namespace/_config.js
+++ b/test/function/samples/cannot-call-internal-namespace/_config.js
@@ -1,21 +1,8 @@
-const path = require('path');
+const assert = require('assert');
 
 module.exports = {
 	description: 'errors if code calls an internal namespace',
-	error: {
-		code: 'CANNOT_CALL_NAMESPACE',
-		message: `Cannot call a namespace ('foo')`,
-		pos: 33,
-		watchFiles: [path.resolve(__dirname, 'main.js'), path.resolve(__dirname, 'foo.js')],
-		loc: {
-			file: path.resolve(__dirname, 'main.js'),
-			line: 2,
-			column: 0
-		},
-		frame: `
-			1: import * as foo from './foo.js';
-			2: foo();
-			   ^
-		`
-	}
+	warnings(warnings) {
+		assert.deepStrictEqual(warnings.map(String), ["main.js (3:2) Cannot call a namespace ('foo')"]);
+	},
 };

--- a/test/function/samples/cannot-call-internal-namespace/main.js
+++ b/test/function/samples/cannot-call-internal-namespace/main.js
@@ -1,2 +1,5 @@
 import * as foo from './foo.js';
-foo();
+try {
+  foo();
+}
+catch {}

--- a/test/function/samples/cannot-call-internal-namespace/main.js
+++ b/test/function/samples/cannot-call-internal-namespace/main.js
@@ -1,5 +1,9 @@
 import * as foo from './foo.js';
+
 try {
-  foo();
-}
-catch {}
+	foo();
+} catch {}
+
+try {
+	foo``;
+} catch {}


### PR DESCRIPTION
This converts the error when a namespace is called into a warning.

The reason being that there may exist valid runtime paths through the code that do not trigger the error, despite it being invalid. So allowing the build to proceed can allow valid runtime code to work despite the underlying "typing issue".

Alternatively it might be worth considering a strict / loose mode for Rollup "typing errors" so far as it cares about module semantics, but I actually think it would be better to treat Rollup as allowing anything to execute which would execute in a JS engine, since it is not a type system.

Landing as-is seems sensible to me, but I would be open to suggestions too.

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
