### PR TITLE
Improve synthetic entry handling

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -22,6 +22,7 @@ import { timeEnd, timeStart } from './utils/timers';
 
 export default class Bundle {
 	private facadeChunkByModule = new Map<Module, Chunk>();
+	private includedNamespaces = new Set<Module>();
 
 	constructor(
 		private readonly outputOptions: NormalizedOutputOptions,
@@ -202,6 +203,7 @@ export default class Bundle {
 				this.graph.modulesById,
 				chunkByModule,
 				this.facadeChunkByModule,
+				this.includedNamespaces,
 				alias
 			);
 			chunks.push(chunk);

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -176,6 +176,7 @@ export default class Chunk {
 	exportMode: 'none' | 'named' | 'default' = 'named';
 	facadeModule: Module | null = null;
 	id: string | null = null;
+	namespaceVariableName = '';
 	suggestedVariableName: string;
 	variableName = '';
 
@@ -987,7 +988,7 @@ export default class Chunk {
 	): DependenciesToBeDeconflicted {
 		const dependencies = new Set<Chunk | ExternalModule>();
 		const deconflictedDefault = new Set<ExternalModule>();
-		const deconflictedNamespace = new Set<ExternalModule>();
+		const deconflictedNamespace = new Set<Chunk | ExternalModule>();
 		for (const variable of [...this.exportNamesByVariable.keys(), ...this.imports]) {
 			if (addNonNamespacesAndInteropHelpers || variable.isNamespace) {
 				const module = variable.module!;
@@ -1008,6 +1009,13 @@ export default class Chunk {
 					const chunk = this.chunkByModule.get(module)!;
 					if (chunk !== this) {
 						dependencies.add(chunk);
+						if (
+							addNonNamespacesAndInteropHelpers &&
+							chunk.exportMode === 'default' &&
+							variable.isNamespace
+						) {
+							deconflictedNamespace.add(chunk);
+						}
 					}
 				}
 			}

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -135,6 +135,7 @@ export default class Chunk {
 		modulesById: Map<string, Module | ExternalModule>,
 		chunkByModule: Map<Module, Chunk>,
 		facadeChunkByModule: Map<Module, Chunk>,
+		includedNamespaces: Set<Module>,
 		facadedModule: Module,
 		facadeName: FacadeName
 	): Chunk {
@@ -147,6 +148,7 @@ export default class Chunk {
 			modulesById,
 			chunkByModule,
 			facadeChunkByModule,
+			includedNamespaces,
 			null
 		);
 		chunk.assignFacadeName(facadeName, facadedModule);
@@ -219,12 +221,16 @@ export default class Chunk {
 		private readonly modulesById: Map<string, Module | ExternalModule>,
 		private readonly chunkByModule: Map<Module, Chunk>,
 		private readonly facadeChunkByModule: Map<Module, Chunk>,
+		private readonly includedNamespaces: Set<Module>,
 		private readonly manualChunkAlias: string | null
 	) {
 		this.execIndex = orderedModules.length > 0 ? orderedModules[0].execIndex : Infinity;
 		const chunkModules = new Set(orderedModules);
 
 		for (const module of orderedModules) {
+			if (module.namespace.included) {
+				includedNamespaces.add(module);
+			}
 			if (this.isEmpty && module.isIncluded()) {
 				this.isEmpty = false;
 			}
@@ -235,8 +241,8 @@ export default class Chunk {
 				if (!chunkModules.has(importer)) {
 					this.dynamicEntryModules.push(module);
 					// Modules with synthetic exports need an artificial namespace for dynamic imports
-					if (module.syntheticNamedExports) {
-						module.namespace.include();
+					if (module.syntheticNamedExports && !outputOptions.preserveModules) {
+						includedNamespaces.add(module);
 						this.exports.add(module.namespace);
 					}
 				}
@@ -360,6 +366,7 @@ export default class Chunk {
 						this.modulesById,
 						this.chunkByModule,
 						this.facadeChunkByModule,
+						this.includedNamespaces,
 						module,
 						facadeName
 					)
@@ -380,7 +387,7 @@ export default class Chunk {
 			) {
 				this.strictFacade = true;
 			} else if (!this.facadeChunkByModule.get(module)?.strictFacade) {
-				module.namespace.include();
+				this.includedNamespaces.add(module);
 				this.exports.add(module.namespace);
 			}
 		}
@@ -582,7 +589,7 @@ export default class Chunk {
 
 		for (const module of this.orderedModules) {
 			let renderedLength = 0;
-			if (module.isIncluded()) {
+			if (module.isIncluded() || this.includedNamespaces.has(module)) {
 				const source = module.render(renderOptions).trim();
 				renderedLength = source.length();
 				if (renderedLength) {
@@ -592,7 +599,7 @@ export default class Chunk {
 					this.usedModules.push(module);
 				}
 				const namespace = module.namespace;
-				if (namespace.included && !this.outputOptions.preserveModules) {
+				if (this.includedNamespaces.has(module) && !this.outputOptions.preserveModules) {
 					const rendered = namespace.renderBlock(renderOptions);
 					if (namespace.renderFirst()) hoistedSource += n + rendered;
 					else magicString.addSource(new MagicString(rendered));
@@ -1260,7 +1267,8 @@ export default class Chunk {
 			this.chunkByModule,
 			syntheticExports,
 			this.exportNamesByVariable,
-			this.accessedGlobalsByScope
+			this.accessedGlobalsByScope,
+			this.includedNamespaces
 		);
 	}
 
@@ -1269,9 +1277,8 @@ export default class Chunk {
 		// when we are not preserving modules, we need to make all namespace variables available for
 		// rendering the namespace object
 		if (!this.outputOptions.preserveModules) {
-			const namespace = module.namespace;
-			if (namespace.included) {
-				const memberVariables = namespace.getMemberVariables();
+			if (this.includedNamespaces.has(module)) {
+				const memberVariables = module.namespace.getMemberVariables();
 				for (const name of Object.keys(memberVariables)) {
 					moduleImports.add(memberVariables[name]);
 				}
@@ -1296,7 +1303,7 @@ export default class Chunk {
 			}
 		}
 		if (
-			module.namespace.included ||
+			this.includedNamespaces.has(module) ||
 			(module.isEntryPoint && module.preserveSignature !== false) ||
 			module.includedDynamicImporters.some(importer => this.chunkByModule.get(importer) !== this)
 		) {
@@ -1307,9 +1314,9 @@ export default class Chunk {
 				node.included &&
 				resolution instanceof Module &&
 				this.chunkByModule.get(resolution) === this &&
-				!resolution.namespace.included
+				!this.includedNamespaces.has(resolution)
 			) {
-				resolution.namespace.include();
+				this.includedNamespaces.add(resolution);
 				this.ensureReexportsAreAvailableForModule(resolution);
 			}
 		}

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -185,7 +185,7 @@ export default class Graph {
 	private includeStatements() {
 		for (const module of [...this.entryModules, ...this.implicitEntryModules]) {
 			if (module.preserveSignature !== false) {
-				module.includeAllExports();
+				module.includeAllExports(false);
 			} else {
 				markModuleAndImpureDependenciesAsExecuted(module);
 			}

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -536,11 +536,13 @@ export default class Module {
 		}
 
 		for (const exportName of this.getExports()) {
-			const variable = this.getVariableForExportName(exportName);
-			variable.deoptimizePath(UNKNOWN_PATH);
-			if (!variable.included) {
-				variable.include();
-				this.graph.needsTreeshakingPass = true;
+			if (exportName !== this.syntheticNamedExports) {
+				const variable = this.getVariableForExportName(exportName);
+				variable.deoptimizePath(UNKNOWN_PATH);
+				if (!variable.included) {
+					variable.include();
+					this.graph.needsTreeshakingPass = true;
+				}
 			}
 		}
 

--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -50,26 +50,21 @@ export default class NamespaceVariable extends Variable {
 				memberVariables[name] = this.context.traceExport(name);
 			}
 		}
-		this.memberVariables = memberVariables;
 		return (this.memberVariables = memberVariables);
 	}
 
 	include() {
-		if (!this.included) {
-			this.included = true;
-			for (const identifier of this.references) {
-				if (identifier.context.getModuleExecIndex() <= this.context.getModuleExecIndex()) {
-					this.referencedEarly = true;
-					break;
-				}
-			}
-			this.mergedNamespaces = this.context.includeAndGetAdditionalMergedNamespaces();
-			const memberVariables = this.getMemberVariables();
-			// We directly include the variables instead of context.include to not automatically
-			// generate imports for members from other modules
-			for (const memberName of Object.keys(memberVariables)) memberVariables[memberName].include();
-			if (typeof this.syntheticNamedExports === 'string') {
-				this.context.traceExport(this.syntheticNamedExports).include();
+		this.included = true;
+		this.context.includeAllExports();
+	}
+
+	prepareNamespace(mergedNamespaces: Variable[]) {
+		this.mergedNamespaces = mergedNamespaces;
+		const moduleExecIndex = this.context.getModuleExecIndex();
+		for (const identifier of this.references) {
+			if (identifier.context.getModuleExecIndex() <= moduleExecIndex) {
+				this.referencedEarly = true;
+				break;
 			}
 		}
 	}

--- a/src/finalisers/shared/getExportBlock.ts
+++ b/src/finalisers/shared/getExportBlock.ts
@@ -164,7 +164,11 @@ function getReexportedImportName(
 		return depNamedExportsMode ? `${moduleVariableName}['default']` : moduleVariableName;
 	}
 	if (imported === '*') {
-		return !isChunk && namespaceInteropHelpersByInteropType[String(interop(moduleId))]
+		return (
+			isChunk
+				? !depNamedExportsMode
+				: namespaceInteropHelpersByInteropType[String(interop(moduleId))]
+		)
 			? namespaceVariableName
 			: moduleVariableName;
 	}

--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -61,8 +61,8 @@ export default function getInteropBlock(
 				...(imports || []),
 				...(reexports || [])
 			] as ReexportSpecifier[]) {
-				let helper: string | null = null;
-				let variableName: string;
+				let helper: string | undefined | null;
+				let variableName: string | undefined;
 				if (imported === 'default') {
 					if (!hasDefault) {
 						hasDefault = true;
@@ -79,7 +79,7 @@ export default function getInteropBlock(
 					}
 				}
 				if (helper) {
-					addInteropStatement(variableName, helper, name);
+					addInteropStatement(variableName!, helper, name);
 				}
 			}
 		}

--- a/src/finalisers/shared/getInteropBlock.ts
+++ b/src/finalisers/shared/getInteropBlock.ts
@@ -42,14 +42,15 @@ export default function getInteropBlock(
 		reexports
 	} of dependencies) {
 		if (isChunk) {
-			if (reexports) {
-				for (const { imported, reexported } of reexports) {
-					if (imported === '*' && reexported !== '*') {
-						if (!namedExportsMode) {
-							addInteropStatement(namespaceVariableName!, getDefaultOnlyHelper(), name);
-						}
-						break;
+			for (const { imported, reexported } of [
+				...(imports || []),
+				...(reexports || [])
+			] as ReexportSpecifier[]) {
+				if (imported === '*' && reexported !== '*') {
+					if (!namedExportsMode) {
+						addInteropStatement(namespaceVariableName!, getDefaultOnlyHelper(), name);
 					}
+					break;
 				}
 			}
 		} else {

--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -16,7 +16,7 @@ import { getSafeName } from './safeName';
 
 export interface DependenciesToBeDeconflicted {
 	deconflictedDefault: Set<ExternalModule>;
-	deconflictedNamespace: Set<ExternalModule>;
+	deconflictedNamespace: Set<ExternalModule | Chunk>;
 	dependencies: Set<ExternalModule | Chunk>;
 }
 
@@ -135,9 +135,9 @@ function deconflictImportsOther(
 			usedNames
 		);
 	}
-	for (const externalModule of deconflictedNamespace) {
-		externalModule.namespaceVariableName = getSafeName(
-			`${externalModule.suggestedVariableName}__namespace`,
+	for (const externalModuleOrChunk of deconflictedNamespace) {
+		externalModuleOrChunk.namespaceVariableName = getSafeName(
+			`${externalModuleOrChunk.suggestedVariableName}__namespace`,
 			usedNames
 		);
 	}
@@ -181,7 +181,12 @@ function deconflictImportsOther(
 			}
 		} else {
 			const chunk = chunkByModule.get(module!)!;
-			if (chunk.exportMode === 'default' || (preserveModules && variable.isNamespace)) {
+			if (preserveModules && variable.isNamespace) {
+				variable.setRenderNames(
+					null,
+					chunk.exportMode === 'default' ? chunk.namespaceVariableName : chunk.variableName
+				);
+			} else if (chunk.exportMode === 'default') {
 				variable.setRenderNames(null, chunk.variableName);
 			} else {
 				variable.setRenderNames(

--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -86,7 +86,7 @@ function deconflictImportsEsmOrSystem(
 	_interop: GetInterop,
 	_preserveModules: boolean,
 	_externalLiveBindings: boolean,
-	_chunkByModule: Map<Module, Chunk>,
+	chunkByModule: Map<Module, Chunk>,
 	syntheticExports: Set<SyntheticNamedExportVariable>
 ) {
 	// All namespace imports are contained here;
@@ -95,10 +95,13 @@ function deconflictImportsEsmOrSystem(
 		dependency.variableName = getSafeName(dependency.suggestedVariableName, usedNames);
 	}
 	for (const variable of imports) {
-		const module = variable.module;
+		const module = variable.module!;
 		const name = variable.name;
-		if (module instanceof ExternalModule && name === '*') {
-			variable.setRenderNames(null, module.variableName);
+		if (variable.isNamespace) {
+			variable.setRenderNames(
+				null,
+				(module instanceof ExternalModule ? module : chunkByModule.get(module)!).variableName
+			);
 		} else if (module instanceof ExternalModule && name === 'default') {
 			variable.setRenderNames(
 				null,

--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -52,7 +52,8 @@ export function deconflictChunk(
 	chunkByModule: Map<Module, Chunk>,
 	syntheticExports: Set<SyntheticNamedExportVariable>,
 	exportNamesByVariable: Map<Variable, string[]>,
-	accessedGlobalsByScope: Map<ChildScope, Set<string>>
+	accessedGlobalsByScope: Map<ChildScope, Set<string>>,
+	includedNamespaces: Set<Module>
 ) {
 	for (const module of modules) {
 		module.scope.addUsedOutsideNames(
@@ -62,7 +63,7 @@ export function deconflictChunk(
 			accessedGlobalsByScope
 		);
 	}
-	deconflictTopLevelVariables(usedNames, modules);
+	deconflictTopLevelVariables(usedNames, modules, includedNamespaces);
 	DECONFLICT_IMPORTED_VARIABLES_BY_FORMAT[format](
 		usedNames,
 		imports,
@@ -201,7 +202,11 @@ function deconflictImportsOther(
 	}
 }
 
-function deconflictTopLevelVariables(usedNames: Set<string>, modules: Module[]) {
+function deconflictTopLevelVariables(
+	usedNames: Set<string>,
+	modules: Module[],
+	includedNamespaces: Set<Module>
+) {
 	for (const module of modules) {
 		for (const variable of module.scope.variables.values()) {
 			if (
@@ -215,8 +220,8 @@ function deconflictTopLevelVariables(usedNames: Set<string>, modules: Module[]) 
 				variable.setRenderNames(null, getSafeName(variable.name, usedNames));
 			}
 		}
-		const namespace = module.namespace;
-		if (namespace.included) {
+		if (includedNamespaces.has(module)) {
+			const namespace = module.namespace;
 			namespace.setRenderNames(null, getSafeName(namespace.name, usedNames));
 		}
 	}

--- a/test/chunking-form/samples/deprecated/preserve-modules-dynamic-namespace/_expected/es/main.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-dynamic-namespace/_expected/es/main.js
@@ -1,3 +1,3 @@
-import * as ms from './m1.js';
+import * as m1 from './m1.js';
 
-console.log(ms);
+console.log(m1);

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_config.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	description:
+		'handle dynamically importing a module with synthetic named exports when preserving modules',
+	options: {
+		input: ['main', 'lib'],
+		plugins: {
+			name: 'test-plugin',
+			transform(code, id) {
+				if (id.endsWith('lib.js')) {
+					return { code, syntheticNamedExports: '__moduleExports' };
+				}
+			}
+		},
+		output: {
+			preserveModules: true
+		}
+	}
+};

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/amd/lib.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/amd/lib.js
@@ -1,0 +1,8 @@
+define(function () { 'use strict';
+
+	const __moduleExports = { foo: 'bar' };
+	var lib = 'baz';
+
+	return lib;
+
+});

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/amd/main.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/amd/main.js
@@ -1,0 +1,9 @@
+define(['require'], function (require) { 'use strict';
+
+	function _interopNamespaceDefaultOnly(e) {
+		return Object.freeze({__proto__: null, 'default': e});
+	}
+
+	new Promise(function (resolve, reject) { require(['./lib'], function (m) { resolve(/*#__PURE__*/_interopNamespaceDefaultOnly(m)); }, reject) }).then(console.log);
+
+});

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/cjs/lib.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/cjs/lib.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const __moduleExports = { foo: 'bar' };
+var lib = 'baz';
+
+module.exports = lib;

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/cjs/main.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function _interopNamespaceDefaultOnly(e) {
+	return Object.freeze({__proto__: null, 'default': e});
+}
+
+Promise.resolve().then(function () { return /*#__PURE__*/_interopNamespaceDefaultOnly(require('./lib.js')); }).then(console.log);

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/es/lib.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/es/lib.js
@@ -1,0 +1,4 @@
+const __moduleExports = { foo: 'bar' };
+var lib = 'baz';
+
+export default lib;

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/es/main.js
@@ -1,0 +1,1 @@
+import('./lib.js').then(console.log);

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/system/lib.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/system/lib.js
@@ -1,0 +1,11 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const __moduleExports = { foo: 'bar' };
+			var lib = exports('default', 'baz');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/_expected/system/main.js
@@ -1,0 +1,10 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			module.import('./lib.js').then(console.log);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/lib.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/lib.js
@@ -1,0 +1,2 @@
+export const __moduleExports = { foo: 'bar' };
+export default 'baz';

--- a/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/main.js
+++ b/test/chunking-form/samples/dynamic-import-synthetic-exports-preserve-modules/main.js
@@ -1,0 +1,1 @@
+import('./lib.js').then(console.log);

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/es/main.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/es/main.js
@@ -1,4 +1,4 @@
 import './m2.js';
-import { m as ms } from './generated-m1.js';
+import { m as m1 } from './generated-m1.js';
 
-console.log(ms);
+console.log(m1);

--- a/test/chunking-form/samples/namespace-object-import/_expected/es/main1.js
+++ b/test/chunking-form/samples/namespace-object-import/_expected/es/main1.js
@@ -1,5 +1,5 @@
-import { a, m as main2$1 } from './generated-main2.js';
+import { a, m as main2 } from './generated-main2.js';
 
 console.log(a);
 
-console.log(main2$1);
+console.log(main2);

--- a/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/es/main1.js
+++ b/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/es/main1.js
@@ -1,5 +1,5 @@
 import './generated-dep.js';
 import 'external';
-import { l as lib } from './generated-index.js';
+import { l as index } from './generated-index.js';
 
-console.log(lib);
+console.log(index);

--- a/test/chunking-form/samples/namespace-reexports/_expected/es/main.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/es/main.js
@@ -1,7 +1,7 @@
 import { p } from './hsl2hsv.js';
-import { l as lib } from './generated-index.js';
+import { l as index } from './generated-index.js';
 
 console.log(p);
-var main = new Map(Object.entries(lib));
+var main = new Map(Object.entries(index));
 
 export default main;

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_config.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	description: 'import namespace from chunks with default export mode when preserving modules',
+	options: {
+		input: ['main', 'lib'],
+		output: {
+			preserveModules: true
+		}
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/amd/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/amd/lib.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var lib = 'foo';
+
+	return lib;
+
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/amd/main.js
@@ -1,0 +1,16 @@
+define(['require', 'exports', './lib'], function (require, exports, lib) { 'use strict';
+
+	function _interopNamespaceDefaultOnly(e) {
+		return Object.freeze({__proto__: null, 'default': e});
+	}
+
+	var lib__namespace = /*#__PURE__*/_interopNamespaceDefaultOnly(lib);
+
+	console.log(lib__namespace);
+	new Promise(function (resolve, reject) { require(['./lib'], function (m) { resolve(/*#__PURE__*/_interopNamespaceDefaultOnly(m)); }, reject) }).then(console.log);
+
+	exports.lib = lib__namespace;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/cjs/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/cjs/lib.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var lib = 'foo';
+
+module.exports = lib;

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/cjs/main.js
@@ -1,0 +1,16 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var lib = require('./lib.js');
+
+function _interopNamespaceDefaultOnly(e) {
+	return Object.freeze({__proto__: null, 'default': e});
+}
+
+var lib__namespace = /*#__PURE__*/_interopNamespaceDefaultOnly(lib);
+
+console.log(lib__namespace);
+Promise.resolve().then(function () { return /*#__PURE__*/_interopNamespaceDefaultOnly(require('./lib.js')); }).then(console.log);
+
+exports.lib = lib__namespace;

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/es/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/es/lib.js
@@ -1,0 +1,3 @@
+var lib = 'foo';
+
+export default lib;

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/es/main.js
@@ -1,0 +1,6 @@
+import * as lib$1 from './lib.js';
+import * as lib from './lib.js';
+export { lib };
+
+console.log(lib$1);
+import('./lib.js').then(console.log);

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/es/main.js
@@ -1,6 +1,5 @@
-import * as lib$1 from './lib.js';
 import * as lib from './lib.js';
 export { lib };
 
-console.log(lib$1);
+console.log(lib);
 import('./lib.js').then(console.log);

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/system/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/system/lib.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var lib = exports('default', 'foo');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/_expected/system/main.js
@@ -1,0 +1,16 @@
+System.register(['./lib.js'], function (exports, module) {
+	'use strict';
+	var lib;
+	return {
+		setters: [function (module) {
+			lib = module;
+			exports('lib', module);
+		}],
+		execute: function () {
+
+			console.log(lib);
+			module.import('./lib.js').then(console.log);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/lib.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace/main.js
@@ -1,0 +1,4 @@
+import * as lib from './lib.js';
+console.log(lib);
+import('./lib.js').then(console.log);
+export { lib };

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_config.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	description: 'import namespace from chunks with default export mode when preserving modules',
+	options: {
+		input: ['main', 'lib'],
+		output: {
+			preserveModules: true
+		}
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/amd/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/amd/lib.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var lib = 'foo';
+
+	return lib;
+
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/amd/main.js
@@ -1,0 +1,11 @@
+define(['./lib'], function (lib) { 'use strict';
+
+	function _interopNamespaceDefaultOnly(e) {
+		return Object.freeze({__proto__: null, 'default': e});
+	}
+
+	var lib__namespace = /*#__PURE__*/_interopNamespaceDefaultOnly(lib);
+
+	console.log(lib__namespace);
+
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/cjs/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/cjs/lib.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var lib = 'foo';
+
+module.exports = lib;

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/cjs/main.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var lib = require('./lib.js');
+
+function _interopNamespaceDefaultOnly(e) {
+	return Object.freeze({__proto__: null, 'default': e});
+}
+
+var lib__namespace = /*#__PURE__*/_interopNamespaceDefaultOnly(lib);
+
+console.log(lib__namespace);

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/es/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/es/lib.js
@@ -1,0 +1,3 @@
+var lib = 'foo';
+
+export default lib;

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/es/main.js
@@ -1,0 +1,3 @@
+import * as lib from './lib.js';
+
+console.log(lib);

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/system/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/system/lib.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			var lib = exports('default', 'foo');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register(['./lib.js'], function () {
+	'use strict';
+	var lib;
+	return {
+		setters: [function (module) {
+			lib = module;
+		}],
+		execute: function () {
+
+			console.log(lib);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/lib.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/lib.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/test/chunking-form/samples/preserve-modules-default-mode-namespace2/main.js
+++ b/test/chunking-form/samples/preserve-modules-default-mode-namespace2/main.js
@@ -1,0 +1,2 @@
+import * as lib from './lib.js';
+console.log(lib);

--- a/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/es/main.js
@@ -1,3 +1,3 @@
-import * as ms from './m1.js';
+import * as m1 from './m1.js';
 
-console.log(ms);
+console.log(m1);

--- a/test/form/samples/entry-with-unused-synthetic-exports/_config.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/_config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	description: 'does not include unused synthetic namespace object in entry points',
+	options: {
+		plugins: {
+			name: 'test-plugin',
+			transform(code) {
+				return { code, syntheticNamedExports: '__moduleExports' };
+			}
+		}
+	}
+};

--- a/test/form/samples/entry-with-unused-synthetic-exports/_expected/amd.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/_expected/amd.js
@@ -1,0 +1,5 @@
+define(function () { 'use strict';
+
+	console.log(lib);
+
+});

--- a/test/form/samples/entry-with-unused-synthetic-exports/_expected/cjs.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/_expected/cjs.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(lib);

--- a/test/form/samples/entry-with-unused-synthetic-exports/_expected/es.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/_expected/es.js
@@ -1,0 +1,1 @@
+console.log(lib);

--- a/test/form/samples/entry-with-unused-synthetic-exports/_expected/iife.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/_expected/iife.js
@@ -1,0 +1,6 @@
+(function () {
+	'use strict';
+
+	console.log(lib);
+
+}());

--- a/test/form/samples/entry-with-unused-synthetic-exports/_expected/system.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/_expected/system.js
@@ -1,0 +1,10 @@
+System.register([], function () {
+	'use strict';
+	return {
+		execute: function () {
+
+			console.log(lib);
+
+		}
+	};
+});

--- a/test/form/samples/entry-with-unused-synthetic-exports/_expected/umd.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/_expected/umd.js
@@ -1,0 +1,8 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+}((function () { 'use strict';
+
+	console.log(lib);
+
+})));

--- a/test/form/samples/entry-with-unused-synthetic-exports/main.js
+++ b/test/form/samples/entry-with-unused-synthetic-exports/main.js
@@ -1,0 +1,2 @@
+console.log(lib);
+export const __moduleExports = { not: 'included' };

--- a/test/function/samples/preserve-modules-default-mode-namespace/_config.js
+++ b/test/function/samples/preserve-modules-default-mode-namespace/_config.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'import namespace from chunks with default export mode when preserving modules',
+	options: {
+		input: ['main', 'lib'],
+		output: {
+			preserveModules: true
+		}
+	},
+	exports(exports) {
+		assert.deepStrictEqual(exports, { lib: { __proto__: null, default: 'foo' } });
+	}
+};

--- a/test/function/samples/preserve-modules-default-mode-namespace/lib.js
+++ b/test/function/samples/preserve-modules-default-mode-namespace/lib.js
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/test/function/samples/preserve-modules-default-mode-namespace/main.js
+++ b/test/function/samples/preserve-modules-default-mode-namespace/main.js
@@ -1,0 +1,2 @@
+import * as lib from './lib.js';
+export { lib };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves rollup/plugins#532

### Description
This resolves several issues around namespace imports, dynamic imports and synthetic exports
- Do not include the synthetic namespace by default in static entry points unless it is actually used to reduce file size
- Use a helper to create a proper namespace object when in a non-es format, a namespace is imported from a chunk with `default` export mode. Previously, the default export would have become the namespace in such a situation; now it is properly an object with a `default` property.
- Use the same variable when in a chunk, a namespace is both imported and reexported as a binding. Previously, this would have caused two namespace imports from the same dependency with different variables to be rendered.
- Make sure the chunking of one output does not interfere with the namespace objects of another output. Different chunking/use of preserveModules can cause different namespaces to be rendered as objects. Previously, the information which namespaces become reified objects was shared between outputs. This is fixed now.
- Do no try to handle the synthetic namespace when dynamically importing a module with synthetic named exports when preserving modules. This essentially fixes rollup/plugins#532. A side-effect is that when preserving modules, namespace imports do not contain synthetic values because here, we do not create reified namespace objects. Regular synthetic imports work, though. Note also that for technical reasons, the synthetic namespace object is still included.