### PR TITLE
Handle loading symlinked config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # rollup changelog
 
+## 2.27.1
+*2020-09-17*
+
+### Bug Fixes
+* Do not fail when using ES module imports in symlinked config files (#3783)
+
+### Pull Requests
+* [#3783](https://github.com/rollup/rollup/pull/3783): Handle loading symlinked config files (@lukastaegert)
+
 ## 2.27.0
 *2020-09-16*
 

--- a/cli/run/getConfigPath.ts
+++ b/cli/run/getConfigPath.ts
@@ -1,14 +1,14 @@
-import { readdirSync, realpathSync } from 'fs';
+import { readdirSync } from 'fs';
 import * as path from 'path';
 import relative from 'require-relative';
 import { handleError } from '../logging';
 
 const DEFAULT_CONFIG_BASE = 'rollup.config';
 
-export function getConfigPath(commandConfig: any): string {
+export function getConfigPath(commandConfig: string | true): string {
 	const cwd = process.cwd();
 	if (commandConfig === true) {
-		return path.join(cwd, findConfigFileNameInCwd());
+		return path.resolve(findConfigFileNameInCwd());
 	}
 	if (commandConfig.slice(0, 5) === 'node:') {
 		const pkgName = commandConfig.slice(5);
@@ -28,7 +28,7 @@ export function getConfigPath(commandConfig: any): string {
 			}
 		}
 	}
-	return realpathSync(commandConfig);
+	return path.resolve(commandConfig);
 }
 
 function findConfigFileNameInCwd(): string {

--- a/test/cli/samples/symlinked-config/_config.js
+++ b/test/cli/samples/symlinked-config/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'loads a symlinked config file',
+	command: 'rollup -c',
+	execute: true
+};

--- a/test/cli/samples/symlinked-config/main.js
+++ b/test/cli/samples/symlinked-config/main.js
@@ -1,0 +1,1 @@
+assert.equal(ANSWER, 42);

--- a/test/cli/samples/symlinked-config/rollup.config.js
+++ b/test/cli/samples/symlinked-config/rollup.config.js
@@ -1,0 +1,1 @@
+rollup.config.symlinked

--- a/test/cli/samples/symlinked-config/rollup.config.symlinked
+++ b/test/cli/samples/symlinked-config/rollup.config.symlinked
@@ -1,0 +1,11 @@
+import replace from '@rollup/plugin-replace';
+
+export default {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};

--- a/test/cli/samples/symlinked-named-config/_config.js
+++ b/test/cli/samples/symlinked-named-config/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'loads a symlinked config file with the given name',
+	command: 'rollup --config my.rollup.config.js',
+	execute: true
+};

--- a/test/cli/samples/symlinked-named-config/main.js
+++ b/test/cli/samples/symlinked-named-config/main.js
@@ -1,0 +1,1 @@
+assert.equal(ANSWER, 42);

--- a/test/cli/samples/symlinked-named-config/my.rollup.config.js
+++ b/test/cli/samples/symlinked-named-config/my.rollup.config.js
@@ -1,0 +1,1 @@
+rollup.config.symlinked

--- a/test/cli/samples/symlinked-named-config/rollup.config.symlinked
+++ b/test/cli/samples/symlinked-named-config/rollup.config.symlinked
@@ -1,0 +1,11 @@
+import replace from '@rollup/plugin-replace';
+
+export default {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+	plugins: [
+		replace({ 'ANSWER': 42 })
+	]
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3781 

### Description
The reason at its core here is that when using `require.cache` to intercept module loading and requiring a symlink, the filename in the cache will always be the symlink target (i.e. a symlink is treated as the symlinked file by Node). This was already handled when specifying an explicit file name but the logic was missing for the default file names. This is fixed now.
