### PR TITLE
Handle debugger statements as if-statement branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # rollup changelog
 
+## 2.26.11
+*2020-09-08*
+
+### Bug Fixes
+* Do not fail for unknown nodes as if statement branches (#3769)
+
+### Pull Requests
+* [#3769](https://github.com/rollup/rollup/pull/3769): Handle debugger statements as if-statement branches (@lukastaegert)
+
 ## 2.26.10
 *2020-09-04*
 

--- a/src/ast/nodes/IfStatement.ts
+++ b/src/ast/nodes/IfStatement.ts
@@ -70,18 +70,12 @@ export default class IfStatement extends StatementBase implements DeoptimizableE
 
 	parseNode(esTreeNode: GenericEsTreeNode) {
 		this.consequentScope = new TrackingScope(this.scope);
-		this.consequent = new this.context.nodeConstructors[esTreeNode.consequent.type](
-			esTreeNode.consequent,
-			this,
-			this.consequentScope
-		);
+		this.consequent = new (this.context.nodeConstructors[esTreeNode.consequent.type] ||
+			this.context.nodeConstructors.UnknownNode)(esTreeNode.consequent, this, this.consequentScope);
 		if (esTreeNode.alternate) {
 			this.alternateScope = new TrackingScope(this.scope);
-			this.alternate = new this.context.nodeConstructors[esTreeNode.alternate.type](
-				esTreeNode.alternate,
-				this,
-				this.alternateScope
-			);
+			this.alternate = new (this.context.nodeConstructors[esTreeNode.alternate.type] ||
+				this.context.nodeConstructors.UnknownNode)(esTreeNode.alternate, this, this.alternateScope);
 		}
 		super.parseNode(esTreeNode);
 	}

--- a/test/function/samples/unknown-statement/_config.js
+++ b/test/function/samples/unknown-statement/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles unknown statements'
+};

--- a/test/function/samples/unknown-statement/main.js
+++ b/test/function/samples/unknown-statement/main.js
@@ -1,0 +1,4 @@
+debugger;
+
+if (true) debugger;
+else debugger;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3766 

### Description
The new logic for if-statement simplification that relies on injecting additional scopes to detect hoisted variables introduced a bug where "unknown" nodes, in this case a debugger statement, were no longer properly handled. This is fixed here.