### PR TITLE
Also pass resolved ids to external if they use the object form

### DIFF
--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -423,7 +423,7 @@ export class ModuleLoader {
 		if (resolveIdResult) {
 			if (typeof resolveIdResult === 'object') {
 				id = resolveIdResult.id;
-				if (resolveIdResult.external) {
+				if (resolveIdResult.external || this.options.external(resolveIdResult.id, importer, true)) {
 					external = true;
 				}
 				if (resolveIdResult.moduleSideEffects != null) {

--- a/test/function/samples/external-resolved/_config.js
+++ b/test/function/samples/external-resolved/_config.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+const testedIds = [];
+
+module.exports = {
+	description: 'passes both unresolved and resolved ids to the external option',
+	context: {
+		require() {
+			return true;
+		}
+	},
+	exports(exports) {
+		assert.deepStrictEqual(exports, {
+			resolvedExternal: true,
+			resolvedObject: true,
+			resolvedObjectExternal: true,
+			resolvedString: true
+		});
+		assert.deepStrictEqual(testedIds, [
+			'resolve-string',
+			'resolve-external',
+			'resolve-object',
+			'resolve-object-external',
+			'resolved-string',
+			'resolved-object'
+		]);
+	},
+	options: {
+		external(id) {
+			testedIds.push(id);
+			return id.startsWith('resolved');
+		},
+		plugins: {
+			name: 'test-plugin',
+			resolveId(source) {
+				switch (source) {
+					case 'resolve-string':
+						return 'resolved-string';
+					case 'resolve-external':
+						return false;
+					case 'resolve-object':
+						return { id: 'resolved-object', external: false };
+					case 'resolve-object-external':
+						return { id: 'resolved-object-external', external: true };
+					default:
+						return null;
+				}
+			}
+		}
+	}
+};

--- a/test/function/samples/external-resolved/main.js
+++ b/test/function/samples/external-resolved/main.js
@@ -1,0 +1,4 @@
+export {default as resolvedString} from 'resolve-string';
+export {default as resolvedExternal} from 'resolve-external';
+export {default as resolvedObject} from 'resolve-object';
+export {default as resolvedObjectExternal} from 'resolve-object-external';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#3743 

### Description
As it turned out, when a plugin resolves an id using the object form, the resolved id is not again passed to the `external` option for a second check, which is fixed here. Thus, the examples in the documentation work again :)