### PR TITLE
Fix preserveModulesRoot path on Windows

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -456,7 +456,7 @@ export default class Chunk {
 			const currentPath = `${currentDir}/${fileName}`;
 			const { preserveModulesRoot } = options;
 			if (preserveModulesRoot && currentPath.startsWith(preserveModulesRoot)) {
-				path = currentPath.slice(preserveModulesRoot.length).replace(/^\//, '');
+				path = currentPath.slice(preserveModulesRoot.length).replace(/^[\\/]/, '');
 			} else {
 				path = relative(preserveModulesRelativeDir, currentPath);
 			}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (Existing tests were red on Windows) (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:

### Description
Unfortunately as Windows tests do not run on forks, there was a Windows issue that was not noticed