### PR TITLE
Handle imports from chunks with names that correspond to parent directory names of other chunks

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1015,7 +1015,7 @@ export default class Chunk {
 			relativePath = relativePath.slice(0, -3);
 		}
 		if (relativePath === '..') relativePath = '../../' + basename(targetPath);
-		else if (relativePath === '.') relativePath = '../' + basename(targetPath);
+		else if (relativePath === '') relativePath = '../' + basename(targetPath);
 		return relativePath.startsWith('../') ? relativePath : './' + relativePath;
 	}
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1014,16 +1014,9 @@ export default class Chunk {
 		if (stripJsExtension && relativePath.endsWith('.js')) {
 			relativePath = relativePath.slice(0, -3);
 		}
-		if (
-			relativePath.endsWith('..') &&
-			(relativePath.length === 2 || relativePath[relativePath.length - 3] === '/')
-		)
+		if (relativePath.endsWith('..') && relativePath.length === 2)
 			relativePath = relativePath.slice(0, -2) + '../../' + basename(targetPath);
-		else if (
-			relativePath.endsWith('.') &&
-			(relativePath.length === 1 || relativePath[relativePath.length - 2] === '/')
-		)
-			relativePath = relativePath.slice(0, -1) + '../' + basename(targetPath);
+		else if (relativePath.length === 0) relativePath = '../' + basename(targetPath);
 		return relativePath.startsWith('../') ? relativePath : './' + relativePath;
 	}
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1014,6 +1014,16 @@ export default class Chunk {
 		if (stripJsExtension && relativePath.endsWith('.js')) {
 			relativePath = relativePath.slice(0, -3);
 		}
+		if (
+			relativePath.endsWith('..') &&
+			(relativePath.length === 2 || relativePath[relativePath.length - 3] === '/')
+		)
+			relativePath = relativePath.slice(0, -2) + '../../' + basename(targetPath);
+		else if (
+			relativePath.endsWith('.') &&
+			(relativePath.length === 1 || relativePath[relativePath.length - 2] === '/')
+		)
+			relativePath = relativePath.slice(0, -1) + '../' + basename(targetPath);
 		return relativePath.startsWith('../') ? relativePath : './' + relativePath;
 	}
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1014,8 +1014,8 @@ export default class Chunk {
 		if (stripJsExtension && relativePath.endsWith('.js')) {
 			relativePath = relativePath.slice(0, -3);
 		}
-		if (relativePath === '..') relativePath = '../../' + basename(targetPath);
-		else if (relativePath === '') relativePath = '../' + basename(targetPath);
+		if (relativePath === '..') return '../../' + basename(targetPath);
+		if (relativePath === '') return '../' + basename(targetPath);
 		return relativePath.startsWith('../') ? relativePath : './' + relativePath;
 	}
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1014,9 +1014,8 @@ export default class Chunk {
 		if (stripJsExtension && relativePath.endsWith('.js')) {
 			relativePath = relativePath.slice(0, -3);
 		}
-		if (relativePath.endsWith('..') && relativePath.length === 2)
-			relativePath = relativePath.slice(0, -2) + '../../' + basename(targetPath);
-		else if (relativePath.length === 0) relativePath = '../' + basename(targetPath);
+		if (relativePath === '..') relativePath = '../../' + basename(targetPath);
+		else if (relativePath === '.') relativePath = '../' + basename(targetPath);
 		return relativePath.startsWith('../') ? relativePath : './' + relativePath;
 	}
 

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -1118,44 +1118,6 @@ describe('hooks', () => {
 			})
 			.then(bundle => bundle.generate({ format: 'es' })));
 
-	it('handles relative pathing for chunks directory URLs', () => {
-		return rollup
-			.rollup({
-				input: {
-					'base/main': 'main.js',
-					'base/main/feature': 'feature.js',
-					'base/main/feature/sub': 'subfeature.js'
-				},
-				plugins: [
-					loader({
-						'main.js': 'export function fn () { return "main"; } console.log(fn());',
-						'feature.js': 'import { fn } from "main.js"; console.log(fn() + " feature");',
-						'subfeature.js': 'import { fn } from "main.js"; console.log(fn() + " subfeature");'
-					}),
-					{
-						resolveId(id) {
-							return id;
-						}
-					}
-				]
-			})
-			.then(bundle =>
-				bundle.generate({
-					entryFileNames: `[name]`,
-					chunkFileNames: `[name]`,
-					format: 'es'
-				})
-			)
-			.then(({ output: [main, feature, subfeature] }) => {
-				assert.strictEqual(main.fileName, 'base/main');
-				assert.ok(main.code.startsWith('function fn'));
-				assert.strictEqual(feature.fileName, 'base/main/feature');
-				assert.ok(feature.code.startsWith("import { fn } from '../main'"));
-				assert.strictEqual(subfeature.fileName, 'base/main/feature/sub');
-				assert.ok(subfeature.code.startsWith("import { fn } from '../../main'"));
-			});
-	});
-
 	describe('deprecated', () => {
 		it('caches chunk emission in transform hook', () => {
 			let cache;

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -1118,6 +1118,44 @@ describe('hooks', () => {
 			})
 			.then(bundle => bundle.generate({ format: 'es' })));
 
+	it('handles relative pathing for chunks directory URLs', () => {
+		return rollup
+			.rollup({
+				input: {
+					'base/main': 'main.js',
+					'base/main/feature': 'feature.js',
+					'base/main/feature/sub': 'subfeature.js'
+				},
+				plugins: [
+					loader({
+						'main.js': 'export function fn () { return "main"; } console.log(fn());',
+						'feature.js': 'import { fn } from "main.js"; console.log(fn() + " feature");',
+						'subfeature.js': 'import { fn } from "main.js"; console.log(fn() + " subfeature");'
+					}),
+					{
+						resolveId(id) {
+							return id;
+						}
+					}
+				]
+			})
+			.then(bundle =>
+				bundle.generate({
+					entryFileNames: `[name]`,
+					chunkFileNames: `[name]`,
+					format: 'es'
+				})
+			)
+			.then(({ output: [main, feature, subfeature] }) => {
+				assert.strictEqual(main.fileName, 'base/main');
+				assert.ok(main.code.startsWith('function fn'));
+				assert.strictEqual(feature.fileName, 'base/main/feature');
+				assert.ok(feature.code.startsWith("import { fn } from '../main'"));
+				assert.strictEqual(subfeature.fileName, 'base/main/feature/sub');
+				assert.ok(subfeature.code.startsWith("import { fn } from '../../main'"));
+			});
+	});
+
 	describe('deprecated', () => {
 		it('caches chunk emission in transform hook', () => {
 			let cache;
@@ -1380,39 +1418,6 @@ describe('hooks', () => {
 				.then(({ output: [, output] }) => {
 					assert.strictEqual(output.fileName, 'assets/test-0a676135.ext');
 					assert.strictEqual(output.source, 'hello world');
-				});
-		});
-
-		it('handles relative pathing for chunks directory URLs', () => {
-			return rollup
-				.rollup({
-					input: {
-						main: 'main.js',
-						'main/chunk': 'chunk.js'
-					},
-					plugins: [
-						loader({
-							'main.js': 'import { fn } from "chunk.js"; fn();',
-							'chunk.js': 'export function fn () { console.log("chunk") }'
-						}),
-						{
-							resolveId(id) {
-								return id;
-							}
-						}
-					]
-				})
-				.then(bundle =>
-					bundle.generate({
-						entryFileNames: `[name]`,
-						chunkFileNames: `[name]`,
-						format: 'es'
-					})
-				)
-				.then(({ output: [main, chunk] }) => {
-					assert.strictEqual(main.fileName, 'main');
-					assert.ok(main.code.startsWith("import { fn } from './main/chunk'"));
-					assert.strictEqual(chunk.fileName, 'main/chunk');
 				});
 		});
 	});


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

This allows RollupJS to support builds where you have a directory module that is built as a module, while containing subpaths itself.

For example:

```js
input: {
  'pkg': 'main.js',
  'pkg/feature': 'feature.js'
}
```

Without this patch, the relative path for the `pkg/feature` chunk reference to `pkg` will look like `./..` which doesn't resolve as a URL properly.

I haven't fleshed out tests here as I wanted to see if there is interest first. @lukastaegert let me know your thoughts and I can do the work to finish it up as necessary.