### PR TITLE
Handle side-effects next to side-effect-free default exports in case the default export is reexported

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -330,7 +330,8 @@ export default class Module {
 	getDependenciesToBeIncluded(): Set<Module | ExternalModule> {
 		if (this.relevantDependencies) return this.relevantDependencies;
 		const relevantDependencies = new Set<Module | ExternalModule>();
-		const additionalSideEffectModules = new Set();
+		const additionalSideEffectModules = new Set<Module>();
+		const possibleDependencies = new Set(this.dependencies);
 		let dependencyVariables = this.imports;
 		if (
 			this.isEntryPoint ||
@@ -350,15 +351,17 @@ export default class Module {
 				variable = original;
 				for (const module of modules) {
 					additionalSideEffectModules.add(module);
+					possibleDependencies.add(module);
 				}
 			}
 			relevantDependencies.add(variable.module!);
 		}
 		if (this.options.treeshake) {
-			const possibleDependencies = new Set(this.dependencies);
 			for (const dependency of possibleDependencies) {
 				if (
-					!(dependency.moduleSideEffects || additionalSideEffectModules.has(dependency)) ||
+					!(
+						dependency.moduleSideEffects || additionalSideEffectModules.has(dependency as Module)
+					) ||
 					relevantDependencies.has(dependency)
 				) {
 					continue;

--- a/test/form/samples/side-effect-default-reexport/default-export/reexport.js
+++ b/test/form/samples/side-effect-default-reexport/default-export/reexport.js
@@ -1,0 +1,1 @@
+export { default as Menu } from './index';

--- a/test/form/samples/side-effect-default-reexport/main.js
+++ b/test/form/samples/side-effect-default-reexport/main.js
@@ -1,8 +1,7 @@
-import DefaultExport from './default-export/index.js';
+import { Menu as DefaultExport } from './default-export/reexport.js';
 console.log('test-package-default-export', DefaultExport.Item);
 
 import { Menu as NamedExport } from './named-export/index.js';
 console.log('test-package-named-export', NamedExport.Item);
 
 export { default } from './default-export2/index.js';
-


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3565

### Description
Apparently side-effects next to a default export statement were still not included when there were side-effect-free modules in between through which the default is reexported as a named export.