### PR TITLE
Fix api docs loadconfigfile

### DIFF
--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -227,8 +227,8 @@ loadConfigFile(path.resolve(__dirname, 'rollup.config.js'), { format: 'es' }).th
 		// The following will generate all outputs for all inputs, and write them to disk the same
 		// way the CLI does it:
 		for (const optionsObj of options) {
-			const bundle = await rollup.rollup(options);
-			await Promise.all(options.output.map(bundle.write));
+			const bundle = await rollup.rollup(optionsObj);
+			await Promise.all(optionsObj.output.map(bundle.write));
 		}
 
 		// You can also pass this directly to "rollup.watch"

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -222,7 +222,7 @@ loadConfigFile(path.resolve(__dirname, 'rollup.config.js'), { format: 'es' }).th
 		// This prints all deferred warnings
 		warnings.flush();
 
-		// options is an array of "inputOptions" object with an additional "output"
+		// options is an array of "inputOptions" objects with an additional "output"
 		// property that contains an array of "outputOptions".
 		// The following will generate all outputs for all inputs, and write them to disk the same
 		// way the CLI does it:

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -80,29 +80,29 @@ The `inputOptions` object can contain the following properties (see the [big lis
 
 ```js
 const inputOptions = {
-  // core input options
-  external,
-  input, // condtionally required
-  plugins,
+	// core input options
+	external,
+	input, // condtionally required
+	plugins,
 
-  // advanced input options
-  cache,
-  onwarn,
-  preserveEntrySignatures,
-  strictDeprecations,
+	// advanced input options
+	cache,
+	onwarn,
+	preserveEntrySignatures,
+	strictDeprecations,
 
-  // danger zone
-  acorn,
-  acornInjectPlugins,
-  context,
-  moduleContext,
-  preserveSymlinks,
-  shimMissingExports,
-  treeshake,
+	// danger zone
+	acorn,
+	acornInjectPlugins,
+	context,
+	moduleContext,
+	preserveSymlinks,
+	shimMissingExports,
+	treeshake,
 
-  // experimental
-  experimentalCacheExpiry,
-  perf
+	// experimental
+	experimentalCacheExpiry,
+	perf
 };
 ```
 
@@ -112,48 +112,48 @@ The `outputOptions` object can contain the following properties (see the [big li
 
 ```js
 const outputOptions = {
-  // core output options
-  dir,
-  file,
-  format, // required
-  globals,
-  name,
-  plugins,
+	// core output options
+	dir,
+	file,
+	format, // required
+	globals,
+	name,
+	plugins,
 
-  // advanced output options
-  assetFileNames,
-  banner,
-  chunkFileNames,
-  compact,
-  entryFileNames,
-  extend,
-  externalLiveBindings,
-  footer,
-  hoistTransitiveImports,
-  inlineDynamicImports,
-  interop,
-  intro,
-  manualChunks,
-  minifyInternalExports,
-  outro,
-  paths,
-  preserveModules,
-  sourcemap,
-  sourcemapExcludeSources,
-  sourcemapFile,
-  sourcemapPathTransform,
+	// advanced output options
+	assetFileNames,
+	banner,
+	chunkFileNames,
+	compact,
+	entryFileNames,
+	extend,
+	externalLiveBindings,
+	footer,
+	hoistTransitiveImports,
+	inlineDynamicImports,
+	interop,
+	intro,
+	manualChunks,
+	minifyInternalExports,
+	outro,
+	paths,
+	preserveModules,
+	sourcemap,
+	sourcemapExcludeSources,
+	sourcemapFile,
+	sourcemapPathTransform,
 
-  // danger zone
-  amd,
-  esModule,
-  exports,
-  freeze,
-  indent,
-  namespaceToStringTag,
-  noConflict,
-  preferConst,
-  strict,
-  systemNullSetters
+	// danger zone
+	amd,
+	esModule,
+	exports,
+	freeze,
+	indent,
+	namespaceToStringTag,
+	noConflict,
+	preferConst,
+	strict,
+	systemNullSetters
 };
 ```
 
@@ -186,16 +186,16 @@ The `watchOptions` argument is a config (or an array of configs) that you would 
 
 ```js
 const watchOptions = {
-  ...inputOptions,
-  output: [outputOptions],
-  watch: {
-    buildDelay,
-    chokidar,
-    clearScreen,
-    skipWrite,
-    exclude,
-    include
-  }
+	...inputOptions,
+	output: [outputOptions],
+	watch: {
+		buildDelay,
+		chokidar,
+		clearScreen,
+		skipWrite,
+		exclude,
+		include
+	}
 };
 ```
 
@@ -213,23 +213,26 @@ const rollup = require('rollup');
 // load the config file next to the current script;
 // the provided config object has the same effect as passing "--format es"
 // on the command line and will override the format of all outputs
-loadConfigFile(path.resolve(__dirname, 'rollup.config.js'), { format: 'es' })
-  .then(async ({options, warnings}) => {
-    // "warnings" wraps the default `onwarn` handler passed by the CLI.
-    // This prints all warnings up to this point:
-    console.log(`We currently have ${warnings.count} warnings`);
+loadConfigFile(path.resolve(__dirname, 'rollup.config.js'), { format: 'es' }).then(
+	async ({ options, warnings }) => {
+		// "warnings" wraps the default `onwarn` handler passed by the CLI.
+		// This prints all warnings up to this point:
+		console.log(`We currently have ${warnings.count} warnings`);
 
-    // This prints all deferred warnings
-    warnings.flush();
-    
-    // options is an "inputOptions" object with an additional "output"
-    // property that contains an array of "outputOptions".
-    // The following will generate all outputs and write them to disk the same
-    // way the CLI does it:
-    const bundle = await rollup.rollup(options);
-    await Promise.all(options.output.map(bundle.write));
- 
-    // You can also pass this directly to "rollup.watch"
-    rollup.watch(options);
-  })
+		// This prints all deferred warnings
+		warnings.flush();
+
+		// options is an array of "inputOptions" object with an additional "output"
+		// property that contains an array of "outputOptions".
+		// The following will generate all outputs for all inputs, and write them to disk the same
+		// way the CLI does it:
+		for (const optionsObj of options) {
+			const bundle = await rollup.rollup(options);
+			await Promise.all(options.output.map(bundle.write));
+		}
+
+		// You can also pass this directly to "rollup.watch"
+		rollup.watch(options);
+	}
+);
 ```

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -80,29 +80,29 @@ The `inputOptions` object can contain the following properties (see the [big lis
 
 ```js
 const inputOptions = {
-	// core input options
-	external,
-	input, // condtionally required
-	plugins,
+  // core input options
+  external,
+  input, // condtionally required
+  plugins,
 
-	// advanced input options
-	cache,
-	onwarn,
-	preserveEntrySignatures,
-	strictDeprecations,
+  // advanced input options
+  cache,
+  onwarn,
+  preserveEntrySignatures,
+  strictDeprecations,
 
-	// danger zone
-	acorn,
-	acornInjectPlugins,
-	context,
-	moduleContext,
-	preserveSymlinks,
-	shimMissingExports,
-	treeshake,
+  // danger zone
+  acorn,
+  acornInjectPlugins,
+  context,
+  moduleContext,
+  preserveSymlinks,
+  shimMissingExports,
+  treeshake,
 
-	// experimental
-	experimentalCacheExpiry,
-	perf
+  // experimental
+  experimentalCacheExpiry,
+  perf
 };
 ```
 
@@ -112,48 +112,48 @@ The `outputOptions` object can contain the following properties (see the [big li
 
 ```js
 const outputOptions = {
-	// core output options
-	dir,
-	file,
-	format, // required
-	globals,
-	name,
-	plugins,
+  // core output options
+  dir,
+  file,
+  format, // required
+  globals,
+  name,
+  plugins,
 
-	// advanced output options
-	assetFileNames,
-	banner,
-	chunkFileNames,
-	compact,
-	entryFileNames,
-	extend,
-	externalLiveBindings,
-	footer,
-	hoistTransitiveImports,
-	inlineDynamicImports,
-	interop,
-	intro,
-	manualChunks,
-	minifyInternalExports,
-	outro,
-	paths,
-	preserveModules,
-	sourcemap,
-	sourcemapExcludeSources,
-	sourcemapFile,
-	sourcemapPathTransform,
+  // advanced output options
+  assetFileNames,
+  banner,
+  chunkFileNames,
+  compact,
+  entryFileNames,
+  extend,
+  externalLiveBindings,
+  footer,
+  hoistTransitiveImports,
+  inlineDynamicImports,
+  interop,
+  intro,
+  manualChunks,
+  minifyInternalExports,
+  outro,
+  paths,
+  preserveModules,
+  sourcemap,
+  sourcemapExcludeSources,
+  sourcemapFile,
+  sourcemapPathTransform,
 
-	// danger zone
-	amd,
-	esModule,
-	exports,
-	freeze,
-	indent,
-	namespaceToStringTag,
-	noConflict,
-	preferConst,
-	strict,
-	systemNullSetters
+  // danger zone
+  amd,
+  esModule,
+  exports,
+  freeze,
+  indent,
+  namespaceToStringTag,
+  noConflict,
+  preferConst,
+  strict,
+  systemNullSetters
 };
 ```
 
@@ -186,16 +186,16 @@ The `watchOptions` argument is a config (or an array of configs) that you would 
 
 ```js
 const watchOptions = {
-	...inputOptions,
-	output: [outputOptions],
-	watch: {
-		buildDelay,
-		chokidar,
-		clearScreen,
-		skipWrite,
-		exclude,
-		include
-	}
+  ...inputOptions,
+  output: [outputOptions],
+  watch: {
+    buildDelay,
+    chokidar,
+    clearScreen,
+    skipWrite,
+    exclude,
+    include
+  }
 };
 ```
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
The docs for `rollup/dist/loadConfigFile` incorrectly state that the `options` property of the object returned by `loadConfigFile` is an "inputOptions" object, when in fact it is an array of "inputOptions" objects. This PR fixes the text and code example in the docs.  
Relevant stackoverflow question: https://stackoverflow.com/questions/62153013/rollup-js-use-rollup-config-js-in-js-api
