### PR TITLE
Prevent unintended ASI for nested conditionals

### DIFF
--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -187,6 +187,7 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 				isCalleeOfRenderedParent: renderedParentType
 					? isCalleeOfRenderedParent
 					: (this.parent as CallExpression).callee === this,
+				preventASI: true,
 				renderedParentType: renderedParentType || this.parent.type
 			});
 		} else {

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -180,6 +180,7 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 				isCalleeOfRenderedParent: renderedParentType
 					? isCalleeOfRenderedParent
 					: (this.parent as CallExpression).callee === this,
+				preventASI,
 				renderedParentType: renderedParentType || this.parent.type
 			});
 		} else {

--- a/src/ast/nodes/YieldExpression.ts
+++ b/src/ast/nodes/YieldExpression.ts
@@ -26,7 +26,7 @@ export default class YieldExpression extends NodeBase {
 
 	render(code: MagicString, options: RenderOptions) {
 		if (this.argument) {
-			this.argument.render(code, options);
+			this.argument.render(code, options, { preventASI: true });
 			if (this.argument.start === this.start + 5 /* 'yield'.length */) {
 				code.prependLeft(this.start + 5, ' ');
 			}

--- a/test/function/samples/prevent-tree-shaking-asi/main.js
+++ b/test/function/samples/prevent-tree-shaking-asi/main.js
@@ -2,7 +2,9 @@ function test1() {
 	return true ?
 		/* kept */
 
-		'expected' :
+		true ?
+			'expected' :
+			'unexpected' :
 		'unexpected';
 }
 assert.strictEqual(test1(), 'expected');
@@ -12,7 +14,9 @@ function test2() {
 		'unexpected' :
 		/* kept */
 
-		'expected';
+		false ?
+			'unexpected' :
+			'expected';
 }
 assert.strictEqual(test2(), 'expected');
 
@@ -20,7 +24,7 @@ function test3() {
 	return true &&
 		/* kept */
 
-		'expected';
+		'expected'  || false;
 }
 assert.strictEqual(test3(), 'expected');
 
@@ -40,3 +44,9 @@ try {
 } catch (err) {
 	assert.strictEqual(err.message, 'expected');
 }
+
+function* test5() {
+	yield false ||
+	'expected'
+}
+assert.strictEqual(test5().next().value, 'expected');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3729 

### Description
Apparently, the flag to prevent ASI-related issues was not correctly passed to nested expressions. This is fixed now, and also fixes this issue for yield expressions.