### PR TITLE
Make sure UnknownFooExpressions are included when referenced as return values in a MultiExpression

### DIFF
--- a/src/ast/nodes/shared/MultiExpression.ts
+++ b/src/ast/nodes/shared/MultiExpression.ts
@@ -1,9 +1,10 @@
 import { CallOptions } from '../../CallOptions';
 import { DeoptimizableEntity } from '../../DeoptimizableEntity';
-import { HasEffectsContext } from '../../ExecutionContext';
+import { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
 import { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import { LiteralValueOrUnknown, UnknownValue } from '../../values';
 import { ExpressionEntity } from './Expression';
+import { IncludeChildren } from './Node';
 
 export class MultiExpression implements ExpressionEntity {
 	included = false;
@@ -61,7 +62,15 @@ export class MultiExpression implements ExpressionEntity {
 		return false;
 	}
 
-	include(): void {}
+	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {
+		// This is only relevant to include values that do not have an AST representation,
+		// such as UnknownArrayExpression. Thus we only need to include them once.
+		for (const expression of this.expressions) {
+			if (!expression.included) {
+				expression.include(context, includeChildrenRecursively);
+			}
+		}
+	}
 
 	includeCallArguments(): void {}
 }

--- a/test/function/samples/chained-mutable-array-methods/_config.js
+++ b/test/function/samples/chained-mutable-array-methods/_config.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+
+module.exports = {
+	description:
+		'recognizes side-effects when applying mutable array methods to chained array methods (#3555)',
+	exports(exports) {
+		assert.deepStrictEqual(exports.a, ['PASS']);
+	}
+};

--- a/test/function/samples/chained-mutable-array-methods/main.js
+++ b/test/function/samples/chained-mutable-array-methods/main.js
@@ -1,0 +1,5 @@
+function f(x) {
+	return (x ? [] : ['FAIL']).map(o => o);
+}
+export const a = f(0);
+a.splice(0, 1, 'PASS');


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3555

### Description
Apparently when using a return value of a function that contained conditional expressions and builtin methods, later mutations of that return value would not be tracked properly. This is fixed here. See the examples at #3555.
