### PR TITLE
Support backslash escaping, retain exact newline escaping

### DIFF
--- a/src/utils/escapeId.ts
+++ b/src/utils/escapeId.ts
@@ -1,12 +1,7 @@
-const quoteNewlineRegEx = /['\r\n\u2028\u2029]/g;
-const replacements = {
-	'\n': '\\n',
-	'\r': '\\r',
-	"'": "\\'",
-	'\u2028': '\\u2028',
-	'\u2029': '\\u2029'
-};
-
+const needsEscapeRegEx = /[\\'\r\n\u2028\u2029]/;
+const quoteNewlineRegEx = /(['\r\n\u2028\u2029])/g;
+const backSlashRegEx = /\\/g;
 export function escapeId(id: string) {
-	return id.replace(quoteNewlineRegEx, match => replacements[match as keyof typeof replacements]);
+	if (!id.match(needsEscapeRegEx)) return id;
+	return id.replace(backSlashRegEx, '\\\\').replace(quoteNewlineRegEx, '\\$1');
 }

--- a/test/form/samples/quote-id/_config.js
+++ b/test/form/samples/quote-id/_config.js
@@ -2,15 +2,21 @@ const path = require('path');
 
 const external1 = "quoted'\r\n\u2028\u2029external1";
 const external2 = path.join(__dirname, "quoted'\r\n\u2028\u2029external2");
+const external3 = 'C:\\File\\Path.js';
 
 module.exports = {
-	description: 'supports quote characters in external ids',
+	description: 'handles escaping for external ids',
 	options: {
 		output: {
+			paths: id => {
+				if (id.startsWith('C:')) return id;
+				return path.relative(__dirname, id);
+			},
 			name: 'Q',
 			globals: {
 				[external1]: 'quotedExternal1',
-				[external2]: 'quotedExternal2'
+				[external2]: 'quotedExternal2',
+				[external3]: 'quotedExternal3'
 			}
 		},
 		plugins: [
@@ -21,6 +27,9 @@ module.exports = {
 					}
 					if (id === 'external2') {
 						return { id: external2, external: true };
+					}
+					if (id === 'external3') {
+						return { id: external3, external: true };
 					}
 				}
 			}

--- a/test/form/samples/quote-id/_expected/amd.js
+++ b/test/form/samples/quote-id/_expected/amd.js
@@ -1,5 +1,7 @@
-define(['quoted\'\r\n\u2028\u2029external1', './quoted\'\r\n\u2028\u2029external2'], function (quoted_____external1, quoted_____external2) { 'use strict';
+define(['quoted\'\\
+\ \ external1', 'quoted\'\\
+\ \ external2', 'C:\\File\\Path.js'], function (quoted_____external1, quoted_____external2, Path_js) { 'use strict';
 
-	console.log(quoted_____external1.foo, quoted_____external2.bar);
+	console.log(quoted_____external1.foo, quoted_____external2.bar, Path_js.baz);
 
 });

--- a/test/form/samples/quote-id/_expected/cjs.js
+++ b/test/form/samples/quote-id/_expected/cjs.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var quoted_____external1 = require('quoted\'\r\n\u2028\u2029external1');
-var quoted_____external2 = require('./quoted\'\r\n\u2028\u2029external2');
+var quoted_____external1 = require('quoted\'\\
+\ \ external1');
+var quoted_____external2 = require('quoted\'\\
+\ \ external2');
+var Path_js = require('C:\\File\\Path.js');
 
-console.log(quoted_____external1.foo, quoted_____external2.bar);
+console.log(quoted_____external1.foo, quoted_____external2.bar, Path_js.baz);

--- a/test/form/samples/quote-id/_expected/es.js
+++ b/test/form/samples/quote-id/_expected/es.js
@@ -1,4 +1,7 @@
-import { foo } from 'quoted\'\r\n\u2028\u2029external1';
-import { bar } from './quoted\'\r\n\u2028\u2029external2';
+import { foo } from 'quoted\'\\
+\ \ external1';
+import { bar } from 'quoted\'\\
+\ \ external2';
+import { baz } from 'C:\\File\\Path.js';
 
-console.log(foo, bar);
+console.log(foo, bar, baz);

--- a/test/form/samples/quote-id/_expected/iife.js
+++ b/test/form/samples/quote-id/_expected/iife.js
@@ -1,6 +1,6 @@
-(function (quoted_____external1, quoted_____external2) {
+(function (quoted_____external1, quoted_____external2, Path_js) {
 	'use strict';
 
-	console.log(quoted_____external1.foo, quoted_____external2.bar);
+	console.log(quoted_____external1.foo, quoted_____external2.bar, Path_js.baz);
 
-}(quotedExternal1, quotedExternal2));
+}(quotedExternal1, quotedExternal2, quotedExternal3));

--- a/test/form/samples/quote-id/_expected/system.js
+++ b/test/form/samples/quote-id/_expected/system.js
@@ -1,15 +1,19 @@
-System.register('Q', ['quoted\'\r\n\u2028\u2029external1', './quoted\'\r\n\u2028\u2029external2'], function () {
+System.register('Q', ['quoted\'\\
+\ \ external1', 'quoted\'\\
+\ \ external2', 'C:\\File\\Path.js'], function () {
 	'use strict';
-	var foo, bar;
+	var foo, bar, baz;
 	return {
 		setters: [function (module) {
 			foo = module.foo;
 		}, function (module) {
 			bar = module.bar;
+		}, function (module) {
+			baz = module.baz;
 		}],
 		execute: function () {
 
-			console.log(foo, bar);
+			console.log(foo, bar, baz);
 
 		}
 	};

--- a/test/form/samples/quote-id/_expected/umd.js
+++ b/test/form/samples/quote-id/_expected/umd.js
@@ -1,9 +1,13 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('quoted\'\r\n\u2028\u2029external1'), require('./quoted\'\r\n\u2028\u2029external2')) :
-	typeof define === 'function' && define.amd ? define(['quoted\'\r\n\u2028\u2029external1', './quoted\'\r\n\u2028\u2029external2'], factory) :
-	(global = global || self, factory(global.quotedExternal1, global.quotedExternal2));
-}(this, (function (quoted_____external1, quoted_____external2) { 'use strict';
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('quoted\'\\
+\ \ external1'), require('quoted\'\\
+\ \ external2'), require('C:\\File\\Path.js')) :
+	typeof define === 'function' && define.amd ? define(['quoted\'\\
+\ \ external1', 'quoted\'\\
+\ \ external2', 'C:\\File\\Path.js'], factory) :
+	(global = global || self, factory(global.quotedExternal1, global.quotedExternal2, global.quotedExternal3));
+}(this, (function (quoted_____external1, quoted_____external2, Path_js) { 'use strict';
 
-	console.log(quoted_____external1.foo, quoted_____external2.bar);
+	console.log(quoted_____external1.foo, quoted_____external2.bar, Path_js.baz);
 
 })));

--- a/test/form/samples/quote-id/main.js
+++ b/test/form/samples/quote-id/main.js
@@ -1,3 +1,4 @@
 import { foo } from 'external1';
 import { bar } from 'external2';
-console.log(foo, bar);
+import { baz } from 'external3';
+console.log(foo, bar, baz);


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

This adds backslash escaping as well to the recent escaping work.

I've also reverted to the direct newline escaping over the table approach here, but we can add back the table too if you prefer.

I've also added an extra check in the escaping function to avoid any replacement if escaping is unnecessary. This is a super minor mostly theoretical pref improvement to avoid copying strings.