### PR TITLE
Do not tree-shake arguments that contain a spread element

### DIFF
--- a/src/ast/scopes/ParameterScope.ts
+++ b/src/ast/scopes/ParameterScope.ts
@@ -51,6 +51,14 @@ export default class ParameterScope extends ChildScope {
 		let calledFromTryStatement = false;
 		let argIncluded = false;
 		const restParam = this.hasRest && this.parameters[this.parameters.length - 1];
+		for (const checkedArg of args) {
+			if (checkedArg instanceof SpreadElement) {
+				for (const arg of args) {
+					arg.include(context, false);
+				}
+				break;
+			}
+		}
 		for (let index = args.length - 1; index >= 0; index--) {
 			const paramVars = this.parameters[index] || restParam;
 			const arg = args[index];

--- a/test/function/samples/spread-arguments-unused/_config.js
+++ b/test/function/samples/spread-arguments-unused/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description:
+		'handles using the spread operator to add arguments when the first argument is unused (#3652)'
+};

--- a/test/function/samples/spread-arguments-unused/main.js
+++ b/test/function/samples/spread-arguments-unused/main.js
@@ -1,0 +1,5 @@
+function test(unused, used) {
+	assert.strictEqual(used, 'used');
+}
+
+test(...['unused', 'used']);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3652 

### Description
Disabling argument tree-shaking if a spread element is passed seems prudent as it is hard to associate arguments with variables in such a case, otherwise the logic would grow really convoluted.
