### PR TITLE
Properly construct namespace when dynamically importing chunks with facades in default export mode

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1081,7 +1081,10 @@ export default class Chunk {
 					if (chunk === this) {
 						node.setInternalResolution(resolution.namespace);
 					} else {
-						node.setExternalResolution(chunk!.exportMode, resolution);
+						node.setExternalResolution(
+							this.facadeChunkByModule.get(resolution)?.exportMode || chunk!.exportMode,
+							resolution
+						);
 					}
 				} else {
 					node.setExternalResolution('auto', resolution);

--- a/test/function/samples/dynamic-import-default-mode-facade/_config.js
+++ b/test/function/samples/dynamic-import-default-mode-facade/_config.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'handles dynamic imports from facades using default export mode',
+	options: {
+		input: ['main', 'foo', 'bar']
+	},
+	exports(exports) {
+		return exports.then(exported => assert.deepStrictEqual(exported, { default: 4 }));
+	}
+};

--- a/test/function/samples/dynamic-import-default-mode-facade/bar.js
+++ b/test/function/samples/dynamic-import-default-mode-facade/bar.js
@@ -1,0 +1,3 @@
+import foo from './foo.js';
+import square from './square.js';
+export default square(3) + foo;

--- a/test/function/samples/dynamic-import-default-mode-facade/foo.js
+++ b/test/function/samples/dynamic-import-default-mode-facade/foo.js
@@ -1,0 +1,2 @@
+import square from './square.js';
+export default square(2);

--- a/test/function/samples/dynamic-import-default-mode-facade/main.js
+++ b/test/function/samples/dynamic-import-default-mode-facade/main.js
@@ -1,0 +1,1 @@
+export default import('./foo.js');

--- a/test/function/samples/dynamic-import-default-mode-facade/square.js
+++ b/test/function/samples/dynamic-import-default-mode-facade/square.js
@@ -1,0 +1,1 @@
+export default x => x * x;


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3708 

### Description
When a module was dynamically imported that formed the entry point of a chunk and that chunk had a facade chunk and this happened in AMD or CJS format where the chunk was in default export mode, THEN Rollup would not properly form a namespace to wrap the import as the `default` of an object. Kindof hard to explain, but here is the fix.