### PR TITLE
[docs] add output.PreserveModulesRoot to big list of options

### DIFF
--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -856,6 +856,30 @@ const main = require('./main.js');
 console.log(main.default); // 42
 ```
 
+#### output.preserveModulesRoot
+Type: `string`<br>
+CLI: `--preserveModulesRoot <directory-name>`
+
+A directory path to input modules that should be stripped away from [`output.dir`](guide/en/#outputdir) path while [`output.preserveModules`](guide/en#outputpreservemodules) is `true`.
+
+For example, given the following configuration:
+
+```javascript
+export default ({
+  input: [ 'src/module.js', `src/another/module.js` ],
+  output: [{
+    format: 'es',
+    dir: 'dist',
+    preserveModules: true,
+    preserveModulesRoot: 'src'
+  }]
+});
+```
+
+The `preserveModulesRoot` setting ensures that the input modules will be output to the paths `dist/module.js` and `dist/another/module.js`.
+
+This option is particularly useful while using plugins such as `@rollup/plugin-node-resolve`, which may cause changes in the output directory structure. This can happen when third-party modules are not marked [`external`](guide/en/#external), or while developing in a monorepo of multiple packages that rely on one another and are not marked [`external`](guide/en/#external).
+
 #### output.sourcemap
 Type: `boolean | 'inline' | 'hidden'`<br>
 CLI: `-m`/`--sourcemap`/`--no-sourcemap`<br>


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Adds docs that were missed in https://github.com/rollup/rollup/pull/3786
