### PR TITLE
Update FAQ: I think it was meant "external" instead of "other-entry.js"

### DIFF
--- a/docs/06-faqs.md
+++ b/docs/06-faqs.md
@@ -58,7 +58,7 @@ This does not affect code execution order or behaviour, but it will speed up how
 
 With this optimization, a JavaScript engine will discover all transitive dependencies after parsing an entry module, avoiding the waterfall:
 1. Load and parse `main.js`. At the end, imports to `other-entry.js` and `external` will be discovered.
-2. Load and parse `other-entry.js` and `external`. The import of `other-entry.js` is already loaded and parsed.
+2. Load and parse `other-entry.js` and `external`. The import of `external` is already loaded and parsed.
 3. Execute `main.js`.
 
 There may be situations where this optimization is not desired, in which case you can turn it off via the [`output.hoistTransitiveImports`](guide/en/#outputhoisttransitiveimports) option. This optimization is also never applied when using the [`output.preserveModules`](guide/en/#outputpreservemodules) option.

--- a/docs/06-faqs.md
+++ b/docs/06-faqs.md
@@ -58,7 +58,7 @@ This does not affect code execution order or behaviour, but it will speed up how
 
 With this optimization, a JavaScript engine will discover all transitive dependencies after parsing an entry module, avoiding the waterfall:
 1. Load and parse `main.js`. At the end, imports to `other-entry.js` and `external` will be discovered.
-2. Load and parse `other-entry.js` and `external`. The import of `external` is already loaded and parsed.
+2. Load and parse `other-entry.js` and `external`. The import of `external` from `other-entry.js` is already loaded and parsed.
 3. Execute `main.js`.
 
 There may be situations where this optimization is not desired, in which case you can turn it off via the [`output.hoistTransitiveImports`](guide/en/#outputhoisttransitiveimports) option. This optimization is also never applied when using the [`output.preserveModules`](guide/en/#outputpreservemodules) option.


### PR DESCRIPTION
`external` is the one imported twice in `main.js` and later in `other-entry.js`

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

In the question [Why do additional imports turn up in my entry chunks when code-splitting?](https://github.com/rollup/rollup/blob/31e7348061597fd77f7154e327ec94acbe18fed2/docs/06-faqs.md#why-do-additional-imports-turn-up-in-my-entry-chunks-when-code-splitting) it was stated

>With this optimization, a JavaScript engine will discover all transitive dependencies after parsing an entry module, avoiding the waterfall:
>
>  1.  Load and parse main.js. At the end, imports to other-entry.js and external will be discovered.
>  2.  Load and parse other-entry.js and external. The import of other-entry.js is already loaded and parsed.
>  3.  Execute main.js.


In line **2** it should say _"The import of **external** is already loaded and parsed"_ because `other-entry.js` is the one that imports `external`