### PR TITLE
Observe side-effects in files containing a default export declaration that reexports a variable

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -129,7 +129,11 @@ export default class Chunk {
 		for (const dependency of facadedModule.getDependenciesToBeIncluded()) {
 			chunk.dependencies.add(dependency instanceof Module ? dependency.chunk! : dependency);
 		}
-		if (!chunk.dependencies.has(facadedModule.chunk!) && facadedModule.hasEffects()) {
+		if (
+			!chunk.dependencies.has(facadedModule.chunk!) &&
+			facadedModule.moduleSideEffects &&
+			facadedModule.hasEffects()
+		) {
 			chunk.dependencies.add(facadedModule.chunk!);
 		}
 		chunk.facadeModule = facadedModule;

--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -1,4 +1,4 @@
-import { AstContext } from '../../Module';
+import Module, { AstContext } from '../../Module';
 import ClassDeclaration from '../nodes/ClassDeclaration';
 import ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import FunctionDeclaration from '../nodes/FunctionDeclaration';
@@ -12,7 +12,10 @@ export default class ExportDefaultVariable extends LocalVariable {
 
 	// Not initialised during construction
 	private originalId: IdentifierWithVariable | null = null;
-	private originalVariable: Variable | null = null;
+	private originalVariableAndDeclarationModules: {
+		modules: Module[];
+		original: Variable;
+	} | null = null;
 
 	constructor(
 		name: string,
@@ -61,22 +64,34 @@ export default class ExportDefaultVariable extends LocalVariable {
 	}
 
 	getOriginalVariable(): Variable {
-		if (this.originalVariable === null) {
+		return this.getOriginalVariableAndDeclarationModules().original;
+	}
+
+	getOriginalVariableAndDeclarationModules(): { modules: Module[]; original: Variable } {
+		if (this.originalVariableAndDeclarationModules === null) {
 			if (
 				!this.originalId ||
 				(!this.hasId &&
 					(this.originalId.variable.isReassigned ||
 						this.originalId.variable instanceof UndefinedVariable))
 			) {
-				this.originalVariable = this;
+				this.originalVariableAndDeclarationModules = { modules: [], original: this };
 			} else {
 				const assignedOriginal = this.originalId.variable;
-				this.originalVariable =
-					assignedOriginal instanceof ExportDefaultVariable
-						? assignedOriginal.getOriginalVariable()
-						: assignedOriginal;
+				if (assignedOriginal instanceof ExportDefaultVariable) {
+					const { modules, original } = assignedOriginal.getOriginalVariableAndDeclarationModules();
+					this.originalVariableAndDeclarationModules = {
+						modules: modules.concat(this.module),
+						original
+					};
+				} else {
+					this.originalVariableAndDeclarationModules = {
+						modules: [this.module],
+						original: assignedOriginal
+					};
+				}
 			}
 		}
-		return this.originalVariable;
+		return this.originalVariableAndDeclarationModules;
 	}
 }

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -60,7 +60,7 @@ module.exports = {
 		        `
 					);
 					fs.writeFileSync(messageFile, 'loaded');
-				}, 300);
+				}, 500);
 			}
 		});
 	},
@@ -69,7 +69,7 @@ module.exports = {
 	},
 	abortOnStderr(data) {
 		if (reloadTriggered && data.includes('created _actual')) {
-			return new Promise(resolve => setTimeout(() => resolve(true), 300));
+			return new Promise(resolve => setTimeout(() => resolve(true), 500));
 		} else if (data.includes('Reloading updated config')) {
 			reloadTriggered = true;
 			return false;

--- a/test/form/samples/side-effect-default-reexport/_config.js
+++ b/test/form/samples/side-effect-default-reexport/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description:
+		'Observes side-effects in side-effect-free modules that contain a used default export that just reexports from another module',
+	options: {
+		treeshake: { moduleSideEffects: false }
+	}
+};

--- a/test/form/samples/side-effect-default-reexport/_expected.js
+++ b/test/form/samples/side-effect-default-reexport/_expected.js
@@ -1,0 +1,32 @@
+var Menu = {
+	name: 'menu'
+};
+
+var Item = {
+	name: 'item'
+};
+
+Menu.Item1 = Item;
+
+Menu.Item2 = Item;
+
+var NamedExport = {
+	name: 'menu'
+};
+
+var Menu$1 = {
+	name: 'menu'
+};
+
+var Item$1 = {
+	name: 'item'
+};
+
+Menu$1.Item1 = Item$1;
+
+Menu$1.Item2 = Item$1;
+
+console.log('test-package-default-export', Menu.Item);
+console.log('test-package-named-export', NamedExport.Item);
+
+export default Menu$1;

--- a/test/form/samples/side-effect-default-reexport/default-export/index.js
+++ b/test/form/samples/side-effect-default-reexport/default-export/index.js
@@ -1,0 +1,6 @@
+import Menu from './index2';
+import Item from './item';
+
+Menu.Item2 = Item;
+
+export default Menu;

--- a/test/form/samples/side-effect-default-reexport/default-export/index2.js
+++ b/test/form/samples/side-effect-default-reexport/default-export/index2.js
@@ -1,0 +1,6 @@
+import Menu from './menu';
+import Item from './item';
+
+Menu.Item1 = Item;
+
+export default Menu;

--- a/test/form/samples/side-effect-default-reexport/default-export/item.js
+++ b/test/form/samples/side-effect-default-reexport/default-export/item.js
@@ -1,0 +1,3 @@
+export default {
+	name: 'item'
+};

--- a/test/form/samples/side-effect-default-reexport/default-export/menu.js
+++ b/test/form/samples/side-effect-default-reexport/default-export/menu.js
@@ -1,0 +1,3 @@
+export default {
+	name: 'menu'
+};

--- a/test/form/samples/side-effect-default-reexport/default-export2/index.js
+++ b/test/form/samples/side-effect-default-reexport/default-export2/index.js
@@ -1,0 +1,6 @@
+import Menu from './index2';
+import Item from './item';
+
+Menu.Item2 = Item;
+
+export default Menu;

--- a/test/form/samples/side-effect-default-reexport/default-export2/index2.js
+++ b/test/form/samples/side-effect-default-reexport/default-export2/index2.js
@@ -1,0 +1,6 @@
+import Menu from './menu';
+import Item from './item';
+
+Menu.Item1 = Item;
+
+export default Menu;

--- a/test/form/samples/side-effect-default-reexport/default-export2/item.js
+++ b/test/form/samples/side-effect-default-reexport/default-export2/item.js
@@ -1,0 +1,3 @@
+export default {
+	name: 'item'
+};

--- a/test/form/samples/side-effect-default-reexport/default-export2/menu.js
+++ b/test/form/samples/side-effect-default-reexport/default-export2/menu.js
@@ -1,0 +1,3 @@
+export default {
+	name: 'menu'
+};

--- a/test/form/samples/side-effect-default-reexport/main.js
+++ b/test/form/samples/side-effect-default-reexport/main.js
@@ -1,0 +1,8 @@
+import DefaultExport from './default-export/index.js';
+console.log('test-package-default-export', DefaultExport.Item);
+
+import { Menu as NamedExport } from './named-export/index.js';
+console.log('test-package-named-export', NamedExport.Item);
+
+export { default } from './default-export2/index.js';
+

--- a/test/form/samples/side-effect-default-reexport/named-export/index.js
+++ b/test/form/samples/side-effect-default-reexport/named-export/index.js
@@ -1,0 +1,6 @@
+import { Menu } from './index2';
+import Item from './item';
+
+Menu.Item2 = Item;
+
+export { Menu };

--- a/test/form/samples/side-effect-default-reexport/named-export/index2.js
+++ b/test/form/samples/side-effect-default-reexport/named-export/index2.js
@@ -1,0 +1,6 @@
+import Menu from './menu';
+import Item from './item';
+
+Menu.Item1 = Item;
+
+export { Menu };

--- a/test/form/samples/side-effect-default-reexport/named-export/item.js
+++ b/test/form/samples/side-effect-default-reexport/named-export/item.js
@@ -1,0 +1,3 @@
+export default {
+	name: 'item'
+};

--- a/test/form/samples/side-effect-default-reexport/named-export/menu.js
+++ b/test/form/samples/side-effect-default-reexport/named-export/menu.js
@@ -1,0 +1,3 @@
+export default {
+	name: 'menu'
+};


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3565 

### Description
This improves side-effect handling to make sure that when a module contains a default export declaration that is used, then side-effects in that module are included even if it is declared as having no side-effects and the default export just references a variable from another module. See #3565 for more reasoning.