### PR TITLE
Use default named export with plugins

### DIFF
--- a/cli/run/commandPlugins.ts
+++ b/cli/run/commandPlugins.ts
@@ -33,7 +33,7 @@ function loadAndRegisterPlugin(inputOptions: InputOptions, pluginText: string) {
 		// -p "{transform(c,i){...}}"
 		plugin = new Function('return ' + pluginText);
 	} else {
-		const match = pluginText.match(/^([@.\/\\\w|^{}|-]+)(=(.*))?$/);
+		const match = pluginText.match(/^([@.\/\\\w|^{}-]+)(=(.*))?$/);
 		if (match) {
 			// -p plugin
 			// -p plugin=arg
@@ -63,15 +63,10 @@ function loadAndRegisterPlugin(inputOptions: InputOptions, pluginText: string) {
 			}
 		}
 	}
+	// some plugins do not use `module.exports` for their entry point,
+	// in which case we try the named default export and the plugin name
 	if (typeof plugin === 'object') {
-		// some plugins do not use `module.exports` for their entry point.
-		if ('default' in plugin) {
-			// attempt to use the named default export.
-			plugin = plugin.default;
-		} else if (pluginText in plugin) {
-			// attempt to use the plugin name as the named import name.
-			plugin = plugin[pluginText];
-		}
+		plugin = plugin.default || plugin[pluginText]
 	}
 	inputOptions.plugins!.push(
 		typeof plugin === 'function' ? plugin.call(plugin, pluginArg) : plugin

--- a/cli/run/commandPlugins.ts
+++ b/cli/run/commandPlugins.ts
@@ -63,10 +63,15 @@ function loadAndRegisterPlugin(inputOptions: InputOptions, pluginText: string) {
 			}
 		}
 	}
-	if (typeof plugin === 'object' && pluginText in plugin) {
-		// some plugins do not use `export default` for their entry point.
-		// attempt to use the plugin name as the named import name.
-		plugin = plugin[pluginText];
+	if (typeof plugin === 'object') {
+		// some plugins do not use `module.exports` for their entry point.
+		if ('default' in plugin) {
+			// attempt to use the named default export.
+			plugin = plugin.default;
+		} else if (pluginText in plugin) {
+			// attempt to use the plugin name as the named import name.
+			plugin = plugin[pluginText];
+		}
 	}
 	inputOptions.plugins!.push(
 		typeof plugin === 'function' ? plugin.call(plugin, pluginArg) : plugin

--- a/test/cli/samples/plugin/default-export/_config.js
+++ b/test/cli/samples/plugin/default-export/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'CLI --plugin with default export',
+	skipIfWindows: true,
+	command: `echo 'console.log(VALUE);' | rollup -p "./my-plugin={VALUE: 'default', ZZZ: 1}"`
+};

--- a/test/cli/samples/plugin/default-export/_expected.js
+++ b/test/cli/samples/plugin/default-export/_expected.js
@@ -1,0 +1,1 @@
+console.log("default");

--- a/test/cli/samples/plugin/default-export/my-plugin.js
+++ b/test/cli/samples/plugin/default-export/my-plugin.js
@@ -1,0 +1,14 @@
+exports.default = function(options) {
+	if (options === void 0) options = {};
+	return {
+		transform(code) {
+			// dumb search and replace for test purposes
+			for (var key in options) {
+				const rx = new RegExp(key, 'g');
+				const value = JSON.stringify(options[key]);
+				code = code.replace(rx, value);
+			}
+			return code;
+		}
+	};
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: https://github.com/rollup/plugins/issues/360

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Adds support for `exports.default` when including a plugin on the CLI