### PR TITLE
Fix performance regression when a file is imported by many importers

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -196,7 +196,7 @@ export default class Graph {
 		}
 		return {
 			dynamicallyImportedIds,
-			dynamicImporters: foundModule.dynamicImporters,
+			dynamicImporters: foundModule.dynamicImporters.sort(),
 			hasModuleSideEffects: foundModule.moduleSideEffects,
 			id: foundModule.id,
 			implicitlyLoadedAfterOneOf:
@@ -204,7 +204,7 @@ export default class Graph {
 			implicitlyLoadedBefore:
 				foundModule instanceof Module ? Array.from(foundModule.implicitlyLoadedBefore, getId) : [],
 			importedIds,
-			importers: foundModule.importers,
+			importers: foundModule.importers.sort(),
 			isEntry: foundModule instanceof Module && foundModule.isEntryPoint,
 			isExternal: foundModule instanceof ExternalModule
 		};

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -294,7 +294,6 @@ export class ModuleLoader {
 						this.handleResolveId(await this.resolveId(source, module.id), source, module.id))
 				);
 				resolution.importers.push(module.id);
-				resolution.importers.sort();
 			}),
 			...module.dynamicImports.map(async dynamicImport => {
 				const resolvedId = await this.resolveDynamicImport(
@@ -312,7 +311,6 @@ export class ModuleLoader {
 						resolvedId
 					));
 					resolution.dynamicImporters.push(module.id);
-					resolution.dynamicImporters.sort();
 				}
 			})
 		]);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3640

### Description
In Rollup 2.9.0, new properties `importers` and `dynamicImporters` were added to `this.getModuleInfo`. While the graph was built, these properties were extended ver often for some files (in the example in #3640, `react` and another file were imported both by more than 5000 files).
These properties were also sorted and the logic was built in a way so that the properties were sorted after any new importer was added. Now if you add 5000 properties to an array and sort the array after each added property, this does not scale well.

This PR fixes this regression by only sorting when the `this.getModuleInfo` is actually called.