### PR TITLE
Ensure --watch mode exits correctly when stdin is closed.

### DIFF
--- a/cli/run/watch.ts
+++ b/cli/run/watch.ts
@@ -29,6 +29,7 @@ export default async function watch(command: any) {
 	// only listen to stdin if it is a pipe
 	if (!process.stdin.isTTY) {
 		process.stdin.on('end', close);
+		process.stdin.resume();
 	}
 
 	if (configFile) {

--- a/cli/run/watch.ts
+++ b/cli/run/watch.ts
@@ -26,7 +26,6 @@ export default async function watch(command: any) {
 
 	onExit(close);
 	process.on('uncaughtException' as any, close);
-	// only listen to stdin if it is a pipe
 	if (!process.stdin.isTTY) {
 		process.stdin.on('end', close);
 		process.stdin.resume();

--- a/test/cli/samples/watch/close-stdin/_config.js
+++ b/test/cli/samples/watch/close-stdin/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	command: 'node wrapper.js main.js --watch --format es --file _actual/out.js',
+	description: 'closes the watcher when stdin closes'
+};

--- a/test/cli/samples/watch/close-stdin/_expected/out.js
+++ b/test/cli/samples/watch/close-stdin/_expected/out.js
@@ -1,0 +1,3 @@
+var main = 42;
+
+export default main;

--- a/test/cli/samples/watch/close-stdin/main.js
+++ b/test/cli/samples/watch/close-stdin/main.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/cli/samples/watch/close-stdin/wrapper.js
+++ b/test/cli/samples/watch/close-stdin/wrapper.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+const stream = require('stream');
+const fs = require('fs');
+const path = require('path');
+
+delete process.stdin;
+process.stdin = new stream.Readable({
+	encoding: 'utf8',
+	read() {
+		return null;
+	}
+});
+
+const outputDir = path.resolve(__dirname, '_actual');
+fs.mkdirSync(outputDir);
+const outputFile = path.resolve(outputDir, 'out.js');
+fs.writeFileSync(outputFile, 'NOT WRITTEN');
+
+const watcher = fs.watch(outputFile, () => {
+	watcher.close();
+	// This closes stdin
+	process.stdin.push(null);
+});
+
+require('../../../../../dist/bin/rollup');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

This PR ensures that the `rollup --watch` process exits correctly when stdin is closed by the parent process.

This is necessary when rollup is used as the front end for an Elixir Phoenix application. In dev mode, the phoenix watchers run the rollup command as a child process and the underlying erlang port mechanism assumes that the child process closes when the parent stdin is closed. Without this fix the old zombie processes never close and accumulate as you stop and start in development mode.

This was discussed and fixed in 2017 in the original rollup-watcher repository:

  * https://github.com/rollup/rollup-watch/issues/30#issuecomment-316468552
  * https://github.com/rollup/rollup-watch/pull/57/files

It appears to then have been removed as a side effect of another change

  * https://github.com/rollup/rollup/pull/2410

Finally, was requested back in a PR that never got merged because of some doubt around the need to hide it behind a CLI flag

  * https://github.com/rollup/rollup/pull/2653/files

For reference, webpack implements this hidden behind the --watch-stdin CLI flag.
