### PR TITLE
Wrap object expressions in parentheses if they become children of an arrow function expression

### DIFF
--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -272,7 +272,10 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 		{ renderedParentType }: NodeRenderOptions = BLANK
 	) {
 		super.render(code, options);
-		if (renderedParentType === NodeType.ExpressionStatement) {
+		if (
+			renderedParentType === NodeType.ExpressionStatement ||
+			renderedParentType === NodeType.ArrowFunctionExpression
+		) {
 			code.appendRight(this.start, '(');
 			code.prependLeft(this.end, ')');
 		}

--- a/test/function/samples/simplify-arrow-expression-with-object/_config.js
+++ b/test/function/samples/simplify-arrow-expression-with-object/_config.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'correctly simplifies arrow expressions where the right hand side becomes an object',
+	exports(exports) {
+		assert.deepStrictEqual(exports.conditional(), { x: 42, y: 43 });
+		assert.deepStrictEqual(exports.logical(), { x: 42, y: 43 });
+	}
+};

--- a/test/function/samples/simplify-arrow-expression-with-object/main.js
+++ b/test/function/samples/simplify-arrow-expression-with-object/main.js
@@ -1,0 +1,2 @@
+export const logical = () => true && { x: 42, y: 43, };
+export const conditional = () => true ? { x: 42, y: 43, } : null;


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3530 

### Description
This makes sure that object expressions are not mis-interpreted as block statements when the body of an arrow function expression is simplified
