### PR TITLE
Turn namespace assignment error into a warning

### DIFF
--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -262,7 +262,8 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			this.object instanceof Identifier &&
 			this.scope.findVariable(this.object.name).isNamespace
 		) {
-			return this.context.error(
+			this.scope.findVariable(this.object.name).include();
+			this.context.warn(
 				{
 					code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
 					message: `Illegal reassignment to import '${this.object.name}'`

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -258,18 +258,18 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 	}
 
 	private disallowNamespaceReassignment() {
-		if (
-			this.object instanceof Identifier &&
-			this.scope.findVariable(this.object.name).isNamespace
-		) {
-			this.scope.findVariable(this.object.name).include();
-			this.context.warn(
-				{
-					code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
-					message: `Illegal reassignment to import '${this.object.name}'`
-				},
-				this.start
-			);
+		if (this.object instanceof Identifier) {
+			const variable = this.scope.findVariable(this.object.name);
+			if (variable.isNamespace) {
+				variable.include();
+				this.context.warn(
+					{
+						code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
+						message: `Illegal reassignment to import '${this.object.name}'`
+					},
+					this.start
+				);
+			}
 		}
 	}
 

--- a/test/function/samples/namespace-reassign-import-fails/_config.js
+++ b/test/function/samples/namespace-reassign-import-fails/_config.js
@@ -1,24 +1,26 @@
 const path = require('path');
 
 module.exports = {
-	description: 'disallows reassignments to namespace exports',
-	error: {
-		code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
-		message: `Illegal reassignment to import 'exp'`,
-		pos: 31,
-		watchFiles: [path.resolve(__dirname, 'main.js'), path.resolve(__dirname, 'foo.js')],
-		loc: {
-			file: path.resolve(__dirname, 'main.js'),
-			line: 3,
-			column: 0
-		},
-		frame: `
+	description: 'warns for reassignments to namespace exports',
+	warnings: [
+		{
+			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
+			message: `Illegal reassignment to import 'exp'`,
+			id: path.resolve(__dirname, 'main.js'),
+			pos: 31,
+			loc: {
+				file: path.resolve(__dirname, 'main.js'),
+				line: 3,
+				column: 0
+			},
+			frame: `
 			1: import * as exp from './foo';
 			2:
 			3: exp.foo = 2;
 			   ^
 		`
-	}
+		}
+	]
 };
 
 // test copied from https://github.com/esnext/es6-module-transpiler/tree/master/test/examples/namespace-reassign-import-fails

--- a/test/function/samples/namespace-update-import-fails/_config.js
+++ b/test/function/samples/namespace-update-import-fails/_config.js
@@ -2,23 +2,25 @@ const path = require('path');
 
 module.exports = {
 	description: 'disallows updates to namespace exports',
-	error: {
-		code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
-		message: `Illegal reassignment to import 'exp'`,
-		pos: 31,
-		watchFiles: [path.resolve(__dirname, 'main.js'), path.resolve(__dirname, 'foo.js')],
-		loc: {
-			file: path.resolve(__dirname, 'main.js'),
-			line: 3,
-			column: 0
-		},
-		frame: `
+	warnings: [
+		{
+			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
+			message: `Illegal reassignment to import 'exp'`,
+			id: path.resolve(__dirname, 'main.js'),
+			pos: 31,
+			loc: {
+				file: path.resolve(__dirname, 'main.js'),
+				line: 3,
+				column: 0
+			},
+			frame: `
 			1: import * as exp from './foo';
 			2:
 			3: exp['foo']++;
 			   ^
 		`
-	}
+		}
+	]
 };
 
 // test copied from https://github.com/esnext/es6-module-transpiler/tree/master/test/examples/namespace-update-import-fails


### PR DESCRIPTION
Similarly to https://github.com/rollup/rollup/pull/3475 this turns the static error into a warning that will become a runtime error only on the execution paths that actually attempt it.

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
