### PR TITLE
Respect output.paths in dynamic imports

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -711,7 +711,7 @@ export default class Chunk {
 						? `'${
 								resolution.renormalizeRenderPath
 									? this.getRelativePath(resolution.renderPath, stripKnownJsExtensions)
-									: resolution.id
+									: resolution.renderPath
 						  }'`
 						: resolution;
 				node.renderFinalResolution(code, renderedResolution);

--- a/test/form/samples/paths-function/_expected/amd.js
+++ b/test/form/samples/paths-function/_expected/amd.js
@@ -1,7 +1,28 @@
-define(['https://unpkg.com/foo'], function (foo) { 'use strict';
+define(['require', 'https://unpkg.com/foo'], function (require, foo) { 'use strict';
+
+	function _interopNamespace(e) {
+		if (e && e.__esModule) { return e; } else {
+			var n = {};
+			if (e) {
+				Object.keys(e).forEach(function (k) {
+					var d = Object.getOwnPropertyDescriptor(e, k);
+					Object.defineProperty(n, k, d.get ? d : {
+						enumerable: true,
+						get: function () {
+							return e[k];
+						}
+					});
+				});
+			}
+			n['default'] = e;
+			return n;
+		}
+	}
 
 	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
-	assert.equal( foo, 42 );
+	assert.equal(foo, 42);
+
+	new Promise(function (resolve, reject) { require(['https://unpkg.com/foo'], function (m) { resolve(_interopNamespace(m)); }, reject) }).then(({ default: foo }) => assert.equal(foo, 42));
 
 });

--- a/test/form/samples/paths-function/_expected/cjs.js
+++ b/test/form/samples/paths-function/_expected/cjs.js
@@ -2,6 +2,27 @@
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
+function _interopNamespace(e) {
+	if (e && e.__esModule) { return e; } else {
+		var n = {};
+		if (e) {
+			Object.keys(e).forEach(function (k) {
+				var d = Object.getOwnPropertyDescriptor(e, k);
+				Object.defineProperty(n, k, d.get ? d : {
+					enumerable: true,
+					get: function () {
+						return e[k];
+					}
+				});
+			});
+		}
+		n['default'] = e;
+		return n;
+	}
+}
+
 var foo = _interopDefault(require('https://unpkg.com/foo'));
 
-assert.equal( foo, 42 );
+assert.equal(foo, 42);
+
+new Promise(function (resolve) { resolve(_interopNamespace(require('https://unpkg.com/foo'))); }).then(({ default: foo }) => assert.equal(foo, 42));

--- a/test/form/samples/paths-function/_expected/es.js
+++ b/test/form/samples/paths-function/_expected/es.js
@@ -1,3 +1,5 @@
 import foo from 'https://unpkg.com/foo';
 
-assert.equal( foo, 42 );
+assert.equal(foo, 42);
+
+import('https://unpkg.com/foo').then(({ default: foo }) => assert.equal(foo, 42));

--- a/test/form/samples/paths-function/_expected/iife.js
+++ b/test/form/samples/paths-function/_expected/iife.js
@@ -3,6 +3,8 @@
 
 	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
-	assert.equal( foo, 42 );
+	assert.equal(foo, 42);
+
+	import('https://unpkg.com/foo').then(({ default: foo }) => assert.equal(foo, 42));
 
 }(foo));

--- a/test/form/samples/paths-function/_expected/system.js
+++ b/test/form/samples/paths-function/_expected/system.js
@@ -1,4 +1,4 @@
-System.register(['https://unpkg.com/foo'], function () {
+System.register(['https://unpkg.com/foo'], function (exports, module) {
 	'use strict';
 	var foo;
 	return {
@@ -7,7 +7,9 @@ System.register(['https://unpkg.com/foo'], function () {
 		}],
 		execute: function () {
 
-			assert.equal( foo, 42 );
+			assert.equal(foo, 42);
+
+			module.import('https://unpkg.com/foo').then(({ default: foo }) => assert.equal(foo, 42));
 
 		}
 	};

--- a/test/form/samples/paths-function/_expected/umd.js
+++ b/test/form/samples/paths-function/_expected/umd.js
@@ -6,6 +6,8 @@
 
 	foo = foo && Object.prototype.hasOwnProperty.call(foo, 'default') ? foo['default'] : foo;
 
-	assert.equal( foo, 42 );
+	assert.equal(foo, 42);
+
+	import('https://unpkg.com/foo').then(({ default: foo }) => assert.equal(foo, 42));
 
 })));

--- a/test/form/samples/paths-function/main.js
+++ b/test/form/samples/paths-function/main.js
@@ -1,3 +1,5 @@
 import foo from 'foo';
 
-assert.equal( foo, 42 );
+assert.equal(foo, 42);
+
+import('foo').then(({ default: foo }) => assert.equal(foo, 42));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3464 

### Description
This will make sure that both static and dynamic imports will respect the `paths` option.
