### PR TITLE
Properly handle default exporting "undefined"

### DIFF
--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -4,6 +4,7 @@ import ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import FunctionDeclaration from '../nodes/FunctionDeclaration';
 import Identifier, { IdentifierWithVariable } from '../nodes/Identifier';
 import LocalVariable from './LocalVariable';
+import UndefinedVariable from './UndefinedVariable';
 import Variable from './Variable';
 
 export default class ExportDefaultVariable extends LocalVariable {
@@ -61,7 +62,12 @@ export default class ExportDefaultVariable extends LocalVariable {
 
 	getOriginalVariable(): Variable {
 		if (this.originalVariable === null) {
-			if (!this.originalId || (!this.hasId && this.originalId.variable.isReassigned)) {
+			if (
+				!this.originalId ||
+				(!this.hasId &&
+					(this.originalId.variable.isReassigned ||
+						this.originalId.variable instanceof UndefinedVariable))
+			) {
 				this.originalVariable = this;
 			} else {
 				const assignedOriginal = this.originalId.variable;

--- a/test/form/samples/undefined-default-export/_config.js
+++ b/test/form/samples/undefined-default-export/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles default exporting undefined'
+};

--- a/test/form/samples/undefined-default-export/_expected.js
+++ b/test/form/samples/undefined-default-export/_expected.js
@@ -1,0 +1,5 @@
+var dep = undefined;
+
+console.log(dep);
+
+export { dep };

--- a/test/form/samples/undefined-default-export/dep.js
+++ b/test/form/samples/undefined-default-export/dep.js
@@ -1,0 +1,1 @@
+export default undefined;

--- a/test/form/samples/undefined-default-export/main.js
+++ b/test/form/samples/undefined-default-export/main.js
@@ -1,0 +1,3 @@
+import dep from './dep.js';
+console.log(dep);
+export { dep };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3557 

### Description
This will make sure that the default export simplification logic does not kick in when `undefined` is exported, leading to a crash.