### PR TITLE
Prevent ASI when simplifying a nested logical expression

### DIFF
--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -184,7 +184,8 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 				renderedParentType: renderedParentType || this.parent.type
 			});
 		} else {
-			super.render(code, options);
+			this.left.render(code, options, { preventASI });
+			this.right.render(code, options);
 		}
 	}
 

--- a/test/function/samples/prevent-tree-shaking-asi/main.js
+++ b/test/function/samples/prevent-tree-shaking-asi/main.js
@@ -28,13 +28,19 @@ function test3() {
 }
 assert.strictEqual(test3(), 'expected');
 
-function test4() {
+function test4(value) {
+	return true &&
+		value  || false;
+}
+assert.strictEqual(test4('expected'), 'expected');
+
+function test5() {
 	return 'removed',
 		/* kept */
 
 		'expected';
 }
-assert.strictEqual(test4(), 'expected');
+assert.strictEqual(test5(), 'expected');
 
 try {
   throw true ?
@@ -45,8 +51,8 @@ try {
 	assert.strictEqual(err.message, 'expected');
 }
 
-function* test5() {
+function* test6() {
 	yield false ||
 	'expected'
 }
-assert.strictEqual(test5().next().value, 'expected');
+assert.strictEqual(test6().next().value, 'expected');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3729

### Description
There was one situation left in #3279 where a logical expression was simplified that was nested in one that was not simplified. In that situation, still an unintended ASI could happen which is hereby resolved.