### PR TITLE
Allow treeshaking of arguments of functions that are returned by conditional expressions

### DIFF
--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -23,6 +23,7 @@ import * as NodeType from './NodeType';
 import { ExpressionEntity } from './shared/Expression';
 import { MultiExpression } from './shared/MultiExpression';
 import { ExpressionNode, IncludeChildren, NodeBase } from './shared/Node';
+import SpreadElement from './SpreadElement';
 
 export default class ConditionalExpression extends NodeBase implements DeoptimizableEntity {
 	alternate!: ExpressionNode;
@@ -151,6 +152,15 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 			this.alternate.include(context, includeChildrenRecursively);
 		} else {
 			this.usedBranch.include(context, includeChildrenRecursively);
+		}
+	}
+
+	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void {
+		if (this.usedBranch === null) {
+			this.consequent.includeCallArguments(context, args);
+			this.alternate.includeCallArguments(context, args);
+		} else {
+			this.usedBranch.includeCallArguments(context, args);
 		}
 	}
 

--- a/test/form/samples/tree-shake-arguments-conditional/_config.js
+++ b/test/form/samples/tree-shake-arguments-conditional/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'tracks tree-shaking of arguments through simplified conditionals'
+};

--- a/test/form/samples/tree-shake-arguments-conditional/_expected.js
+++ b/test/form/samples/tree-shake-arguments-conditional/_expected.js
@@ -1,0 +1,7 @@
+function ignoringArgs() {
+	return 'no args';
+}
+
+const handler =  ignoringArgs;
+
+console.log(handler());

--- a/test/form/samples/tree-shake-arguments-conditional/main.js
+++ b/test/form/samples/tree-shake-arguments-conditional/main.js
@@ -1,0 +1,11 @@
+function ignoringArgs() {
+	return 'no args';
+}
+
+function takingArgs(arg) {
+	return arg;
+}
+
+const handler = false ? takingArgs : ignoringArgs;
+
+console.log(handler('should be removed'));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3674 

### Description
This will track function identity through conditional expressions with regard to tree-shaking function arguments as in this example: https://rollupjs.org/repl/?circleci=12359&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmZ1bmN0aW9uJTIwaWdub3JpbmdBcmdzJTIwKCklMjAlN0IlMjAlNUNuJTIwJTIwcmV0dXJuJTIwJ25vJTIwYXJncyclM0IlNUNuJTdEJTVDbiU1Q25mdW5jdGlvbiUyMHRha2luZ0FyZ3MoYXJnKSUyMCU3QiU1Q24lMjAlMjByZXR1cm4lMjBhcmclM0IlNUNuJTdEJTVDbiU1Q25jb25zdCUyMGhhbmRsZXIlMjAlM0QlMjBmYWxzZSUyMCUzRiUyMHRha2luZ0FyZ3MlMjAlM0ElMjBpZ25vcmluZ0FyZ3MlM0IlNUNuJTVDbmNvbnNvbGUubG9nKGhhbmRsZXIoJ3Nob3VsZCUyMGJlJTIwcmVtb3ZlZCcpKSUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmVzJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlMkMlMjJnbG9iYWxzJTIyJTNBJTdCJTdEJTdEJTJDJTIyZXhhbXBsZSUyMiUzQW51bGwlN0Q=