### PR TITLE
Fix accessing nested properties of namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # rollup changelog
 
+## 2.17.1
+*2020-06-19*
+
+### Bug Fixes
+* Properly resolve accessing properties of namespace members again (#3643)
+
+### Pull Requests
+* [#3643](https://github.com/rollup/rollup/pull/3643): Fix accessing nested properties of namespaces (@lukastaegert)
+
 ## 2.17.0
 *2020-06-17*
 

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -93,16 +93,16 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		const baseVariable = path && this.scope.findVariable(path[0].key);
 		if (baseVariable && baseVariable.isNamespace) {
 			const resolvedVariable = this.resolveNamespaceVariables(baseVariable, path!.slice(1));
-			if (resolvedVariable) {
-				if (typeof resolvedVariable === 'string') {
-					this.replacement = resolvedVariable;
-				} else {
-					if (resolvedVariable instanceof ExternalVariable && resolvedVariable.module) {
-						resolvedVariable.module.suggestName(path![0].key);
-					}
-					this.variable = resolvedVariable;
-					this.scope.addNamespaceMemberAccess(getStringFromPath(path!), resolvedVariable);
+			if (!resolvedVariable) {
+				super.bind();
+			} else if (typeof resolvedVariable === 'string') {
+				this.replacement = resolvedVariable;
+			} else {
+				if (resolvedVariable instanceof ExternalVariable && resolvedVariable.module) {
+					resolvedVariable.module.suggestName(path![0].key);
 				}
+				this.variable = resolvedVariable;
+				this.scope.addNamespaceMemberAccess(getStringFromPath(path!), resolvedVariable);
 			}
 		} else {
 			super.bind();

--- a/test/cli/samples/watch/bundle-error/_config.js
+++ b/test/cli/samples/watch/bundle-error/_config.js
@@ -11,11 +11,11 @@ module.exports = {
 		fs.writeFileSync(mainFile, '<=>');
 	},
 	after() {
-		setTimeout(() => fs.unlinkSync(mainFile), 300);
+		setTimeout(() => fs.unlinkSync(mainFile), 100);
 	},
 	abortOnStderr(data) {
 		if (data.includes('Error: Unexpected token')) {
-			setTimeout(() => fs.writeFileSync(mainFile, 'export default 42;'), 300);
+			setTimeout(() => fs.writeFileSync(mainFile, 'export default 42;'), 500);
 			return false;
 		}
 		if (data.includes('created _actual')) {

--- a/test/function/samples/nested-namespace-member-expression/_config.js
+++ b/test/function/samples/nested-namespace-member-expression/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'handles accessing members of namespaces correctly',
+	exports(exports) {
+		assert.strictEqual(exports, false);
+	}
+};

--- a/test/function/samples/nested-namespace-member-expression/helpers.js
+++ b/test/function/samples/nested-namespace-member-expression/helpers.js
@@ -1,0 +1,1 @@
+export var global = {Object: {}};

--- a/test/function/samples/nested-namespace-member-expression/main.js
+++ b/test/function/samples/nested-namespace-member-expression/main.js
@@ -1,0 +1,2 @@
+import * as helpers from './helpers.js';
+export default helpers.global.Object === Object;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3642 

### Description
As part of a refactoring in #3637, accessing properties of namespace members was no longer working correctly, which is fixed here.
