### PR TITLE
Target Node.js v14 instead of v13

### DIFF
--- a/.github/workflows/node-windows.yml
+++ b/.github/workflows/node-windows.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['13', '12', '10']
+        node: ['14', '12', '10']
 
     name: ${{ matrix.node }} (Windows)
     steps:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This is my first contribution. I'm adding GitHub actions at my job, and I figured I would investigate how Rollup does it; in turn, I noticed this potential oversight.

Because Node.js v13 has been superseded by v14 with the intention to make the latter an LTS version, builds should target the eventual LTS version.