### PR TITLE
Handle default reexports of synthetic named exports over several stages

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1064,10 +1064,14 @@ export default class Chunk {
 
 	private setUpChunkImportsAndExportsForModule(module: Module) {
 		for (let variable of module.imports) {
-			if (variable instanceof SyntheticNamedExportVariable) {
-				variable = variable.getBaseVariable();
-			} else if (variable instanceof ExportDefaultVariable) {
+			if (variable instanceof ExportDefaultVariable) {
 				variable = variable.getOriginalVariable();
+			}
+			while (variable instanceof SyntheticNamedExportVariable) {
+				variable = variable.getBaseVariable();
+				if (variable instanceof ExportDefaultVariable) {
+					variable = variable.getOriginalVariable();
+				}
 			}
 			if (variable.module && (variable.module as Module).chunk !== this) {
 				this.imports.add(variable);

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_config.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	description:
+		'handles synthetic named exports that are reexported as a default export over several stages',
+	options: {
+		input: ['main.js'],
+		plugins: {
+			transform(code) {
+				return { code, syntheticNamedExports: true };
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-component.js
@@ -1,0 +1,5 @@
+define(['./generated-main'], function (main) { 'use strict';
+
+	console.log(main.lib, main.lib.named, main.lib.named.named);
+
+});

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-main.js
@@ -1,0 +1,15 @@
+define(['require', 'exports'], function (require, exports) { 'use strict';
+
+	var lib = { named: { named: 42 } };
+
+	console.log('side-effect', lib.named);
+
+	console.log('side-effect', lib.named.named);
+
+	const component = new Promise(function (resolve, reject) { require(['./generated-component'], resolve, reject) });
+
+	exports.component = component;
+	exports.lib = lib;
+	exports.named = lib.named.named;
+
+});

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-main.js
@@ -1,6 +1,6 @@
 define(['require', 'exports'], function (require, exports) { 'use strict';
 
-	var lib = { named: { named: 42 } };
+	const lib = { named: { named: 42 } };
 
 	console.log('side-effect', lib.named);
 

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/main.js
@@ -1,0 +1,10 @@
+define(['exports', './generated-main'], function (exports, main) { 'use strict';
+
+
+
+	exports.component = main.component;
+	exports.lib = main.lib.named.named;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-component.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var main = require('./generated-main.js');
+
+console.log(main.lib, main.lib.named, main.lib.named.named);

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-main.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var lib = { named: { named: 42 } };
+
+console.log('side-effect', lib.named);
+
+console.log('side-effect', lib.named.named);
+
+const component = Promise.resolve().then(function () { return require('./generated-component.js'); });
+
+exports.component = component;
+exports.lib = lib;
+exports.named = lib.named.named;

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-main.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var lib = { named: { named: 42 } };
+const lib = { named: { named: 42 } };
 
 console.log('side-effect', lib.named);
 

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/main.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var main = require('./generated-main.js');
+
+
+
+exports.component = main.component;
+exports.lib = main.lib.named.named;

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-component.js
@@ -1,0 +1,3 @@
+import { l as lib } from './generated-main.js';
+
+console.log(lib, lib.named, lib.named.named);

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-main.js
@@ -1,4 +1,4 @@
-var lib = { named: { named: 42 } };
+const lib = { named: { named: 42 } };
 
 console.log('side-effect', lib.named);
 

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-main.js
@@ -1,0 +1,10 @@
+var lib = { named: { named: 42 } };
+
+console.log('side-effect', lib.named);
+
+console.log('side-effect', lib.named.named);
+
+const component = import('./generated-component.js');
+
+var named = lib.named.named;
+export { component as c, lib as l, named as n };

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/main.js
@@ -1,0 +1,6 @@
+export { c as component } from './generated-main.js';
+
+
+
+var named = lib.named.named;
+export { named as lib };

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-component.js
@@ -1,0 +1,14 @@
+System.register(['./generated-main.js'], function () {
+	'use strict';
+	var lib;
+	return {
+		setters: [function (module) {
+			lib = module.l;
+		}],
+		execute: function () {
+
+			console.log(lib, lib.named, lib.named.named);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-main.js
@@ -1,0 +1,18 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var lib = exports('l', { named: { named: 42 } });
+
+			console.log('side-effect', lib.named);
+
+			console.log('side-effect', lib.named.named);
+
+			const component = exports('c', module.import('./generated-component.js'));
+
+			exports('n', lib.named.named);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-main.js
@@ -3,7 +3,7 @@ System.register([], function (exports, module) {
 	return {
 		execute: function () {
 
-			var lib = exports('l', { named: { named: 42 } });
+			const lib = exports('l', { named: { named: 42 } });
 
 			console.log('side-effect', lib.named);
 

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/main.js
@@ -1,0 +1,15 @@
+System.register(['./generated-main.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('component', module.c);
+		}],
+		execute: function () {
+
+
+
+			exports('lib', lib.named.named);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/component.js
@@ -1,0 +1,4 @@
+import lib from './lib';
+import lib2 from './lib-reexport2';
+import lib3 from './lib-reexport';
+console.log(lib, lib2, lib3);

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib-reexport.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib-reexport.js
@@ -1,0 +1,3 @@
+import { named } from './lib-reexport2.js';
+console.log('side-effect', named);
+export default named;

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib-reexport2.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib-reexport2.js
@@ -1,0 +1,3 @@
+import { named } from './lib.js';
+console.log('side-effect', named);
+export default named;

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib.js
@@ -1,0 +1,1 @@
+export default { named: { named: 42 } };

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/lib.js
@@ -1,1 +1,2 @@
-export default { named: { named: 42 } };
+const lib = { named: { named: 42 } };
+export { lib as default };

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/main.js
@@ -1,0 +1,2 @@
+export { default as lib } from './lib-reexport.js';
+export const component = import('./component.js');

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_config.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	description:
+		'handles synthetic named exports that are reexported as a default export where both the default and a named export is used',
+	options: {
+		input: ['main.js'],
+		plugins: {
+			transform(code) {
+				return { code, syntheticNamedExports: true };
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/amd/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/amd/generated-component.js
@@ -1,0 +1,5 @@
+define(['./main'], function (main) { 'use strict';
+
+	console.log(main.lib, main.lib.someExport);
+
+});

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/amd/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/amd/main.js
@@ -1,0 +1,14 @@
+define(['require', 'exports'], function (require, exports) { 'use strict';
+
+	var lib = {};
+
+	console.log('side-effect', lib);
+
+	const component = new Promise(function (resolve, reject) { require(['./generated-component'], resolve, reject) });
+
+	exports.component = component;
+	exports.lib = lib;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/cjs/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/cjs/generated-component.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var main = require('./main.js');
+
+console.log(main.lib, main.lib.someExport);

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/cjs/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/cjs/main.js
@@ -1,0 +1,12 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var lib = {};
+
+console.log('side-effect', lib);
+
+const component = Promise.resolve().then(function () { return require('./generated-component.js'); });
+
+exports.component = component;
+exports.lib = lib;

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/es/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/es/generated-component.js
@@ -1,0 +1,3 @@
+import { lib } from './main.js';
+
+console.log(lib, lib.someExport);

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/es/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/es/main.js
@@ -1,0 +1,7 @@
+var lib = {};
+
+console.log('side-effect', lib);
+
+const component = import('./generated-component.js');
+
+export { component, lib };

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/system/generated-component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/system/generated-component.js
@@ -1,0 +1,14 @@
+System.register(['./main.js'], function () {
+	'use strict';
+	var lib;
+	return {
+		setters: [function (module) {
+			lib = module.lib;
+		}],
+		execute: function () {
+
+			console.log(lib, lib.someExport);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/system/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var lib = exports('lib', {});
+
+			console.log('side-effect', lib);
+
+			const component = exports('component', module.import('./generated-component.js'));
+
+		}
+	};
+});

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/component.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/component.js
@@ -1,0 +1,2 @@
+import lib, { someExport } from './lib-reexport';
+console.log(lib, someExport);

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/lib-reexport.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/lib-reexport.js
@@ -1,0 +1,3 @@
+import lib from './lib.js';
+console.log('side-effect', lib);
+export default lib;

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/lib.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/lib.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/chunking-form/samples/synthetic-named-exports-default-reexport/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-default-reexport/main.js
@@ -1,0 +1,2 @@
+export { default as lib } from './lib-reexport.js';
+export const component = import('./component.js');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves rollup/plugins#392

### Description
This fixes an important issue that turned up with the latest version of `@rollup/plugin-commonjs`. The core issue is that both default exports and synthetic named exports employ some import short-circuit logic, and the logic did not account for the fact that this could go over several stages. After this PR, there can still be some unnecessary exports in certain chunks but the imports should be as optimal as they can be.