### PR TITLE
Prevent unneeded exports when entry facades are created and ensure all exported variables in facades are imported

### DIFF
--- a/src/ast/variables/SyntheticNamedExportVariable.ts
+++ b/src/ast/variables/SyntheticNamedExportVariable.ts
@@ -1,4 +1,5 @@
 import Module, { AstContext } from '../../Module';
+import ExportDefaultVariable from './ExportDefaultVariable';
 import Variable from './Variable';
 
 export default class SyntheticNamedExportVariable extends Variable {
@@ -14,9 +15,14 @@ export default class SyntheticNamedExportVariable extends Variable {
 	}
 
 	getBaseVariable(): Variable {
-		return this.defaultVariable instanceof SyntheticNamedExportVariable
-			? this.defaultVariable.getBaseVariable()
-			: this.defaultVariable;
+		let baseVariable = this.defaultVariable;
+		if (baseVariable instanceof ExportDefaultVariable) {
+			baseVariable = baseVariable.getOriginalVariable();
+		}
+		if (baseVariable instanceof SyntheticNamedExportVariable) {
+			baseVariable = baseVariable.getBaseVariable();
+		}
+		return baseVariable;
 	}
 
 	getName(): string {

--- a/test/chunking-form/samples/circular-entry-points2/_config.js
+++ b/test/chunking-form/samples/circular-entry-points2/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'does not create a facade for one circular entry point if possible',
+	expectedWarnings: ['CIRCULAR_DEPENDENCY'],
+	options: {
+		input: ['main1.js', 'main2.js']
+	}
+};

--- a/test/chunking-form/samples/circular-entry-points2/_expected/amd/main1.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/amd/main1.js
@@ -1,0 +1,9 @@
+define(['exports', './main2'], function (exports, main2) { 'use strict';
+
+
+
+	exports.p = main2.p2;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/circular-entry-points2/_expected/amd/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/amd/main2.js
@@ -1,0 +1,28 @@
+define(['exports'], function (exports) { 'use strict';
+
+  class C {
+    fn (num) {
+      console.log(num - p$1);
+    }
+  }
+
+  var p = 43;
+
+  new C().fn(p);
+
+  class C$1 {
+    fn (num) {
+      console.log(num - p);
+    }
+  }
+
+  var p$1 = 42;
+
+  new C$1().fn(p$1);
+
+  exports.p = p;
+  exports.p2 = p$1;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/circular-entry-points2/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/cjs/main1.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var main2 = require('./main2.js');
+
+
+
+exports.p = main2.p2;

--- a/test/chunking-form/samples/circular-entry-points2/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/cjs/main2.js
@@ -1,0 +1,26 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+class C {
+  fn (num) {
+    console.log(num - p$1);
+  }
+}
+
+var p = 43;
+
+new C().fn(p);
+
+class C$1 {
+  fn (num) {
+    console.log(num - p);
+  }
+}
+
+var p$1 = 42;
+
+new C$1().fn(p$1);
+
+exports.p = p;
+exports.p2 = p$1;

--- a/test/chunking-form/samples/circular-entry-points2/_expected/es/main1.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/es/main1.js
@@ -1,0 +1,1 @@
+export { p2 as p } from './main2.js';

--- a/test/chunking-form/samples/circular-entry-points2/_expected/es/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/es/main2.js
@@ -1,0 +1,21 @@
+class C {
+  fn (num) {
+    console.log(num - p$1);
+  }
+}
+
+var p = 43;
+
+new C().fn(p);
+
+class C$1 {
+  fn (num) {
+    console.log(num - p);
+  }
+}
+
+var p$1 = 42;
+
+new C$1().fn(p$1);
+
+export { p, p$1 as p2 };

--- a/test/chunking-form/samples/circular-entry-points2/_expected/system/main1.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/system/main1.js
@@ -1,0 +1,13 @@
+System.register(['./main2.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('p', module.p2);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/circular-entry-points2/_expected/system/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/system/main2.js
@@ -1,0 +1,28 @@
+System.register([], function (exports) {
+  'use strict';
+  return {
+    execute: function () {
+
+      class C {
+        fn (num) {
+          console.log(num - p$1);
+        }
+      }
+
+      var p = exports('p', 43);
+
+      new C().fn(p);
+
+      class C$1 {
+        fn (num) {
+          console.log(num - p);
+        }
+      }
+
+      var p$1 = exports('p2', 42);
+
+      new C$1().fn(p$1);
+
+    }
+  };
+});

--- a/test/chunking-form/samples/circular-entry-points2/dep1.js
+++ b/test/chunking-form/samples/circular-entry-points2/dep1.js
@@ -1,0 +1,7 @@
+import { p } from './main2.js';
+
+export class C {
+  fn (num) {
+    console.log(num - p);
+  }
+}

--- a/test/chunking-form/samples/circular-entry-points2/dep2.js
+++ b/test/chunking-form/samples/circular-entry-points2/dep2.js
@@ -1,0 +1,7 @@
+import { p } from './main1.js';
+
+export class C {
+  fn (num) {
+    console.log(num - p);
+  }
+}

--- a/test/chunking-form/samples/circular-entry-points2/main1.js
+++ b/test/chunking-form/samples/circular-entry-points2/main1.js
@@ -1,0 +1,4 @@
+import { C } from './dep1.js';
+export var p = 42;
+
+new C().fn(p);

--- a/test/chunking-form/samples/circular-entry-points2/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/main2.js
@@ -1,0 +1,5 @@
+import { C } from './dep2.js';
+export var p = 43;
+export {p as p2} from './main1'
+
+new C().fn(p);

--- a/test/chunking-form/samples/circular-entry-points3/_config.js
+++ b/test/chunking-form/samples/circular-entry-points3/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description:
+		'creates facades for all circular entry points if they become tainted by another entry',
+	expectedWarnings: ['CIRCULAR_DEPENDENCY'],
+	options: {
+		input: ['main1.js', 'main2.js', 'main3.js']
+	}
+};

--- a/test/chunking-form/samples/circular-entry-points3/_expected/amd/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/amd/generated-main1.js
@@ -1,0 +1,27 @@
+define(['exports'], function (exports) { 'use strict';
+
+  class C {
+    fn (num) {
+      console.log(num - p$1);
+    }
+  }
+
+  var p = 43;
+
+  new C().fn(p);
+
+  class C$1 {
+    fn (num) {
+      console.log(num - p);
+    }
+  }
+
+  var p$1 = 42;
+
+  new C$1().fn(p$1);
+
+  exports.C = C;
+  exports.p = p;
+  exports.p$1 = p$1;
+
+});

--- a/test/chunking-form/samples/circular-entry-points3/_expected/amd/main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/amd/main1.js
@@ -1,0 +1,9 @@
+define(['exports', './generated-main1'], function (exports, main2) { 'use strict';
+
+
+
+	exports.p = main2.p$1;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/circular-entry-points3/_expected/amd/main2.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/amd/main2.js
@@ -1,0 +1,10 @@
+define(['exports', './generated-main1'], function (exports, main2) { 'use strict';
+
+
+
+	exports.p = main2.p;
+	exports.p2 = main2.p$1;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/circular-entry-points3/_expected/amd/main3.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/amd/main3.js
@@ -1,0 +1,9 @@
+define(['exports', './generated-main1'], function (exports, main2) { 'use strict';
+
+
+
+	exports.C = main2.C;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/circular-entry-points3/_expected/cjs/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/cjs/generated-main1.js
@@ -1,0 +1,25 @@
+'use strict';
+
+class C {
+  fn (num) {
+    console.log(num - p$1);
+  }
+}
+
+var p = 43;
+
+new C().fn(p);
+
+class C$1 {
+  fn (num) {
+    console.log(num - p);
+  }
+}
+
+var p$1 = 42;
+
+new C$1().fn(p$1);
+
+exports.C = C;
+exports.p = p;
+exports.p$1 = p$1;

--- a/test/chunking-form/samples/circular-entry-points3/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/cjs/main1.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var main2 = require('./generated-main1.js');
+
+
+
+exports.p = main2.p$1;

--- a/test/chunking-form/samples/circular-entry-points3/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/cjs/main2.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var main2 = require('./generated-main1.js');
+
+
+
+exports.p = main2.p;
+exports.p2 = main2.p$1;

--- a/test/chunking-form/samples/circular-entry-points3/_expected/cjs/main3.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/cjs/main3.js
@@ -1,0 +1,9 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var main2 = require('./generated-main1.js');
+
+
+
+exports.C = main2.C;

--- a/test/chunking-form/samples/circular-entry-points3/_expected/es/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/es/generated-main1.js
@@ -1,0 +1,21 @@
+class C {
+  fn (num) {
+    console.log(num - p$1);
+  }
+}
+
+var p = 43;
+
+new C().fn(p);
+
+class C$1 {
+  fn (num) {
+    console.log(num - p);
+  }
+}
+
+var p$1 = 42;
+
+new C$1().fn(p$1);
+
+export { C, p$1 as a, p };

--- a/test/chunking-form/samples/circular-entry-points3/_expected/es/main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/es/main1.js
@@ -1,0 +1,1 @@
+export { a as p } from './generated-main1.js';

--- a/test/chunking-form/samples/circular-entry-points3/_expected/es/main2.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/es/main2.js
@@ -1,0 +1,1 @@
+export { p, a as p2 } from './generated-main1.js';

--- a/test/chunking-form/samples/circular-entry-points3/_expected/es/main3.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/es/main3.js
@@ -1,0 +1,1 @@
+export { C } from './generated-main1.js';

--- a/test/chunking-form/samples/circular-entry-points3/_expected/system/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/system/generated-main1.js
@@ -1,0 +1,28 @@
+System.register([], function (exports) {
+  'use strict';
+  return {
+    execute: function () {
+
+      class C {
+        fn (num) {
+          console.log(num - p$1);
+        }
+      } exports('C', C);
+
+      var p = exports('p', 43);
+
+      new C().fn(p);
+
+      class C$1 {
+        fn (num) {
+          console.log(num - p);
+        }
+      }
+
+      var p$1 = exports('a', 42);
+
+      new C$1().fn(p$1);
+
+    }
+  };
+});

--- a/test/chunking-form/samples/circular-entry-points3/_expected/system/main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/system/main1.js
@@ -1,0 +1,13 @@
+System.register(['./generated-main1.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('p', module.a);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/circular-entry-points3/_expected/system/main2.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/system/main2.js
@@ -1,0 +1,16 @@
+System.register(['./generated-main1.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			var _setter = {};
+			_setter.p = module.p;
+			_setter.p2 = module.a;
+			exports(_setter);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/circular-entry-points3/_expected/system/main3.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/system/main3.js
@@ -1,0 +1,13 @@
+System.register(['./generated-main1.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('C', module.C);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/circular-entry-points3/dep1.js
+++ b/test/chunking-form/samples/circular-entry-points3/dep1.js
@@ -1,0 +1,7 @@
+import { p } from './main2.js';
+
+export class C {
+  fn (num) {
+    console.log(num - p);
+  }
+}

--- a/test/chunking-form/samples/circular-entry-points3/dep2.js
+++ b/test/chunking-form/samples/circular-entry-points3/dep2.js
@@ -1,0 +1,7 @@
+import { p } from './main1.js';
+
+export class C {
+  fn (num) {
+    console.log(num - p);
+  }
+}

--- a/test/chunking-form/samples/circular-entry-points3/main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/main1.js
@@ -1,0 +1,4 @@
+import { C } from './dep1.js';
+export var p = 42;
+
+new C().fn(p);

--- a/test/chunking-form/samples/circular-entry-points3/main2.js
+++ b/test/chunking-form/samples/circular-entry-points3/main2.js
@@ -1,0 +1,5 @@
+import { C } from './dep2.js';
+export var p = 43;
+export {p as p2} from './main1'
+
+new C().fn(p);

--- a/test/chunking-form/samples/circular-entry-points3/main3.js
+++ b/test/chunking-form/samples/circular-entry-points3/main3.js
@@ -1,0 +1,1 @@
+export { C } from './dep2.js';

--- a/test/chunking-form/samples/default-reexport-namespace/Component_one.js
+++ b/test/chunking-form/samples/default-reexport-namespace/Component_one.js
@@ -1,0 +1,4 @@
+import * as icons from './icons/index';
+const __component__ = { icons };
+
+export default __component__;

--- a/test/chunking-form/samples/default-reexport-namespace/_config.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'Properly handle adding a default reexport to a namespace (#3583)',
+	options: {
+		input: ['main.js', 'icons/one.js']
+	}
+};

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/amd/main.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/amd/main.js
@@ -1,0 +1,17 @@
+define(['exports', './one'], function (exports, one) { 'use strict';
+
+	const __icon__ = {};
+
+	var icons = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		one: one,
+		two: __icon__
+	});
+
+	const __component__ = { icons };
+
+	exports.Component_one = __component__;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/amd/one.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/amd/one.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	const __icon__ = {};
+
+	return __icon__;
+
+});

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/cjs/main.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/cjs/main.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var one = require('./one.js');
+
+const __icon__ = {};
+
+var icons = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	one: one,
+	two: __icon__
+});
+
+const __component__ = { icons };
+
+exports.Component_one = __component__;

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/cjs/one.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/cjs/one.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const __icon__ = {};
+
+module.exports = __icon__;

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/es/main.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/es/main.js
@@ -1,0 +1,13 @@
+import __icon__$1 from './one.js';
+
+const __icon__ = {};
+
+var icons = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	one: __icon__$1,
+	two: __icon__
+});
+
+const __component__ = { icons };
+
+export { __component__ as Component_one };

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/es/one.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/es/one.js
@@ -1,0 +1,3 @@
+const __icon__ = {};
+
+export default __icon__;

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/system/main.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/system/main.js
@@ -1,0 +1,22 @@
+System.register(['./one.js'], function (exports) {
+	'use strict';
+	var __icon__$1;
+	return {
+		setters: [function (module) {
+			__icon__$1 = module.default;
+		}],
+		execute: function () {
+
+			const __icon__ = {};
+
+			var icons = /*#__PURE__*/Object.freeze({
+				__proto__: null,
+				one: __icon__$1,
+				two: __icon__
+			});
+
+			const __component__ = exports('Component_one', { icons });
+
+		}
+	};
+});

--- a/test/chunking-form/samples/default-reexport-namespace/_expected/system/one.js
+++ b/test/chunking-form/samples/default-reexport-namespace/_expected/system/one.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const __icon__ = exports('default', {});
+
+		}
+	};
+});

--- a/test/chunking-form/samples/default-reexport-namespace/icons/index.js
+++ b/test/chunking-form/samples/default-reexport-namespace/icons/index.js
@@ -1,0 +1,2 @@
+export { default as one } from './one';
+export { default as two } from './two';

--- a/test/chunking-form/samples/default-reexport-namespace/icons/one.js
+++ b/test/chunking-form/samples/default-reexport-namespace/icons/one.js
@@ -1,0 +1,3 @@
+const __icon__ = {}
+
+export default __icon__

--- a/test/chunking-form/samples/default-reexport-namespace/icons/two.js
+++ b/test/chunking-form/samples/default-reexport-namespace/icons/two.js
@@ -1,0 +1,3 @@
+const __icon__ = {}
+
+export default __icon__

--- a/test/chunking-form/samples/default-reexport-namespace/main.js
+++ b/test/chunking-form/samples/default-reexport-namespace/main.js
@@ -1,0 +1,1 @@
+export { default as Component_one } from './Component_one.js'

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/amd/generated-m1.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/amd/generated-m1.js
@@ -5,7 +5,6 @@ define(['exports', './m2'], function (exports, m2) { 'use strict';
 		m2: m2
 	});
 
-	exports.m2 = m2;
 	exports.ms = ms;
 
 });

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/cjs/generated-m1.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/cjs/generated-m1.js
@@ -7,5 +7,4 @@ var ms = /*#__PURE__*/Object.freeze({
 	m2: m2
 });
 
-exports.m2 = m2;
 exports.ms = ms;

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/es/generated-m1.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/es/generated-m1.js
@@ -1,5 +1,4 @@
 import m2 from './m2.js';
-export { default as a } from './m2.js';
 
 var ms = /*#__PURE__*/Object.freeze({
 	__proto__: null,

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/system/generated-m1.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/system/generated-m1.js
@@ -4,7 +4,6 @@ System.register(['./m2.js'], function (exports) {
 	return {
 		setters: [function (module) {
 			m2 = module.default;
-			exports('a', module.default);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/namespace-reexports/_expected/amd/generated-index.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/amd/generated-index.js
@@ -9,7 +9,6 @@ define(['exports', './hsl2hsv'], function (exports, hsl2hsv$1) { 'use strict';
 		hsl2hsv: hsl2hsv$1.default
 	});
 
-	exports.hsl2hsv = hsl2hsv$1.default;
 	exports.lib = lib;
 
 });

--- a/test/chunking-form/samples/namespace-reexports/_expected/cjs/generated-index.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/cjs/generated-index.js
@@ -11,5 +11,4 @@ var lib = /*#__PURE__*/Object.freeze({
 	hsl2hsv: hsl2hsv$1.default
 });
 
-exports.hsl2hsv = hsl2hsv$1.default;
 exports.lib = lib;

--- a/test/chunking-form/samples/namespace-reexports/_expected/es/generated-index.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/es/generated-index.js
@@ -1,5 +1,4 @@
 import hsl2hsv$1 from './hsl2hsv.js';
-export { default as h } from './hsl2hsv.js';
 
 var hsl2hsv = 'asdf';
 

--- a/test/chunking-form/samples/namespace-reexports/_expected/system/generated-index.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/system/generated-index.js
@@ -4,7 +4,6 @@ System.register(['./hsl2hsv.js'], function (exports) {
 	return {
 		setters: [function (module) {
 			hsl2hsv$1 = module.default;
-			exports('h', module.default);
 		}],
 		execute: function () {
 

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/amd/generated-main.js
@@ -10,6 +10,5 @@ define(['require', 'exports'], function (require, exports) { 'use strict';
 
 	exports.component = component;
 	exports.lib = lib;
-	exports.named = lib.named.named;
 
 });

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/cjs/generated-main.js
@@ -10,4 +10,3 @@ const component = Promise.resolve().then(function () { return require('./generat
 
 exports.component = component;
 exports.lib = lib;
-exports.named = lib.named.named;

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/generated-main.js
@@ -6,5 +6,4 @@ console.log('side-effect', lib.named.named);
 
 const component = import('./generated-component.js');
 
-var named = lib.named.named;
-export { component as c, lib as l, named as n };
+export { component as c, lib as l };

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/es/main.js
@@ -1,3 +1,4 @@
+import { l as lib } from './generated-main.js';
 export { c as component } from './generated-main.js';
 
 

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/generated-main.js
@@ -11,8 +11,6 @@ System.register([], function (exports, module) {
 
 			const component = exports('c', module.import('./generated-component.js'));
 
-			exports('n', lib.named.named);
-
 		}
 	};
 });

--- a/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/main.js
+++ b/test/chunking-form/samples/synthetic-named-exports-chained-default-reexport/_expected/system/main.js
@@ -1,7 +1,9 @@
 System.register(['./generated-main.js'], function (exports) {
 	'use strict';
+	var lib;
 	return {
 		setters: [function (module) {
+			lib = module.l;
 			exports('component', module.c);
 		}],
 		execute: function () {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3583 

### Description
As it turns out when using synthetic exports, created facades did not import the base variable for the synthetic export, producing invalid code. Also, this will prevent extraneous exports when facades are created.