### PR TITLE
Support numeric separator

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,7 +31,7 @@ MIT, ISC
 ## acorn
 License: MIT
 By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
-Repository: git+https://github.com/acornjs/acorn.git
+Repository: https://github.com/acornjs/acorn.git
 
 > Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 > 
@@ -58,7 +58,7 @@ Repository: git+https://github.com/acornjs/acorn.git
 ## acorn-class-fields
 License: MIT
 By: Adrian Heine
-Repository: git+https://github.com/acornjs/acorn-class-fields.git
+Repository: https://github.com/acornjs/acorn-class-fields
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -85,7 +85,7 @@ Repository: git+https://github.com/acornjs/acorn-class-fields.git
 ## acorn-numeric-separator
 License: MIT
 By: Adrian Heine
-Repository: git+https://github.com/acornjs/acorn-numeric-separator.git
+Repository: https://github.com/acornjs/acorn-numeric-separator
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -112,7 +112,7 @@ Repository: git+https://github.com/acornjs/acorn-numeric-separator.git
 ## acorn-private-class-elements
 License: MIT
 By: Adrian Heine
-Repository: git+https://github.com/acornjs/acorn-private-class-elements.git
+Repository: https://github.com/acornjs/acorn-private-class-elements
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -139,7 +139,7 @@ Repository: git+https://github.com/acornjs/acorn-private-class-elements.git
 ## acorn-static-class-features
 License: MIT
 By: Adrian Heine
-Repository: git+https://github.com/acornjs/acorn-static-class-features.git
+Repository: https://github.com/acornjs/acorn-static-class-features
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -166,7 +166,7 @@ Repository: git+https://github.com/acornjs/acorn-static-class-features.git
 ## acorn-walk
 License: MIT
 By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
-Repository: git+https://github.com/acornjs/acorn.git
+Repository: https://github.com/acornjs/acorn.git
 
 > Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 > 
@@ -193,7 +193,7 @@ Repository: git+https://github.com/acornjs/acorn.git
 ## anymatch
 License: ISC
 By: Elan Shanker
-Repository: git+https://github.com/micromatch/anymatch.git
+Repository: https://github.com/micromatch/anymatch
 
 > The ISC License
 > 
@@ -216,14 +216,14 @@ Repository: git+https://github.com/micromatch/anymatch.git
 ## binary-extensions
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/binary-extensions.git
+Repository: sindresorhus/binary-extensions
 
 ---------------------------------------
 
 ## braces
 License: MIT
 By: Jon Schlinkert, Brian Woodward, Elan Shanker, Eugene Sharygin, hemanth.hm
-Repository: git+https://github.com/micromatch/braces.git
+Repository: micromatch/braces
 
 > The MIT License (MIT)
 > 
@@ -252,7 +252,7 @@ Repository: git+https://github.com/micromatch/braces.git
 ## camelcase
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/camelcase.git
+Repository: sindresorhus/camelcase
 
 ---------------------------------------
 
@@ -288,7 +288,7 @@ Repository: git+https://github.com/paulmillr/chokidar.git
 ## colorette
 License: MIT
 By: Jorge Bucaran
-Repository: git+https://github.com/jorgebucaran/colorette.git
+Repository: jorgebucaran/colorette
 
 > Copyright © Jorge Bucaran <<https://jorgebucaran.com>>
 > 
@@ -303,21 +303,21 @@ Repository: git+https://github.com/jorgebucaran/colorette.git
 ## date-time
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/date-time.git
+Repository: sindresorhus/date-time
 
 ---------------------------------------
 
 ## decamelize
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/decamelize.git
+Repository: sindresorhus/decamelize
 
 ---------------------------------------
 
 ## fill-range
 License: MIT
 By: Jon Schlinkert, Edo Rivai, Paul Miller, Rouven Weßling
-Repository: git+https://github.com/jonschlinkert/fill-range.git
+Repository: jonschlinkert/fill-range
 
 > The MIT License (MIT)
 > 
@@ -346,7 +346,7 @@ Repository: git+https://github.com/jonschlinkert/fill-range.git
 ## glob-parent
 License: ISC
 By: Gulp Team, Elan Shanker, Blaine Bublitz
-Repository: git+https://github.com/gulpjs/glob-parent.git
+Repository: gulpjs/glob-parent
 
 > The ISC License
 > 
@@ -369,13 +369,13 @@ Repository: git+https://github.com/gulpjs/glob-parent.git
 ## hash.js
 License: MIT
 By: Fedor Indutny
-Repository: git+ssh://git@github.com/indutny/hash.js.git
+Repository: git@github.com:indutny/hash.js
 
 ---------------------------------------
 
 ## inherits
 License: ISC
-Repository: git://github.com/isaacs/inherits.git
+Repository: git://github.com/isaacs/inherits
 
 > The ISC License
 > 
@@ -398,14 +398,14 @@ Repository: git://github.com/isaacs/inherits.git
 ## is-binary-path
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/is-binary-path.git
+Repository: sindresorhus/is-binary-path
 
 ---------------------------------------
 
 ## is-extglob
 License: MIT
 By: Jon Schlinkert
-Repository: git+https://github.com/jonschlinkert/is-extglob.git
+Repository: jonschlinkert/is-extglob
 
 > The MIT License (MIT)
 > 
@@ -434,7 +434,7 @@ Repository: git+https://github.com/jonschlinkert/is-extglob.git
 ## is-glob
 License: MIT
 By: Jon Schlinkert, Brian Woodward, Daniel Perez
-Repository: git+https://github.com/micromatch/is-glob.git
+Repository: micromatch/is-glob
 
 > The MIT License (MIT)
 > 
@@ -463,7 +463,7 @@ Repository: git+https://github.com/micromatch/is-glob.git
 ## is-number
 License: MIT
 By: Jon Schlinkert, Olsten Larck, Rouven Weßling
-Repository: git+https://github.com/jonschlinkert/is-number.git
+Repository: jonschlinkert/is-number
 
 > The MIT License (MIT)
 > 
@@ -499,14 +499,14 @@ Repository: git+https://github.com/Rich-Harris/is-reference.git
 ## locate-character
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/Rich-Harris/locate-character.git
+Repository: Rich-Harris/locate-character
 
 ---------------------------------------
 
 ## magic-string
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/rich-harris/magic-string.git
+Repository: https://github.com/rich-harris/magic-string
 
 > Copyright 2018 Rich Harris
 > 
@@ -521,7 +521,7 @@ Repository: git+https://github.com/rich-harris/magic-string.git
 ## micromatch
 License: MIT
 By: Jon Schlinkert, Amila Welihinda, Bogdan Chadkin, Brian Woodward, Devon Govett, Elan Shanker, Fabrício Matté, Martin Kolárik, Olsten Larck, Paul Miller, Tom Byrer, Tyler Akins, Peter Bright
-Repository: git+https://github.com/micromatch/micromatch.git
+Repository: micromatch/micromatch
 
 > The MIT License (MIT)
 > 
@@ -549,7 +549,7 @@ Repository: git+https://github.com/micromatch/micromatch.git
 
 ## minimalistic-assert
 License: ISC
-Repository: git+https://github.com/calvinmetcalf/minimalistic-assert.git
+Repository: https://github.com/calvinmetcalf/minimalistic-assert.git
 
 > Copyright 2015 Calvin Metcalf
 > 
@@ -570,7 +570,7 @@ Repository: git+https://github.com/calvinmetcalf/minimalistic-assert.git
 ## normalize-path
 License: MIT
 By: Jon Schlinkert, Blaine Bublitz
-Repository: git+https://github.com/jonschlinkert/normalize-path.git
+Repository: jonschlinkert/normalize-path
 
 > The MIT License (MIT)
 > 
@@ -599,14 +599,14 @@ Repository: git+https://github.com/jonschlinkert/normalize-path.git
 ## parse-ms
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/parse-ms.git
+Repository: sindresorhus/parse-ms
 
 ---------------------------------------
 
 ## picomatch
 License: MIT
 By: Jon Schlinkert
-Repository: git+https://github.com/micromatch/picomatch.git
+Repository: micromatch/picomatch
 
 > The MIT License (MIT)
 > 
@@ -635,14 +635,14 @@ Repository: git+https://github.com/micromatch/picomatch.git
 ## pretty-bytes
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/pretty-bytes.git
+Repository: sindresorhus/pretty-bytes
 
 ---------------------------------------
 
 ## pretty-ms
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/pretty-ms.git
+Repository: sindresorhus/pretty-ms
 
 ---------------------------------------
 
@@ -685,14 +685,14 @@ Repository: git://github.com/kamicane/require-relative.git
 ## rollup-pluginutils
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/rollup/rollup-pluginutils.git
+Repository: rollup/rollup-pluginutils
 
 ---------------------------------------
 
 ## signal-exit
 License: ISC
 By: Ben Coe
-Repository: git+https://github.com/tapjs/signal-exit.git
+Repository: https://github.com/tapjs/signal-exit.git
 
 > The ISC License
 > 
@@ -716,7 +716,7 @@ Repository: git+https://github.com/tapjs/signal-exit.git
 ## sourcemap-codec
 License: MIT
 By: Rich Harris
-Repository: git+https://github.com/Rich-Harris/sourcemap-codec.git
+Repository: https://github.com/Rich-Harris/sourcemap-codec
 
 > The MIT License
 > 
@@ -745,14 +745,14 @@ Repository: git+https://github.com/Rich-Harris/sourcemap-codec.git
 ## time-zone
 License: MIT
 By: Sindre Sorhus
-Repository: git+https://github.com/sindresorhus/time-zone.git
+Repository: sindresorhus/time-zone
 
 ---------------------------------------
 
 ## to-regex-range
 License: MIT
 By: Jon Schlinkert, Rouven Weßling
-Repository: git+https://github.com/micromatch/to-regex-range.git
+Repository: micromatch/to-regex-range
 
 > The MIT License (MIT)
 > 
@@ -781,7 +781,7 @@ Repository: git+https://github.com/micromatch/to-regex-range.git
 ## yargs-parser
 License: ISC
 By: Ben Coe
-Repository: git+https://github.com/yargs/yargs-parser.git
+Repository: https://github.com/yargs/yargs-parser.git
 
 > Copyright (c) 2016, Contributors
 > 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,7 +31,7 @@ MIT, ISC
 ## acorn
 License: MIT
 By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
-Repository: https://github.com/acornjs/acorn.git
+Repository: git+https://github.com/acornjs/acorn.git
 
 > Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 > 
@@ -58,7 +58,34 @@ Repository: https://github.com/acornjs/acorn.git
 ## acorn-class-fields
 License: MIT
 By: Adrian Heine
-Repository: https://github.com/acornjs/acorn-class-fields
+Repository: git+https://github.com/acornjs/acorn-class-fields.git
+
+> Copyright (C) 2017-2018 by Adrian Heine
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
+---------------------------------------
+
+## acorn-numeric-separator
+License: MIT
+By: Adrian Heine
+Repository: git+https://github.com/acornjs/acorn-numeric-separator.git
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -85,7 +112,7 @@ Repository: https://github.com/acornjs/acorn-class-fields
 ## acorn-private-class-elements
 License: MIT
 By: Adrian Heine
-Repository: https://github.com/acornjs/acorn-private-class-elements
+Repository: git+https://github.com/acornjs/acorn-private-class-elements.git
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -112,7 +139,7 @@ Repository: https://github.com/acornjs/acorn-private-class-elements
 ## acorn-static-class-features
 License: MIT
 By: Adrian Heine
-Repository: https://github.com/acornjs/acorn-static-class-features
+Repository: git+https://github.com/acornjs/acorn-static-class-features.git
 
 > Copyright (C) 2017-2018 by Adrian Heine
 > 
@@ -139,7 +166,7 @@ Repository: https://github.com/acornjs/acorn-static-class-features
 ## acorn-walk
 License: MIT
 By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
-Repository: https://github.com/acornjs/acorn.git
+Repository: git+https://github.com/acornjs/acorn.git
 
 > Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 > 
@@ -166,7 +193,7 @@ Repository: https://github.com/acornjs/acorn.git
 ## anymatch
 License: ISC
 By: Elan Shanker
-Repository: https://github.com/micromatch/anymatch
+Repository: git+https://github.com/micromatch/anymatch.git
 
 > The ISC License
 > 
@@ -189,14 +216,14 @@ Repository: https://github.com/micromatch/anymatch
 ## binary-extensions
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/binary-extensions
+Repository: git+https://github.com/sindresorhus/binary-extensions.git
 
 ---------------------------------------
 
 ## braces
 License: MIT
 By: Jon Schlinkert, Brian Woodward, Elan Shanker, Eugene Sharygin, hemanth.hm
-Repository: micromatch/braces
+Repository: git+https://github.com/micromatch/braces.git
 
 > The MIT License (MIT)
 > 
@@ -225,7 +252,7 @@ Repository: micromatch/braces
 ## camelcase
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/camelcase
+Repository: git+https://github.com/sindresorhus/camelcase.git
 
 ---------------------------------------
 
@@ -261,7 +288,7 @@ Repository: git+https://github.com/paulmillr/chokidar.git
 ## colorette
 License: MIT
 By: Jorge Bucaran
-Repository: jorgebucaran/colorette
+Repository: git+https://github.com/jorgebucaran/colorette.git
 
 > Copyright © Jorge Bucaran <<https://jorgebucaran.com>>
 > 
@@ -276,21 +303,21 @@ Repository: jorgebucaran/colorette
 ## date-time
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/date-time
+Repository: git+https://github.com/sindresorhus/date-time.git
 
 ---------------------------------------
 
 ## decamelize
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/decamelize
+Repository: git+https://github.com/sindresorhus/decamelize.git
 
 ---------------------------------------
 
 ## fill-range
 License: MIT
 By: Jon Schlinkert, Edo Rivai, Paul Miller, Rouven Weßling
-Repository: jonschlinkert/fill-range
+Repository: git+https://github.com/jonschlinkert/fill-range.git
 
 > The MIT License (MIT)
 > 
@@ -319,7 +346,7 @@ Repository: jonschlinkert/fill-range
 ## glob-parent
 License: ISC
 By: Gulp Team, Elan Shanker, Blaine Bublitz
-Repository: gulpjs/glob-parent
+Repository: git+https://github.com/gulpjs/glob-parent.git
 
 > The ISC License
 > 
@@ -342,13 +369,13 @@ Repository: gulpjs/glob-parent
 ## hash.js
 License: MIT
 By: Fedor Indutny
-Repository: git@github.com:indutny/hash.js
+Repository: git+ssh://git@github.com/indutny/hash.js.git
 
 ---------------------------------------
 
 ## inherits
 License: ISC
-Repository: git://github.com/isaacs/inherits
+Repository: git://github.com/isaacs/inherits.git
 
 > The ISC License
 > 
@@ -371,14 +398,14 @@ Repository: git://github.com/isaacs/inherits
 ## is-binary-path
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/is-binary-path
+Repository: git+https://github.com/sindresorhus/is-binary-path.git
 
 ---------------------------------------
 
 ## is-extglob
 License: MIT
 By: Jon Schlinkert
-Repository: jonschlinkert/is-extglob
+Repository: git+https://github.com/jonschlinkert/is-extglob.git
 
 > The MIT License (MIT)
 > 
@@ -407,7 +434,7 @@ Repository: jonschlinkert/is-extglob
 ## is-glob
 License: MIT
 By: Jon Schlinkert, Brian Woodward, Daniel Perez
-Repository: micromatch/is-glob
+Repository: git+https://github.com/micromatch/is-glob.git
 
 > The MIT License (MIT)
 > 
@@ -436,7 +463,7 @@ Repository: micromatch/is-glob
 ## is-number
 License: MIT
 By: Jon Schlinkert, Olsten Larck, Rouven Weßling
-Repository: jonschlinkert/is-number
+Repository: git+https://github.com/jonschlinkert/is-number.git
 
 > The MIT License (MIT)
 > 
@@ -472,14 +499,14 @@ Repository: git+https://github.com/Rich-Harris/is-reference.git
 ## locate-character
 License: MIT
 By: Rich Harris
-Repository: Rich-Harris/locate-character
+Repository: git+https://github.com/Rich-Harris/locate-character.git
 
 ---------------------------------------
 
 ## magic-string
 License: MIT
 By: Rich Harris
-Repository: https://github.com/rich-harris/magic-string
+Repository: git+https://github.com/rich-harris/magic-string.git
 
 > Copyright 2018 Rich Harris
 > 
@@ -494,7 +521,7 @@ Repository: https://github.com/rich-harris/magic-string
 ## micromatch
 License: MIT
 By: Jon Schlinkert, Amila Welihinda, Bogdan Chadkin, Brian Woodward, Devon Govett, Elan Shanker, Fabrício Matté, Martin Kolárik, Olsten Larck, Paul Miller, Tom Byrer, Tyler Akins, Peter Bright
-Repository: micromatch/micromatch
+Repository: git+https://github.com/micromatch/micromatch.git
 
 > The MIT License (MIT)
 > 
@@ -522,7 +549,7 @@ Repository: micromatch/micromatch
 
 ## minimalistic-assert
 License: ISC
-Repository: https://github.com/calvinmetcalf/minimalistic-assert.git
+Repository: git+https://github.com/calvinmetcalf/minimalistic-assert.git
 
 > Copyright 2015 Calvin Metcalf
 > 
@@ -543,7 +570,7 @@ Repository: https://github.com/calvinmetcalf/minimalistic-assert.git
 ## normalize-path
 License: MIT
 By: Jon Schlinkert, Blaine Bublitz
-Repository: jonschlinkert/normalize-path
+Repository: git+https://github.com/jonschlinkert/normalize-path.git
 
 > The MIT License (MIT)
 > 
@@ -572,14 +599,14 @@ Repository: jonschlinkert/normalize-path
 ## parse-ms
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/parse-ms
+Repository: git+https://github.com/sindresorhus/parse-ms.git
 
 ---------------------------------------
 
 ## picomatch
 License: MIT
 By: Jon Schlinkert
-Repository: micromatch/picomatch
+Repository: git+https://github.com/micromatch/picomatch.git
 
 > The MIT License (MIT)
 > 
@@ -608,14 +635,14 @@ Repository: micromatch/picomatch
 ## pretty-bytes
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/pretty-bytes
+Repository: git+https://github.com/sindresorhus/pretty-bytes.git
 
 ---------------------------------------
 
 ## pretty-ms
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/pretty-ms
+Repository: git+https://github.com/sindresorhus/pretty-ms.git
 
 ---------------------------------------
 
@@ -658,14 +685,14 @@ Repository: git://github.com/kamicane/require-relative.git
 ## rollup-pluginutils
 License: MIT
 By: Rich Harris
-Repository: rollup/rollup-pluginutils
+Repository: git+https://github.com/rollup/rollup-pluginutils.git
 
 ---------------------------------------
 
 ## signal-exit
 License: ISC
 By: Ben Coe
-Repository: https://github.com/tapjs/signal-exit.git
+Repository: git+https://github.com/tapjs/signal-exit.git
 
 > The ISC License
 > 
@@ -689,7 +716,7 @@ Repository: https://github.com/tapjs/signal-exit.git
 ## sourcemap-codec
 License: MIT
 By: Rich Harris
-Repository: https://github.com/Rich-Harris/sourcemap-codec
+Repository: git+https://github.com/Rich-Harris/sourcemap-codec.git
 
 > The MIT License
 > 
@@ -718,14 +745,14 @@ Repository: https://github.com/Rich-Harris/sourcemap-codec
 ## time-zone
 License: MIT
 By: Sindre Sorhus
-Repository: sindresorhus/time-zone
+Repository: git+https://github.com/sindresorhus/time-zone.git
 
 ---------------------------------------
 
 ## to-regex-range
 License: MIT
 By: Jon Schlinkert, Rouven Weßling
-Repository: micromatch/to-regex-range
+Repository: git+https://github.com/micromatch/to-regex-range.git
 
 > The MIT License (MIT)
 > 
@@ -754,7 +781,7 @@ Repository: micromatch/to-regex-range
 ## yargs-parser
 License: ISC
 By: Ben Coe
-Repository: https://github.com/yargs/yargs-parser.git
+Repository: git+https://github.com/yargs/yargs-parser.git
 
 > Copyright (c) 2016, Contributors
 > 

--- a/package-lock.json
+++ b/package-lock.json
@@ -565,6 +565,12 @@
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
+    "acorn-numeric-separator": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.2.tgz",
+      "integrity": "sha512-ZNN1qnKvjWycDSQBfuD1TCiB81ItjjeGUPLHuqfP8X8HXwAodGTWsAaqSOQ1Nc9t+Wlb3tcEFdBrwUFUIzDiiA==",
+      "dev": true
+    },
     "acorn-private-class-elements": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.6.tgz",
@@ -2398,7 +2404,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -2651,7 +2657,7 @@
     },
     "jsesc": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
@@ -3780,7 +3786,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3813,7 +3819,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "acorn": "^7.3.1",
     "acorn-class-fields": "^0.3.6",
     "acorn-jsx": "^5.2.0",
+    "acorn-numeric-separator": "^0.3.2",
     "acorn-static-class-features": "^0.2.3",
     "acorn-walk": "^7.1.1",
     "buble": "^0.20.0",

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -1,4 +1,5 @@
 import injectClassFields from 'acorn-class-fields';
+import injectNumericSeparator from 'acorn-numeric-separator';
 import injectStaticClassFeatures from 'acorn-static-class-features';
 import {
 	ExternalOption,
@@ -115,6 +116,7 @@ const getAcorn = (config: GenericConfigObject): acorn.Options => ({
 const getAcornInjectPlugins = (config: GenericConfigObject): Function[] => [
 	injectClassFields,
 	injectStaticClassFeatures,
+	injectNumericSeparator,
 	...(ensureArray(config.acornInjectPlugins) as any)
 ];
 

--- a/test/form/samples/numeric_separators/_config.js
+++ b/test/form/samples/numeric_separators/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'supports numeric separators'
+};

--- a/test/form/samples/numeric_separators/_expected.js
+++ b/test/form/samples/numeric_separators/_expected.js
@@ -1,0 +1,3 @@
+const x = 123_456;
+
+export { x };

--- a/test/form/samples/numeric_separators/main.js
+++ b/test/form/samples/numeric_separators/main.js
@@ -1,0 +1,1 @@
+export const x = 123_456;

--- a/test/function/samples/options-hook/_config.js
+++ b/test/function/samples/options-hook/_config.js
@@ -15,7 +15,7 @@ module.exports = {
 						preserveParens: false,
 						sourceType: 'module'
 					},
-					acornInjectPlugins: [null, null],
+					acornInjectPlugins: [null, null, null],
 					context: 'undefined',
 					experimentalCacheExpiry: 10,
 					inlineDynamicImports: false,

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -25,3 +25,8 @@ declare module 'acorn-export-ns-from' {
 	const plugin: (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
 	export default plugin;
 }
+
+declare module 'acorn-numeric-separator' {
+	const plugin: (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
+	export default plugin;
+}


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: https://github.com/rollup/rollup/issues/3605

### Description

Node already supports numeric separators and using babel target "node: current" breaks rollup.
