### PR TITLE
Fix and improve default export alias logic

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1005,10 +1005,9 @@ export default class Chunk {
 
 	private setUpChunkImportsAndExportsForModule(module: Module) {
 		for (let variable of module.imports) {
-			if (
-				variable instanceof SyntheticNamedExportVariable ||
-				variable instanceof ExportDefaultVariable
-			) {
+			if (variable instanceof SyntheticNamedExportVariable) {
+				variable = variable.getBaseVariable();
+			} else if (variable instanceof ExportDefaultVariable) {
 				variable = variable.getOriginalVariable();
 			}
 			if ((variable.module as Module).chunk !== this) {
@@ -1030,7 +1029,7 @@ export default class Chunk {
 				this.exports.add(exportedVariable);
 				const isSynthetic = exportedVariable instanceof SyntheticNamedExportVariable;
 				const importedVariable = isSynthetic
-					? (exportedVariable as SyntheticNamedExportVariable).getOriginalVariable()
+					? (exportedVariable as SyntheticNamedExportVariable).getBaseVariable()
 					: exportedVariable;
 				const exportingModule = importedVariable.module;
 				if (

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -769,15 +769,13 @@ export default class Chunk {
 		for (const dep of this.dependencies) {
 			const imports: ImportSpecifier[] = [];
 			for (const variable of this.imports) {
-				const renderedVariable =
-					variable instanceof ExportDefaultVariable ? variable.getOriginalVariable() : variable;
 				if (
 					(variable.module instanceof Module
 						? variable.module.chunk === dep
 						: variable.module === dep) &&
-					!renderedImports.has(renderedVariable)
+					!renderedImports.has(variable)
 				) {
-					renderedImports.add(renderedVariable);
+					renderedImports.add(variable);
 					imports.push({
 						imported:
 							variable.module instanceof ExternalModule
@@ -1007,10 +1005,13 @@ export default class Chunk {
 
 	private setUpChunkImportsAndExportsForModule(module: Module) {
 		for (let variable of module.imports) {
+			if (
+				variable instanceof SyntheticNamedExportVariable ||
+				variable instanceof ExportDefaultVariable
+			) {
+				variable = variable.getOriginalVariable();
+			}
 			if ((variable.module as Module).chunk !== this) {
-				if (variable instanceof SyntheticNamedExportVariable) {
-					variable = variable.getOriginalVariable();
-				}
 				this.imports.add(variable);
 				if (
 					!(variable instanceof NamespaceVariable && this.graph.preserveModules) &&

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -339,23 +339,23 @@ export default class Module {
 	getDependenciesToBeIncluded(): Set<Module | ExternalModule> {
 		if (this.relevantDependencies) return this.relevantDependencies;
 		const relevantDependencies = new Set<Module | ExternalModule>();
-		for (const variable of this.imports) {
-			relevantDependencies.add(
-				variable instanceof SyntheticNamedExportVariable ||
-					variable instanceof ExportDefaultVariable
-					? variable.getOriginalVariable().module!
-					: variable.module!
-			);
+		for (let variable of this.imports) {
+			if (variable instanceof SyntheticNamedExportVariable) {
+				variable = variable.getBaseVariable();
+			} else if (variable instanceof ExportDefaultVariable) {
+				variable = variable.getOriginalVariable();
+			}
+			relevantDependencies.add(variable.module!);
 		}
 		if (this.isEntryPoint || this.dynamicallyImportedBy.length > 0 || this.graph.preserveModules) {
 			for (const exportName of [...this.getReexports(), ...this.getExports()]) {
-				const variable = this.getVariableForExportName(exportName);
-				relevantDependencies.add(
-					variable instanceof SyntheticNamedExportVariable ||
-						variable instanceof ExportDefaultVariable
-						? variable.getOriginalVariable().module!
-						: variable.module!
-				);
+				let variable = this.getVariableForExportName(exportName);
+				if (variable instanceof SyntheticNamedExportVariable) {
+					variable = variable.getBaseVariable();
+				} else if (variable instanceof ExportDefaultVariable) {
+					variable = variable.getOriginalVariable();
+				}
+				relevantDependencies.add(variable.module!);
 			}
 		}
 		if (this.graph.treeshakingOptions) {

--- a/src/ast/nodes/ExportDefaultDeclaration.ts
+++ b/src/ast/nodes/ExportDefaultDeclaration.ts
@@ -17,13 +17,13 @@ import { ExpressionNode, IncludeChildren, NodeBase } from './shared/Node';
 const WHITESPACE = /\s/;
 
 // The header ends at the first non-white-space after "default"
-function getDeclarationStart(code: string, start = 0) {
+function getDeclarationStart(code: string, start: number) {
 	start = findFirstOccurrenceOutsideComment(code, 'default', start) + 7;
 	while (WHITESPACE.test(code[start])) start++;
 	return start;
 }
 
-function getIdInsertPosition(code: string, declarationKeyword: string, start = 0) {
+function getIdInsertPosition(code: string, declarationKeyword: string, start: number) {
 	const declarationEnd =
 		findFirstOccurrenceOutsideComment(code, declarationKeyword, start) + declarationKeyword.length;
 	code = code.slice(declarationEnd, findFirstOccurrenceOutsideComment(code, '{', declarationEnd));
@@ -84,15 +84,7 @@ export default class ExportDefaultDeclaration extends NodeBase {
 			);
 		} else if (this.variable.getOriginalVariable() !== this.variable) {
 			// Remove altogether to prevent re-declaring the same variable
-			if (options.format === 'system' && this.variable.exportName) {
-				code.overwrite(
-					start,
-					end,
-					`exports('${this.variable.exportName}', ${this.variable.getName()});`
-				);
-			} else {
-				treeshakeNode(this, code, start, end);
-			}
+			treeshakeNode(this, code, start, end);
 			return;
 		} else if (this.variable.included) {
 			this.renderVariableDeclaration(code, declarationStart, options);

--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -73,22 +73,4 @@ export default class ExportDefaultVariable extends LocalVariable {
 		}
 		return this.originalVariable;
 	}
-
-	setRenderNames(baseName: string | null, name: string | null) {
-		const original = this.getOriginalVariable();
-		if (original === this) {
-			super.setRenderNames(baseName, name);
-		} else {
-			original.setRenderNames(baseName, name);
-		}
-	}
-
-	setSafeName(name: string | null) {
-		const original = this.getOriginalVariable();
-		if (original === this) {
-			super.setSafeName(name);
-		} else {
-			original.setSafeName(name);
-		}
-	}
 }

--- a/src/ast/variables/SyntheticNamedExportVariable.ts
+++ b/src/ast/variables/SyntheticNamedExportVariable.ts
@@ -13,16 +13,16 @@ export default class SyntheticNamedExportVariable extends Variable {
 		this.defaultVariable = defaultVariable;
 	}
 
+	getBaseVariable(): Variable {
+		return this.defaultVariable instanceof SyntheticNamedExportVariable
+			? this.defaultVariable.getBaseVariable()
+			: this.defaultVariable;
+	}
+
 	getName(): string {
 		const name = this.name;
 		const renderBaseName = this.defaultVariable.getName();
 		return `${renderBaseName}${getPropertyAccess(name)}`;
-	}
-
-	getOriginalVariable(): Variable {
-		return this.defaultVariable instanceof SyntheticNamedExportVariable
-			? this.defaultVariable.getOriginalVariable()
-			: this.defaultVariable;
 	}
 
 	include() {

--- a/src/ast/variables/SyntheticNamedExportVariable.ts
+++ b/src/ast/variables/SyntheticNamedExportVariable.ts
@@ -1,13 +1,12 @@
 import Module, { AstContext } from '../../Module';
-import ExportDefaultVariable from './ExportDefaultVariable';
 import Variable from './Variable';
 
 export default class SyntheticNamedExportVariable extends Variable {
 	context: AstContext;
-	defaultVariable: ExportDefaultVariable;
+	defaultVariable: Variable;
 	module: Module;
 
-	constructor(context: AstContext, name: string, defaultVariable: ExportDefaultVariable) {
+	constructor(context: AstContext, name: string, defaultVariable: Variable) {
 		super(name);
 		this.context = context;
 		this.module = context.module;
@@ -21,7 +20,9 @@ export default class SyntheticNamedExportVariable extends Variable {
 	}
 
 	getOriginalVariable(): Variable {
-		return this.defaultVariable.getOriginalVariable();
+		return this.defaultVariable instanceof SyntheticNamedExportVariable
+			? this.defaultVariable.getOriginalVariable()
+			: this.defaultVariable;
 	}
 
 	include() {

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/generated-dep1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/generated-dep1.js
@@ -3,8 +3,8 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			var x = 42;
-			exports('x', x);console.log('dep1');
+			var x = exports('x', 42);
+			console.log('dep1');
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/generated-dep2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/generated-dep2.js
@@ -3,8 +3,8 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			var x = 43;
-			exports('x', x);console.log('dep2');
+			var x = exports('x', 43);
+			console.log('dep2');
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/generated-shared.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/generated-shared.js
@@ -6,6 +6,6 @@ define(['exports'], function (exports) { 'use strict';
         var shared = commonjsGlobal.data;
 
         exports.commonjsGlobal = commonjsGlobal;
-        exports.d = shared;
+        exports.shared = shared;
 
 });

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main1.js
@@ -3,7 +3,7 @@ define(['./generated-shared'], function (shared) { 'use strict';
 	shared.commonjsGlobal.fn = d => d + 1;
 	var cjs = shared.commonjsGlobal.fn;
 
-	var main1 = shared.d.map(cjs);
+	var main1 = shared.shared.map(cjs);
 
 	return main1;
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/amd/main2.js
@@ -1,6 +1,6 @@
 define(['./generated-shared'], function (shared) { 'use strict';
 
-	var main2 = shared.d.map(d => d + 2);
+	var main2 = shared.shared.map(d => d + 2);
 
 	return main2;
 

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/generated-shared.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/generated-shared.js
@@ -6,4 +6,4 @@ commonjsGlobal.data = [4, 5, 6];
 var shared = commonjsGlobal.data;
 
 exports.commonjsGlobal = commonjsGlobal;
-exports.d = shared;
+exports.shared = shared;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main1.js
@@ -5,6 +5,6 @@ var shared = require('./generated-shared.js');
 shared.commonjsGlobal.fn = d => d + 1;
 var cjs = shared.commonjsGlobal.fn;
 
-var main1 = shared.d.map(cjs);
+var main1 = shared.shared.map(cjs);
 
 module.exports = main1;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/cjs/main2.js
@@ -2,6 +2,6 @@
 
 var shared = require('./generated-shared.js');
 
-var main2 = shared.d.map(d => d + 2);
+var main2 = shared.shared.map(d => d + 2);
 
 module.exports = main2;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/generated-shared.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/generated-shared.js
@@ -3,4 +3,4 @@ var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 
 commonjsGlobal.data = [4, 5, 6];
 var shared = commonjsGlobal.data;
 
-export { commonjsGlobal as c, shared as d };
+export { commonjsGlobal as c, shared as s };

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main1.js
@@ -1,8 +1,8 @@
-import { c as commonjsGlobal, d } from './generated-shared.js';
+import { c as commonjsGlobal, s as shared } from './generated-shared.js';
 
 commonjsGlobal.fn = d => d + 1;
 var cjs = commonjsGlobal.fn;
 
-var main1 = d.map(cjs);
+var main1 = shared.map(cjs);
 
 export default main1;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/es/main2.js
@@ -1,5 +1,5 @@
-import { d } from './generated-shared.js';
+import { s as shared } from './generated-shared.js';
 
-var main2 = d.map(d => d + 2);
+var main2 = shared.map(d => d + 2);
 
 export default main2;

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/generated-shared.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/generated-shared.js
@@ -6,8 +6,7 @@ System.register([], function (exports) {
                         var commonjsGlobal = exports('c', typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {});
 
                         commonjsGlobal.data = [4, 5, 6];
-                        var shared = commonjsGlobal.data;
-                        exports('d', shared);
+                        var shared = exports('s', commonjsGlobal.data);
 
                 }
         };

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main1.js
@@ -1,17 +1,17 @@
 System.register(['./generated-shared.js'], function (exports) {
 	'use strict';
-	var commonjsGlobal, d;
+	var commonjsGlobal, shared;
 	return {
 		setters: [function (module) {
 			commonjsGlobal = module.c;
-			d = module.d;
+			shared = module.s;
 		}],
 		execute: function () {
 
 			commonjsGlobal.fn = d => d + 1;
 			var cjs = commonjsGlobal.fn;
 
-			var main1 = exports('default', d.map(cjs));
+			var main1 = exports('default', shared.map(cjs));
 
 		}
 	};

--- a/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-namespace-boundary/_expected/system/main2.js
@@ -1,13 +1,13 @@
 System.register(['./generated-shared.js'], function (exports) {
 	'use strict';
-	var d;
+	var shared;
 	return {
 		setters: [function (module) {
-			d = module.d;
+			shared = module.s;
 		}],
 		execute: function () {
 
-			var main2 = exports('default', d.map(d => d + 2));
+			var main2 = exports('default', shared.map(d => d + 2));
 
 		}
 	};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/generated-foo.js
@@ -2,7 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	const foo = {};
 
-	exports.bar = foo;
 	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main1.js
@@ -1,5 +1,5 @@
-define(['./generated-proxy2'], function (proxy2) { 'use strict';
+define(['./generated-foo'], function (foo) { 'use strict';
 
-	console.log(proxy2.bar, proxy2.bar);
+	console.log(foo.foo, foo.foo);
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/amd/main2.js
@@ -1,5 +1,5 @@
-define(['./generated-proxy2'], function (proxy2) { 'use strict';
+define(['./generated-foo'], function (foo) { 'use strict';
 
-	console.log(proxy2.bar, proxy2.bar);
+	console.log(foo.foo, foo.foo);
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/generated-foo.js
@@ -2,5 +2,4 @@
 
 const foo = {};
 
-exports.bar = foo;
 exports.foo = foo;

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main1.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var proxy2 = require('./generated-proxy2.js');
+var foo = require('./generated-foo.js');
 
-console.log(proxy2.bar, proxy2.bar);
+console.log(foo.foo, foo.foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/cjs/main2.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var proxy2 = require('./generated-proxy2.js');
+var foo = require('./generated-foo.js');
 
-console.log(proxy2.bar, proxy2.bar);
+console.log(foo.foo, foo.foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/generated-foo.js
@@ -1,0 +1,3 @@
+const foo = {};
+
+export { foo as f };

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/generated-proxy2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/generated-proxy2.js
@@ -1,3 +1,0 @@
-const foo = {};
-
-export { foo as b, foo as f };

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import { f as bar } from './generated-proxy2.js';
+import { f as foo } from './generated-foo.js';
 
-console.log(bar, bar);
+console.log(foo, foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/es/main2.js
@@ -1,3 +1,3 @@
-import { f as bar } from './generated-proxy2.js';
+import { f as foo } from './generated-foo.js';
 
-console.log(bar, bar);
+console.log(foo, foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/generated-foo.js
@@ -3,11 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			const foo = {};
-
-			exports('f', foo);
-
-			exports('b', foo);
+			const foo = exports('f', {});
 
 		}
 	};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main1.js
@@ -1,13 +1,13 @@
-System.register(['./generated-proxy2.js'], function () {
+System.register(['./generated-foo.js'], function () {
 	'use strict';
-	var bar;
+	var foo;
 	return {
 		setters: [function (module) {
-			bar = module.f;
+			foo = module.f;
 		}],
 		execute: function () {
 
-			console.log(bar, bar);
+			console.log(foo, foo);
 
 		}
 	};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals-2/_expected/system/main2.js
@@ -1,13 +1,13 @@
-System.register(['./generated-proxy2.js'], function () {
+System.register(['./generated-foo.js'], function () {
 	'use strict';
-	var bar;
+	var foo;
 	return {
 		setters: [function (module) {
-			bar = module.f;
+			foo = module.f;
 		}],
 		execute: function () {
 
-			console.log(bar, bar);
+			console.log(foo, foo);
 
 		}
 	};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/generated-foo.js
@@ -2,7 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	const foo = {};
 
-	exports.bar = foo;
 	exports.foo = foo;
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main1.js
@@ -1,5 +1,5 @@
-define(['./generated-proxy'], function (proxy) { 'use strict';
+define(['./generated-foo'], function (foo) { 'use strict';
 
-	console.log(proxy.bar, proxy.bar);
+	console.log(foo.foo, foo.foo);
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/amd/main2.js
@@ -1,5 +1,5 @@
-define(['./generated-proxy'], function (proxy) { 'use strict';
+define(['./generated-foo'], function (foo) { 'use strict';
 
-	console.log(proxy.bar, proxy.bar);
+	console.log(foo.foo, foo.foo);
 
 });

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/generated-foo.js
@@ -2,5 +2,4 @@
 
 const foo = {};
 
-exports.bar = foo;
 exports.foo = foo;

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main1.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var proxy = require('./generated-proxy.js');
+var foo = require('./generated-foo.js');
 
-console.log(proxy.bar, proxy.bar);
+console.log(foo.foo, foo.foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/cjs/main2.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var proxy = require('./generated-proxy.js');
+var foo = require('./generated-foo.js');
 
-console.log(proxy.bar, proxy.bar);
+console.log(foo.foo, foo.foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/generated-foo.js
@@ -1,0 +1,3 @@
+const foo = {};
+
+export { foo as f };

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/generated-proxy.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/generated-proxy.js
@@ -1,3 +1,0 @@
-const foo = {};
-
-export { foo as b, foo as f };

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import { f as bar } from './generated-proxy.js';
+import { f as foo } from './generated-foo.js';
 
-console.log(bar, bar);
+console.log(foo, foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/es/main2.js
@@ -1,3 +1,3 @@
-import { f as bar } from './generated-proxy.js';
+import { f as foo } from './generated-foo.js';
 
-console.log(bar, bar);
+console.log(foo, foo);

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/generated-foo.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/generated-foo.js
@@ -3,10 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			const firebase = {};
-			exports('a', firebase);
-
-			exports('b', firebase);
+			const foo = exports('f', {});
 
 		}
 	};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main1.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main1.js
@@ -1,13 +1,13 @@
-System.register(['./generated-proxy.js'], function () {
+System.register(['./generated-foo.js'], function () {
 	'use strict';
-	var bar;
+	var foo;
 	return {
 		setters: [function (module) {
-			bar = module.f;
+			foo = module.f;
 		}],
 		execute: function () {
 
-			console.log(bar, bar);
+			console.log(foo, foo);
 
 		}
 	};

--- a/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main2.js
+++ b/test/chunking-form/samples/deduplicate-imports-referencing-originals/_expected/system/main2.js
@@ -1,13 +1,13 @@
-System.register(['./generated-proxy.js'], function () {
+System.register(['./generated-foo.js'], function () {
 	'use strict';
-	var bar;
+	var foo;
 	return {
 		setters: [function (module) {
-			bar = module.f;
+			foo = module.f;
 		}],
 		execute: function () {
 
-			console.log(bar, bar);
+			console.log(foo, foo);
 
 		}
 	};

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/amd/generated-module1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/amd/generated-module1.js
@@ -2,7 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	const firebase = {};
 
-	exports.a = firebase;
-	exports.b = firebase;
+	exports.firebase = firebase;
 
 });

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/amd/main1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/amd/main1.js
@@ -1,5 +1,5 @@
-define(['./generated-module3'], function (module3) { 'use strict';
+define(['./generated-module1'], function (module1) { 'use strict';
 
-	console.log(module3.b, module3.b);
+	console.log(module1.firebase, module1.firebase);
 
 });

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/amd/main2.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/amd/main2.js
@@ -1,5 +1,5 @@
-define(['./generated-module3'], function (module3) { 'use strict';
+define(['./generated-module1'], function (module1) { 'use strict';
 
-	console.log(module3.b, module3.b);
+	console.log(module1.firebase, module1.firebase);
 
 });

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/generated-module1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/generated-module1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const firebase = {};
+
+exports.firebase = firebase;

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/generated-module3.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/generated-module3.js
@@ -1,6 +1,0 @@
-'use strict';
-
-const firebase = {};
-
-exports.a = firebase;
-exports.b = firebase;

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/main1.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var module3 = require('./generated-module3.js');
+var module1 = require('./generated-module1.js');
 
-console.log(module3.b, module3.b);
+console.log(module1.firebase, module1.firebase);

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/cjs/main2.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var module3 = require('./generated-module3.js');
+var module1 = require('./generated-module1.js');
 
-console.log(module3.b, module3.b);
+console.log(module1.firebase, module1.firebase);

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/es/generated-module1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/es/generated-module1.js
@@ -1,0 +1,3 @@
+const firebase = {};
+
+export { firebase as f };

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/es/generated-module3.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/es/generated-module3.js
@@ -1,3 +1,0 @@
-const firebase = {};
-
-export { firebase as a, firebase as b };

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/es/main1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/es/main1.js
@@ -1,3 +1,3 @@
-import { a as b } from './generated-module3.js';
+import { f as firebase } from './generated-module1.js';
 
-console.log(b, b);
+console.log(firebase, firebase);

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/es/main2.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/es/main2.js
@@ -1,3 +1,3 @@
-import { a as b } from './generated-module3.js';
+import { f as firebase } from './generated-module1.js';
 
-console.log(b, b);
+console.log(firebase, firebase);

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/system/generated-module1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/system/generated-module1.js
@@ -3,9 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			const foo = exports('f', {});
-
-			exports('b', foo);
+			const firebase = exports('f', {});
 
 		}
 	};

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/system/main1.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/system/main1.js
@@ -1,13 +1,13 @@
-System.register(['./generated-module3.js'], function () {
+System.register(['./generated-module1.js'], function () {
 	'use strict';
-	var b;
+	var firebase;
 	return {
 		setters: [function (module) {
-			b = module.a;
+			firebase = module.f;
 		}],
 		execute: function () {
 
-			console.log(b, b);
+			console.log(firebase, firebase);
 
 		}
 	};

--- a/test/chunking-form/samples/default-export-name-conflict/_expected/system/main2.js
+++ b/test/chunking-form/samples/default-export-name-conflict/_expected/system/main2.js
@@ -1,13 +1,13 @@
-System.register(['./generated-module3.js'], function () {
+System.register(['./generated-module1.js'], function () {
 	'use strict';
-	var b;
+	var firebase;
 	return {
 		setters: [function (module) {
-			b = module.a;
+			firebase = module.f;
 		}],
 		execute: function () {
 
-			console.log(b, b);
+			console.log(firebase, firebase);
 
 		}
 	};

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/amd/generated-shared.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/amd/generated-shared.js
@@ -2,6 +2,6 @@ define(['exports'], function (exports) { 'use strict';
 
 	const data = [1, 2, 3];
 
-	exports.d = data;
+	exports.data = data;
 
 });

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main1.js
@@ -1,6 +1,6 @@
 define(['./generated-shared'], function (shared) { 'use strict';
 
-	var main1 = shared.d.map(d => d + 1);
+	var main1 = shared.data.map(d => d + 1);
 
 	return main1;
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/amd/main2.js
@@ -1,6 +1,6 @@
 define(['./generated-shared'], function (shared) { 'use strict';
 
-	var main2 = shared.d.map(d => d + 2);
+	var main2 = shared.data.map(d => d + 2);
 
 	return main2;
 

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/generated-shared.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/generated-shared.js
@@ -2,4 +2,4 @@
 
 const data = [1, 2, 3];
 
-exports.d = data;
+exports.data = data;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main1.js
@@ -2,6 +2,6 @@
 
 var shared = require('./generated-shared.js');
 
-var main1 = shared.d.map(d => d + 1);
+var main1 = shared.data.map(d => d + 1);
 
 module.exports = main1;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/cjs/main2.js
@@ -2,6 +2,6 @@
 
 var shared = require('./generated-shared.js');
 
-var main2 = shared.d.map(d => d + 2);
+var main2 = shared.data.map(d => d + 2);
 
 module.exports = main2;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/main1.js
@@ -1,5 +1,5 @@
-import { d } from './generated-shared.js';
+import { d as data } from './generated-shared.js';
 
-var main1 = d.map(d => d + 1);
+var main1 = data.map(d => d + 1);
 
 export default main1;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/es/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/es/main2.js
@@ -1,5 +1,5 @@
-import { d } from './generated-shared.js';
+import { d as data } from './generated-shared.js';
 
-var main2 = d.map(d => d + 2);
+var main2 = data.map(d => d + 2);
 
 export default main2;

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/generated-shared.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/generated-shared.js
@@ -3,8 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			const data = [1, 2, 3];
-			exports('d', data);
+			const data = exports('d', [1, 2, 3]);
 
 		}
 	};

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/main1.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/main1.js
@@ -1,13 +1,13 @@
 System.register(['./generated-shared.js'], function (exports) {
 	'use strict';
-	var d;
+	var data;
 	return {
 		setters: [function (module) {
-			d = module.d;
+			data = module.d;
 		}],
 		execute: function () {
 
-			var main1 = exports('default', d.map(d => d + 1));
+			var main1 = exports('default', data.map(d => d + 1));
 
 		}
 	};

--- a/test/chunking-form/samples/default-identifier-renaming/_expected/system/main2.js
+++ b/test/chunking-form/samples/default-identifier-renaming/_expected/system/main2.js
@@ -1,13 +1,13 @@
 System.register(['./generated-shared.js'], function (exports) {
 	'use strict';
-	var d;
+	var data;
 	return {
 		setters: [function (module) {
-			d = module.d;
+			data = module.d;
 		}],
 		execute: function () {
 
-			var main2 = exports('default', d.map(d => d + 2));
+			var main2 = exports('default', data.map(d => d + 2));
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/_virtual/other.js_commonjs-proxy
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/_virtual/other.js_commonjs-proxy
@@ -2,6 +2,6 @@ define(['../other'], function (other) { 'use strict';
 
 
 
-	return other.__moduleExports;
+	return other;
 
 });

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/commonjs.js
@@ -1,10 +1,10 @@
-define(['exports', 'external', './_virtual/_external_commonjs-external', './_virtual/other.js_commonjs-proxy'], function (exports, external, _external_commonjsExternal, other) { 'use strict';
+define(['exports', 'external', './other'], function (exports, external, other) { 'use strict';
 
 	external = external && Object.prototype.hasOwnProperty.call(external, 'default') ? external['default'] : external;
 
-	const { value } = other;
+	const { value } = other.default;
 
-	console.log(_external_commonjsExternal, value);
+	console.log(external, value);
 
 	var commonjs = 42;
 

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/other.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/other.js
@@ -7,6 +7,7 @@ define(['exports'], function (exports) { 'use strict';
 	};
 
 	exports.__moduleExports = other;
+	exports.default = other;
 	exports.value = value;
 
 	Object.defineProperty(exports, '__esModule', { value: true });

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/_virtual/other.js_commonjs-proxy
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/_virtual/other.js_commonjs-proxy
@@ -4,4 +4,4 @@ var other = require('../other.js');
 
 
 
-module.exports = other.__moduleExports;
+module.exports = other;

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/commonjs.js
@@ -2,13 +2,14 @@
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
-require('external');
-var _external_commonjsExternal = require('./_virtual/_external_commonjs-external');
-var other = require('./_virtual/other.js_commonjs-proxy');
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-const { value } = other;
+var external = _interopDefault(require('external'));
+var other = require('./other.js');
 
-console.log(_external_commonjsExternal, value);
+const { value } = other.default;
+
+console.log(external, value);
 
 var commonjs = 42;
 

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/other.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/other.js
@@ -9,4 +9,5 @@ var other = {
 };
 
 exports.__moduleExports = other;
+exports.default = other;
 exports.value = value;

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/_virtual/_external_commonjs-external
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/_virtual/_external_commonjs-external
@@ -1,5 +1,2 @@
 import external$1 from 'external';
-
-
-
-export default external$1;
+export { default } from 'external';

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/_virtual/other.js_commonjs-proxy
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/_virtual/other.js_commonjs-proxy
@@ -1,5 +1,2 @@
-import { __moduleExports as other$1 } from '../other.js';
-
-
-
-export default other$1;
+import other$1 from '../other.js';
+export { default } from '../other.js';

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/commonjs.js
@@ -1,8 +1,7 @@
-import 'external';
-import external$1 from './_virtual/_external_commonjs-external';
-import require$$0 from './_virtual/other.js_commonjs-proxy';
+import external$1 from 'external';
+import other$1 from './other.js';
 
-const { value } = require$$0;
+const { value } = other$1;
 
 console.log(external$1, value);
 

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/main.js
@@ -1,4 +1,4 @@
 import external$1 from 'external';
-import value from './commonjs.js';
+import commonjs$1 from './commonjs.js';
 
-console.log(value, external$1);
+console.log(commonjs$1, external$1);

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/other.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/other.js
@@ -4,4 +4,5 @@ var other = {
 	value: value
 };
 
+export default other;
 export { other as __moduleExports, value };

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/_virtual/_external_commonjs-external
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/_virtual/_external_commonjs-external
@@ -4,10 +4,11 @@ System.register(['external'], function (exports) {
 	return {
 		setters: [function (module) {
 			external = module.default;
+			exports('default', module.default);
 		}],
 		execute: function () {
 
-			exports('default', external);
+
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/_virtual/other.js_commonjs-proxy
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/_virtual/other.js_commonjs-proxy
@@ -3,11 +3,12 @@ System.register(['../other.js'], function (exports) {
 	var other;
 	return {
 		setters: [function (module) {
-			other = module.__moduleExports;
+			other = module.default;
+			exports('default', module.default);
 		}],
 		execute: function () {
 
-			exports('default', other);
+
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/commonjs.js
@@ -1,20 +1,19 @@
-System.register(['external', './_virtual/_external_commonjs-external', './_virtual/other.js_commonjs-proxy'], function (exports) {
+System.register(['external', './other.js'], function (exports) {
 	'use strict';
-	var external, require$$0;
+	var external, other;
 	return {
-		setters: [function () {}, function (module) {
+		setters: [function (module) {
 			external = module.default;
 		}, function (module) {
-			require$$0 = module.default;
+			other = module.default;
 		}],
 		execute: function () {
 
-			const { value } = require$$0;
+			const { value } = other;
 
 			console.log(external, value);
 
-			var commonjs = exports('__moduleExports', 42);
-			exports('default', commonjs);
+			var commonjs = exports('default', 42);
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/main.js
@@ -1,15 +1,15 @@
 System.register(['external', './commonjs.js'], function () {
 	'use strict';
-	var external, value;
+	var external, commonjs;
 	return {
 		setters: [function (module) {
 			external = module.default;
 		}, function (module) {
-			value = module.default;
+			commonjs = module.default;
 		}],
 		execute: function () {
 
-			console.log(value, external);
+			console.log(commonjs, external);
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/other.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/other.js
@@ -5,7 +5,7 @@ System.register([], function (exports) {
 
 			var value = exports('value', 43);
 
-			var other = exports('__moduleExports', {
+			var other = exports('default', {
 				value: value
 			});
 

--- a/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/system/m2.js
+++ b/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/system/m2.js
@@ -3,8 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			var m2 = {a:1};
-			exports('default', m2);
+			var m2 = exports('default', {a:1});
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/system/m3.js
+++ b/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/system/m3.js
@@ -3,8 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			var m3 = {b:2};
-			exports('default', m3);
+			var m3 = exports('default', {b:2});
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/es/main.js
@@ -1,5 +1,2 @@
 import foo from './dep2.js';
-
-
-
-export default foo;
+export { default } from './dep2.js';

--- a/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-non-entry-imports/_expected/system/main.js
@@ -4,10 +4,11 @@ System.register(['./dep2.js'], function (exports) {
 	return {
 		setters: [function (module) {
 			foo = module.default;
+			exports('default', module.default);
 		}],
 		execute: function () {
 
-			exports('default', foo);
+
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_config.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_config.js
@@ -1,5 +1,4 @@
 module.exports = {
-	solo: true,
 	description:
 		'correctly resolves imports via a proxy module as direct imports when preserving modules',
 	options: {

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_config.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	solo: true,
+	description:
+		'correctly resolves imports via a proxy module as direct imports when preserving modules',
+	options: {
+		preserveModules: true,
+		external: 'external'
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/amd/main.js
@@ -1,4 +1,4 @@
-define(['external', './proxy'], function (path, proxy) { 'use strict';
+define(['external'], function (path) { 'use strict';
 
 	path = path && Object.prototype.hasOwnProperty.call(path, 'default') ? path['default'] : path;
 

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/amd/main.js
@@ -1,0 +1,8 @@
+define(['external', './proxy'], function (path, proxy) { 'use strict';
+
+	path = path && Object.prototype.hasOwnProperty.call(path, 'default') ? path['default'] : path;
+
+	console.log(path.normalize('foo\\bar'));
+	console.log(path.normalize('foo\\bar'));
+
+});

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/amd/proxy.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/amd/proxy.js
@@ -1,0 +1,9 @@
+define(['external'], function (path) { 'use strict';
+
+	path = path && Object.prototype.hasOwnProperty.call(path, 'default') ? path['default'] : path;
+
+
+
+	return path;
+
+});

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/cjs/main.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var path = _interopDefault(require('external'));
+require('./proxy.js');
+
+console.log(path.normalize('foo\\bar'));
+console.log(path.normalize('foo\\bar'));

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/cjs/main.js
@@ -3,7 +3,6 @@
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
 var path = _interopDefault(require('external'));
-require('./proxy.js');
 
 console.log(path.normalize('foo\\bar'));
 console.log(path.normalize('foo\\bar'));

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/cjs/proxy.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/cjs/proxy.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var path = _interopDefault(require('external'));
+
+
+
+module.exports = path;

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/main.js
@@ -1,5 +1,4 @@
-import proxyPath from 'external';
-import './proxy.js';
+import path$1 from 'external';
 
-console.log(proxyPath.normalize('foo\\bar'));
-console.log(proxyPath.normalize('foo\\bar'));
+console.log(path$1.normalize('foo\\bar'));
+console.log(path$1.normalize('foo\\bar'));

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/main.js
@@ -1,0 +1,5 @@
+import proxyPath from 'external';
+import './proxy.js';
+
+console.log(proxyPath.normalize('foo\\bar'));
+console.log(proxyPath.normalize('foo\\bar'));

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/proxy.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/proxy.js
@@ -1,5 +1,2 @@
 import path$1 from 'external';
-
-
-
-export default path$1;
+export { default } from 'external';

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/proxy.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/es/proxy.js
@@ -1,0 +1,5 @@
+import path$1 from 'external';
+
+
+
+export default path$1;

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/main.js
@@ -1,14 +1,14 @@
-System.register(['external', './proxy.js'], function () {
+System.register(['external'], function () {
 	'use strict';
-	var proxyPath;
+	var path;
 	return {
 		setters: [function (module) {
-			proxyPath = module.default;
-		}, function () {}],
+			path = module.default;
+		}],
 		execute: function () {
 
-			console.log(proxyPath.normalize('foo\\bar'));
-			console.log(proxyPath.normalize('foo\\bar'));
+			console.log(path.normalize('foo\\bar'));
+			console.log(path.normalize('foo\\bar'));
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/main.js
@@ -1,0 +1,15 @@
+System.register(['external', './proxy.js'], function () {
+	'use strict';
+	var proxyPath;
+	return {
+		setters: [function (module) {
+			proxyPath = module.default;
+		}, function () {}],
+		execute: function () {
+
+			console.log(proxyPath.normalize('foo\\bar'));
+			console.log(proxyPath.normalize('foo\\bar'));
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/proxy.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/proxy.js
@@ -4,10 +4,11 @@ System.register(['external'], function (exports) {
 	return {
 		setters: [function (module) {
 			path = module.default;
+			exports('default', module.default);
 		}],
 		execute: function () {
 
-			exports('default', path);
+
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/proxy.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/_expected/system/proxy.js
@@ -1,0 +1,14 @@
+System.register(['external'], function (exports) {
+	'use strict';
+	var path;
+	return {
+		setters: [function (module) {
+			path = module.default;
+		}],
+		execute: function () {
+
+			exports('default', path);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-proxy-import/main.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/main.js
@@ -1,0 +1,5 @@
+import path from 'external';
+import proxyPath from './proxy';
+
+console.log(path.normalize('foo\\bar'));
+console.log(proxyPath.normalize('foo\\bar'));

--- a/test/chunking-form/samples/preserve-modules-proxy-import/proxy.js
+++ b/test/chunking-form/samples/preserve-modules-proxy-import/proxy.js
@@ -1,0 +1,2 @@
+import path from 'external';
+export default path;

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/es/main1.js
@@ -1,5 +1,2 @@
 import { f as foo } from './generated-dep2.js';
-
-
-
-export default foo;
+export { f as default } from './generated-dep2.js';

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main1.js
@@ -4,10 +4,11 @@ System.register(['./generated-dep2.js'], function (exports) {
 	return {
 		setters: [function (module) {
 			foo = module.f;
+			exports('default', module.f);
 		}],
 		execute: function () {
 
-			exports('default', foo);
+
 
 		}
 	};

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -36,7 +36,7 @@ module.exports = {
 		              format: "es"
 		            }
 		          });
-		        }, 400);
+		        }, 500);
 		      }
 		    });
 		  });
@@ -60,7 +60,7 @@ module.exports = {
 		        `
 					);
 					fs.writeFileSync(messageFile, 'loaded');
-				}, 400);
+				}, 500);
 			}
 		});
 	},

--- a/test/form/samples/aaa/_config.js
+++ b/test/form/samples/aaa/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'puts the export after the declaration for default exported classes in SystemJS',
+	options: {
+		output: {
+			name: 'bundle'
+		}
+	}
+};

--- a/test/form/samples/aaa/_expected/amd.js
+++ b/test/form/samples/aaa/_expected/amd.js
@@ -1,0 +1,11 @@
+define(function () { 'use strict';
+
+	class main {
+		constructor() {
+			console.log('class');
+		}
+	}
+
+	return main;
+
+});

--- a/test/form/samples/aaa/_expected/cjs.js
+++ b/test/form/samples/aaa/_expected/cjs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+class main {
+	constructor() {
+		console.log('class');
+	}
+}
+
+module.exports = main;

--- a/test/form/samples/aaa/_expected/es.js
+++ b/test/form/samples/aaa/_expected/es.js
@@ -1,0 +1,7 @@
+class main {
+	constructor() {
+		console.log('class');
+	}
+}
+
+export default main;

--- a/test/form/samples/aaa/_expected/iife.js
+++ b/test/form/samples/aaa/_expected/iife.js
@@ -1,0 +1,12 @@
+var bundle = (function () {
+	'use strict';
+
+	class main {
+		constructor() {
+			console.log('class');
+		}
+	}
+
+	return main;
+
+}());

--- a/test/form/samples/aaa/_expected/system.js
+++ b/test/form/samples/aaa/_expected/system.js
@@ -1,0 +1,14 @@
+System.register('bundle', [], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			class main {
+				constructor() {
+					console.log('class');
+				}
+			} exports('default', main);
+
+		}
+	};
+});

--- a/test/form/samples/aaa/_expected/umd.js
+++ b/test/form/samples/aaa/_expected/umd.js
@@ -1,0 +1,15 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global = global || self, global.bundle = factory());
+}(this, (function () { 'use strict';
+
+	class main {
+		constructor() {
+			console.log('class');
+		}
+	}
+
+	return main;
+
+})));

--- a/test/form/samples/aaa/main.js
+++ b/test/form/samples/aaa/main.js
@@ -1,0 +1,5 @@
+export default class {
+	constructor() {
+		console.log('class');
+	}
+}

--- a/test/form/samples/export-default-2/_expected/system.js
+++ b/test/form/samples/export-default-2/_expected/system.js
@@ -3,8 +3,7 @@ System.register('myBundle', [], function (exports) {
 	return {
 		execute: function () {
 
-			var bar = 1;
-			exports('default', bar);
+			var bar = exports('default', 1);
 
 		}
 	};

--- a/test/form/samples/export-default-3/_expected/system.js
+++ b/test/form/samples/export-default-3/_expected/system.js
@@ -3,9 +3,7 @@ System.register('myBundle', [], function (exports) {
 	return {
 		execute: function () {
 
-			var bar = 1;
-
-			exports('default', bar);
+			var bar = exports('default', 1);
 
 		}
 	};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3517 

### Description
This will fix an issue in the logic that identified certain types of default exports, e.g. `export default foo`, with the variables they were exporting, e.g. `foo`. This caused wrong variable names and unnecessarily complex code in some cases.
