### PR TITLE
Properly include reexports for implicit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,9 @@
       }
     },
     "codecov": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.1.tgz",
-      "integrity": "sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.2.tgz",
+      "integrity": "sha512-fmCjAkTese29DUX3GMIi4EaKGflHa4K51EoMc29g8fBHawdk/+KEq5CWOeXLdd9+AT7o1wO4DIpp/Z1KCqCz1g==",
       "dev": true,
       "requires": {
         "argv": "0.0.2",
@@ -4051,7 +4051,7 @@
       "requires": {
         "commenting": "1.1.0",
         "glob": "7.1.6",
-        "lodash": "4.17.19",
+        "lodash": "4.17.15",
         "magic-string": "0.25.7",
         "mkdirp": "1.0.4",
         "moment": "2.25.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "acorn-walk": "^7.2.0",
     "buble": "^0.20.0",
     "chokidar": "^3.4.1",
-    "codecov": "^3.7.1",
+    "codecov": "^3.7.2",
     "colorette": "^1.2.1",
     "core-js": "^3.6.5",
     "cross-os": "^1.3.0",

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -292,7 +292,12 @@ export default class Module {
 		const additionalSideEffectModules = new Set<Module>();
 		const possibleDependencies = new Set(this.dependencies);
 		let dependencyVariables = this.imports;
-		if (this.isEntryPoint || this.includedDynamicImporters.length > 0 || this.namespace.included) {
+		if (
+			this.isEntryPoint ||
+			this.includedDynamicImporters.length > 0 ||
+			this.namespace.included ||
+			this.implicitlyLoadedAfter.size > 0
+		) {
 			dependencyVariables = new Set(dependencyVariables);
 			for (const exportName of [...this.getReexports(), ...this.getExports()]) {
 				dependencyVariables.add(this.getVariableForExportName(exportName));

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_config.js
@@ -1,0 +1,20 @@
+module.exports = {
+	description: 'handles shared dependencies between implicit chunks without side-effects',
+	options: {
+		plugins: {
+			name: 'test-plugin',
+			buildStart() {
+				this.emitFile({
+					type: 'chunk',
+					id: 'core.js',
+					implicitlyLoadedAfterOneOf: ['main']
+				});
+				this.emitFile({
+					type: 'chunk',
+					id: 'button.js',
+					implicitlyLoadedAfterOneOf: ['main']
+				});
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/amd/generated-button.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/amd/generated-button.js
@@ -1,0 +1,7 @@
+define(['exports', './main'], function (exports, main) { 'use strict';
+
+	const bar = main.foo + 'bar';
+
+	exports.bar = bar;
+
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/amd/generated-core.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/amd/generated-core.js
@@ -1,0 +1,7 @@
+define(['exports', './main'], function (exports, main) { 'use strict';
+
+
+
+	exports.foo = main.foo;
+
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/amd/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/amd/main.js
@@ -1,0 +1,9 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = 'foo';
+
+	exports.foo = foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/cjs/generated-button.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/cjs/generated-button.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var main = require('./main.js');
+
+const bar = main.foo + 'bar';
+
+exports.bar = bar;

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/cjs/generated-core.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/cjs/generated-core.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var main = require('./main.js');
+
+
+
+exports.foo = main.foo;

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/cjs/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const foo = 'foo';
+
+exports.foo = foo;

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/es/generated-button.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/es/generated-button.js
@@ -1,0 +1,5 @@
+import { foo } from './main.js';
+
+const bar = foo + 'bar';
+
+export { bar };

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/es/generated-core.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/es/generated-core.js
@@ -1,0 +1,1 @@
+export { foo } from './main.js';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/es/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/es/main.js
@@ -1,0 +1,3 @@
+const foo = 'foo';
+
+export { foo };

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/system/generated-button.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/system/generated-button.js
@@ -1,0 +1,14 @@
+System.register(['./main.js'], function (exports) {
+	'use strict';
+	var foo;
+	return {
+		setters: [function (module) {
+			foo = module.foo;
+		}],
+		execute: function () {
+
+			const bar = exports('bar', foo + 'bar');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/system/generated-core.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/system/generated-core.js
@@ -1,0 +1,13 @@
+System.register(['./main.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('foo', module.foo);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/system/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/_expected/system/main.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = exports('foo', 'foo');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/button.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/button.js
@@ -1,0 +1,1 @@
+export { bar } from './shared/button';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/core.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/core.js
@@ -1,0 +1,1 @@
+export { foo } from './shared/core.js';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/main.js
@@ -1,0 +1,1 @@
+export { foo } from './shared/core.js';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/shared/button.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/shared/button.js
@@ -1,0 +1,2 @@
+import { foo } from './core.js';
+export const bar = foo + 'bar';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/shared/core.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-no-side-effect/shared/core.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	description: 'handles shared dependencies when there are only reexports',
+	options: {
+		plugins: {
+			name: 'test-plugin',
+			buildStart() {
+				this.emitFile({
+					type: 'chunk',
+					id: 'implicit.js',
+					implicitlyLoadedAfterOneOf: ['main']
+				});
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/amd/generated-implicit.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/amd/generated-implicit.js
@@ -1,0 +1,7 @@
+define(['exports', './main'], function (exports, main) { 'use strict';
+
+
+
+	exports.foo = main.foo;
+
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/amd/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/amd/main.js
@@ -1,0 +1,9 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = 'shared';
+
+	exports.foo = foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/cjs/generated-implicit.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/cjs/generated-implicit.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var main = require('./main.js');
+
+
+
+exports.foo = main.foo;

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/cjs/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const foo = 'shared';
+
+exports.foo = foo;

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/es/generated-implicit.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/es/generated-implicit.js
@@ -1,0 +1,1 @@
+export { foo } from './main.js';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/es/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/es/main.js
@@ -1,0 +1,3 @@
+const foo = 'shared';
+
+export { foo };

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/system/generated-implicit.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/system/generated-implicit.js
@@ -1,0 +1,13 @@
+System.register(['./main.js'], function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports('foo', module.foo);
+		}],
+		execute: function () {
+
+
+
+		}
+	};
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/system/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/_expected/system/main.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = exports('foo', 'shared');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/implicit.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/implicit.js
@@ -1,0 +1,1 @@
+export * from './shared.js';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/main.js
@@ -1,0 +1,1 @@
+export * from './shared.js';

--- a/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/shared.js
+++ b/test/chunking-form/samples/implicit-dependencies/shared-dependency-reexport/shared.js
@@ -1,0 +1,1 @@
+export const foo = 'shared';


### PR DESCRIPTION
…dencies

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3683 

### Description
When an implicitly dependent chunk contained reexports from other chunks that were not actually used in that chunk, then the reexporting modules were not properly linked as a dependency to the implicit entry chunk. This resulted in missing exports in some cases and weird errors in others.
This fixes this by using the same logic as for regular and dynamic entry points here (which was forgotten for implicit entry points).