### PR TITLE
Fix SystemJS default variable conflict

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -994,7 +994,6 @@ export default class Chunk {
 
 	private getDependenciesToBeDeconflicted(
 		addNonNamespacesAndInteropHelpers: boolean,
-		addInternalDependencies: boolean,
 		addDependenciesWithoutBindings: boolean,
 		interop: GetInterop
 	): DependenciesToBeDeconflicted {
@@ -1017,7 +1016,7 @@ export default class Chunk {
 							}
 						}
 					}
-				} else if (addInternalDependencies) {
+				} else {
 					const chunk = this.chunkByModule.get(module)!;
 					if (chunk !== this) {
 						dependencies.add(chunk);
@@ -1259,7 +1258,6 @@ export default class Chunk {
 			this.orderedModules,
 			this.getDependenciesToBeDeconflicted(
 				format !== 'es' && format !== 'system',
-				format !== 'system',
 				format === 'amd' || format === 'umd' || format === 'iife',
 				interop
 			),

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_config.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description: 'deconflicts SystemJS default export variable with namespace imports',
+	options: {
+		external: 'external',
+		output: { preserveModules: true }
+	}
+};

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/amd/main.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/amd/main.js
@@ -1,0 +1,7 @@
+define(['./other'], function (other) { 'use strict';
+
+	var main = other + "extended";
+
+	return main;
+
+});

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/amd/other.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/amd/other.js
@@ -1,0 +1,9 @@
+define(['exports'], function (exports) { 'use strict';
+
+	const foo = 'bar';
+
+	exports.foo = foo;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+});

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/cjs/main.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var other = require('./other.js');
+
+var main = other + "extended";
+
+module.exports = main;

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/cjs/other.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/cjs/other.js
@@ -1,0 +1,7 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const foo = 'bar';
+
+exports.foo = foo;

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/es/main.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/es/main.js
@@ -1,0 +1,5 @@
+import * as other from './other.js';
+
+var main = other + "extended";
+
+export default main;

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/es/other.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/es/other.js
@@ -1,0 +1,3 @@
+const foo = 'bar';
+
+export { foo };

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/system/main.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register(['./other.js'], function (exports) {
+	'use strict';
+	var other;
+	return {
+		setters: [function (module) {
+			other = module;
+		}],
+		execute: function () {
+
+			var main = exports('default', other + "extended");
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/system/other.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/_expected/system/other.js
@@ -1,0 +1,10 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			const foo = exports('foo', 'bar');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/main.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/main.js
@@ -1,0 +1,3 @@
+import * as main from './other.js';
+
+export default main + "extended";

--- a/test/chunking-form/samples/deconflict-system-default-export-variable/other.js
+++ b/test/chunking-form/samples/deconflict-system-default-export-variable/other.js
@@ -1,0 +1,1 @@
+export const foo = 'bar'

--- a/test/chunking-form/samples/deprecated/preserve-modules-dynamic-namespace/_expected/system/main.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-dynamic-namespace/_expected/system/main.js
@@ -1,13 +1,13 @@
 System.register(['./m1.js'], function () {
 	'use strict';
-	var ms;
+	var m1;
 	return {
 		setters: [function (module) {
-			ms = module;
+			m1 = module;
 		}],
 		execute: function () {
 
-			console.log(ms);
+			console.log(m1);
 
 		}
 	};

--- a/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-dynamic-namespace/_expected/system/main.js
@@ -1,13 +1,13 @@
 System.register(['./m1.js'], function () {
 	'use strict';
-	var ms;
+	var m1;
 	return {
 		setters: [function (module) {
-			ms = module;
+			m1 = module;
 		}],
 		execute: function () {
 
-			console.log(ms);
+			console.log(m1);
 
 		}
 	};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
resolves rollup/plugins#583

### Description
In SystemJS at the moment, every default export is creating a new variable. This is causing issues when by accident the variable name conflicts with the name of an imported namespace, which is fixed here.
