### PR TITLE
Avoid variable name conflict when reexporting several namespaces from a chunk

### DIFF
--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -85,20 +85,21 @@ function deconflictImportsEsmOrSystem(
 	imports: Set<Variable>,
 	dependenciesToBeDeconflicted: DependenciesToBeDeconflicted,
 	_interop: GetInterop,
-	_preserveModules: boolean,
+	preserveModules: boolean,
 	_externalLiveBindings: boolean,
 	chunkByModule: Map<Module, Chunk>,
 	syntheticExports: Set<SyntheticNamedExportVariable>
 ) {
-	// All namespace imports are contained here;
-	// this is needed for synthetic exports and namespace reexports
+	// This is needed for namespace reexports
 	for (const dependency of dependenciesToBeDeconflicted.dependencies) {
-		dependency.variableName = getSafeName(dependency.suggestedVariableName, usedNames);
+		if (preserveModules || dependency instanceof ExternalModule) {
+			dependency.variableName = getSafeName(dependency.suggestedVariableName, usedNames);
+		}
 	}
 	for (const variable of imports) {
 		const module = variable.module!;
 		const name = variable.name;
-		if (variable.isNamespace) {
+		if (variable.isNamespace && (preserveModules || module instanceof ExternalModule)) {
 			variable.setRenderNames(
 				null,
 				(module instanceof ExternalModule ? module : chunkByModule.get(module)!).variableName

--- a/test/chunking-form/samples/combined-namespace-reexport/_config.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'correctly handles combined namespace reexports',
+	options: {
+		input: ['main1', 'main2']
+	}
+};

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/amd/generated-geometry.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/amd/generated-geometry.js
@@ -1,0 +1,22 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = 'foo';
+
+	var volume = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		foo: foo
+	});
+
+	const bar = 'bar';
+
+	var geometry = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		bar: bar
+	});
+
+	exports.bar = bar;
+	exports.foo = foo;
+	exports.geometry = geometry;
+	exports.volume = volume;
+
+});

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/amd/main1.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/amd/main1.js
@@ -1,0 +1,11 @@
+define(['./generated-geometry'], function (geometry) { 'use strict';
+
+	var mod = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		volume: geometry.volume,
+		geometry: geometry.geometry
+	});
+
+	console.log(mod);
+
+});

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/amd/main2.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/amd/main2.js
@@ -1,0 +1,5 @@
+define(['./generated-geometry'], function (geometry) { 'use strict';
+
+	console.log(geometry.foo, geometry.bar);
+
+});

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/cjs/generated-geometry.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/cjs/generated-geometry.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const foo = 'foo';
+
+var volume = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	foo: foo
+});
+
+const bar = 'bar';
+
+var geometry = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	bar: bar
+});
+
+exports.bar = bar;
+exports.foo = foo;
+exports.geometry = geometry;
+exports.volume = volume;

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/cjs/main1.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var geometry = require('./generated-geometry.js');
+
+var mod = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	volume: geometry.volume,
+	geometry: geometry.geometry
+});
+
+console.log(mod);

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/cjs/main2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var geometry = require('./generated-geometry.js');
+
+console.log(geometry.foo, geometry.bar);

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/es/generated-geometry.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/es/generated-geometry.js
@@ -1,0 +1,15 @@
+const foo = 'foo';
+
+var volume = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	foo: foo
+});
+
+const bar = 'bar';
+
+var geometry = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	bar: bar
+});
+
+export { bar as b, foo as f, geometry as g, volume as v };

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/es/main1.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/es/main1.js
@@ -1,0 +1,9 @@
+import { v as volume, g as geometry } from './generated-geometry.js';
+
+var mod = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	volume: volume,
+	geometry: geometry
+});
+
+console.log(mod);

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/es/main2.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/es/main2.js
@@ -1,0 +1,3 @@
+import { f as foo, b as bar } from './generated-geometry.js';
+
+console.log(foo, bar);

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/system/generated-geometry.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/system/generated-geometry.js
@@ -1,0 +1,24 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = exports('f', 'foo');
+
+			var volume = /*#__PURE__*/Object.freeze({
+				__proto__: null,
+				foo: foo
+			});
+			exports('v', volume);
+
+			const bar = exports('b', 'bar');
+
+			var geometry = /*#__PURE__*/Object.freeze({
+				__proto__: null,
+				bar: bar
+			});
+			exports('g', geometry);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/system/main1.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/system/main1.js
@@ -1,0 +1,21 @@
+System.register(['./generated-geometry.js'], function () {
+	'use strict';
+	var volume, geometry;
+	return {
+		setters: [function (module) {
+			volume = module.v;
+			geometry = module.g;
+		}],
+		execute: function () {
+
+			var mod = /*#__PURE__*/Object.freeze({
+				__proto__: null,
+				volume: volume,
+				geometry: geometry
+			});
+
+			console.log(mod);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/combined-namespace-reexport/_expected/system/main2.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/_expected/system/main2.js
@@ -1,0 +1,15 @@
+System.register(['./generated-geometry.js'], function () {
+	'use strict';
+	var foo, bar;
+	return {
+		setters: [function (module) {
+			foo = module.f;
+			bar = module.b;
+		}],
+		execute: function () {
+
+			console.log(foo, bar);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/combined-namespace-reexport/geometry.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/geometry.js
@@ -1,0 +1,1 @@
+export const bar = 'bar';

--- a/test/chunking-form/samples/combined-namespace-reexport/index.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/index.js
@@ -1,0 +1,2 @@
+export * as volume from './volume';
+export * as geometry from './geometry';

--- a/test/chunking-form/samples/combined-namespace-reexport/main1.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/main1.js
@@ -1,0 +1,2 @@
+import * as mod from './index.js';
+console.log(mod);

--- a/test/chunking-form/samples/combined-namespace-reexport/main2.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/main2.js
@@ -1,0 +1,4 @@
+import { bar } from './geometry.js';
+import { foo } from './volume.js';
+
+console.log(foo, bar);

--- a/test/chunking-form/samples/combined-namespace-reexport/volume.js
+++ b/test/chunking-form/samples/combined-namespace-reexport/volume.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/es/main.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/es/main.js
@@ -1,4 +1,4 @@
 import './m2.js';
-import { m as m1 } from './generated-m1.js';
+import { m as ms } from './generated-m1.js';
 
-console.log(m1);
+console.log(ms);

--- a/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/es/main1.js
+++ b/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/es/main1.js
@@ -1,5 +1,5 @@
 import './generated-dep.js';
 import 'external';
-import { l as index } from './generated-index.js';
+import { l as lib } from './generated-index.js';
 
-console.log(index);
+console.log(lib);

--- a/test/chunking-form/samples/namespace-reexports/_expected/es/main.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/es/main.js
@@ -1,7 +1,7 @@
 import { p } from './hsl2hsv.js';
-import { l as index } from './generated-index.js';
+import { l as lib } from './generated-index.js';
 
 console.log(p);
-var main = new Map(Object.entries(index));
+var main = new Map(Object.entries(lib));
 
 export default main;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3741 

### Description
The problem was that an optimization meant for preserveModules was also applied in all other cases where it did not make sense and was indeed harmful.
