### PR TITLE
Warn when implicitly using default export mode

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -137,7 +137,7 @@ const deferredHandlers: {
 
 	MIXED_EXPORTS: warnings => {
 		title('Mixing named and default exports');
-		info(`https://rollupjs.org/guide/en/#output-exports`);
+		info(`https://rollupjs.org/guide/en/#outputexports`);
 		stderr(bold('The following entry modules are using named and default exports together:'));
 		const displayedWarnings = warnings.length > 5 ? warnings.slice(0, 3) : warnings;
 		for (const warning of displayedWarnings) {

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -922,7 +922,7 @@ Default: `'auto'`
 
 What export mode to use. Defaults to `auto`, which guesses your intentions based on what the `input` module exports:
 
-* `default` – suitable if you are only exporting one thing using `export default ...`
+* `default` – suitable if you are only exporting one thing using `export default ...`; note that this can cause issues when generating CommonJS output that is meant to be interchangeable with ESM output, see below
 * `named` – suitable if you are exporting more than one thing
 * `none` – suitable if you are not exporting anything (e.g. you are building an app, not a library)
 
@@ -944,6 +944,10 @@ The wrinkle is that if you use `named` exports but *also* have a `default` expor
 const yourMethod = require( 'your-lib' ).yourMethod;
 const yourLib = require( 'your-lib' ).default;
 ```
+
+Note: There are some tools such as Babel, TypeScript, Webpack, and `@rollup/plugin-commonjs` that are capable of resolving a CommonJS `require(...)` call with an ES module. If you are generating CommonJS output that is meant to be interchangeable with ESM output for those tools, you should always use `named` export mode. The reason is that most of those tools will by default return the namespace of an ES module on `require` where the default export is the `.default` property.
+
+To notify you about this, Rollup will generate a warning when such a situation is encountered and no explicit value for `output.exports` has been selected.
 
 #### output.externalLiveBindings
 Type: `boolean`<br>

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -922,32 +922,56 @@ Default: `'auto'`
 
 What export mode to use. Defaults to `auto`, which guesses your intentions based on what the `input` module exports:
 
-* `default` – suitable if you are only exporting one thing using `export default ...`; note that this can cause issues when generating CommonJS output that is meant to be interchangeable with ESM output, see below
-* `named` – suitable if you are exporting more than one thing
-* `none` – suitable if you are not exporting anything (e.g. you are building an app, not a library)
+* `default` – if you are only exporting one thing using `export default ...`; note that this can cause issues when generating CommonJS output that is meant to be interchangeable with ESM output, see below
+* `named` – if you are using named exports
+* `none` – if you are not exporting anything (e.g. you are building an app, not a library)
+
+As this is only an output transformation, you can only choose `default` if there a default export is the only export for all entry chunks. Likewise, you can only choose `none` if there are no exports, otherwise Rollup will error.
 
 The difference between `default` and `named` affects how other people can consume your bundle. If you use `default`, a CommonJS user could do this, for example:
 
 ```js
-const yourLib = require( 'your-lib' );
+// your-lib package entry
+export default "Hello world";
+
+// a CommonJS consumer
+/* require( "your-lib" ) returns "Hello World" */
+const hello = require( "your-lib" );
 ```
 
 With `named`, a user would do this instead:
 
 ```js
-const yourMethod = require( 'your-lib' ).yourMethod;
+// your-lib package entry
+export const hello = "Hello world";
+
+// a CommonJS consumer
+/* require( "your-lib" ) returns {hello: "Hello World"} */
+const hello = require( "your-lib" ).hello;
+/* or using destructuring */
+const {hello} = require( "your-lib" );
 ```
 
 The wrinkle is that if you use `named` exports but *also* have a `default` export, a user would have to do something like this to use the default export:
 
 ```js
-const yourMethod = require( 'your-lib' ).yourMethod;
-const yourLib = require( 'your-lib' ).default;
+// your-lib package entry
+export default "foo";
+export const bar = "bar";
+
+// a CommonJS consumer
+/* require( "your-lib" ) returns {default: "foo", bar: "bar"} */
+const foo = require( "your-lib" ).default;
+const bar = require( "your-lib" ).bar;
+/* or using destructuring */
+const {default: foo, bar} = require( "your-lib" );
 ```
 
 Note: There are some tools such as Babel, TypeScript, Webpack, and `@rollup/plugin-commonjs` that are capable of resolving a CommonJS `require(...)` call with an ES module. If you are generating CommonJS output that is meant to be interchangeable with ESM output for those tools, you should always use `named` export mode. The reason is that most of those tools will by default return the namespace of an ES module on `require` where the default export is the `.default` property.
 
-To notify you about this, Rollup will generate a warning when such a situation is encountered and no explicit value for `output.exports` has been selected.
+In other words for those tools, you cannot create a package interface where `const lib = require("your-lib")` yields the same as `import lib from "your-lib"`. With named export mode however, `const {lib} = require("your-lib")` will be equivalent to `import {lib} from "your-lib"`.
+
+To alert you to this, Rollup will generate a warning when you encounter such a situation and did not select an explicit value for `output.exports`.
 
 #### output.externalLiveBindings
 Type: `boolean`<br>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -111,6 +111,8 @@ export default command => {
 			chunkFileNames: 'shared/[name].js',
 			dir: 'dist',
 			entryFileNames: '[name]',
+			// TODO Only loadConfigFile is using default exports mode; this should be changed in Rollup@3
+			exports: 'auto',
 			externalLiveBindings: false,
 			format: 'cjs',
 			freeze: false,

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -295,6 +295,7 @@ export default class Chunk {
 			this.exportMode = getExportMode(
 				this,
 				this.outputOptions,
+				this.unsetOptions,
 				this.facadeModule!.id,
 				this.inputOptions.onwarn
 			);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -162,7 +162,7 @@ export function errInvalidExportOptionValue(optionValue: string) {
 	return {
 		code: Errors.INVALID_EXPORT_OPTION,
 		message: `"output.exports" must be "default", "named", "none", "auto", or left unspecified (defaults to "auto"), received "${optionValue}"`,
-		url: `https://rollupjs.org/guide/en/#output-exports`
+		url: `https://rollupjs.org/guide/en/#outputexports`
 	};
 }
 
@@ -262,7 +262,7 @@ export function errMixedExport(facadeModuleId: string, name?: string) {
 		)}" is using named and default exports together. Consumers of your bundle will have to use \`${
 			name || 'chunk'
 		}["default"]\` to access the default export, which may not be what you want. Use \`output.exports: "named"\` to disable this warning`,
-		url: `https://rollupjs.org/guide/en/#output-exports`
+		url: `https://rollupjs.org/guide/en/#outputexports`
 	};
 }
 
@@ -290,7 +290,7 @@ export function errPreferNamedExports(facadeModuleId: string) {
 		code: Errors.PREFER_NAMED_EXPORTS,
 		id: facadeModuleId,
 		message: `Entry module "${file}" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "${file}" to use named exports only.`,
-		url: `https://rollupjs.org/guide/en/#output-exports`
+		url: `https://rollupjs.org/guide/en/#outputexports`
 	};
 }
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -58,6 +58,7 @@ export enum Errors {
 	MIXED_EXPORTS = 'MIXED_EXPORTS',
 	NAMESPACE_CONFLICT = 'NAMESPACE_CONFLICT',
 	PLUGIN_ERROR = 'PLUGIN_ERROR',
+	PREFER_NAMED_EXPORTS = 'PREFER_NAMED_EXPORTS',
 	UNRESOLVED_ENTRY = 'UNRESOLVED_ENTRY',
 	UNRESOLVED_IMPORT = 'UNRESOLVED_IMPORT',
 	VALIDATION_ERROR = 'VALIDATION_ERROR',
@@ -280,6 +281,16 @@ export function errNamespaceConflict(
 		name,
 		reexporter: reexportingModule.id,
 		sources: [reexportingModule.exportsAll[name], additionalExportAllModule.exportsAll[name]]
+	};
+}
+
+export function errPreferNamedExports(facadeModuleId: string) {
+	const file = relativeId(facadeModuleId);
+	return {
+		code: Errors.PREFER_NAMED_EXPORTS,
+		id: facadeModuleId,
+		message: `Entry module "${file}" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "${file}" to use named exports only.`,
+		url: `https://rollupjs.org/guide/en/#output-exports`
 	};
 }
 

--- a/src/utils/getExportMode.ts
+++ b/src/utils/getExportMode.ts
@@ -1,10 +1,16 @@
 import Chunk from '../Chunk';
 import { NormalizedOutputOptions, WarningHandler } from '../rollup/types';
-import { errIncompatibleExportOptionValue, errMixedExport, error } from './error';
+import {
+	errIncompatibleExportOptionValue,
+	errMixedExport,
+	error,
+	errPreferNamedExports
+} from './error';
 
 export default function getExportMode(
 	chunk: Chunk,
 	{ exports: exportMode, name, format }: NormalizedOutputOptions,
+	unsetOptions: Set<string>,
 	facadeModuleId: string,
 	warn: WarningHandler
 ) {
@@ -22,6 +28,9 @@ export default function getExportMode(
 		if (exportKeys.length === 0) {
 			exportMode = 'none';
 		} else if (exportKeys.length === 1 && exportKeys[0] === 'default') {
+			if (format === 'cjs' && unsetOptions.has('exports')) {
+				warn(errPreferNamedExports(facadeModuleId));
+			}
 			exportMode = 'default';
 		} else {
 			if (format !== 'es' && exportKeys.indexOf('default') !== -1) {

--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -39,7 +39,7 @@ export function normalizeOutputOptions(
 		dynamicImportFunction: getDynamicImportFunction(config, inputOptions),
 		entryFileNames: getEntryFileNames(config, unsetOptions),
 		esModule: (config.esModule as boolean | undefined) ?? true,
-		exports: getExports(config),
+		exports: getExports(config, unsetOptions),
 		extend: (config.extend as boolean | undefined) || false,
 		externalLiveBindings: (config.externalLiveBindings as boolean | undefined) ?? true,
 		file,
@@ -223,9 +223,14 @@ const getEntryFileNames = (config: GenericConfigObject, unsetOptions: Set<string
 	return configEntryFileNames ?? '[name].js';
 };
 
-function getExports(config: GenericConfigObject): 'default' | 'named' | 'none' | 'auto' {
+function getExports(
+	config: GenericConfigObject,
+	unsetOptions: Set<string>
+): 'default' | 'named' | 'none' | 'auto' {
 	const configExports = config.exports as string | undefined;
-	if (configExports && !['default', 'named', 'none', 'auto'].includes(configExports)) {
+	if (configExports == null) {
+		unsetOptions.add('exports');
+	} else if (!['default', 'named', 'none', 'auto'].includes(configExports)) {
 		return error(errInvalidExportOptionValue(configExports));
 	}
 	return (configExports as 'default' | 'named' | 'none' | 'auto') || 'auto';

--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -120,7 +120,7 @@ const getFormat = (config: GenericConfigObject): InternalModuleFormat => {
 		default:
 			return error({
 				message: `You must specify "output.format", which can be one of "amd", "cjs", "system", "es", "iife" or "umd".`,
-				url: `https://rollupjs.org/guide/en/#output-format`
+				url: `https://rollupjs.org/guide/en/#outputformat`
 			});
 	}
 };

--- a/test/cli/samples/config-async-function/rollup.config.js
+++ b/test/cli/samples/config-async-function/rollup.config.js
@@ -2,5 +2,6 @@ export default async () => ({
 	input: 'main.js',
 	output: {
 		format: 'cjs',
+		exports: 'auto'
 	},
 });

--- a/test/cli/samples/config-mjs-plugins/rollup.config.mjs
+++ b/test/cli/samples/config-mjs-plugins/rollup.config.mjs
@@ -7,6 +7,6 @@ import plugin from './plugin.mjs';
 
 export default {
 	input: 'main.js',
-	output: { format: 'cjs' },
+	output: { format: 'cjs', exports: 'auto' },
 	plugins: [shebang(), replace({ ANSWER: 42 }), plugin(), nestedPlugin()]
 };

--- a/test/cli/samples/config-multiple-getfilename/rollup.config.js
+++ b/test/cli/samples/config-multiple-getfilename/rollup.config.js
@@ -25,6 +25,7 @@ export default {
 			format: 'cjs',
 			dir: '_actual',
 			entryFileNames: 'cjs-[name].js',
+			exports: 'auto'
 		},
 	],
 };

--- a/test/cli/samples/context/_expected.js
+++ b/test/cli/samples/context/_expected.js
@@ -1,6 +1,8 @@
 'use strict';
 
-console.log(window);
-var main = 42;
+Object.defineProperty(exports, '__esModule', { value: true });
 
-module.exports = main;
+console.log(window);
+const foo = 42;
+
+exports.foo = foo;

--- a/test/cli/samples/context/main.js
+++ b/test/cli/samples/context/main.js
@@ -1,2 +1,2 @@
 console.log(this);
-export default 42;
+export const foo = 42;

--- a/test/cli/samples/multiple-configs/rollup.config.js
+++ b/test/cli/samples/multiple-configs/rollup.config.js
@@ -2,7 +2,8 @@ export default [{
 	input: 'main.js',
 	output: {
 		file: '_actual/bundle1.js',
-		format: 'cjs'
+		format: 'cjs',
+		exports: 'auto'
 	}
 }, {
 	input: 'main.js',
@@ -13,6 +14,7 @@ export default [{
 	}],
 	output: {
 		file: '_actual/bundle2.js',
-		format: 'cjs'
+		format: 'cjs',
+		exports: 'auto'
 	}
 }];

--- a/test/cli/samples/multiple-targets-different-plugins/rollup.config.js
+++ b/test/cli/samples/multiple-targets-different-plugins/rollup.config.js
@@ -5,11 +5,13 @@ export default {
 	output: [
 		{
 			format: 'cjs',
-			file: '_actual/main.js'
+			file: '_actual/main.js',
+			exports: 'auto'
 		},
 		{
 			format: 'cjs',
 			file: '_actual/minified.js',
+			exports: 'auto',
 			plugins: [terser()]
 		}
 	]

--- a/test/cli/samples/multiple-targets-shared-config/rollup.config.js
+++ b/test/cli/samples/multiple-targets-shared-config/rollup.config.js
@@ -4,6 +4,7 @@ export default {
 		{
 			format: 'cjs',
 			file: '_actual/cjs.js',
+			exports: 'auto',
 			sourcemap: true
 		},
 		{

--- a/test/cli/samples/multiple-targets/rollup.config.js
+++ b/test/cli/samples/multiple-targets/rollup.config.js
@@ -3,7 +3,8 @@ export default {
 	output: [
 		{
 			format: 'cjs',
-			file: '_actual/cjs.js'
+			file: '_actual/cjs.js',
+			exports: 'auto'
 		},
 		{
 			format: 'es',

--- a/test/cli/samples/warn-import-export/_config.js
+++ b/test/cli/samples/warn-import-export/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Mixing named and default exports\n' +
-				'https://rollupjs.org/guide/en/#output-exports\n' +
+				'https://rollupjs.org/guide/en/#outputexports\n' +
 				'The following entry modules are using named and default exports together:\n' +
 				'main.js\n' +
 				'\n' +

--- a/test/cli/samples/warn-mixed-exports-multiple/_config.js
+++ b/test/cli/samples/warn-mixed-exports-multiple/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Mixing named and default exports\n' +
-				'https://rollupjs.org/guide/en/#output-exports\n' +
+				'https://rollupjs.org/guide/en/#outputexports\n' +
 				'The following entry modules are using named and default exports together:\n' +
 				'main.js\n' +
 				'lib1.js\n' +

--- a/test/form/index.js
+++ b/test/form/index.js
@@ -41,6 +41,7 @@ runTestSuiteWithSamples('form', path.resolve(__dirname, 'samples'), (dir, config
 					bundle,
 					Object.assign(
 						{
+							exports: 'auto',
 							file: inputFile,
 							format: defaultFormat
 						},
@@ -88,7 +89,7 @@ async function generateAndTestBundle(bundle, outputOptions, expectedFile, { show
 			? actualMap.sourcesContent.map(normaliseOutput)
 			: null;
 	} catch (err) {
-		assert.equal(err.code, 'ENOENT');
+		assert.strictEqual(err.code, 'ENOENT');
 	}
 
 	try {
@@ -104,6 +105,6 @@ async function generateAndTestBundle(bundle, outputOptions, expectedFile, { show
 		console.log(actualCode + '\n\n\n');
 	}
 
-	assert.equal(actualCode, expectedCode);
-	assert.deepEqual(actualMap, expectedMap);
+	assert.strictEqual(actualCode, expectedCode);
+	assert.deepStrictEqual(actualMap, expectedMap);
 }

--- a/test/function/index.js
+++ b/test/function/index.js
@@ -76,15 +76,14 @@ runTestSuiteWithSamples('function', path.resolve(__dirname, 'samples'), (dir, co
 
 					let result;
 
-					return Promise.resolve()
-						.then(() =>
-							bundle.generate(
-								Object.assign(
-									{
-										format: 'cjs'
-									},
-									(config.options || {}).output || {}
-								)
+					return bundle
+						.generate(
+							Object.assign(
+								{
+									exports: 'auto',
+									format: 'cjs'
+								},
+								(config.options || {}).output || {}
 							)
 						)
 						.then(({ output }) => {

--- a/test/function/samples/deprecated/preserveModules/mixed-exports/_config.js
+++ b/test/function/samples/deprecated/preserveModules/mixed-exports/_config.js
@@ -13,14 +13,14 @@ module.exports = {
 			id: path.resolve(__dirname, 'main.js'),
 			message:
 				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
-			url: 'https://rollupjs.org/guide/en/#output-exports'
+			url: 'https://rollupjs.org/guide/en/#outputexports'
 		},
 		{
 			code: 'MIXED_EXPORTS',
 			id: path.resolve(__dirname, 'lib1.js'),
 			message:
 				'Entry module "lib1.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
-			url: 'https://rollupjs.org/guide/en/#output-exports'
+			url: 'https://rollupjs.org/guide/en/#outputexports'
 		}
 	]
 };

--- a/test/function/samples/export-type-mismatch-b/_config.js
+++ b/test/function/samples/export-type-mismatch-b/_config.js
@@ -5,6 +5,6 @@ module.exports = {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
 			'"output.exports" must be "default", "named", "none", "auto", or left unspecified (defaults to "auto"), received "blah"',
-		url: 'https://rollupjs.org/guide/en/#output-exports'
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/output-options-hook/_config.js
+++ b/test/function/samples/output-options-hook/_config.js
@@ -54,6 +54,7 @@ module.exports = {
 			outputOptions(options) {
 				assert.deepStrictEqual(JSON.parse(JSON.stringify(options)), {
 					banner: "throw new Error('unused')",
+					exports: 'auto',
 					format: 'cjs'
 				});
 				assert.ok(/^\d+\.\d+\.\d+/.test(this.meta.rollupVersion));

--- a/test/function/samples/preserve-modules/mixed-exports/_config.js
+++ b/test/function/samples/preserve-modules/mixed-exports/_config.js
@@ -12,14 +12,14 @@ module.exports = {
 			id: path.resolve(__dirname, 'main.js'),
 			message:
 				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
-			url: 'https://rollupjs.org/guide/en/#output-exports'
+			url: 'https://rollupjs.org/guide/en/#outputexports'
 		},
 		{
 			code: 'MIXED_EXPORTS',
 			id: path.resolve(__dirname, 'lib1.js'),
 			message:
 				'Entry module "lib1.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
-			url: 'https://rollupjs.org/guide/en/#output-exports'
+			url: 'https://rollupjs.org/guide/en/#outputexports'
 		}
 	]
 };

--- a/test/function/samples/warn-implicit-cjs-auto/_config.js
+++ b/test/function/samples/warn-implicit-cjs-auto/_config.js
@@ -9,7 +9,7 @@ module.exports = {
 			id: path.join(__dirname, 'main.js'),
 			message:
 				'Entry module "main.js" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "main.js" to use named exports only.',
-			url: 'https://rollupjs.org/guide/en/#output-exports'
+			url: 'https://rollupjs.org/guide/en/#outputexports'
 		}
 	]
 };

--- a/test/function/samples/warn-implicit-cjs-auto/_config.js
+++ b/test/function/samples/warn-implicit-cjs-auto/_config.js
@@ -1,0 +1,15 @@
+const path = require('path');
+
+module.exports = {
+	description: 'warns when using implicit default export mode in CommonJS',
+	options: { output: { exports: undefined } },
+	warnings: [
+		{
+			code: 'PREFER_NAMED_EXPORTS',
+			id: path.join(__dirname, 'main.js'),
+			message:
+				'Entry module "main.js" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "main.js" to use named exports only.',
+			url: 'https://rollupjs.org/guide/en/#output-exports'
+		}
+	]
+};

--- a/test/function/samples/warn-implicit-cjs-auto/main.js
+++ b/test/function/samples/warn-implicit-cjs-auto/main.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/function/samples/warn-on-auto-named-default-exports/_config.js
+++ b/test/function/samples/warn-on-auto-named-default-exports/_config.js
@@ -8,7 +8,7 @@ module.exports = {
 			id: path.resolve(__dirname, 'main.js'),
 			message:
 				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
-			url: 'https://rollupjs.org/guide/en/#output-exports'
+			url: 'https://rollupjs.org/guide/en/#outputexports'
 		}
 	]
 };

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -284,7 +284,7 @@ describe('hooks', () => {
 			.then(bundle =>
 				Promise.all([
 					bundle.generate({ format: 'es', assetFileNames: 'asset' }),
-					bundle.generate({ format: 'cjs', assetFileNames: 'asset' })
+					bundle.generate({ format: 'cjs', assetFileNames: 'asset', exports: 'auto' })
 				])
 			)
 			.then(([{ output: output1 }, { output: output2 }]) => {

--- a/test/misc/acorn-plugins.js
+++ b/test/misc/acorn-plugins.js
@@ -3,46 +3,43 @@ const rollup = require('../../dist/rollup');
 const { executeBundle, loader } = require('../utils.js');
 
 describe('acorn plugins', () => {
-	it('injects plugins passed in acornInjectPlugins', () => {
+	it('injects plugins passed in acornInjectPlugins', async () => {
 		let pluginAInjected = false;
 		let pluginBInjected = false;
 
-		return rollup
-			.rollup({
-				input: 'x.js',
-				plugins: [loader({ 'x.js': `export default 42` })],
-				acornInjectPlugins: [
-					function pluginA(Parser) {
-						assert.equal(typeof Parser.parse, 'function');
-						return class extends Parser {
-							readToken(code) {
-								pluginAInjected = true;
-								super.readToken(code);
-							}
-						};
-					},
-					function pluginB(Parser) {
-						assert.equal(typeof Parser.parse, 'function');
-						return class extends Parser {
-							readToken(code) {
-								pluginBInjected = true;
-								super.readToken(code);
-							}
-						};
-					}
-				]
-			})
-			.then(executeBundle)
-			.then(result => {
-				assert.equal(result, 42);
-				assert(
-					pluginAInjected,
-					'A plugin passed via acornInjectPlugins should inject itself into Acorn.'
-				);
-				assert(
-					pluginBInjected,
-					'A plugin passed via acornInjectPlugins should inject itself into Acorn.'
-				);
-			});
+		const bundle = await rollup.rollup({
+			input: 'x.js',
+			plugins: [loader({ 'x.js': `export const foo = 42` })],
+			acornInjectPlugins: [
+				function pluginA(Parser) {
+					assert.equal(typeof Parser.parse, 'function');
+					return class extends Parser {
+						readToken(code) {
+							pluginAInjected = true;
+							super.readToken(code);
+						}
+					};
+				},
+				function pluginB(Parser) {
+					assert.equal(typeof Parser.parse, 'function');
+					return class extends Parser {
+						readToken(code) {
+							pluginBInjected = true;
+							super.readToken(code);
+						}
+					};
+				}
+			]
+		});
+		const result = await executeBundle(bundle);
+		assert.equal(result.foo, 42);
+		assert(
+			pluginAInjected,
+			'A plugin passed via acornInjectPlugins should inject itself into Acorn.'
+		);
+		assert(
+			pluginBInjected,
+			'A plugin passed via acornInjectPlugins should inject itself into Acorn.'
+		);
 	});
 });

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -22,6 +22,7 @@ runTestSuiteWithSamples('sourcemaps', path.resolve(__dirname, 'samples'), (dir, 
 					);
 					const outputOptions = Object.assign(
 						{
+							exports: 'auto',
 							file: dir + '/_actual/bundle.' + format + '.js',
 							format,
 							sourcemap: true

--- a/test/utils.js
+++ b/test/utils.js
@@ -67,6 +67,7 @@ function deindent(str) {
 function executeBundle(bundle, require) {
 	return bundle
 		.generate({
+			exports: 'auto',
 			format: 'cjs'
 		})
 		.then(({ output: [cjs] }) => {

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -97,7 +97,8 @@ describe('rollup.watch', () => {
 					},
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -147,7 +148,8 @@ describe('rollup.watch', () => {
 					},
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -184,7 +186,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					},
 					plugins: {
 						watchChange(id) {
@@ -243,7 +246,8 @@ describe('rollup.watch', () => {
 					input: ['test/_tmp/input/main1.js', 'test/_tmp/input/main2.js'],
 					output: {
 						dir: 'test/_tmp/output',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -281,7 +285,8 @@ describe('rollup.watch', () => {
 					},
 					output: {
 						dir: 'test/_tmp/output',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -316,7 +321,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -355,7 +361,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -395,7 +402,8 @@ describe('rollup.watch', () => {
 					},
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -427,7 +435,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -468,7 +477,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -514,7 +524,8 @@ describe('rollup.watch', () => {
 					},
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 				const events = [];
@@ -545,7 +556,8 @@ describe('rollup.watch', () => {
 					},
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 				const events = [];
@@ -571,7 +583,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -610,7 +623,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -650,7 +664,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					},
 					watch: {
 						include: ['test/_tmp/input/+(main|foo).js']
@@ -704,7 +719,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					},
 					watch: {
 						exclude: ['test/_tmp/input/bar.js']
@@ -760,14 +776,16 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main1.js',
 						output: {
 							file: 'test/_tmp/output/bundle1.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						}
 					},
 					{
 						input: 'test/_tmp/input/main2.js',
 						output: {
 							file: 'test/_tmp/output/bundle2.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						}
 					}
 				]);
@@ -808,14 +826,16 @@ describe('rollup.watch', () => {
 						watch: false,
 						output: {
 							file: 'test/_tmp/output/bundle1.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						}
 					},
 					{
 						input: 'test/_tmp/input/main2.js',
 						output: {
 							file: 'test/_tmp/output/bundle2.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						}
 					}
 				]);
@@ -881,7 +901,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				});
 
@@ -918,6 +939,7 @@ describe('rollup.watch', () => {
 					output: {
 						dir: 'test/_tmp/output',
 						format: 'cjs',
+						exports: 'auto',
 						entryFileNames: '[name].[hash].js',
 						chunkFileNames: '[name].[hash].js'
 					}
@@ -994,7 +1016,8 @@ describe('rollup.watch', () => {
 			},
 			output: {
 				file: 'test/_tmp/output/bundle.js',
-				format: 'cjs'
+				format: 'cjs',
+				exports: 'auto'
 			}
 		});
 		return sequence(watcher, [
@@ -1032,7 +1055,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					},
 					watch: {
 						skipWrite: true
@@ -1093,7 +1117,8 @@ describe('rollup.watch', () => {
 			input: 'test/_tmp/input/main.js',
 			output: {
 				file: 'test/_tmp/output/bundle.js',
-				format: 'cjs'
+				format: 'cjs',
+				exports: 'auto'
 			}
 		});
 
@@ -1132,7 +1157,8 @@ describe('rollup.watch', () => {
 					input: 'test/_tmp/input/main.js',
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				},
 				{
@@ -1140,7 +1166,8 @@ describe('rollup.watch', () => {
 					watch: { clearScreen: true },
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				},
 				{
@@ -1148,7 +1175,8 @@ describe('rollup.watch', () => {
 					watch: { buildDelay: 1000 },
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				},
 				{
@@ -1156,7 +1184,8 @@ describe('rollup.watch', () => {
 					watch: { buildDelay: 50 },
 					output: {
 						file: 'test/_tmp/output/bundle.js',
-						format: 'cjs'
+						format: 'cjs',
+						exports: 'auto'
 					}
 				}
 			],
@@ -1215,7 +1244,8 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main.js',
 						output: {
 							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						},
 						plugins: {
 							buildStart() {
@@ -1267,7 +1297,8 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main.js',
 						output: {
 							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						},
 						plugins: {
 							load() {
@@ -1310,7 +1341,8 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main.js',
 						output: {
 							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						},
 						plugins: {
 							resolveId(id) {
@@ -1374,7 +1406,8 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main.js',
 						output: {
 							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						},
 						plugins: {
 							transform(code, id) {
@@ -1422,7 +1455,8 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main.js',
 						output: {
 							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						},
 						plugins: {
 							transform() {
@@ -1465,7 +1499,8 @@ describe('rollup.watch', () => {
 						input: 'test/_tmp/input/main.js',
 						output: {
 							file: 'test/_tmp/output/bundle.js',
-							format: 'cjs'
+							format: 'cjs',
+							exports: 'auto'
 						},
 						plugins: {
 							buildStart() {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
rollup/plugins#481

### Description
This adds a warning when not explicitly specifying a value for `output.exports` when generating CommonJS output and only a default export is present:

> 'Entry module "main.js" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "main.js" to use named exports only.'

As the warning also contains a link to the URL of the output.exports documentation, this one has been extended as well to give a little more context.

This is to encourage moving away from default export mode in CommonJS as it is the source of many interop problems, see rollup/plugins#481