### PR TITLE
Acknowledge that the `input` option is conditionally required

### DIFF
--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -30,7 +30,7 @@ Config files support the options listed below. Consult the [big list of options]
 export default { // can be an array (for multiple inputs)
   // core input options
   external,
-  input, // required
+  input, // conditionally required
   plugins,
 
   // advanced input options

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -81,7 +81,7 @@ The `inputOptions` object can contain the following properties (see the [big lis
 const inputOptions = {
   // core input options
   external,
-  input, // required
+  input, // condtionally required
   plugins,
 
   // advanced input options

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -91,6 +91,8 @@ export default {
 };
 ```
 
+The option can be omitted if some plugin emits at least one chunk (using [`this.emitFile`](guide/en/#thisemitfileemittedfile-emittedchunk--emittedasset--string)) by the end of the [`buildStart`](guide/en/#buildstart) hook.
+
 When using the command line interface, multiple inputs can be provided by using the option multiple times. When provided as the first options, it is equivalent to not prefix them with `--input`:
 
 ```sh


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: #3664

### Description

The `input` option is not required if some plugin emits a chunk by the end of the `buildStart` hook, but this is not well documented. This PR adds documentation for this.