### PR TITLE
add RegExp to the include and exclude fields of the WatcherOptions type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # rollup changelog
 
-## 2.26.9
 *unreleased*
 
 ### Pull Requests

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -1509,7 +1509,7 @@ Default: `true`
 Whether to clear the screen when a rebuild is triggered.
 
 #### watch.exclude
-Type: `string`<br>
+Type: `string | RegExp | (string | RegExp)[]`<br>
 CLI: `--watch.exclude <files>`
 
 Prevent files from being watched:
@@ -1525,7 +1525,7 @@ export default {
 ```
 
 #### watch.include
-Type: `string`<br>
+Type: `string | RegExp | (string | RegExp)[]`<br>
 CLI: `--watch.include <files>`
 
 Limit the file-watching to certain files. Note that this only filters the module graph but does not allow to add additional watch files:

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -754,8 +754,8 @@ export interface WatcherOptions {
 	buildDelay?: number;
 	chokidar?: ChokidarOptions;
 	clearScreen?: boolean;
-	exclude?: string[];
-	include?: string[];
+	exclude?: (string | RegExp)[];
+	include?: (string | RegExp)[];
 	skipWrite?: boolean;
 }
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -754,8 +754,8 @@ export interface WatcherOptions {
 	buildDelay?: number;
 	chokidar?: ChokidarOptions;
 	clearScreen?: boolean;
-	exclude?: (string | RegExp)[];
-	include?: (string | RegExp)[];
+	exclude?: string | RegExp | (string | RegExp)[];
+	include?: string | RegExp | (string | RegExp)[];
 	skipWrite?: boolean;
 }
 


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

### Description

Currently, both `include` and `exclude` of the `WatcherOptions` type are typed as only allowing an array of strings

```typescript
export interface WatcherOptions {
  ....     
  exclude?: string[];
  include?: string[];
}
```

I found this out by trying to do this:

```typescript
watch: {
  exclude: [/dir/] // Type 'RegExp[]' is not assignable to type 'string[]'
```

This would wrongly make you think you can only add a string array.

I've changed the type to:

```typescript
export interface WatcherOptions {
  ...
  exclude?: (string | RegExp)[];
  include?: (string | RegExp)[];
}
```