### PR TITLE
Docs: Exception for babel plugin and commonjs plugin

### DIFF
--- a/docs/07-tools.md
+++ b/docs/07-tools.md
@@ -74,7 +74,7 @@ Some libraries expose ES modules that you can import as-is — `the-answer` is o
 
 The [@rollup/plugin-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs) plugin does exactly that.
 
-Note that `@rollup/plugin-commonjs` should go *before* other plugins that transform your modules — this is to prevent other plugins from making changes that break the CommonJS detection.
+Note that most of the times `@rollup/plugin-commonjs` should go *before* other plugins that transform your modules — this is to prevent other plugins from making changes that break the CommonJS detection. An exception for this rule is the Babel plugin, if you're using it then place it before the commonjs one.
 
 
 ### Peer dependencies


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [X] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [X] no

List any relevant issue numbers:
[rollup/rollup-plugin-commonjs #247](https://github.com/rollup/rollup-plugin-commonjs/issues/247#issuecomment-370677203)

### Description

Due to the previous listed issue and resolution; current documentation was inaccurate. This fixes the issue with Babel specifically, although I'm not sure if the "Note" should exist at all 🤔 