### PR TITLE
Throw error if sourcemapPathTransform-option does not return a string (#3484)

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -669,11 +669,21 @@ export default class Chunk {
 				chunkSourcemapChain,
 				options.sourcemapExcludeSources!
 			);
-			map.sources = map.sources.map(sourcePath =>
-				normalize(
-					options.sourcemapPathTransform ? options.sourcemapPathTransform(sourcePath) : sourcePath
-				)
-			);
+			map.sources = map.sources.map(sourcePath => {
+				const { sourcemapPathTransform } = options;
+
+				if (sourcemapPathTransform) {
+					const newSourcePath = sourcemapPathTransform(sourcePath);
+
+					if (typeof newSourcePath !== 'string') {
+						throw new Error('sourcemapPathTransform function must return a string.');
+					}
+
+					return normalize(newSourcePath);
+				}
+
+				return normalize(sourcePath);
+			});
 
 			timeEnd('sourcemap', 3);
 		}

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -26,7 +26,7 @@ import { Addons } from './utils/addons';
 import { collapseSourcemaps } from './utils/collapseSourcemaps';
 import { createHash } from './utils/crypto';
 import { deconflictChunk } from './utils/deconflictChunk';
-import { error } from './utils/error';
+import { errFailedValidation, error } from './utils/error';
 import { sortByExecutionOrder } from './utils/executionOrder';
 import { assignExportsToMangledNames, assignExportsToNames } from './utils/exportNames';
 import getIndentString from './utils/getIndentString';
@@ -669,21 +669,23 @@ export default class Chunk {
 				chunkSourcemapChain,
 				options.sourcemapExcludeSources!
 			);
-			map.sources = map.sources.map(sourcePath => {
-				const { sourcemapPathTransform } = options;
+			map.sources = map.sources
+				.map(sourcePath => {
+					const { sourcemapPathTransform } = options;
 
-				if (sourcemapPathTransform) {
-					const newSourcePath = sourcemapPathTransform(sourcePath);
+					if (sourcemapPathTransform) {
+						const newSourcePath = sourcemapPathTransform(sourcePath);
 
-					if (typeof newSourcePath !== 'string') {
-						throw new Error('sourcemapPathTransform function must return a string.');
+						if (typeof newSourcePath !== 'string') {
+							error(errFailedValidation(`sourcemapPathTransform function must return a string.`));
+						}
+
+						return newSourcePath;
 					}
 
-					return normalize(newSourcePath);
-				}
-
-				return normalize(sourcePath);
-			});
+					return sourcePath;
+				})
+				.map(normalize);
 
 			timeEnd('sourcemap', 3);
 		}

--- a/test/function/samples/invalid-transform-source-function/_config.js
+++ b/test/function/samples/invalid-transform-source-function/_config.js
@@ -1,0 +1,17 @@
+const path = require('path');
+
+module.exports = {
+	description:
+		'throw descriptive error if sourcemapPathTransform-function does not return a string (#3484)',
+	options: {
+		output: {
+			name: 'myModule',
+			sourcemap: true,
+			file: path.resolve(__dirname, 'main.js'),
+			sourcemapPathTransform: () => {}
+		}
+	},
+	generateError: {
+		message: 'sourcemapPathTransform function must return a string.'
+	}
+};

--- a/test/function/samples/invalid-transform-source-function/_config.js
+++ b/test/function/samples/invalid-transform-source-function/_config.js
@@ -12,6 +12,7 @@ module.exports = {
 		}
 	},
 	generateError: {
+		code: 'VALIDATION_ERROR',
 		message: 'sourcemapPathTransform function must return a string.'
 	}
 };

--- a/test/function/samples/invalid-transform-source-function/main.js
+++ b/test/function/samples/invalid-transform-source-function/main.js
@@ -1,0 +1,1 @@
+export default 42;


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

I tried writing a test for this but couldn't manage to find test cases which overs actual errors (and I also couldn't find any documentation of how tests are set up in this project, sorry If I missed something).

What I tried:
```js
module.exports = {
	description: 'throw descriptive error if sourcemapPathTransform-function does not return a string (#3484)',
	options: {
		output: {
			name: 'myModule',
			file: path.resolve(__dirname, '_actual/bundle.js'),
			sourcemapPathTransform: () => {}
		}
	},
	error: () => true,
	stderr: (stderr) =>
		assertStderrIncludes(
			stderr,
			'[!] Error: sourcemapPathTransform function must return a string.'
		),
}
```

but `error` does not seem to be part of the sourcemaps test suites 😕

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#3484 
### Description
The return-value of `sourcemapPathTransform` is not properly validated, at least not in a JS Environment and the config of rollup is written in js... This "fix" will throw an error if the sourcemapPathTransform-options is not set according to the documentation (returning a string).

