### PR TITLE
Improve side-effect tracking for call arguments

### DIFF
--- a/src/ast/ExecutionContext.ts
+++ b/src/ast/ExecutionContext.ts
@@ -1,5 +1,5 @@
 import { ExpressionEntity } from './nodes/shared/Expression';
-import { PathTracker } from './utils/PathTracker';
+import { DiscriminatedPathTracker, PathTracker } from './utils/PathTracker';
 import ThisVariable from './variables/ThisVariable';
 
 interface ExecutionContextIgnore {
@@ -22,9 +22,9 @@ export interface HasEffectsContext extends InclusionContext {
 	accessed: PathTracker;
 	assigned: PathTracker;
 	brokenFlow: number;
-	called: PathTracker;
+	called: DiscriminatedPathTracker;
 	ignore: ExecutionContextIgnore;
-	instantiated: PathTracker;
+	instantiated: DiscriminatedPathTracker;
 	replacedVariableInits: Map<ThisVariable, ExpressionEntity>;
 }
 
@@ -40,7 +40,7 @@ export function createHasEffectsContext(): HasEffectsContext {
 		accessed: new PathTracker(),
 		assigned: new PathTracker(),
 		brokenFlow: BROKEN_FLOW_NONE,
-		called: new PathTracker(),
+		called: new DiscriminatedPathTracker(),
 		ignore: {
 			breaks: false,
 			continues: false,
@@ -48,7 +48,7 @@ export function createHasEffectsContext(): HasEffectsContext {
 			returnAwaitYield: false
 		},
 		includedLabels: new Set(),
-		instantiated: new PathTracker(),
+		instantiated: new DiscriminatedPathTracker(),
 		replacedVariableInits: new Map()
 	};
 }

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -184,7 +184,7 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 		const trackedExpressions = (callOptions.withNew
 			? context.instantiated
 			: context.called
-		).getEntities(path);
+		).getEntities(path, callOptions);
 		if (trackedExpressions.has(this)) return false;
 		trackedExpressions.add(this);
 		return this.returnExpression!.hasEffectsWhenCalledAtPath(path, callOptions, context);

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -124,7 +124,7 @@ export default class Property extends NodeBase implements DeoptimizableEntity {
 			const trackedExpressions = (callOptions.withNew
 				? context.instantiated
 				: context.called
-			).getEntities(path);
+			).getEntities(path, callOptions);
 			if (trackedExpressions.has(this)) return false;
 			trackedExpressions.add(this);
 			return this.returnExpression!.hasEffectsWhenCalledAtPath(path, callOptions, context);

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -150,7 +150,7 @@ export default class LocalVariable extends Variable {
 		const trackedExpressions = (callOptions.withNew
 			? context.instantiated
 			: context.called
-		).getEntities(path);
+		).getEntities(path, callOptions);
 		if (trackedExpressions.has(this)) return false;
 		trackedExpressions.add(this);
 		return (this.init && this.init.hasEffectsWhenCalledAtPath(path, callOptions, context))!;

--- a/test/cli/samples/watch/watch-config-error/_config.js
+++ b/test/cli/samples/watch/watch-config-error/_config.js
@@ -20,7 +20,8 @@ module.exports = {
 		);
 	},
 	after() {
-		fs.unlinkSync(configFile);
+		// synchronous sometimes does not seem to work, probably because the watch is not yet removed properly
+		setTimeout(() => fs.unlinkSync(configFile), 100);
 	},
 	abortOnStderr(data) {
 		if (data.includes(`created _actual${path.sep}main1.js`)) {

--- a/test/function/samples/nested-foreach/_config.js
+++ b/test/function/samples/nested-foreach/_config.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'detects side-effects in nested .forEach calls (#3533)',
+	exports: exports => assert.strictEqual(exports.result, 9)
+};

--- a/test/function/samples/nested-foreach/main.js
+++ b/test/function/samples/nested-foreach/main.js
@@ -1,0 +1,4 @@
+const list = [1, 2];
+export let result = 0;
+
+list.forEach(p => list.forEach(pp => (result += p * pp)));


### PR DESCRIPTION
…tracked side-effects in nested calls

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3533

### Description
See #3533. In this situation, the tracking logic that is meant to prevent infinite recursions in Rollup's side-effect detection would fire for the inner `.forEach` call expression because it thought this call had already been tracked as it was the same variable and path of the outer `.forEach` call. Of course this is not the case, so for call expressions, the recursion prevention logic will now also discriminate based on original call expression and not only variable.