### PR TITLE
Document that the default value of --format is 'cjs'

### DIFF
--- a/cli/help.md
+++ b/cli/help.md
@@ -9,7 +9,7 @@ Basic options:
                               is unspecified, defaults to rollup.config.js)
 -d, --dir <dirname>         Directory for chunks (if absent, prints to stdout)
 -e, --external <ids>        Comma-separate list of module IDs to exclude
--f, --format <format>       Type of output (amd, cjs, es, iife, umd, system)
+-f, --format <format>       Type of output (amd, cjs, es, iife, umd, system) (default is cjs)
 -g, --globals <pairs>       Comma-separate list of `moduleID:Global` pairs
 -h, --help                  Show this help message
 -i, --input <filename>      Input (alternative to <entry file>)

--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -267,7 +267,7 @@ Many options have command line equivalents. In those cases, any arguments passed
                               is unspecified, defaults to rollup.config.js)
 -d, --dir <dirname>         Directory for chunks (if absent, prints to stdout)
 -e, --external <ids>        Comma-separate list of module IDs to exclude
--f, --format <format>       Type of output (amd, cjs, es, iife, umd, system)
+-f, --format <format>       Type of output (amd, cjs, es, iife, umd, system) (default is cjs)
 -g, --globals <pairs>       Comma-separate list of `moduleID:Global` pairs
 -h, --help                  Show this help message
 -i, --input <filename>      Input (alternative to <entry file>)

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -127,7 +127,8 @@ The file to write to. Will also be used to generate sourcemaps, if applicable. C
 
 #### output.format
 Type: `string`<br>
-CLI: `-f`/`--format <formatspecifier>`
+CLI: `-f`/`--format <formatspecifier>`<br>
+Default: `"cjs"`
 
 Specifies the format of the generated bundle. One of the following:
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

My config had lazily omitted the `--format`, yet I was using the output in a browser.
This works sometimes (if the input has no exports?), but is incorrect in general.
I would have been less likely to make this mistake if the default was documented.