### PR TITLE
Do not entirely move else branch if another else branch might accidentally be referenced.

### DIFF
--- a/test/function/samples/simplified-nested-if/_config.js
+++ b/test/function/samples/simplified-nested-if/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description:
+		'do not catch else branches from parent if statements when simplifiying if-statements',
+	context: {
+		unknown: true
+	}
+};

--- a/test/function/samples/simplified-nested-if/main.js
+++ b/test/function/samples/simplified-nested-if/main.js
@@ -1,22 +1,24 @@
+export let foo = 0;
+
 if (unknown)
-	for (var x = 1; x--; x > 0)
-		if (!unknown) console.log('effect');
+	for (var x = 1; x-- > 0; )
+		if (!unknown) foo++;
 		else 'Side effect free code to be dropped';
 else throw new Error("Shouldn't be reached");
 
 if (unknown)
-	for (var x = 1; x--; x > 0)
-		if ((console.log(), false)) console.log('effect');
+	for (var x = 1; x-- > 0; )
+		if (foo++, false) foo++;
 		else 'Side effect free code to be dropped';
 else throw new Error("Shouldn't be reached");
 
 if (unknown) {
-	for (var x = 1; x--; x > 0)
-		if (!unknown) console.log('effect');
+	for (var x = 1; x-- > 0; )
+		if (!unknown) foo++;
 		else 'Side effect free code to be dropped';
 } else throw new Error("Shouldn't be reached");
 
 if (unknown)
-	for (var x = 1; x--; x > 0)
-		if (!unknown) console.log('effect');
+	for (var x = 1; x-- > 0; )
+		if (!unknown) foo++;
 		else 'Side effect free code to be dropped';

--- a/test/function/samples/simplified-nested-if/main.js
+++ b/test/function/samples/simplified-nested-if/main.js
@@ -1,0 +1,22 @@
+if (unknown)
+	for (var x = 1; x--; x > 0)
+		if (!unknown) console.log('effect');
+		else 'Side effect free code to be dropped';
+else throw new Error("Shouldn't be reached");
+
+if (unknown)
+	for (var x = 1; x--; x > 0)
+		if ((console.log(), false)) console.log('effect');
+		else 'Side effect free code to be dropped';
+else throw new Error("Shouldn't be reached");
+
+if (unknown) {
+	for (var x = 1; x--; x > 0)
+		if (!unknown) console.log('effect');
+		else 'Side effect free code to be dropped';
+} else throw new Error("Shouldn't be reached");
+
+if (unknown)
+	for (var x = 1; x--; x > 0)
+		if (!unknown) console.log('effect');
+		else 'Side effect free code to be dropped';


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3716

### Description
In case an if statement is nested within another if statement with no block statement in between and the outer if statement has an `else` branch, then any else branch of the inner if statement will not be entirely removed to avoid accidentally catching the `else` branch of the outer if statement.