### PR TITLE
set browser build in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,10 +141,11 @@
   },
   "exports": {
     ".": {
-      "browser": "./dist/es/rollup.browser.js",
-      "require": "./dist/rollup.js",
-      "import": "./dist/es/rollup.js",
-      "default": "./dist/rollup.js"
+      "node": {
+        "require": "./dist/rollup.js",
+        "import": "./dist/es/rollup.js"
+      },
+      "default": "./dist/es/rollup.browser.js"
     },
     "./dist/": "./dist/"
   }

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
   },
   "exports": {
     ".": {
+      "browser": "./dist/es/rollup.browser.js",
       "require": "./dist/rollup.js",
       "import": "./dist/es/rollup.js",
       "default": "./dist/rollup.js"


### PR DESCRIPTION
This sets the exports `"browser"` condition to point to the correct ES browser build to use for RollupJS.

@lukastaegert we had quite a bit of discussion about this stuff previously, but I don't think we had any disagreements about this support mode specifically. If there are any concerns and you want to discuss anything in more detail, I'm happy to leave this till you are back from your holiday and we can arrange a time to chat?

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
