### PR TITLE
Add import specifiers to bundle information

### DIFF
--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -46,7 +46,7 @@ async function build() {
       //   fileName: string,              // the chunk file name
       //   implicitlyLoadedBefore: string[]; // entries that should only be loaded after this chunk
       //   imports: string[],             // external modules imported statically by the chunk
-      //   importSpecifiers: {[imported: string]: string[]} // list of imported bindings per dependency
+      //   importedBindings: {[imported: string]: string[]} // imported bindings per dependency
       //   isDynamicEntry: boolean,       // is this chunk a dynamic entry point
       //   isEntry: boolean,              // is this chunk a static entry point
       //   isImplicitEntry: boolean,      // should this chunk only be loaded after other chunks

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -46,6 +46,7 @@ async function build() {
       //   fileName: string,              // the chunk file name
       //   implicitlyLoadedBefore: string[]; // entries that should only be loaded after this chunk
       //   imports: string[],             // external modules imported statically by the chunk
+      //   importSpecifiers: {[imported: string]: string[]} // list of imported bindings per dependency
       //   isDynamicEntry: boolean,       // is this chunk a dynamic entry point
       //   isEntry: boolean,              // is this chunk a static entry point
       //   isImplicitEntry: boolean,      // should this chunk only be loaded after other chunks

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -248,7 +248,7 @@ Called at the end of `bundle.generate()` or immediately before the files are wri
   fileName: string,
   implicitlyLoadedBefore: string[],
   imports: string[],
-  importSpecifiers: {[imported: string]: string[]},
+  importedBindings: {[imported: string]: string[]},
   isDynamicEntry: boolean,
   isEntry: boolean,
   isImplicitEntry: boolean,

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -248,6 +248,7 @@ Called at the end of `bundle.generate()` or immediately before the files are wri
   fileName: string,
   implicitlyLoadedBefore: string[],
   imports: string[],
+  importSpecifiers: {[imported: string]: string[]},
   isDynamicEntry: boolean,
   isEntry: boolean,
   isImplicitEntry: boolean,

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -476,8 +476,8 @@ export default class Chunk {
 			dynamicImports: Array.from(this.dynamicDependencies, getId),
 			fileName: this.id!,
 			implicitlyLoadedBefore: Array.from(this.implicitlyLoadedBefore, getId),
+			importedBindings: this.getImportedBindingsPerDependency(),
 			imports: Array.from(this.dependencies, getId),
-			importSpecifiers: this.getDependencyImportSpecifiers(),
 			map: undefined,
 			referencedFiles: this.getReferencedFiles()
 		});
@@ -1020,7 +1020,17 @@ export default class Chunk {
 		return { deconflictedDefault, deconflictedNamespace, dependencies };
 	}
 
-	private getDependencyImportSpecifiers(): { [imported: string]: string[] } {
+	private getFallbackChunkName(): string {
+		if (this.manualChunkAlias) {
+			return this.manualChunkAlias;
+		}
+		if (this.fileName) {
+			return getAliasName(this.fileName);
+		}
+		return getAliasName(this.orderedModules[this.orderedModules.length - 1].id);
+	}
+
+	private getImportedBindingsPerDependency(): { [imported: string]: string[] } {
 		const importSpecifiers: { [imported: string]: string[] } = {};
 		for (const [dependency, declaration] of this.renderedDependencies!) {
 			const specifiers = new Set<string>();
@@ -1037,16 +1047,6 @@ export default class Chunk {
 			importSpecifiers[dependency.id!] = [...specifiers];
 		}
 		return importSpecifiers;
-	}
-
-	private getFallbackChunkName(): string {
-		if (this.manualChunkAlias) {
-			return this.manualChunkAlias;
-		}
-		if (this.fileName) {
-			return getAliasName(this.fileName);
-		}
-		return getAliasName(this.orderedModules[this.orderedModules.length - 1].id);
 	}
 
 	private getImportSpecifiers(): Map<Chunk | ExternalModule, ImportSpecifier[]> {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -477,6 +477,7 @@ export default class Chunk {
 			fileName: this.id!,
 			implicitlyLoadedBefore: Array.from(this.implicitlyLoadedBefore, getId),
 			imports: Array.from(this.dependencies, getId),
+			importSpecifiers: this.getDependencyImportSpecifiers(),
 			map: undefined,
 			referencedFiles: this.getReferencedFiles()
 		});
@@ -1017,6 +1018,25 @@ export default class Chunk {
 			}
 		}
 		return { deconflictedDefault, deconflictedNamespace, dependencies };
+	}
+
+	private getDependencyImportSpecifiers(): { [imported: string]: string[] } {
+		const importSpecifiers: { [imported: string]: string[] } = {};
+		for (const [dependency, declaration] of this.renderedDependencies!) {
+			const specifiers = new Set<string>();
+			if (declaration.imports) {
+				for (const { imported } of declaration.imports) {
+					specifiers.add(imported);
+				}
+			}
+			if (declaration.reexports) {
+				for (const { imported } of declaration.reexports) {
+					specifiers.add(imported);
+				}
+			}
+			importSpecifiers[dependency.id!] = [...specifiers];
+		}
+		return importSpecifiers;
 	}
 
 	private getFallbackChunkName(): string {

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -683,10 +683,10 @@ export interface RenderedChunk extends PreRenderedChunk {
 	dynamicImports: string[];
 	fileName: string;
 	implicitlyLoadedBefore: string[];
-	imports: string[];
-	importSpecifiers: {
+	importedBindings: {
 		[imported: string]: string[];
 	};
+	imports: string[];
 	map?: SourceMap;
 	referencedFiles: string[];
 }

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -684,6 +684,9 @@ export interface RenderedChunk extends PreRenderedChunk {
 	fileName: string;
 	implicitlyLoadedBefore: string[];
 	imports: string[];
+	importSpecifiers: {
+		[imported: string]: string[];
+	};
 	map?: SourceMap;
 	referencedFiles: string[];
 }

--- a/test/incremental/index.js
+++ b/test/incremental/index.js
@@ -204,8 +204,14 @@ describe('incremental', () => {
 					asts[module.id] = module.ast;
 				});
 
-				assert.deepEqual(asts.entry, acorn.parse(modules.entry, { sourceType: 'module' }));
-				assert.deepEqual(asts.foo, acorn.parse(modules.foo, { sourceType: 'module' }));
+				assert.deepEqual(
+					asts.entry,
+					acorn.parse(modules.entry, { sourceType: 'module', ecmaVersion: 2020 })
+				);
+				assert.deepEqual(
+					asts.foo,
+					acorn.parse(modules.foo, { sourceType: 'module', ecmaVersion: 2020 })
+				);
 			});
 	});
 

--- a/test/misc/bundle-information.js
+++ b/test/misc/bundle-information.js
@@ -66,13 +66,13 @@ describe('The bundle object', () => {
 					'imports'
 				);
 				assert.deepEqual(
-					output.map(chunk => chunk.importSpecifiers),
+					output.map(chunk => chunk.importedBindings),
 					[
 						{ 'generated-shared-c4fdd061.js': ['u', 's'] },
 						{ 'generated-shared-c4fdd061.js': [] },
 						{}
 					],
-					'importSpecifiers'
+					'importedBindings'
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.dynamicImports),
@@ -175,9 +175,9 @@ describe('The bundle object', () => {
 					'imports'
 				);
 				assert.deepEqual(
-					output.map(chunk => chunk.importSpecifiers),
+					output.map(chunk => chunk.importedBindings),
 					[{ external1: ['bar', 'default'], external2: ['*'], external3: ['*'] }],
-					'importSpecifiers'
+					'importedBindings'
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.dynamicImports),
@@ -424,9 +424,9 @@ describe('The bundle object', () => {
 					'imports'
 				);
 				assert.deepEqual(
-					output.map(chunk => chunk.importSpecifiers),
+					output.map(chunk => chunk.importedBindings),
 					[{}],
-					'importSpecifiers'
+					'importedBindings'
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.dynamicImports),
@@ -506,9 +506,9 @@ console.log(other);Promise.all([import('./dynamic1'), import('./dynamic2')]).the
 					'imports'
 				);
 				assert.deepEqual(
-					output.map(chunk => chunk.importSpecifiers),
+					output.map(chunk => chunk.importedBindings),
 					[{ '_virtual/other': ['other'] }, {}, {}, {}],
-					'importSpecifiers'
+					'importedBindings'
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.exports),

--- a/test/misc/bundle-information.js
+++ b/test/misc/bundle-information.js
@@ -9,9 +9,11 @@ describe('The bundle object', () => {
 				input: ['input1', 'input2'],
 				plugins: [
 					loader({
-						input1: 'import "shared";console.log("input1");export const out = true;',
+						input1:
+							'import shared, {used} from "shared";console.log("input1", used, shared);export const out = true;',
 						input2: 'import "shared";console.log("input2");export default 42',
-						shared: 'console.log("shared");export const unused = null;'
+						shared:
+							'console.log("shared");export const unused = null;export const used = "used"; export default "stuff";'
 					})
 				]
 			})
@@ -26,15 +28,15 @@ describe('The bundle object', () => {
 			.then(({ output }) => {
 				assert.deepEqual(
 					output.map(chunk => chunk.fileName),
-					['input1-3810e839.js', 'input2-14354d1f.js', 'generated-shared-f6027271.js'],
+					['input1-ff0de9c1.js', 'input2-28dc81ee.js', 'generated-shared-c4fdd061.js'],
 					'fileName'
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.code),
 					[
-						`import './generated-shared-f6027271.js';\n\nconsole.log("input1");const out = true;\n\nexport { out };\n`,
-						`import './generated-shared-f6027271.js';\n\nconsole.log("input2");var input2 = 42;\n\nexport default input2;\n`,
-						'console.log("shared");\n'
+						`import { u as used, s as shared } from './generated-shared-c4fdd061.js';\n\nconsole.log("input1", used, shared);const out = true;\n\nexport { out };\n`,
+						`import './generated-shared-c4fdd061.js';\n\nconsole.log("input2");var input2 = 42;\n\nexport default input2;\n`,
+						`console.log("shared");const used = "used"; var shared = "stuff";\n\nexport { shared as s, used as u };\n`
 					],
 					'code'
 				);
@@ -60,8 +62,17 @@ describe('The bundle object', () => {
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.imports),
-					[['generated-shared-f6027271.js'], ['generated-shared-f6027271.js'], []],
+					[['generated-shared-c4fdd061.js'], ['generated-shared-c4fdd061.js'], []],
 					'imports'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.importSpecifiers),
+					[
+						{ 'generated-shared-c4fdd061.js': ['u', 's'] },
+						{ 'generated-shared-c4fdd061.js': [] },
+						{}
+					],
+					'importSpecifiers'
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.dynamicImports),
@@ -70,7 +81,7 @@ describe('The bundle object', () => {
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.exports),
-					[['out'], ['default'], []],
+					[['out'], ['default'], ['s', 'u']],
 					'exports'
 				);
 				assert.deepEqual(
@@ -78,10 +89,10 @@ describe('The bundle object', () => {
 					[
 						{
 							input1: {
-								originalLength: 62,
+								originalLength: 96,
 								removedExports: [],
 								renderedExports: ['out'],
-								renderedLength: 39
+								renderedLength: 53
 							}
 						},
 						{
@@ -94,10 +105,99 @@ describe('The bundle object', () => {
 						},
 						{
 							shared: {
-								originalLength: 49,
+								originalLength: 100,
 								removedExports: ['unused'],
+								renderedExports: ['used', 'default'],
+								renderedLength: 64
+							}
+						}
+					],
+					'modules'
+				);
+			});
+	});
+
+	it('contains information about external imports and reexports', () => {
+		return rollup
+			.rollup({
+				input: ['input'],
+				external: ['external1', 'external2', 'external3'],
+				plugins: [
+					loader({
+						input:
+							'export {default as foo, bar} from "external1"; import * as external2 from "external2"; export * from "external3"; console.log(external2);'
+					})
+				]
+			})
+			.then(bundle =>
+				bundle.generate({
+					format: 'es',
+					dir: 'dist',
+					entryFileNames: '[name].js'
+				})
+			)
+			.then(({ output }) => {
+				assert.deepEqual(
+					output.map(chunk => chunk.fileName),
+					['input.js'],
+					'fileName'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.code),
+					[
+						`export { bar, default as foo } from 'external1';\nimport * as external2 from 'external2';\nexport * from 'external3';\n\nconsole.log(external2);\n`
+					],
+					'code'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.map),
+					[null],
+					'map'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.isEntry),
+					[true],
+					'isEntry'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.name),
+					['input'],
+					'name'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.facadeModuleId),
+					['input'],
+					'facadeModuleId'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.imports),
+					[['external1', 'external2', 'external3']],
+					'imports'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.importSpecifiers),
+					[{ external1: ['bar', 'default'], external2: ['*'], external3: ['*'] }],
+					'importSpecifiers'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.dynamicImports),
+					[[]],
+					'dynamicImports'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.exports),
+					[['*external3', 'bar', 'foo']],
+					'exports'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.modules),
+					[
+						{
+							input: {
+								originalLength: 137,
+								removedExports: [],
 								renderedExports: [],
-								renderedLength: 22
+								renderedLength: 23
 							}
 						}
 					],
@@ -324,6 +424,11 @@ describe('The bundle object', () => {
 					'imports'
 				);
 				assert.deepEqual(
+					output.map(chunk => chunk.importSpecifiers),
+					[{}],
+					'importSpecifiers'
+				);
+				assert.deepEqual(
 					output.map(chunk => chunk.dynamicImports),
 					[[]],
 					'dynamicImports'
@@ -399,6 +504,11 @@ console.log(other);Promise.all([import('./dynamic1'), import('./dynamic2')]).the
 					output.map(chunk => chunk.imports),
 					[['_virtual/other'], [], [], []],
 					'imports'
+				);
+				assert.deepEqual(
+					output.map(chunk => chunk.importSpecifiers),
+					[{ '_virtual/other': ['other'] }, {}, {}, {}],
+					'importSpecifiers'
 				);
 				assert.deepEqual(
 					output.map(chunk => chunk.exports),


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3374

### Description
This will add a list of imported symbols per chunk to the bundle information