### PR TITLE
fix(types): Allow methods to return void in addition to undefined

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -221,7 +221,7 @@ interface PartialResolvedId {
 	syntheticNamedExports?: boolean | string;
 }
 
-export type ResolveIdResult = string | false | null | undefined | PartialResolvedId;
+export type ResolveIdResult = string | false | EmptyValue | PartialResolvedId;
 
 export type ResolveIdHook = (
 	this: PluginContext,
@@ -235,11 +235,11 @@ export type IsExternal = (
 	isResolved: boolean
 ) => boolean;
 
-export type IsPureModule = (id: string) => boolean | null | undefined;
+export type IsPureModule = (id: string) => boolean | EmptyValue;
 
 export type HasModuleSideEffects = (id: string, external: boolean) => boolean;
 
-type LoadResult = SourceDescription | string | null | undefined;
+type LoadResult = SourceDescription | string | EmptyValue;
 
 export type LoadHook = (this: PluginContext, id: string) => Promise<LoadResult> | LoadResult;
 
@@ -247,7 +247,7 @@ export interface TransformPluginContext extends PluginContext {
 	getCombinedSourcemap: () => SourceMap;
 }
 
-export type TransformResult = string | null | undefined | SourceDescription;
+export type TransformResult = string | EmptyValue | SourceDescription;
 
 export type TransformHook = (
 	this: TransformPluginContext,
@@ -276,7 +276,7 @@ export type ResolveImportMetaHook = (
 	this: PluginContext,
 	prop: string | null,
 	options: { chunkId: string; format: InternalModuleFormat; moduleId: string }
-) => string | null | undefined;
+) => string | EmptyValue;
 
 export type ResolveAssetUrlHook = (
 	this: PluginContext,
@@ -287,7 +287,7 @@ export type ResolveAssetUrlHook = (
 		moduleId: string;
 		relativeAssetPath: string;
 	}
-) => string | null | undefined;
+) => string | EmptyValue;
 
 export type ResolveFileUrlHook = (
 	this: PluginContext,
@@ -301,7 +301,7 @@ export type ResolveFileUrlHook = (
 		referenceId: string;
 		relativePath: string;
 	}
-) => string | null | undefined;
+) => string | EmptyValue;
 
 export type AddonHookFunction = (this: PluginContext) => string | Promise<string>;
 export type AddonHook = string | AddonHookFunction;
@@ -334,7 +334,7 @@ export interface PluginHooks extends OutputPluginHooks {
 	buildEnd: (this: PluginContext, err?: Error) => Promise<void> | void;
 	buildStart: (this: PluginContext, options: NormalizedInputOptions) => Promise<void> | void;
 	load: LoadHook;
-	options: (this: MinimalPluginContext, options: InputOptions) => InputOptions | null | undefined;
+	options: (this: MinimalPluginContext, options: InputOptions) => InputOptions | EmptyValue;
 	resolveDynamicImport: ResolveDynamicImportHook;
 	resolveId: ResolveIdHook;
 	transform: TransformHook;
@@ -349,7 +349,7 @@ interface OutputPluginHooks {
 		bundle: OutputBundle,
 		isWrite: boolean
 	) => void | Promise<void>;
-	outputOptions: (this: PluginContext, options: OutputOptions) => OutputOptions | null | undefined;
+	outputOptions: (this: PluginContext, options: OutputOptions) => OutputOptions | EmptyValue;
 	renderChunk: RenderChunkHook;
 	renderDynamicImport: (
 		this: PluginContext,
@@ -359,7 +359,7 @@ interface OutputPluginHooks {
 			moduleId: string;
 			targetModuleId: string | null;
 		}
-	) => { left: string; right: string } | null | undefined;
+	) => { left: string; right: string } | EmptyValue;
 	renderError: (this: PluginContext, err?: Error) => Promise<void> | void;
 	renderStart: (
 		this: PluginContext,
@@ -461,17 +461,13 @@ interface GetManualChunkApi {
 	getModuleIds: () => IterableIterator<string>;
 	getModuleInfo: GetModuleInfo;
 }
-export type GetManualChunk = (id: string, api: GetManualChunkApi) => string | null | undefined;
+export type GetManualChunk = (id: string, api: GetManualChunkApi) => string | EmptyValue;
 
 export type ExternalOption =
 	| (string | RegExp)[]
 	| string
 	| RegExp
-	| ((
-			source: string,
-			importer: string | undefined,
-			isResolved: boolean
-	  ) => boolean | null | undefined);
+	| ((source: string, importer: string | undefined, isResolved: boolean) => boolean | EmptyValue);
 export type PureModulesOption = boolean | string[] | IsPureModule;
 export type GlobalsOption = { [name: string]: string } | ((name: string) => string);
 export type InputOption = string | string[] | { [entryAlias: string]: string };
@@ -495,7 +491,7 @@ export interface InputOptions {
 	input?: InputOption;
 	/** @deprecated Use the "manualChunks" output option instead. */
 	manualChunks?: ManualChunksOption;
-	moduleContext?: ((id: string) => string | null | undefined) | { [id: string]: string };
+	moduleContext?: ((id: string) => string | EmptyValue) | { [id: string]: string };
 	onwarn?: WarningHandlerWithDefault;
 	perf?: boolean;
 	plugins?: Plugin[];
@@ -813,3 +809,5 @@ interface AcornNode {
 	start: number;
 	type: string;
 }
+
+type EmptyValue = null | void | undefined;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->


Many plugin methods that are allowed to return null or undefined are forced to explicitly return one or the other. For example, the following two variations of the `outputOptions` hook are functionally identical, but one causes a typings error while the other doesn't:

![image](https://user-images.githubusercontent.com/4998038/93910119-8f085b80-fcf8-11ea-9520-aa97150cf65a.png)

![image](https://user-images.githubusercontent.com/4998038/93910248-b95a1900-fcf8-11ea-9138-5c7980c6c5a7.png)

This PR adds a consistent type alias for `null | undefined | void` and updates relevant `null | undefined` instances with the new alias.