### PR TITLE
Observe side-effects in second argument of `Array.from`

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -291,13 +291,13 @@ export default class Chunk {
 			}
 		}
 		for (const module of this.entryModules) {
-			const requiredFacades: FacadeName[] = [...module.userChunkNames].map(name => ({
+			const requiredFacades: FacadeName[] = Array.from(module.userChunkNames, name => ({
 				name
 			}));
 			if (requiredFacades.length === 0 && module.isUserDefinedEntryPoint) {
 				requiredFacades.push({});
 			}
-			requiredFacades.push(...[...module.chunkFileNames].map(fileName => ({ fileName })));
+			requiredFacades.push(...Array.from(module.chunkFileNames, fileName => ({ fileName })));
 			if (requiredFacades.length === 0) {
 				requiredFacades.push({});
 			}
@@ -416,7 +416,7 @@ export default class Chunk {
 	}
 
 	getDynamicImportIds(): string[] {
-		return [...this.dynamicDependencies].map(chunk => chunk.id as string);
+		return Array.from(this.dynamicDependencies, chunk => chunk.id as string);
 	}
 
 	getExportNames(): string[] {
@@ -426,7 +426,7 @@ export default class Chunk {
 	}
 
 	getImportIds(): string[] {
-		return [...this.dependencies].map(chunk => chunk.id as string);
+		return Array.from(this.dependencies, chunk => chunk.id as string);
 	}
 
 	getRenderedHash(outputPluginDriver: PluginDriver): string {

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -717,7 +717,7 @@ export default class Module {
 			ast: this.esTreeAst,
 			code: this.code,
 			customTransformCache: this.customTransformCache,
-			dependencies: [...this.dependencies].map(module => module.id),
+			dependencies: Array.from(this.dependencies, module => module.id),
 			id: this.id,
 			moduleSideEffects: this.moduleSideEffects,
 			originalCode: this.originalCode,

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -234,7 +234,7 @@ export class ModuleLoader {
 
 	private fetchAllDependencies(module: Module): Promise<unknown> {
 		return Promise.all([
-			...[...module.sources].map(async source => {
+			...Array.from(module.sources, async source => {
 				const resolution = await this.fetchResolvedDependency(
 					source,
 					module.id,

--- a/src/ast/nodes/shared/knownGlobals.ts
+++ b/src/ast/nodes/shared/knownGlobals.ts
@@ -76,7 +76,7 @@ const knownGlobals: GlobalDescription = {
 		// @ts-ignore
 		__proto__: null,
 		[ValueProperties]: IMPURE,
-		from: PF,
+		from: O,
 		isArray: PF,
 		of: PF,
 		prototype: O

--- a/test/function/samples/array-from-side-effect/_config.js
+++ b/test/function/samples/array-from-side-effect/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'Observes side-effects in Array.from',
+	exports(exports) {
+		assert.strictEqual(exports.x, 7);
+	}
+};

--- a/test/function/samples/array-from-side-effect/main.js
+++ b/test/function/samples/array-from-side-effect/main.js
@@ -1,0 +1,3 @@
+export let x = 1;
+const list = [1, 2, 3];
+Array.from(list, v => (x += v));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
resolves #3603

### Description
Apparently `Array.from` can have a second argument with side-effects. Unfortunately, this will now mark any call to `Array.from` as having side-effects as the global local does not support anything better yet, but at least it should fix the provided issue. In the future, we might be able to do better.
