### PR TITLE
Properly deconflict synthetic named exports

### DIFF
--- a/src/ast/variables/SyntheticNamedExportVariable.ts
+++ b/src/ast/variables/SyntheticNamedExportVariable.ts
@@ -1,4 +1,5 @@
 import Module, { AstContext } from '../../Module';
+import { RESERVED_NAMES } from '../../utils/reservedNames';
 import ExportDefaultVariable from './ExportDefaultVariable';
 import Variable from './Variable';
 
@@ -25,10 +26,13 @@ export default class SyntheticNamedExportVariable extends Variable {
 		return baseVariable;
 	}
 
+	getBaseVariableName(): string {
+		return this.syntheticNamespace.getBaseVariableName();
+	}
+
 	getName(): string {
 		const name = this.name;
-		const renderBaseName = this.syntheticNamespace.getName();
-		return `${renderBaseName}${getPropertyAccess(name)}`;
+		return `${this.syntheticNamespace.getName()}${getPropertyAccess(name)}`;
 	}
 
 	include() {
@@ -37,8 +41,14 @@ export default class SyntheticNamedExportVariable extends Variable {
 			this.context.includeVariable(this.syntheticNamespace);
 		}
 	}
+
+	setRenderNames(baseName: string | null, name: string | null) {
+		super.setRenderNames(baseName, name);
+	}
 }
 
 const getPropertyAccess = (name: string) => {
-	return /^(?!\d)[\w$]+$/.test(name) ? `.${name}` : `[${JSON.stringify(name)}]`;
+	return !RESERVED_NAMES[name] && /^(?!\d)[\w$]+$/.test(name)
+		? `.${name}`
+		: `[${JSON.stringify(name)}]`;
 };

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -50,9 +50,7 @@ export default class Variable implements ExpressionEntity {
 	getName(): string {
 		const name = this.renderName || this.name;
 		return this.renderBaseName
-			? RESERVED_NAMES[this.name]
-				? `${this.renderBaseName}['${name}']`
-				: `${this.renderBaseName}.${name}`
+			? `${this.renderBaseName}${RESERVED_NAMES[name] ? `['${name}']` : `.${name}`}`
 			: name;
 	}
 

--- a/test/chunking-form/samples/deprecated/indirect-reexports-preserve-modules/_expected/amd/components/index.js
+++ b/test/chunking-form/samples/deprecated/indirect-reexports-preserve-modules/_expected/amd/components/index.js
@@ -1,6 +1,6 @@
 define(['exports', './sub/index'], function (exports, index) { 'use strict';
 
-	const baz = { bar: index.default };
+	const baz = { bar: index['default'] };
 
 	exports.foo = index.foo;
 	exports.baz = baz;

--- a/test/chunking-form/samples/deprecated/indirect-reexports-preserve-modules/_expected/cjs/components/index.js
+++ b/test/chunking-form/samples/deprecated/indirect-reexports-preserve-modules/_expected/cjs/components/index.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 var index = require('./sub/index.js');
 
-const baz = { bar: index.default };
+const baz = { bar: index['default'] };
 
 exports.foo = index.foo;
 exports.baz = baz;

--- a/test/chunking-form/samples/deprecated/preserve-modules-commonjs/_expected/amd/commonjs.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-commonjs/_expected/amd/commonjs.js
@@ -4,7 +4,7 @@ define(['external', './other'], function (external, other) { 'use strict';
 
 	var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
 
-	const { value } = other.default;
+	const { value } = other['default'];
 
 	console.log(external__default['default'], value);
 

--- a/test/chunking-form/samples/deprecated/preserve-modules-commonjs/_expected/cjs/commonjs.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-commonjs/_expected/cjs/commonjs.js
@@ -7,7 +7,7 @@ function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'defau
 
 var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
 
-const { value } = other.default;
+const { value } = other['default'];
 
 console.log(external__default['default'], value);
 

--- a/test/chunking-form/samples/deprecated/preserve-modules-named-export-mode/_expected/amd/main.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-named-export-mode/_expected/amd/main.js
@@ -1,6 +1,6 @@
 define(['require', 'exports', './default', './named'], function (require, exports, _default, named) { 'use strict';
 
-	console.log(_default.default, named.value);
+	console.log(_default['default'], named.value);
 
 	new Promise(function (resolve, reject) { require(['./default'], resolve, reject) }).then(result => console.log(result.default));
 	new Promise(function (resolve, reject) { require(['./named'], resolve, reject) }).then(result => console.log(result.value));

--- a/test/chunking-form/samples/deprecated/preserve-modules-named-export-mode/_expected/cjs/main.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-named-export-mode/_expected/cjs/main.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 var _default = require('./default.js');
 var named = require('./named.js');
 
-console.log(_default.default, named.value);
+console.log(_default['default'], named.value);
 
 Promise.resolve().then(function () { return require('./default.js'); }).then(result => console.log(result.default));
 Promise.resolve().then(function () { return require('./named.js'); }).then(result => console.log(result.value));

--- a/test/chunking-form/samples/indirect-reexports-preserve-modules/_expected/amd/components/index.js
+++ b/test/chunking-form/samples/indirect-reexports-preserve-modules/_expected/amd/components/index.js
@@ -1,6 +1,6 @@
 define(['exports', './sub/index'], function (exports, index) { 'use strict';
 
-	const baz = { bar: index.default };
+	const baz = { bar: index['default'] };
 
 	exports.foo = index.foo;
 	exports.baz = baz;

--- a/test/chunking-form/samples/indirect-reexports-preserve-modules/_expected/cjs/components/index.js
+++ b/test/chunking-form/samples/indirect-reexports-preserve-modules/_expected/cjs/components/index.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 var index = require('./sub/index.js');
 
-const baz = { bar: index.default };
+const baz = { bar: index['default'] };
 
 exports.foo = index.foo;
 exports.baz = baz;

--- a/test/chunking-form/samples/namespace-reexports/_expected/amd/generated-index.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/amd/generated-index.js
@@ -6,7 +6,7 @@ define(['exports', './hsl2hsv'], function (exports, hsl2hsv$1) { 'use strict';
 
 	var lib = /*#__PURE__*/Object.freeze({
 		__proto__: null,
-		hsl2hsv: hsl2hsv$1.default
+		hsl2hsv: hsl2hsv$1['default']
 	});
 
 	exports.lib = lib;

--- a/test/chunking-form/samples/namespace-reexports/_expected/cjs/generated-index.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/cjs/generated-index.js
@@ -8,7 +8,7 @@ console.log(hsl2hsv);
 
 var lib = /*#__PURE__*/Object.freeze({
 	__proto__: null,
-	hsl2hsv: hsl2hsv$1.default
+	hsl2hsv: hsl2hsv$1['default']
 });
 
 exports.lib = lib;

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/commonjs.js
@@ -4,7 +4,7 @@ define(['external', './other'], function (external, other) { 'use strict';
 
 	var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
 
-	const { value } = other.default;
+	const { value } = other['default'];
 
 	console.log(external__default['default'], value);
 

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/commonjs.js
@@ -7,7 +7,7 @@ function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'defau
 
 var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
 
-const { value } = other.default;
+const { value } = other['default'];
 
 console.log(external__default['default'], value);
 

--- a/test/chunking-form/samples/preserve-modules-named-export-mode/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-named-export-mode/_expected/amd/main.js
@@ -1,6 +1,6 @@
 define(['require', 'exports', './default', './named'], function (require, exports, _default, named) { 'use strict';
 
-	console.log(_default.default, named.value);
+	console.log(_default['default'], named.value);
 
 	new Promise(function (resolve, reject) { require(['./default'], resolve, reject) }).then(result => console.log(result.default));
 	new Promise(function (resolve, reject) { require(['./named'], resolve, reject) }).then(result => console.log(result.value));

--- a/test/chunking-form/samples/preserve-modules-named-export-mode/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-named-export-mode/_expected/cjs/main.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 var _default = require('./default.js');
 var named = require('./named.js');
 
-console.log(_default.default, named.value);
+console.log(_default['default'], named.value);
 
 Promise.resolve().then(function () { return require('./default.js'); }).then(result => console.log(result.default));
 Promise.resolve().then(function () { return require('./named.js'); }).then(result => console.log(result.value));

--- a/test/form/samples/deconflict-format-specific-globals/_expected/amd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/amd.js
@@ -37,7 +37,7 @@ define(['module', 'require', 'external'], function (module, require, external) {
 	console.log(_interopDefault$1, _interopNamespace$1, module$1, require$1, exports$1, document$1, URL$1);
 
 	new Promise(function (resolve, reject) { require(['external'], function (m) { resolve(/*#__PURE__*/_interopNamespace(m)); }, reject) }).then(console.log);
-	exports.default = 0;
+	exports['default'] = 0;
 	console.log(new URL(module.uri, document.baseURI).href);
 
 	function nested1() {
@@ -51,7 +51,7 @@ define(['module', 'require', 'external'], function (module, require, external) {
 		console.log(_interopDefault, _interopNamespace$1, module$1, require$1, exports$1, document$1, URL$1);
 
 		new Promise(function (resolve, reject) { require(['external'], function (m) { resolve(/*#__PURE__*/_interopNamespace(m)); }, reject) }).then(console.log);
-		exports.default = 1;
+		exports['default'] = 1;
 		console.log(new URL(module.uri, document.baseURI).href);
 	}
 
@@ -70,6 +70,6 @@ define(['module', 'require', 'external'], function (module, require, external) {
 
 	nested2();
 
-	return exports.default;
+	return exports['default'];
 
 });

--- a/test/form/samples/deconflict-format-specific-globals/_expected/cjs.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/cjs.js
@@ -39,7 +39,7 @@ const URL$1 = 1;
 console.log(_interopDefault$1, _interopNamespace$1, module$1, require$1, exports$1, document$1, URL$1);
 
 Promise.resolve().then(function () { return /*#__PURE__*/_interopNamespace(require('external')); }).then(console.log);
-exports.default = 0;
+exports['default'] = 0;
 console.log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('cjs.js', document.baseURI).href)));
 
 function nested1() {
@@ -53,7 +53,7 @@ function nested1() {
 	console.log(_interopDefault, _interopNamespace$1, module, require$1, exports$1, document$1, URL$1);
 
 	Promise.resolve().then(function () { return /*#__PURE__*/_interopNamespace(require('external')); }).then(console.log);
-	exports.default = 1;
+	exports['default'] = 1;
 	console.log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('cjs.js', document.baseURI).href)));
 }
 
@@ -72,4 +72,4 @@ function nested2() {
 
 nested2();
 
-module.exports = exports.default;
+module.exports = exports['default'];

--- a/test/form/samples/deconflict-format-specific-globals/_expected/iife.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/iife.js
@@ -17,7 +17,7 @@ var bundle = (function (external) {
 	console.log(_interopDefault$1, _interopNamespace$1, module, require, exports$1, document$1, URL$1);
 
 	import('external').then(console.log);
-	exports.default = 0;
+	exports['default'] = 0;
 	console.log((document.currentScript && document.currentScript.src || new URL('iife.js', document.baseURI).href));
 
 	function nested1() {
@@ -31,7 +31,7 @@ var bundle = (function (external) {
 		console.log(_interopDefault, _interopNamespace, module, require, exports$1, document$1, URL$1);
 
 		import('external').then(console.log);
-		exports.default = 1;
+		exports['default'] = 1;
 		console.log((document.currentScript && document.currentScript.src || new URL('iife.js', document.baseURI).href));
 	}
 
@@ -50,6 +50,6 @@ var bundle = (function (external) {
 
 	nested2();
 
-	return exports.default;
+	return exports['default'];
 
 }(external));

--- a/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
@@ -20,7 +20,7 @@
 	console.log(_interopDefault$1, _interopNamespace$1, module, require$1, exports$1, document$1, URL$1);
 
 	import('external').then(console.log);
-	exports.default = 0;
+	exports['default'] = 0;
 	console.log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 
 	function nested1() {
@@ -34,7 +34,7 @@
 		console.log(_interopDefault, _interopNamespace, module, require$1, exports$1, document$1, URL$1);
 
 		import('external').then(console.log);
-		exports.default = 1;
+		exports['default'] = 1;
 		console.log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 	}
 
@@ -53,6 +53,6 @@
 
 	nested2();
 
-	return exports.default;
+	return exports['default'];
 
 })));

--- a/test/function/samples/deconflict-synthetic-named-export-cross-chunk/_config.js
+++ b/test/function/samples/deconflict-synthetic-named-export-cross-chunk/_config.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'deconflicts synthetic named exports across chunks',
+	options: {
+		input: ['main', 'foo'],
+		preserveEntrySignatures: 'allow-extension',
+		plugins: [
+			{
+				transform(code) {
+					return { code, syntheticNamedExports: 'bar' };
+				}
+			}
+		]
+	},
+	exports(exports) {
+		assert.strictEqual(exports(2), 4);
+	}
+};

--- a/test/function/samples/deconflict-synthetic-named-export-cross-chunk/foo.js
+++ b/test/function/samples/deconflict-synthetic-named-export-cross-chunk/foo.js
@@ -1,0 +1,1 @@
+export const bar = { double: x => x * x };

--- a/test/function/samples/deconflict-synthetic-named-export-cross-chunk/main.js
+++ b/test/function/samples/deconflict-synthetic-named-export-cross-chunk/main.js
@@ -1,0 +1,5 @@
+import { double } from './foo.js';
+
+export default function (foo) {
+	return double(foo);
+}

--- a/test/function/samples/deconflict-synthetic-named-export/_config.js
+++ b/test/function/samples/deconflict-synthetic-named-export/_config.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'deconflicts synthetic named exports',
+	options: {
+		plugins: [
+			{
+				transform(code) {
+					return { code, syntheticNamedExports: 'foo' };
+				}
+			}
+		]
+	},
+	exports(exports) {
+		assert.strictEqual(exports(2), 4);
+	}
+};

--- a/test/function/samples/deconflict-synthetic-named-export/foo.js
+++ b/test/function/samples/deconflict-synthetic-named-export/foo.js
@@ -1,0 +1,1 @@
+export const foo = { double: x => x * x };

--- a/test/function/samples/deconflict-synthetic-named-export/main.js
+++ b/test/function/samples/deconflict-synthetic-named-export/main.js
@@ -1,0 +1,5 @@
+import { double } from './foo.js';
+
+export default function (foo) {
+	return double(foo);
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3746

### Description
As it turned out, synthetic named exports were not properly fed into the deconflicting algorithm. This is fixed here.