### PR TITLE
Do not fail for circular imports between manual chunks

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -914,6 +914,7 @@ export default class Chunk {
 
 	private inlineChunkDependencies(chunk: Chunk) {
 		for (const dep of chunk.dependencies) {
+			if (this.dependencies.has(dep)) continue;
 			if (dep instanceof ExternalModule) {
 				this.dependencies.add(dep);
 			} else {

--- a/test/chunking-form/samples/circular-manual-chunks/_config.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'handles manual chunks with circular dependencies',
+	expectedWarnings: ['CIRCULAR_DEPENDENCY'],
+	options: {
+		input: 'main',
+		manualChunks: { lib1: ['lib1'], lib2: ['lib2'] }
+	}
+};

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/amd/generated-lib1.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/amd/generated-lib1.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-lib2'], function (exports, lib2) { 'use strict';
+
+	const lib1 = 'lib1';
+	console.log(`${lib1} imports ${lib2.lib2}`);
+
+	exports.lib1 = lib1;
+
+});

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/amd/generated-lib2.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/amd/generated-lib2.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-lib1'], function (exports, lib1) { 'use strict';
+
+	const lib2 = 'lib2';
+	console.log(`${lib2} imports ${lib1.lib1}`);
+
+	exports.lib2 = lib2;
+
+});

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/amd/main.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/amd/main.js
@@ -1,0 +1,9 @@
+define(['exports', './generated-lib2', './generated-lib1'], function (exports, lib2, lib1) { 'use strict';
+
+
+
+	exports.lib1 = lib1.lib1;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/cjs/generated-lib1.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/cjs/generated-lib1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var lib2 = require('./generated-lib2.js');
+
+const lib1 = 'lib1';
+console.log(`${lib1} imports ${lib2.lib2}`);
+
+exports.lib1 = lib1;

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/cjs/generated-lib2.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/cjs/generated-lib2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var lib1 = require('./generated-lib1.js');
+
+const lib2 = 'lib2';
+console.log(`${lib2} imports ${lib1.lib1}`);
+
+exports.lib2 = lib2;

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/cjs/main.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/cjs/main.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+require('./generated-lib2.js');
+var lib1 = require('./generated-lib1.js');
+
+
+
+exports.lib1 = lib1.lib1;

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/es/generated-lib1.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/es/generated-lib1.js
@@ -1,0 +1,6 @@
+import { l as lib2 } from './generated-lib2.js';
+
+const lib1 = 'lib1';
+console.log(`${lib1} imports ${lib2}`);
+
+export { lib1 as l };

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/es/generated-lib2.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/es/generated-lib2.js
@@ -1,0 +1,6 @@
+import { l as lib1 } from './generated-lib1.js';
+
+const lib2 = 'lib2';
+console.log(`${lib2} imports ${lib1}`);
+
+export { lib2 as l };

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/es/main.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/es/main.js
@@ -1,0 +1,2 @@
+import './generated-lib2.js';
+export { l as lib1 } from './generated-lib1.js';

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/system/generated-lib1.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/system/generated-lib1.js
@@ -1,0 +1,15 @@
+System.register(['./generated-lib2.js'], function (exports) {
+	'use strict';
+	var lib2;
+	return {
+		setters: [function (module) {
+			lib2 = module.l;
+		}],
+		execute: function () {
+
+			const lib1 = exports('l', 'lib1');
+			console.log(`${lib1} imports ${lib2}`);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/system/generated-lib2.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/system/generated-lib2.js
@@ -1,0 +1,15 @@
+System.register(['./generated-lib1.js'], function (exports) {
+	'use strict';
+	var lib1;
+	return {
+		setters: [function (module) {
+			lib1 = module.l;
+		}],
+		execute: function () {
+
+			const lib2 = exports('l', 'lib2');
+			console.log(`${lib2} imports ${lib1}`);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/system/main.js
@@ -1,0 +1,13 @@
+System.register(['./generated-lib2.js', './generated-lib1.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function () {}, function (module) {
+			exports('lib1', module.l);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/circular-manual-chunks/lib1.js
+++ b/test/chunking-form/samples/circular-manual-chunks/lib1.js
@@ -1,0 +1,3 @@
+import { lib2 } from './lib2.js';
+export const lib1 = 'lib1';
+console.log(`${lib1} imports ${lib2}`);

--- a/test/chunking-form/samples/circular-manual-chunks/lib2.js
+++ b/test/chunking-form/samples/circular-manual-chunks/lib2.js
@@ -1,0 +1,3 @@
+import { lib1 } from './lib1';
+export const lib2 = 'lib2';
+console.log(`${lib2} imports ${lib1}`);

--- a/test/chunking-form/samples/circular-manual-chunks/main.js
+++ b/test/chunking-form/samples/circular-manual-chunks/main.js
@@ -1,0 +1,1 @@
+export { lib1 } from './lib1.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3499 

### Description
There was a missing break-off condition that lead to an infinite recursion when there was a circular dependency between manual chunks.
