### PR TITLE
Handle line-comments when removing line-breaks to prevent ASI

### DIFF
--- a/test/function/samples/prevent-asi-with-line-comments/_config.js
+++ b/test/function/samples/prevent-asi-with-line-comments/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'prevent semicolon insertion for return statements when there are line comments',
+	exports(exports) {
+		assert.strictEqual(exports(), 1);
+	}
+};

--- a/test/function/samples/prevent-asi-with-line-comments/main.js
+++ b/test/function/samples/prevent-asi-with-line-comments/main.js
@@ -1,0 +1,4 @@
+export default function () {
+	return true && // comment
+		1;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3761 

### Description
When removing line-breaks to prevent automatic semicolon insertion in certain situation, it needs to be taken into account that a line comment before the end of the line can lead to broken or incomplete code. This is fixed here by removing the entire comment in such a situation.
