### PR TITLE
Docs > Tutorial > Improve discoverability of `manualChunks` for code splitting

### DIFF
--- a/docs/04-tutorial.md
+++ b/docs/04-tutorial.md
@@ -282,7 +282,9 @@ var version=function(){"use strict";var n="1.0.0";return function(){console.log(
 
 ### Code Splitting
 
-To use the code splitting feature, we go back to the original example and modify `src/main.js` to load `src/foo.js` dynamically instead of statically:
+For code splitting, there are cases where Rollup splits code into chunks automatically, like dynamic loading or multiple entry points, and there is a way to explicitly tell Rollup which modules to split into separate chunks via the [`manualChunks`](guide/en/#manualchunks) option.
+
+To use the code splitting feature to achieve the late dynamic loading (where the import is only loaded after executing a function), we go back to the original example and modify `src/main.js` to load `src/foo.js` dynamically instead of statically:
 
 ```js
 // src/main.js

--- a/docs/04-tutorial.md
+++ b/docs/04-tutorial.md
@@ -284,7 +284,7 @@ var version=function(){"use strict";var n="1.0.0";return function(){console.log(
 
 For code splitting, there are cases where Rollup splits code into chunks automatically, like dynamic loading or multiple entry points, and there is a way to explicitly tell Rollup which modules to split into separate chunks via the [`manualChunks`](guide/en/#manualchunks) option.
 
-To use the code splitting feature to achieve the late dynamic loading (where the import is only loaded after executing a function), we go back to the original example and modify `src/main.js` to load `src/foo.js` dynamically instead of statically:
+To use the code splitting feature to achieve the lazy dynamic loading (where some imported module(s) is only loaded after executing a function), we go back to the original example and modify `src/main.js` to load `src/foo.js` dynamically instead of statically:
 
 ```js
 // src/main.js


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Wasted quite some time to learn that `manualChunks` exists. This change is what I think would help me find it earlier.