### PR TITLE
Do not include the whole namespace when illegally mutating a namespace

### DIFF
--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -93,16 +93,16 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		const baseVariable = path && this.scope.findVariable(path[0].key);
 		if (baseVariable && baseVariable.isNamespace) {
 			const resolvedVariable = this.resolveNamespaceVariables(baseVariable, path!.slice(1));
-			if (!resolvedVariable) {
-				super.bind();
-			} else if (typeof resolvedVariable === 'string') {
-				this.replacement = resolvedVariable;
-			} else {
-				if (resolvedVariable instanceof ExternalVariable && resolvedVariable.module) {
-					resolvedVariable.module.suggestName(path![0].key);
+			if (resolvedVariable) {
+				if (typeof resolvedVariable === 'string') {
+					this.replacement = resolvedVariable;
+				} else {
+					if (resolvedVariable instanceof ExternalVariable && resolvedVariable.module) {
+						resolvedVariable.module.suggestName(path![0].key);
+					}
+					this.variable = resolvedVariable;
+					this.scope.addNamespaceMemberAccess(getStringFromPath(path!), resolvedVariable);
 				}
-				this.variable = resolvedVariable;
-				this.scope.addNamespaceMemberAccess(getStringFromPath(path!), resolvedVariable);
 			}
 		} else {
 			super.bind();
@@ -261,7 +261,9 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.object instanceof Identifier) {
 			const variable = this.scope.findVariable(this.object.name);
 			if (variable.isNamespace) {
-				variable.include();
+				if (this.variable) {
+					this.context.includeVariable(this.variable);
+				}
 				this.context.warn(
 					{
 						code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',

--- a/test/cli/samples/config-no-module/_config.js
+++ b/test/cli/samples/config-no-module/_config.js
@@ -1,17 +1,17 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'provides a helpful error message if a transpiled config is interpreted as "module"',
 	minNodeVersion: 13,
 	command: 'cd sub && rollup -c',
 	error: () => true,
-	stderr: (stderr) =>
-		assertStderrIncludes(
+	stderr: stderr =>
+		assertIncludes(
 			stderr,
 			'[!] Error: While loading the Rollup configuration from "rollup.config.js", Node tried to require an ES module from a CommonJS ' +
 				'file, which is not supported. A common cause is if there is a package.json file with "type": "module" in the same folder. You can ' +
 				'try to fix this by changing the extension of your configuration file to ".cjs" or ".mjs" depending on the content, which will ' +
 				'prevent Rollup from trying to preprocess the file but rather hand it to Node directly.\n' +
 				'https://rollupjs.org/guide/en/#using-untranspiled-config-files'
-		),
+		)
 };

--- a/test/cli/samples/config-warnings/_config.js
+++ b/test/cli/samples/config-warnings/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'displays warnings when a config is loaded',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'loaded rollup.config.js with warnings\n(!) Use of eval is strongly discouraged'
 		)

--- a/test/cli/samples/custom-frame-with-pos/_config.js
+++ b/test/cli/samples/custom-frame-with-pos/_config.js
@@ -1,11 +1,11 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'custom (plugin generated) code frame taking priority over pos generated one',
 	command: 'rollup -c',
 	error: () => true,
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'[!] (plugin at position 1) Error: My error.\n' +
 				'main.js (1:5)\n' +

--- a/test/cli/samples/custom-frame/_config.js
+++ b/test/cli/samples/custom-frame/_config.js
@@ -1,16 +1,16 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'errors with plugin generated code frames also contain stack',
 	command: 'rollup -c',
 	error: () => true,
 	stderr: stderr => {
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'[!] (plugin at position 1) Error: My error.\n' +
 				'main.js\ncustom code frame\nError: My error.\n' +
 				'    at Object.transform'
 		);
-		assertStderrIncludes(stderr, 'rollup.config.js:11:17');
+		assertIncludes(stderr, 'rollup.config.js:11:17');
 	}
 };

--- a/test/cli/samples/duplicate-import-options/_config.js
+++ b/test/cli/samples/duplicate-import-options/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'throws if different types of entries are combined',
 	command: 'rollup main.js --format es --input main.js',
 	error: () => true,
 	stderr(stderr) {
-		assertStderrIncludes(stderr, '[!] Either use --input, or pass input path as argument');
+		assertIncludes(stderr, '[!] Either use --input, or pass input path as argument');
 	}
 };

--- a/test/cli/samples/empty-chunk-multiple/_config.js
+++ b/test/cli/samples/empty-chunk-multiple/_config.js
@@ -1,8 +1,8 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'shows warning when multiple chunks empty',
 	command: 'rollup -c',
 	error: () => true,
-	stderr: stderr => assertStderrIncludes(stderr, '(!) Generated empty chunks\na, b')
+	stderr: stderr => assertIncludes(stderr, '(!) Generated empty chunks\na, b')
 };

--- a/test/cli/samples/empty-chunk/_config.js
+++ b/test/cli/samples/empty-chunk/_config.js
@@ -1,8 +1,8 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'shows warning when chunk empty',
 	command: 'rollup -c',
 	error: () => true,
-	stderr: stderr => assertStderrIncludes(stderr, '(!) Generated an empty chunk\nmain')
+	stderr: stderr => assertIncludes(stderr, '(!) Generated an empty chunk\nmain')
 };

--- a/test/cli/samples/node-config-not-found/_config.js
+++ b/test/cli/samples/node-config-not-found/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'throws if a config in node_modules cannot be found',
 	command: 'rollup --config node:baz',
 	error: () => true,
 	stderr(stderr) {
-		assertStderrIncludes(stderr, '[!] Could not resolve config file "node:baz"');
+		assertIncludes(stderr, '[!] Could not resolve config file "node:baz"');
 	}
 };

--- a/test/cli/samples/plugin/cannot-load/_config.js
+++ b/test/cli/samples/plugin/cannot-load/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../../utils.js');
+const { assertIncludes } = require('../../../../utils.js');
 
 module.exports = {
 	description: 'unknown CLI --plugin results in an error',
 	skipIfWindows: true,
 	command: `echo "console.log(123);" | rollup --plugin foobar`,
 	error(err) {
-		assertStderrIncludes(err.message, '[!] Error: Cannot load plugin "foobar"');
+		assertIncludes(err.message, '[!] Error: Cannot load plugin "foobar"');
 	}
 };

--- a/test/cli/samples/plugin/invalid-argument/_config.js
+++ b/test/cli/samples/plugin/invalid-argument/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../../utils.js');
+const { assertIncludes } = require('../../../../utils.js');
 
 module.exports = {
 	description: 'invalid CLI --plugin argument format',
 	skipIfWindows: true,
 	command: `echo "console.log(123);" | rollup --plugin 'foo bar'`,
 	error(err) {
-		assertStderrIncludes(err.message, '[!] Error: Invalid --plugin argument format: "foo bar"');
+		assertIncludes(err.message, '[!] Error: Invalid --plugin argument format: "foo bar"');
 	}
 };

--- a/test/cli/samples/stdin/no-stdin-tty/_config.js
+++ b/test/cli/samples/stdin/no-stdin-tty/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../../utils.js');
+const { assertIncludes } = require('../../../../utils.js');
 
 module.exports = {
 	description: 'does not use input as stdin on TTY interfaces',
 	skipIfWindows: true,
 	command: `echo "console.log('PASS');" | ./wrapper.js -f es`,
 	error(err) {
-		assertStderrIncludes(err.message, 'You must supply options.input to rollup');
+		assertIncludes(err.message, 'You must supply options.input to rollup');
 	}
 };

--- a/test/cli/samples/stdin/stdin-error/_config.js
+++ b/test/cli/samples/stdin/stdin-error/_config.js
@@ -1,9 +1,9 @@
-const { assertStderrIncludes } = require('../../../../utils.js');
+const { assertIncludes } = require('../../../../utils.js');
 
 module.exports = {
 	description: 'handles stdin errors',
 	command: `node wrapper.js`,
 	error(err) {
-		assertStderrIncludes(err.message, 'Could not load -: Stream is broken.');
+		assertIncludes(err.message, 'Could not load -: Stream is broken.');
 	}
 };

--- a/test/cli/samples/stdout-only-inline-sourcemaps/_config.js
+++ b/test/cli/samples/stdout-only-inline-sourcemaps/_config.js
@@ -1,13 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'fails when using non-inline sourcemaps when bundling to stdout',
 	command: 'rollup -i main.js -f es -m',
 	error: () => true,
-	stderr: (stderr) => {
-		assertStderrIncludes(
-			stderr,
-			'[!] Only inline sourcemaps are supported when bundling to stdout.\n'
-		);
-	},
+	stderr: stderr => {
+		assertIncludes(stderr, '[!] Only inline sourcemaps are supported when bundling to stdout.\n');
+	}
 };

--- a/test/cli/samples/warn-broken-sourcemap/_config.js
+++ b/test/cli/samples/warn-broken-sourcemap/_config.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'displays warnings for broken sourcemaps',
@@ -8,7 +8,7 @@ module.exports = {
 	stderr: stderr => {
 		fs.unlinkSync(path.resolve(__dirname, 'bundle'));
 		fs.unlinkSync(path.resolve(__dirname, 'bundle.map'));
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Broken sourcemap\n' +
 				'https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect\n' +

--- a/test/cli/samples/warn-broken-sourcemaps/_config.js
+++ b/test/cli/samples/warn-broken-sourcemaps/_config.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'displays warnings for broken sourcemaps',
@@ -8,7 +8,7 @@ module.exports = {
 	stderr: stderr => {
 		fs.unlinkSync(path.resolve(__dirname, 'bundle'));
 		fs.unlinkSync(path.resolve(__dirname, 'bundle.map'));
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Broken sourcemap\n' +
 				'https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect\n' +

--- a/test/cli/samples/warn-circular-multiple/_config.js
+++ b/test/cli/samples/warn-circular-multiple/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns for multiple circular dependencies',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Circular dependencies\n' +
 				'main.js -> dep1.js -> main.js\n' +

--- a/test/cli/samples/warn-circular/_config.js
+++ b/test/cli/samples/warn-circular/_config.js
@@ -1,9 +1,9 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns for circular dependencies',
 	command: 'rollup -c',
 	stderr(stderr) {
-		assertStderrIncludes(stderr, '(!) Circular dependency\nmain.js -> dep.js -> main.js\n');
+		assertIncludes(stderr, '(!) Circular dependency\nmain.js -> dep.js -> main.js\n');
 	}
 };

--- a/test/cli/samples/warn-eval-multiple/_config.js
+++ b/test/cli/samples/warn-eval-multiple/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns when eval is used multiple times',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Use of eval is strongly discouraged\n' +
 				'https://rollupjs.org/guide/en/#avoiding-eval\n' +

--- a/test/cli/samples/warn-eval/_config.js
+++ b/test/cli/samples/warn-eval/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns when eval is used',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Use of eval is strongly discouraged\n' +
 				'https://rollupjs.org/guide/en/#avoiding-eval\n' +

--- a/test/cli/samples/warn-import-export/_config.js
+++ b/test/cli/samples/warn-import-export/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns about import and export related issues',
 	command: 'rollup -c',
 	stderr: stderr => {
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Mixing named and default exports\n' +
 				'https://rollupjs.org/guide/en/#output-exports\n' +
@@ -13,12 +13,12 @@ module.exports = {
 				'\n' +
 				"Consumers of your bundle will have to use chunk['default'] to access their default export, which may not be what you want. Use `output.exports: 'named'` to disable this warning\n"
 		);
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Unused external imports\n' +
 				"default imported from external module 'external' but never used\n"
 		);
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Import of non-existent export\n' +
 				'main.js\n' +
@@ -28,7 +28,7 @@ module.exports = {
 				'          ^\n' +
 				"4: import 'unresolvedExternal';\n"
 		);
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Missing exports\n' +
 				'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module\n' +
@@ -40,13 +40,13 @@ module.exports = {
 				'                              ^\n' +
 				'7: export default 42;\n'
 		);
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Conflicting re-exports\n' +
 				"main.js re-exports 'foo' from both dep.js and dep2.js (will be ignored)\n" +
 				"main.js re-exports 'bar' from both dep.js and dep2.js (will be ignored)\n"
 		);
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Unresolved dependencies\n' +
 				'https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency\n' +

--- a/test/cli/samples/warn-missing-global-multiple/_config.js
+++ b/test/cli/samples/warn-missing-global-multiple/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns when there are multiple missing globals',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Missing global variable names\n' +
 				'Use output.globals to specify browser global variable names corresponding to external modules\n' +

--- a/test/cli/samples/warn-missing-global/_config.js
+++ b/test/cli/samples/warn-missing-global/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns when there is a missing global variable name',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Missing global variable name\n' +
 				'Use output.globals to specify browser global variable names corresponding to external modules\n' +

--- a/test/cli/samples/warn-mixed-exports-multiple/_config.js
+++ b/test/cli/samples/warn-mixed-exports-multiple/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns when mixed exports are used',
 	command: 'rollup -c',
 	stderr: stderr => {
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Mixing named and default exports\n' +
 				'https://rollupjs.org/guide/en/#output-exports\n' +

--- a/test/cli/samples/warn-multiple/_config.js
+++ b/test/cli/samples/warn-multiple/_config.js
@@ -1,15 +1,15 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'aggregates warnings of different types',
 	command: 'rollup -c',
 	stderr: stderr => {
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Missing shims for Node.js built-ins\n' +
 				"Creating a browser bundle that depends on 'url', 'assert' and 'path'. You might need to include https://github.com/ionic-team/rollup-plugin-node-polyfills\n"
 		);
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Import of non-existent exports\n' +
 				'main.js\n' +
@@ -21,7 +21,7 @@ module.exports = {
 				'8: export {url, assert, path};\n' +
 				'...and 1 other occurrence\n'
 		);
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 
 			"(!) Module level directives cause errors when bundled, 'use stuff' was ignored.\n" +

--- a/test/cli/samples/warn-plugin/_config.js
+++ b/test/cli/samples/warn-plugin/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'displays warnings from plugins',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) Plugin test-plugin: First\n' +
 				'(!) Plugin test-plugin: Second\n' +

--- a/test/cli/samples/warn-this/_config.js
+++ b/test/cli/samples/warn-this/_config.js
@@ -1,10 +1,10 @@
-const { assertStderrIncludes } = require('../../../utils.js');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns "this" is used on the top level',
 	command: 'rollup -c',
 	stderr: stderr =>
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'(!) `this` has been rewritten to `undefined`\n' +
 				'https://rollupjs.org/guide/en/#error-this-is-undefined\n' +

--- a/test/cli/samples/watch/no-watched-config/_config.js
+++ b/test/cli/samples/watch/no-watched-config/_config.js
@@ -1,11 +1,11 @@
-const { assertStderrIncludes } = require('../../../../utils.js');
+const { assertIncludes } = require('../../../../utils.js');
 
 module.exports = {
 	description: 'throws if no config is watched',
 	command: 'rollup -cw',
 	error: () => true,
 	stderr(stderr) {
-		assertStderrIncludes(
+		assertIncludes(
 			stderr,
 			'[!] Error: Invalid value for option "watch" - there must be at least one config where "watch" is not set to "false".'
 		);

--- a/test/function/samples/namespace-reassign-import-fails/_config.js
+++ b/test/function/samples/namespace-reassign-import-fails/_config.js
@@ -1,15 +1,44 @@
+const assert = require('assert');
 const path = require('path');
+const { assertIncludes } = require('../../../utils.js');
+
+const ID_MAIN = path.resolve(__dirname, 'main.js');
 
 module.exports = {
 	description: 'warns for reassignments to namespace exports',
+	code(code) {
+		assertIncludes(code, 'foo = 2');
+		assertIncludes(code, 'undefined = 3');
+	},
 	warnings: [
+		{
+			code: 'MISSING_EXPORT',
+			exporter: 'foo.js',
+			frame: `
+			2:
+			3: exp.foo = 2;
+			4: exp.bar = 3;
+			       ^
+		`,
+			id: ID_MAIN,
+			importer: 'main.js',
+			loc: {
+				column: 4,
+				file: ID_MAIN,
+				line: 4
+			},
+			message: "'bar' is not exported by 'foo.js'",
+			missing: 'bar',
+			pos: 48,
+			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module'
+		},
 		{
 			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
 			message: `Illegal reassignment to import 'exp'`,
-			id: path.resolve(__dirname, 'main.js'),
+			id: ID_MAIN,
 			pos: 31,
 			loc: {
-				file: path.resolve(__dirname, 'main.js'),
+				file: ID_MAIN,
 				line: 3,
 				column: 0
 			},
@@ -18,9 +47,30 @@ module.exports = {
 			2:
 			3: exp.foo = 2;
 			   ^
+			4: exp.bar = 3;
+		`
+		},
+		{
+			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
+			message: `Illegal reassignment to import 'exp'`,
+			id: ID_MAIN,
+			pos: 44,
+			loc: {
+				file: ID_MAIN,
+				line: 4,
+				column: 0
+			},
+			frame: `
+			2:
+			3: exp.foo = 2;
+			4: exp.bar = 3;
+			   ^
 		`
 		}
-	]
+	],
+	runtimeError(error) {
+		assert.strictEqual(error.message, 'Assignment to constant variable.');
+	}
 };
 
 // test copied from https://github.com/esnext/es6-module-transpiler/tree/master/test/examples/namespace-reassign-import-fails

--- a/test/function/samples/namespace-reassign-import-fails/foo.js
+++ b/test/function/samples/namespace-reassign-import-fails/foo.js
@@ -1,1 +1,1 @@
-export var foo = 1;
+export const foo = 1;

--- a/test/function/samples/namespace-reassign-import-fails/main.js
+++ b/test/function/samples/namespace-reassign-import-fails/main.js
@@ -1,3 +1,4 @@
 import * as exp from './foo';
 
 exp.foo = 2;
+exp.bar = 3;

--- a/test/function/samples/namespace-update-import-fails/_config.js
+++ b/test/function/samples/namespace-update-import-fails/_config.js
@@ -1,7 +1,12 @@
+const assert = require('assert');
 const path = require('path');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'disallows updates to namespace exports',
+	code(code) {
+		assertIncludes(code, 'foo++');
+	},
 	warnings: [
 		{
 			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
@@ -20,7 +25,10 @@ module.exports = {
 			   ^
 		`
 		}
-	]
+	],
+	runtimeError(error) {
+		assert.strictEqual(error.message, 'Assignment to constant variable.');
+	}
 };
 
 // test copied from https://github.com/esnext/es6-module-transpiler/tree/master/test/examples/namespace-update-import-fails

--- a/test/function/samples/namespace-update-import-fails/foo.js
+++ b/test/function/samples/namespace-update-import-fails/foo.js
@@ -1,1 +1,1 @@
-export var foo = 1;
+export const foo = 1;

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,7 +12,7 @@ exports.loader = loader;
 exports.normaliseOutput = normaliseOutput;
 exports.runTestSuiteWithSamples = runTestSuiteWithSamples;
 exports.assertDirectoriesAreEqual = assertDirectoriesAreEqual;
-exports.assertStderrIncludes = assertStderrIncludes;
+exports.assertIncludes = assertIncludes;
 
 function normaliseError(error) {
 	delete error.stack;
@@ -219,14 +219,14 @@ function assertFilesAreEqual(actualFiles, expectedFiles, dirs = []) {
 	});
 }
 
-function assertStderrIncludes(stderr, expected) {
+function assertIncludes(actual, expected) {
 	try {
 		assert.ok(
-			stderr.includes(expected),
-			`Could not find ${JSON.stringify(expected)} in ${JSON.stringify(stderr)}`
+			actual.includes(expected),
+			`${JSON.stringify(actual)}\nincludes\n${JSON.stringify(expected)}`
 		);
 	} catch (err) {
-		err.actual = stderr;
+		err.actual = actual;
 		err.expected = expected;
 		throw err;
 	}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#3633

### Description
This will refine how we handle mutating namespace objects in that this no longer includes the whole namespace but only the mutated prop. Note that it will still (unnecessarily) include the whole namespace when mutating a missing prop but I found it too much effort to optimize for this rare condition that already displays two (!) warnings.