### PR TITLE
Store locations for removed comments in cache

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
+	"arrowParens": "avoid",
+	"printWidth": 100,
 	"singleQuote": true,
-	"useTabs": true,
-	"printWidth": 100
+	"trailingComma": "none",
+	"useTabs": true
 }

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -94,7 +94,7 @@ export interface SourceDescription {
 }
 
 export interface TransformModuleJSON {
-	ast: AcornNode;
+	ast?: AcornNode;
 	code: string;
 	// note if plugins use new this.cache to opt-out auto transform cache
 	customTransformCache: boolean;
@@ -108,6 +108,8 @@ export interface TransformModuleJSON {
 }
 
 export interface ModuleJSON extends TransformModuleJSON {
+	alwaysRemovedCode: [number, number][];
+	ast: AcornNode;
 	dependencies: string[];
 	id: string;
 	transformFiles: EmittedFile[] | undefined;

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -160,7 +160,7 @@ export default function transform(
 			}
 
 			return {
-				ast: ast!,
+				ast,
 				code,
 				customTransformCache,
 				moduleSideEffects,

--- a/test/sourcemaps/samples/existing-external-sourcemaps-combined/_config.js
+++ b/test/sourcemaps/samples/existing-external-sourcemaps-combined/_config.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
 
 module.exports = {
-	description: 'combines existing inline sourcemap comments into one',
+	solo: true,
+	description: 'removes sourcemap comments',
 	async test(code) {
-		assert.doesNotMatch(code, /sourceMappingURL=main\.js\.map/);
-		assert.doesNotMatch(code, /sourceMappingURL=other\.js\.map/);
-	},
+		assert.strictEqual(code.indexOf('sourceMappingURL'), -1);
+	}
 };

--- a/test/sourcemaps/samples/existing-external-sourcemaps-combined/_config.js
+++ b/test/sourcemaps/samples/existing-external-sourcemaps-combined/_config.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'combines existing inline sourcemap comments into one',
+	async test(code) {
+		assert.doesNotMatch(code, /sourceMappingURL=main\.js\.map/);
+		assert.doesNotMatch(code, /sourceMappingURL=other\.js\.map/);
+	},
+};

--- a/test/sourcemaps/samples/existing-external-sourcemaps-combined/_config.js
+++ b/test/sourcemaps/samples/existing-external-sourcemaps-combined/_config.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 
 module.exports = {
-	solo: true,
 	description: 'removes sourcemap comments',
 	async test(code) {
 		assert.strictEqual(code.indexOf('sourceMappingURL'), -1);

--- a/test/sourcemaps/samples/existing-external-sourcemaps-combined/main.js
+++ b/test/sourcemaps/samples/existing-external-sourcemaps-combined/main.js
@@ -1,0 +1,4 @@
+import value from "./other";
+const s = `other: ${value}`;
+console.log(s);
+//# sourceMappingURL=main.js.map

--- a/test/sourcemaps/samples/existing-external-sourcemaps-combined/main.js.map
+++ b/test/sourcemaps/samples/existing-external-sourcemaps-combined/main.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"main.js","sourceRoot":"","sources":["main.ts"],"names":[],"mappings":"AAAA,OAAO,KAAK,MAAM,SAAS,CAAC;AAE5B,MAAM,CAAC,GAAW,UAAU,KAAK,EAAE,CAAC;AAEpC,OAAO,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC"}

--- a/test/sourcemaps/samples/existing-external-sourcemaps-combined/other.js
+++ b/test/sourcemaps/samples/existing-external-sourcemaps-combined/other.js
@@ -1,0 +1,3 @@
+const x = "foo";
+export default x;
+//# sourceMappingURL=other.js.map

--- a/test/sourcemaps/samples/existing-external-sourcemaps-combined/other.js.map
+++ b/test/sourcemaps/samples/existing-external-sourcemaps-combined/other.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"other.js","sourceRoot":"","sources":["other.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,GAAW,KAAK,CAAC;AACxB,eAAe,CAAC,CAAC"}

--- a/test/sourcemaps/samples/existing-inline-sourcemaps-combined/_config.js
+++ b/test/sourcemaps/samples/existing-inline-sourcemaps-combined/_config.js
@@ -1,8 +1,9 @@
 const assert = require('assert');
 
 module.exports = {
-	description: 'combines existing sourcemap files into one',
+	solo: true,
+	description: 'removes existing inline sourcemaps',
 	async test(code) {
-		assert.doesNotMatch(code, /sourceMappingURL=data:/);
-	},
+		assert.strictEqual(code.indexOf('sourceMappingURL'), -1);
+	}
 };

--- a/test/sourcemaps/samples/existing-inline-sourcemaps-combined/_config.js
+++ b/test/sourcemaps/samples/existing-inline-sourcemaps-combined/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'combines existing sourcemap files into one',
+	async test(code) {
+		assert.doesNotMatch(code, /sourceMappingURL=data:/);
+	},
+};

--- a/test/sourcemaps/samples/existing-inline-sourcemaps-combined/_config.js
+++ b/test/sourcemaps/samples/existing-inline-sourcemaps-combined/_config.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 
 module.exports = {
-	solo: true,
 	description: 'removes existing inline sourcemaps',
 	async test(code) {
 		assert.strictEqual(code.indexOf('sourceMappingURL'), -1);

--- a/test/sourcemaps/samples/existing-inline-sourcemaps-combined/main.js
+++ b/test/sourcemaps/samples/existing-inline-sourcemaps-combined/main.js
@@ -1,0 +1,4 @@
+import value from "./other";
+const s = `other: ${value}`;
+console.log(s);
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoibWFpbi5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIm1haW4udHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsT0FBTyxLQUFLLE1BQU0sU0FBUyxDQUFDO0FBRTVCLE1BQU0sQ0FBQyxHQUFXLFVBQVUsS0FBSyxFQUFFLENBQUM7QUFFcEMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyJ9

--- a/test/sourcemaps/samples/existing-inline-sourcemaps-combined/other.js
+++ b/test/sourcemaps/samples/existing-inline-sourcemaps-combined/other.js
@@ -1,0 +1,3 @@
+const x = "foo";
+export default x;
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoib3RoZXIuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJvdGhlci50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLENBQUMsR0FBVyxLQUFLLENBQUM7QUFDeEIsZUFBZSxDQUFDLENBQUMifQ==


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3465 

### Description
Comments are not part of the cache, which had the effect that sourcemap comments were no longer removed when rebuilding using cached modules. This fixes this by adding the location of sourcemap comments to the cache (I decided against adding all comments to avoid blowing up the cache unnecessarily).
