### PR TITLE
Add moduleParsed plugin hook

### DIFF
--- a/cli/help.md
+++ b/cli/help.md
@@ -32,6 +32,7 @@ Basic options:
 --exports <mode>            Specify export mode (auto, default, named, none)
 --extend                    Extend global variable defined by --name
 --no-externalLiveBindings   Do not generate code to support live bindings
+--failAfterWarnings         Exit with an error if the build produced warnings
 --footer <text>             Code to insert at end of bundle (outside wrapper)
 --no-freeze                 Do not freeze namespace objects
 --no-hoistTransitiveImports Do not hoist transitive imports into entry chunks
@@ -46,14 +47,13 @@ Basic options:
 --preferConst               Use `const` instead of `var` for exports
 --no-preserveEntrySignatures Avoid facade chunks for entry points
 --preserveModules           Preserve module structure
---preserveModulesRoot       Preserved modules under this path are rooted in output `dir`
+--preserveModulesRoot       Put preserved modules under this path at root level
 --preserveSymlinks          Do not follow symlinks when resolving files
 --shimMissingExports        Create shim variables for missing exports
 --silent                    Don't print warnings
---failAfterWarnings         Exit with an error code if there was a warning during the build
 --sourcemapExcludeSources   Do not include source code in source maps
 --sourcemapFile <file>      Specify bundle position for source maps
---stdin=ext                 Specify file extension used for stdin input - default is none
+--stdin=ext                 Specify file extension used for stdin input
 --no-stdin                  Do not read "-" from stdin
 --no-strict                 Don't emit `"use strict";` in the generated modules
 --strictDeprecations        Throw errors for deprecated features

--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -290,6 +290,7 @@ Many options have command line equivalents. In those cases, any arguments passed
 --exports <mode>            Specify export mode (auto, default, named, none)
 --extend                    Extend global variable defined by --name
 --no-externalLiveBindings   Do not generate code to support live bindings
+--failAfterWarnings         Exit with an error if the build produced warnings
 --footer <text>             Code to insert at end of bundle (outside wrapper)
 --no-freeze                 Do not freeze namespace objects
 --no-hoistTransitiveImports Do not hoist transitive imports into entry chunks
@@ -304,14 +305,13 @@ Many options have command line equivalents. In those cases, any arguments passed
 --preferConst               Use `const` instead of `var` for exports
 --no-preserveEntrySignatures Avoid facade chunks for entry points
 --preserveModules           Preserve module structure
---preserveModulesRoot       Preserved modules under this path are rooted in output `dir`
+--preserveModulesRoot       Put preserved modules under this path at root level
 --preserveSymlinks          Do not follow symlinks when resolving files
 --shimMissingExports        Create shim variables for missing exports
 --silent                    Don't print warnings
---failAfterWarnings         Exit with an error code if there was a warning during the build
 --sourcemapExcludeSources   Do not include source code in source maps
 --sourcemapFile <file>      Specify bundle position for source maps
---stdin=ext                 Specify file extension used for stdin input - default is none
+--stdin=ext                 Specify file extension used for stdin input
 --no-stdin                  Do not read "-" from stdin
 --no-strict                 Don't emit `"use strict";` in the generated modules
 --strictDeprecations        Throw errors for deprecated features

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -79,7 +79,7 @@ See [Output Generation Hooks](guide/en/#output-generation-hooks) for hooks that 
 #### `buildEnd`
 Type: `(error?: Error) => void`<br>
 Kind: `async, parallel`<br>
-Previous Hook: [`transform`](guide/en/#transform), [`resolveId`](guide/en/#resolveid) or [`resolveDynamicImport`](guide/en/#resolvedynamicimport).<br>
+Previous Hook: [`moduleParsed`](guide/en/#moduleparsed), [`resolveId`](guide/en/#resolveid) or [`resolveDynamicImport`](guide/en/#resolvedynamicimport).<br>
 Next Hook: [`outputOptions`](guide/en/#outputoptions) in the output generation phase as this is the last hook of the build phase.
 
 Called when rollup has finished bundling, but before `generate` or `write` is called; you can also return a Promise. If an error occurred during the build, it is passed on to this hook.
@@ -108,6 +108,18 @@ See [custom module meta-data](guide/en/#custom-module-meta-data) for how to use 
 
 You can use [`this.getModuleInfo`](guide/en/#thisgetmoduleinfomoduleid-string--moduleinfo--null) to find out the previous values of `moduleSideEffects`, `syntheticNamedExports` and `meta` inside this hook.
 
+#### `moduleParsed`
+Type: `(moduleInfo: ModuleInfo) => void`<br>
+Kind: `async, parallel`<br>
+Previous Hook: [`transform`](guide/en/#transform) where the currently handled file was transformed.<br>
+NextHook: [`resolveId`](guide/en/#resolveid) and [`resolveDynamicImport`](guide/en/#resolvedynamicimport) to resolve all discovered static and dynamic imports in parallel if present, otherwise [`buildEnd`](guide/en/#buildend).
+
+This hook is called each time a module has been fully parsed by Rollup. See [`this.getModuleInfo`](guide/en/#thisgetmoduleinfomoduleid-string--moduleinfo--null) for what information is passed to this hook.
+
+In contrast to the [`transform`](guide/en/#transform) hook, this hook is never cached and can be used to get information about both cached and other modules, including the final shape of the `meta` property, the `code` and the `ast`.
+
+Note that information about imported modules is not yet available in this hook, and information about importing modules may be incomplete as additional importers could be discovered later. If you need this information, use the [`buildEnd`](guide/en/#buildend) hook.
+
 #### `options`
 Type: `(options: InputOptions) => InputOptions | null`<br>
 Kind: `async, sequential`<br>
@@ -121,7 +133,7 @@ This is the only hook that does not have access to most [plugin context](guide/e
 #### `resolveDynamicImport`
 Type: `(specifier: string | ESTree.Node, importer: string) => string | false | null | {id: string, external?: boolean}`<br>
 Kind: `async, first`<br>
-Previous Hook: [`transform`](guide/en/#transform) where the importing file was transformed.<br>
+Previous Hook: [`moduleParsed`](guide/en/#moduleparsed) for the importing file.<br>
 Next Hook: [`load`](guide/en/#load) if the hook resolved with an id that has not yet been loaded, [`resolveId`](guide/en/#resolveid) if the dynamic import contains a string and was not resolved by the hook, otherwise [`buildEnd`](guide/en/#buildend).
 
 Defines a custom resolver for dynamic imports. Returning `false` signals that the import should be kept as it is and not be passed to other resolvers thus making it external. Similar to the [`resolveId`](guide/en/#resolveid) hook, you can also return an object to resolve the import to a different id while marking it as external at the same time.
@@ -138,7 +150,7 @@ Note that the return value of this hook will not be passed to `resolveId` afterw
 #### `resolveId`
 Type: `(source: string, importer: string | undefined, options: {custom?: {[plugin: string]: any}) => string | false | null | {id: string, external?: boolean, moduleSideEffects?: boolean | "no-treeshake" | null, syntheticNamedExports?: boolean | string | null, meta?: {[plugin: string]: any} | null}`<br>
 Kind: `async, first`<br>
-Previous Hook: [`buildStart`](guide/en/#buildstart) if we are resolving an entry point, [`transform`](guide/en/#transform) if we are resolving an import, or as fallback for [`resolveDynamicImport`](guide/en/#resolvedynamicimport). Additionally this hook can be triggered during the build phase from plugin hooks by calling [`this.emitFile`](guide/en/#thisemitfileemittedfile-emittedchunk--emittedasset--string) to emit an entry point or at any time by calling [`this.resolve`](guide/en/#thisresolvesource-string-importer-string-options-skipself-boolean-custom-plugin-string-any--promiseid-string-external-boolean-modulesideeffects-boolean--no-treeshake-syntheticnamedexports-boolean--string-custom-plugin-string-any--null) to manually resolve an id.<br>
+Previous Hook: [`buildStart`](guide/en/#buildstart) if we are resolving an entry point, [`moduleParsed`](guide/en/#moduleparsed) if we are resolving an import, or as fallback for [`resolveDynamicImport`](guide/en/#resolvedynamicimport). Additionally this hook can be triggered during the build phase from plugin hooks by calling [`this.emitFile`](guide/en/#thisemitfileemittedfile-emittedchunk--emittedasset--string) to emit an entry point or at any time by calling [`this.resolve`](guide/en/#thisresolvesource-string-importer-string-options-skipself-boolean-custom-plugin-string-any--promiseid-string-external-boolean-modulesideeffects-boolean--no-treeshake-syntheticnamedexports-boolean--string-custom-plugin-string-any--null) to manually resolve an id.<br>
 Next Hook: [`load`](guide/en/#load) if the resolved id that has not yet been loaded, otherwise [`buildEnd`](guide/en/#buildend).
 
 Defines a custom resolver. A resolver can be useful for e.g. locating third-party dependencies. Here `source` is the importee exactly as it is written in the import statement, i.e. for
@@ -201,7 +213,7 @@ When triggering this hook from a plugin via [`this.resolve(source, importer, opt
 Type: `(code: string, id: string) => string | null | {code?: string, map?: string | SourceMap, ast? : ESTree.Program, moduleSideEffects?: boolean | "no-treeshake" | null, syntheticNamedExports?: boolean | string | null, meta?: {[plugin: string]: any} | null}`<br>
 Kind: `async, sequential`<br>
 Previous Hook: [`load`](guide/en/#load) where the currently handled file was loaded.<br>
-NextHook: [`resolveId`](guide/en/#resolveid) and [`resolveDynamicImport`](guide/en/#resolvedynamicimport) to resolve all discovered static and dynamic imports in parallel if present, otherwise [`buildEnd`](guide/en/#buildend).
+NextHook: [`moduleParsed`](guide/en/#moduleparsed) once the file has been processed and parsed.
 
 Can be used to transform individual modules. To prevent additional parsing overhead in case e.g. this hook already used `this.parse` to generate an AST for some reason, this hook can optionally return a `{ code, ast, map }` object. The `ast` must be a standard ESTree AST with `start` and `end` properties for each node. If the transformation does not move code, you can preserve existing sourcemaps by setting `map` to `null`. Otherwise you might need to generate the source map. See [the section on source code transformations](#source-code-transformations).
 

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -624,6 +624,8 @@ Returns additional information about the module in question in the form
 ```
 {
   id: string, // the id of the module, for convenience
+  code: string | null, // the source code of the module, `null` if external or not yet available
+  ast: ESTree.Program, // the parsed abstract syntax tree if available
   isEntry: boolean, // is this a user- or plugin-defined entry point
   isExternal: boolean, // for external modules that are referenced but not included in the graph
   importedIds: string[], // the module ids statically imported by this module
@@ -636,7 +638,10 @@ Returns additional information about the module in question in the form
 }
 ```
 
-This utility function returns `null` if the module id cannot be found.
+During the build, this object represents currently available information about the module. Before the [`buildEnd`](guide/en/#buildend) hook, this information may be incomplete as e.g.
+ the `importedIds` are not yet resolved or additional `importers` are discovered.
+ 
+Returns `null` if the module id cannot be found.
 
 #### `this.meta: {rollupVersion: string, watchMode: boolean}`
 

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -267,7 +267,7 @@ function getIncludedModules(modulesById: Map<string, Module | ExternalModule>): 
 	return [...modulesById.values()].filter(
 		module =>
 			module instanceof Module &&
-			(module.isIncluded() || module.isEntryPoint || module.includedDynamicImporters.length > 0)
+			(module.isIncluded() || module.info.isEntry || module.includedDynamicImporters.length > 0)
 	) as Module[];
 }
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -162,7 +162,7 @@ export default class Chunk {
 		}
 		if (
 			!chunk.dependencies.has(chunkByModule.get(facadedModule)!) &&
-			facadedModule.moduleSideEffects &&
+			facadedModule.info.hasModuleSideEffects &&
 			facadedModule.hasEffects()
 		) {
 			chunk.dependencies.add(chunkByModule.get(facadedModule)!);
@@ -234,7 +234,7 @@ export default class Chunk {
 			if (this.isEmpty && module.isIncluded()) {
 				this.isEmpty = false;
 			}
-			if (module.isEntryPoint || outputOptions.preserveModules) {
+			if (module.info.isEntry || outputOptions.preserveModules) {
 				this.entryModules.push(module);
 			}
 			for (const importer of module.includedDynamicImporters) {
@@ -307,7 +307,7 @@ export default class Chunk {
 		} else {
 			assignExportsToNames(remainingExports, this.exportsByName, this.exportNamesByVariable);
 		}
-		if (this.outputOptions.preserveModules || (this.facadeModule && this.facadeModule.isEntryPoint))
+		if (this.outputOptions.preserveModules || (this.facadeModule && this.facadeModule.info.isEntry))
 			this.exportMode = getExportMode(
 				this,
 				this.outputOptions,
@@ -473,7 +473,7 @@ export default class Chunk {
 			exports: this.getExportNames(),
 			facadeModuleId: facadeModule && facadeModule.id,
 			isDynamicEntry: this.dynamicEntryModules.length > 0,
-			isEntry: facadeModule !== null && facadeModule.isEntryPoint,
+			isEntry: facadeModule !== null && facadeModule.info.isEntry,
 			isImplicitEntry: this.implicitEntryModules.length > 0,
 			modules: this.renderedModules,
 			get name() {
@@ -718,7 +718,7 @@ export default class Chunk {
 				intro: addons.intro!,
 				isEntryModuleFacade:
 					this.outputOptions.preserveModules ||
-					(this.facadeModule !== null && this.facadeModule.isEntryPoint),
+					(this.facadeModule !== null && this.facadeModule.info.isEntry),
 				namedExportsMode: this.exportMode !== 'default',
 				outro: addons.outro!,
 				usesTopLevelAwait,
@@ -1307,7 +1307,7 @@ export default class Chunk {
 		}
 		if (
 			this.includedNamespaces.has(module) ||
-			(module.isEntryPoint && module.preserveSignature !== false) ||
+			(module.info.isEntry && module.preserveSignature !== false) ||
 			module.includedDynamicImporters.some(importer => this.chunkByModule.get(importer) !== this)
 		) {
 			this.ensureReexportsAreAvailableForModule(module);

--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -1,22 +1,23 @@
 import ExternalVariable from './ast/variables/ExternalVariable';
 import {
 	CustomPluginOptions,
+	ModuleInfo,
 	NormalizedInputOptions,
 	NormalizedOutputOptions
 } from './rollup/types';
+import { EMPTY_ARRAY } from './utils/blank';
 import { makeLegal } from './utils/identifierHelpers';
 import { isAbsolute, normalize, relative } from './utils/path';
 
 export default class ExternalModule {
 	chunk: void;
-	// TODO Lukas get from resolution
-	custom: CustomPluginOptions = {};
 	declarations: { [name: string]: ExternalVariable };
 	defaultVariableName = '';
 	dynamicImporters: string[] = [];
 	execIndex: number;
 	exportedVariables: Map<ExternalVariable, string>;
 	importers: string[] = [];
+	info: ModuleInfo;
 	mostCommonSuggestion = 0;
 	namespaceVariableName = '';
 	nameSuggestions: { [name: string]: number };
@@ -30,19 +31,35 @@ export default class ExternalModule {
 	constructor(
 		private readonly options: NormalizedInputOptions,
 		public readonly id: string,
-		public moduleSideEffects: boolean | 'no-treeshake',
-		public meta: CustomPluginOptions
+		hasModuleSideEffects: boolean | 'no-treeshake',
+		meta: CustomPluginOptions
 	) {
-		this.id = id;
 		this.execIndex = Infinity;
-		this.moduleSideEffects = moduleSideEffects;
-
-		const parts = id.split(/[\\/]/);
-		this.suggestedVariableName = makeLegal(parts.pop()!);
-
+		this.suggestedVariableName = makeLegal(id.split(/[\\/]/).pop()!);
 		this.nameSuggestions = Object.create(null);
 		this.declarations = Object.create(null);
 		this.exportedVariables = new Map();
+
+		const module = this;
+		this.info = {
+			ast: null,
+			code: null,
+			dynamicallyImportedIds: EMPTY_ARRAY,
+			get dynamicImporters() {
+				return module.dynamicImporters.sort();
+			},
+			hasModuleSideEffects,
+			id,
+			implicitlyLoadedAfterOneOf: EMPTY_ARRAY,
+			implicitlyLoadedBefore: EMPTY_ARRAY,
+			importedIds: EMPTY_ARRAY,
+			get importers() {
+				return module.importers.sort();
+			},
+			isEntry: false,
+			isExternal: true,
+			meta
+		};
 	}
 
 	getVariableForExportName(name: string): ExternalVariable {

--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -9,6 +9,8 @@ import { isAbsolute, normalize, relative } from './utils/path';
 
 export default class ExternalModule {
 	chunk: void;
+	// TODO Lukas get from resolution
+	custom: CustomPluginOptions = {};
 	declarations: { [name: string]: ExternalVariable };
 	defaultVariableName = '';
 	dynamicImporters: string[] = [];

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -12,11 +12,9 @@ import {
 	RollupWatcher,
 	SerializablePluginCache
 } from './rollup/types';
-import { EMPTY_ARRAY } from './utils/blank';
 import { BuildPhase } from './utils/buildPhase';
 import { errImplicitDependantIsNotIncluded, error } from './utils/error';
 import { analyseModuleExecution } from './utils/executionOrder';
-import { getId } from './utils/getId';
 import { PluginDriver } from './utils/PluginDriver';
 import relativeId from './utils/relativeId';
 import { timeEnd, timeStart } from './utils/timers';
@@ -136,49 +134,7 @@ export default class Graph {
 	getModuleInfo = (moduleId: string): ModuleInfo | null => {
 		const foundModule = this.modulesById.get(moduleId);
 		if (!foundModule) return null;
-		return {
-			ast: (foundModule as Module).ast?.esTreeNode || null,
-			code: foundModule instanceof Module ? foundModule.code : null,
-			get dynamicallyImportedIds() {
-				if (foundModule instanceof Module) {
-					const dynamicallyImportedIds: string[] = [];
-					for (const { resolution } of foundModule.dynamicImports) {
-						if (resolution instanceof Module || resolution instanceof ExternalModule) {
-							dynamicallyImportedIds.push(resolution.id);
-						}
-					}
-					return dynamicallyImportedIds;
-				}
-				return EMPTY_ARRAY;
-			},
-			get dynamicImporters() {
-				return foundModule!.dynamicImporters.sort();
-			},
-			hasModuleSideEffects: foundModule.moduleSideEffects,
-			id: foundModule.id,
-			get implicitlyLoadedAfterOneOf() {
-				return foundModule instanceof Module
-					? Array.from(foundModule.implicitlyLoadedAfter, getId)
-					: EMPTY_ARRAY;
-			},
-			get implicitlyLoadedBefore() {
-				return foundModule instanceof Module
-					? Array.from(foundModule.implicitlyLoadedBefore, getId)
-					: [];
-			},
-			get importedIds() {
-				if (foundModule instanceof Module) {
-					return Array.from(foundModule.sources, source => foundModule.resolvedIds[source].id);
-				}
-				return EMPTY_ARRAY;
-			},
-			get importers() {
-				return foundModule!.importers.sort();
-			},
-			isEntry: foundModule instanceof Module && foundModule.isEntryPoint,
-			isExternal: foundModule instanceof ExternalModule,
-			meta: foundModule.meta
-		};
+		return foundModule.info;
 	};
 
 	private async generateModuleGraph(): Promise<void> {
@@ -213,7 +169,7 @@ export default class Graph {
 				this.needsTreeshakingPass = false;
 				for (const module of this.modules) {
 					if (module.isExecuted) {
-						if (module.moduleSideEffects === 'no-treeshake') {
+						if (module.info.hasModuleSideEffects === 'no-treeshake') {
 							module.includeAllInBundle();
 						} else {
 							module.include();
@@ -228,7 +184,7 @@ export default class Graph {
 		for (const externalModule of this.externalModules) externalModule.warnUnusedImports();
 		for (const module of this.implicitEntryModules) {
 			for (const dependant of module.implicitlyLoadedAfter) {
-				if (!(dependant.isEntryPoint || dependant.isIncluded())) {
+				if (!(dependant.info.isEntry || dependant.isIncluded())) {
 					error(errImplicitDependantIsNotIncluded(dependant));
 				}
 			}

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -137,6 +137,8 @@ export default class Graph {
 		const foundModule = this.modulesById.get(moduleId);
 		if (!foundModule) return null;
 		return {
+			ast: (foundModule as Module).ast?.esTreeNode || null,
+			code: foundModule instanceof Module ? foundModule.code : null,
 			get dynamicallyImportedIds() {
 				if (foundModule instanceof Module) {
 					const dynamicallyImportedIds: string[] = [];

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -266,7 +266,9 @@ export class ModuleLoader {
 			module.dynamicImports.map(async dynamicImport => {
 				const resolvedId = await this.resolveDynamicImport(
 					module,
-					dynamicImport.argument,
+					typeof dynamicImport.argument === 'string'
+						? dynamicImport.argument
+						: dynamicImport.argument.esTreeNode,
 					module.id
 				);
 				if (resolvedId === null) return null;
@@ -475,7 +477,6 @@ export class ModuleLoader {
 		specifier: string | acorn.Node,
 		importer: string
 	): Promise<ResolvedId | string | null> {
-		// TODO we only should expose the acorn AST here
 		const resolution = await this.pluginDriver.hookFirst('resolveDynamicImport', [
 			specifier,
 			importer

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -183,7 +183,7 @@ export class ModuleLoader {
 			this.loadEntryModule(unresolvedModule.id, false, unresolvedModule.importer, null).then(
 				async entryModule => {
 					addChunkNamesToModule(entryModule, unresolvedModule, false);
-					if (!entryModule.isEntryPoint) {
+					if (!entryModule.info.isEntry) {
 						this.implicitEntryModules.add(entryModule);
 						const implicitlyLoadedAfterModules = await Promise.all(
 							implicitlyLoadedAfter.map(id =>
@@ -299,7 +299,7 @@ export class ModuleLoader {
 		const existingModule = this.modulesById.get(id);
 		if (existingModule instanceof Module) {
 			if (isEntry) {
-				existingModule.isEntryPoint = true;
+				existingModule.info.isEntry = true;
 				this.implicitEntryModules.delete(existingModule);
 				for (const dependant of existingModule.implicitlyLoadedAfter) {
 					dependant.implicitlyLoadedBefore.delete(existingModule);
@@ -321,6 +321,7 @@ export class ModuleLoader {
 		this.modulesById.set(id, module);
 		this.graph.watchFiles[id] = true;
 		await this.addModuleSource(id, importer, module);
+		await this.pluginDriver.hookParallel('moduleParsed', [module.info]);
 		await Promise.all([
 			this.fetchStaticDependencies(module),
 			this.fetchDynamicDependencies(module)

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -1,3 +1,4 @@
+import * as acorn from 'acorn';
 import { locate } from 'locate-character';
 import MagicString from 'magic-string';
 import { AstContext, CommentDescription } from '../../../Module';
@@ -20,8 +21,7 @@ import * as NodeType from '../NodeType';
 import SpreadElement from '../SpreadElement';
 import { ExpressionEntity } from './Expression';
 
-export interface GenericEsTreeNode {
-	type: string;
+export interface GenericEsTreeNode extends acorn.Node {
 	[key: string]: any;
 }
 
@@ -32,6 +32,7 @@ export interface Node extends Entity {
 	annotations?: CommentDescription[];
 	context: AstContext;
 	end: number;
+	esTreeNode: GenericEsTreeNode;
 	included: boolean;
 	keys: string[];
 	needsBoundaries?: boolean;
@@ -93,6 +94,7 @@ export interface ExpressionNode extends ExpressionEntity, Node {}
 export class NodeBase implements ExpressionNode {
 	context: AstContext;
 	end!: number;
+	esTreeNode: acorn.Node;
 	included = false;
 	keys: string[];
 	parent: Node | { context: AstContext; type: string };
@@ -105,6 +107,7 @@ export class NodeBase implements ExpressionNode {
 		parent: Node | { context: AstContext; type: string },
 		parentScope: ChildScope
 	) {
+		this.esTreeNode = esTreeNode;
 		this.keys = keys[esTreeNode.type] || getAndCreateKeys(esTreeNode);
 		this.parent = parent;
 		this.context = parent.context;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -179,10 +179,6 @@ export interface CustomPluginOptions {
 	[plugin: string]: any;
 }
 
-export interface CustomPluginOptions {
-	[plugin: string]: any;
-}
-
 export interface PluginContext extends MinimalPluginContext {
 	addWatchFile: (id: string) => void;
 	cache: PluginCache;
@@ -269,6 +265,8 @@ export type TransformHook = (
 	id: string
 ) => Promise<TransformResult> | TransformResult;
 
+export type ModuleParsedHook = (this: PluginContext, info: ModuleInfo) => Promise<void> | void;
+
 export type RenderChunkHook = (
 	this: PluginContext,
 	code: string,
@@ -348,8 +346,8 @@ export interface PluginHooks extends OutputPluginHooks {
 	buildEnd: (this: PluginContext, err?: Error) => Promise<void> | void;
 	buildStart: (this: PluginContext, options: NormalizedInputOptions) => Promise<void> | void;
 	load: LoadHook;
+	moduleParsed: ModuleParsedHook;
 	options: (this: MinimalPluginContext, options: InputOptions) => InputOptions | null | undefined;
-	// TODO Lukas parsedModule hook
 	resolveDynamicImport: ResolveDynamicImportHook;
 	resolveId: ResolveIdHook;
 	transform: TransformHook;
@@ -397,6 +395,7 @@ export type AsyncPluginHooks =
 	| 'buildStart'
 	| 'generateBundle'
 	| 'load'
+	| 'moduleParsed'
 	| 'renderChunk'
 	| 'renderError'
 	| 'renderStart'
@@ -433,6 +432,7 @@ export type ParallelPluginHooks =
 	| 'buildStart'
 	| 'footer'
 	| 'intro'
+	| 'moduleParsed'
 	| 'outro'
 	| 'renderError'
 	| 'renderStart'

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -177,6 +177,10 @@ export interface CustomPluginOptions {
 	[plugin: string]: any;
 }
 
+export interface CustomPluginOptions {
+	[plugin: string]: any;
+}
+
 export interface PluginContext extends MinimalPluginContext {
 	addWatchFile: (id: string) => void;
 	cache: PluginCache;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -158,6 +158,8 @@ export type EmitChunk = (id: string, options?: { name?: string }) => string;
 export type EmitFile = (emittedFile: EmittedFile) => string;
 
 interface ModuleInfo {
+	ast: AcornNode | null;
+	code: string | null;
 	dynamicallyImportedIds: readonly string[];
 	dynamicImporters: readonly string[];
 	hasModuleSideEffects: boolean | 'no-treeshake';
@@ -347,6 +349,7 @@ export interface PluginHooks extends OutputPluginHooks {
 	buildStart: (this: PluginContext, options: NormalizedInputOptions) => Promise<void> | void;
 	load: LoadHook;
 	options: (this: MinimalPluginContext, options: InputOptions) => InputOptions | null | undefined;
+	// TODO Lukas parsedModule hook
 	resolveDynamicImport: ResolveDynamicImportHook;
 	resolveId: ResolveIdHook;
 	transform: TransformHook;

--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -48,6 +48,7 @@ const inputHookNames: {
 	buildEnd: 1,
 	buildStart: 1,
 	load: 1,
+	moduleParsed: 1,
 	options: 1,
 	resolveDynamicImport: 1,
 	resolveId: 1,

--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -185,8 +185,6 @@ function getCollapsedSourcemap(
 	} else {
 		const sources = originalSourcemap.sources;
 		const sourcesContent = originalSourcemap.sourcesContent || [];
-
-		// TODO indiscriminately treating IDs and sources as normal paths is probably bad.
 		const directory = dirname(id) || '.';
 		const sourceRoot = originalSourcemap.sourceRoot || '.';
 

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -161,7 +161,7 @@ export default function transform(
 				ast,
 				code,
 				customTransformCache,
-				meta: module.meta,
+				meta: module.info.meta,
 				originalCode,
 				originalSourcemap,
 				sourcemapChain,

--- a/src/utils/traverseStaticDependencies.ts
+++ b/src/utils/traverseStaticDependencies.ts
@@ -10,7 +10,7 @@ export function markModuleAndImpureDependenciesAsExecuted(baseModule: Module) {
 			if (
 				!(dependency instanceof ExternalModule) &&
 				!dependency.isExecuted &&
-				(dependency.moduleSideEffects || module.implicitlyLoadedBefore.has(dependency)) &&
+				(dependency.info.hasModuleSideEffects || module.implicitlyLoadedBefore.has(dependency)) &&
 				!visitedModules.has(dependency.id)
 			) {
 				dependency.isExecuted = true;

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry/_config.js
@@ -24,7 +24,52 @@ module.exports = {
 				});
 			},
 			buildEnd() {
-				assert.deepStrictEqual(this.getModuleInfo(ID_MAIN), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_MAIN))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								source: { type: 'Literal', start: 22, end: 29, value: './lib', raw: "'./lib'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,
@@ -37,7 +82,52 @@ module.exports = {
 					isExternal: false,
 					meta: {}
 				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_DEP), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								source: { type: 'Literal', start: 22, end: 29, value: './lib', raw: "'./lib'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-entry/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-entry/_config.js
@@ -20,7 +20,52 @@ module.exports = {
 				});
 			},
 			buildEnd() {
-				assert.deepStrictEqual(this.getModuleInfo(ID_MAIN), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_MAIN))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								source: { type: 'Literal', start: 22, end: 29, value: './lib', raw: "'./lib'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,
@@ -33,7 +78,52 @@ module.exports = {
 					isExternal: false,
 					meta: {}
 				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_DEP), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								source: { type: 'Literal', start: 22, end: 29, value: './lib', raw: "'./lib'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,

--- a/test/chunking-form/samples/implicit-dependencies/multiple-dependencies/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/multiple-dependencies/_config.js
@@ -33,7 +33,88 @@ module.exports = {
 				});
 			},
 			buildEnd() {
-				assert.deepStrictEqual(this.getModuleInfo(ID_MAIN1), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_MAIN1))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 137,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 13,
+										imported: { type: 'Identifier', start: 9, end: 13, name: 'lib1' },
+										local: { type: 'Identifier', start: 9, end: 13, name: 'lib1' }
+									}
+								],
+								source: { type: 'Literal', start: 21, end: 29, value: './lib1', raw: "'./lib1'" }
+							},
+							{
+								type: 'ImportDeclaration',
+								start: 31,
+								end: 63,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 40,
+										end: 45,
+										imported: { type: 'Identifier', start: 40, end: 45, name: 'lib1b' },
+										local: { type: 'Identifier', start: 40, end: 45, name: 'lib1b' }
+									}
+								],
+								source: { type: 'Literal', start: 53, end: 62, value: './lib1b', raw: "'./lib1b'" }
+							},
+							{
+								type: 'ImportDeclaration',
+								start: 64,
+								end: 94,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 73,
+										end: 77,
+										imported: { type: 'Identifier', start: 73, end: 77, name: 'lib2' },
+										local: { type: 'Identifier', start: 73, end: 77, name: 'lib2' }
+									}
+								],
+								source: { type: 'Literal', start: 85, end: 93, value: './lib2', raw: "'./lib2'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 95,
+								end: 136,
+								expression: {
+									type: 'CallExpression',
+									start: 95,
+									end: 135,
+									callee: {
+										type: 'MemberExpression',
+										start: 95,
+										end: 106,
+										object: { type: 'Identifier', start: 95, end: 102, name: 'console' },
+										property: { type: 'Identifier', start: 103, end: 106, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [
+										{ type: 'Literal', start: 107, end: 114, value: 'main1', raw: "'main1'" },
+										{ type: 'Identifier', start: 116, end: 120, name: 'lib1' },
+										{ type: 'Identifier', start: 123, end: 128, name: 'lib1b' },
+										{ type: 'Identifier', start: 130, end: 134, name: 'lib2' }
+									],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code:
+						"import { lib1 } from './lib1';\nimport { lib1b } from './lib1b';\nimport { lib2 } from './lib2';\nconsole.log('main1', lib1,  lib1b, lib2);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,
@@ -46,7 +127,88 @@ module.exports = {
 					isExternal: false,
 					meta: {}
 				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_MAIN2), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_MAIN2))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 136,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 13,
+										imported: { type: 'Identifier', start: 9, end: 13, name: 'lib1' },
+										local: { type: 'Identifier', start: 9, end: 13, name: 'lib1' }
+									}
+								],
+								source: { type: 'Literal', start: 21, end: 29, value: './lib1', raw: "'./lib1'" }
+							},
+							{
+								type: 'ImportDeclaration',
+								start: 31,
+								end: 63,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 40,
+										end: 45,
+										imported: { type: 'Identifier', start: 40, end: 45, name: 'lib1b' },
+										local: { type: 'Identifier', start: 40, end: 45, name: 'lib1b' }
+									}
+								],
+								source: { type: 'Literal', start: 53, end: 62, value: './lib1b', raw: "'./lib1b'" }
+							},
+							{
+								type: 'ImportDeclaration',
+								start: 64,
+								end: 94,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 73,
+										end: 77,
+										imported: { type: 'Identifier', start: 73, end: 77, name: 'lib3' },
+										local: { type: 'Identifier', start: 73, end: 77, name: 'lib3' }
+									}
+								],
+								source: { type: 'Literal', start: 85, end: 93, value: './lib3', raw: "'./lib3'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 95,
+								end: 135,
+								expression: {
+									type: 'CallExpression',
+									start: 95,
+									end: 134,
+									callee: {
+										type: 'MemberExpression',
+										start: 95,
+										end: 106,
+										object: { type: 'Identifier', start: 95, end: 102, name: 'console' },
+										property: { type: 'Identifier', start: 103, end: 106, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [
+										{ type: 'Literal', start: 107, end: 114, value: 'main2', raw: "'main2'" },
+										{ type: 'Identifier', start: 116, end: 120, name: 'lib1' },
+										{ type: 'Identifier', start: 122, end: 127, name: 'lib1b' },
+										{ type: 'Identifier', start: 129, end: 133, name: 'lib3' }
+									],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code:
+						"import { lib1 } from './lib1';\nimport { lib1b } from './lib1b';\nimport { lib3 } from './lib3';\nconsole.log('main2', lib1, lib1b, lib3);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,
@@ -59,7 +221,87 @@ module.exports = {
 					isExternal: false,
 					meta: {}
 				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_DEP), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 124,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 13,
+										imported: { type: 'Identifier', start: 9, end: 13, name: 'lib1' },
+										local: { type: 'Identifier', start: 9, end: 13, name: 'lib1' }
+									}
+								],
+								source: { type: 'Literal', start: 21, end: 29, value: './lib1', raw: "'./lib1'" }
+							},
+							{
+								type: 'ImportDeclaration',
+								start: 31,
+								end: 61,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 40,
+										end: 44,
+										imported: { type: 'Identifier', start: 40, end: 44, name: 'lib2' },
+										local: { type: 'Identifier', start: 40, end: 44, name: 'lib2' }
+									}
+								],
+								source: { type: 'Literal', start: 52, end: 60, value: './lib2', raw: "'./lib2'" }
+							},
+							{
+								type: 'ImportDeclaration',
+								start: 62,
+								end: 92,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 71,
+										end: 75,
+										imported: { type: 'Identifier', start: 71, end: 75, name: 'lib3' },
+										local: { type: 'Identifier', start: 71, end: 75, name: 'lib3' }
+									}
+								],
+								source: { type: 'Literal', start: 83, end: 91, value: './lib3', raw: "'./lib3'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 93,
+								end: 123,
+								expression: {
+									type: 'CallExpression',
+									start: 93,
+									end: 122,
+									callee: {
+										type: 'MemberExpression',
+										start: 93,
+										end: 104,
+										object: { type: 'Identifier', start: 93, end: 100, name: 'console' },
+										property: { type: 'Identifier', start: 101, end: 104, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [
+										{ type: 'Identifier', start: 105, end: 109, name: 'lib1' },
+										{ type: 'Identifier', start: 111, end: 115, name: 'lib2' },
+										{ type: 'Identifier', start: 117, end: 121, name: 'lib3' }
+									],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code:
+						"import { lib1 } from './lib1';\nimport { lib2 } from './lib2';\nimport { lib3 } from './lib3';\nconsole.log(lib1, lib2, lib3);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,

--- a/test/chunking-form/samples/implicit-dependencies/single-dependency/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/single-dependency/_config.js
@@ -19,7 +19,52 @@ module.exports = {
 				});
 			},
 			buildEnd() {
-				assert.deepStrictEqual(this.getModuleInfo(ID_MAIN), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_MAIN))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								source: { type: 'Literal', start: 22, end: 29, value: './lib', raw: "'./lib'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,
@@ -32,7 +77,52 @@ module.exports = {
 					isExternal: false,
 					meta: {}
 				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_DEP), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								source: { type: 'Literal', start: 22, end: 29, value: './lib', raw: "'./lib'" }
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' },
+										computed: false,
+										optional: false
+									},
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
 					dynamicallyImportedIds: [],
 					dynamicImporters: [],
 					hasModuleSideEffects: true,

--- a/test/function/samples/deprecated/manual-chunks-info/_config.js
+++ b/test/function/samples/deprecated/manual-chunks-info/_config.js
@@ -17,56 +17,213 @@ module.exports = {
 					[getId('main'), 'external', getId('lib'), getId('dynamic')]
 				);
 				assert.deepStrictEqual(
-					[...getModuleIds()].map(id => getModuleInfo(id)),
+					JSON.parse(JSON.stringify([...getModuleIds()].map(id => getModuleInfo(id)))),
 					[
 						{
-							dynamicImporters: [],
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 123,
+								body: [
+									{
+										type: 'ExportNamedDeclaration',
+										start: 0,
+										end: 43,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 7,
+											end: 43,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 13,
+													end: 42,
+													id: { type: 'Identifier', start: 13, end: 20, name: 'promise' },
+													init: {
+														type: 'ImportExpression',
+														start: 23,
+														end: 42,
+														source: {
+															type: 'Literal',
+															start: 30,
+															end: 41,
+															value: './dynamic',
+															raw: "'./dynamic'"
+														}
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 44,
+										end: 85,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 53,
+												end: 69,
+												local: { type: 'Identifier', start: 53, end: 60, name: 'default' },
+												exported: { type: 'Identifier', start: 64, end: 69, name: 'value' }
+											}
+										],
+										source: { type: 'Literal', start: 77, end: 84, value: './lib', raw: "'./lib'" }
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 86,
+										end: 122,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 95,
+												end: 103,
+												local: { type: 'Identifier', start: 95, end: 103, name: 'external' },
+												exported: { type: 'Identifier', start: 95, end: 103, name: 'external' }
+											}
+										],
+										source: {
+											type: 'Literal',
+											start: 111,
+											end: 121,
+											value: 'external',
+											raw: "'external'"
+										}
+									}
+								],
+								sourceType: 'module'
+							},
+							code:
+								"export const promise = import('./dynamic');\nexport { default as value } from './lib';\nexport { external } from 'external';\n",
 							dynamicallyImportedIds: [getId('dynamic')],
+							dynamicImporters: [],
 							hasModuleSideEffects: true,
 							id: getId('main'),
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [],
 							importedIds: [getId('lib'), 'external'],
+							importers: [],
 							isEntry: true,
 							isExternal: false,
 							meta: {}
 						},
 						{
-							dynamicImporters: [getId('dynamic')],
+							ast: null,
+							code: null,
 							dynamicallyImportedIds: [],
+							dynamicImporters: [getId('dynamic')],
 							hasModuleSideEffects: true,
 							id: 'external',
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [getId('main')],
 							importedIds: [],
+							importers: [getId('main')],
 							isEntry: false,
 							isExternal: true,
 							meta: {}
 						},
 						{
-							dynamicImporters: [],
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 19,
+								body: [
+									{
+										type: 'ExportDefaultDeclaration',
+										start: 0,
+										end: 18,
+										declaration: { type: 'Literal', start: 15, end: 17, value: 42, raw: '42' }
+									}
+								],
+								sourceType: 'module'
+							},
+							code: 'export default 42;\n',
 							dynamicallyImportedIds: [],
+							dynamicImporters: [],
 							hasModuleSideEffects: true,
 							id: getId('lib'),
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [getId('dynamic'), getId('main')],
 							importedIds: [],
+							importers: [getId('dynamic'), getId('main')],
 							isEntry: false,
 							isExternal: false,
 							meta: {}
 						},
 						{
-							dynamicImporters: [getId('main')],
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 88,
+								body: [
+									{
+										type: 'ExportNamedDeclaration',
+										start: 0,
+										end: 42,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 7,
+											end: 42,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 13,
+													end: 41,
+													id: { type: 'Identifier', start: 13, end: 20, name: 'promise' },
+													init: {
+														type: 'ImportExpression',
+														start: 23,
+														end: 41,
+														source: {
+															type: 'Literal',
+															start: 30,
+															end: 40,
+															value: 'external',
+															raw: "'external'"
+														}
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 43,
+										end: 87,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 52,
+												end: 71,
+												local: { type: 'Identifier', start: 52, end: 59, name: 'default' },
+												exported: { type: 'Identifier', start: 63, end: 71, name: 'internal' }
+											}
+										],
+										source: { type: 'Literal', start: 79, end: 86, value: './lib', raw: "'./lib'" }
+									}
+								],
+								sourceType: 'module'
+							},
+							code:
+								"export const promise = import('external');\nexport { default as internal } from './lib';\n",
 							dynamicallyImportedIds: ['external'],
+							dynamicImporters: [getId('main')],
 							hasModuleSideEffects: true,
 							id: getId('dynamic'),
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [],
 							importedIds: [getId('lib')],
+							importers: [],
 							isEntry: false,
 							isExternal: false,
 							meta: {}

--- a/test/function/samples/manual-chunks-info/_config.js
+++ b/test/function/samples/manual-chunks-info/_config.js
@@ -16,56 +16,213 @@ module.exports = {
 					[getId('main'), 'external', getId('lib'), getId('dynamic')]
 				);
 				assert.deepStrictEqual(
-					[...getModuleIds()].map(id => getModuleInfo(id)),
+					JSON.parse(JSON.stringify([...getModuleIds()].map(id => getModuleInfo(id)))),
 					[
 						{
-							dynamicImporters: [],
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 123,
+								body: [
+									{
+										type: 'ExportNamedDeclaration',
+										start: 0,
+										end: 43,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 7,
+											end: 43,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 13,
+													end: 42,
+													id: { type: 'Identifier', start: 13, end: 20, name: 'promise' },
+													init: {
+														type: 'ImportExpression',
+														start: 23,
+														end: 42,
+														source: {
+															type: 'Literal',
+															start: 30,
+															end: 41,
+															value: './dynamic',
+															raw: "'./dynamic'"
+														}
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 44,
+										end: 85,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 53,
+												end: 69,
+												local: { type: 'Identifier', start: 53, end: 60, name: 'default' },
+												exported: { type: 'Identifier', start: 64, end: 69, name: 'value' }
+											}
+										],
+										source: { type: 'Literal', start: 77, end: 84, value: './lib', raw: "'./lib'" }
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 86,
+										end: 122,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 95,
+												end: 103,
+												local: { type: 'Identifier', start: 95, end: 103, name: 'external' },
+												exported: { type: 'Identifier', start: 95, end: 103, name: 'external' }
+											}
+										],
+										source: {
+											type: 'Literal',
+											start: 111,
+											end: 121,
+											value: 'external',
+											raw: "'external'"
+										}
+									}
+								],
+								sourceType: 'module'
+							},
+							code:
+								"export const promise = import('./dynamic');\nexport { default as value } from './lib';\nexport { external } from 'external';\n",
 							dynamicallyImportedIds: [getId('dynamic')],
+							dynamicImporters: [],
 							hasModuleSideEffects: true,
 							id: getId('main'),
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [],
 							importedIds: [getId('lib'), 'external'],
+							importers: [],
 							isEntry: true,
 							isExternal: false,
 							meta: {}
 						},
 						{
-							dynamicImporters: [getId('dynamic')],
+							ast: null,
+							code: null,
 							dynamicallyImportedIds: [],
+							dynamicImporters: [getId('dynamic')],
 							hasModuleSideEffects: true,
 							id: 'external',
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [getId('main')],
 							importedIds: [],
+							importers: [getId('main')],
 							isEntry: false,
 							isExternal: true,
 							meta: {}
 						},
 						{
-							dynamicImporters: [],
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 19,
+								body: [
+									{
+										type: 'ExportDefaultDeclaration',
+										start: 0,
+										end: 18,
+										declaration: { type: 'Literal', start: 15, end: 17, value: 42, raw: '42' }
+									}
+								],
+								sourceType: 'module'
+							},
+							code: 'export default 42;\n',
 							dynamicallyImportedIds: [],
+							dynamicImporters: [],
 							hasModuleSideEffects: true,
 							id: getId('lib'),
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [getId('dynamic'), getId('main')],
 							importedIds: [],
+							importers: [getId('dynamic'), getId('main')],
 							isEntry: false,
 							isExternal: false,
 							meta: {}
 						},
 						{
-							dynamicImporters: [getId('main')],
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 88,
+								body: [
+									{
+										type: 'ExportNamedDeclaration',
+										start: 0,
+										end: 42,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 7,
+											end: 42,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 13,
+													end: 41,
+													id: { type: 'Identifier', start: 13, end: 20, name: 'promise' },
+													init: {
+														type: 'ImportExpression',
+														start: 23,
+														end: 41,
+														source: {
+															type: 'Literal',
+															start: 30,
+															end: 40,
+															value: 'external',
+															raw: "'external'"
+														}
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 43,
+										end: 87,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 52,
+												end: 71,
+												local: { type: 'Identifier', start: 52, end: 59, name: 'default' },
+												exported: { type: 'Identifier', start: 63, end: 71, name: 'internal' }
+											}
+										],
+										source: { type: 'Literal', start: 79, end: 86, value: './lib', raw: "'./lib'" }
+									}
+								],
+								sourceType: 'module'
+							},
+							code:
+								"export const promise = import('external');\nexport { default as internal } from './lib';\n",
 							dynamicallyImportedIds: ['external'],
+							dynamicImporters: [getId('main')],
 							hasModuleSideEffects: true,
 							id: getId('dynamic'),
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
-							importers: [],
 							importedIds: [getId('lib')],
+							importers: [],
 							isEntry: false,
 							isExternal: false,
 							meta: {}

--- a/test/function/samples/module-parsed-hook/_config.js
+++ b/test/function/samples/module-parsed-hook/_config.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const path = require('path');
+
+const parsedModules = [];
+
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_DEP = path.join(__dirname, 'dep.js');
+
+module.exports = {
+	description: 'calls the moduleParsedHook once a module is parsed',
+	options: {
+		plugins: {
+			name: 'test-plugin',
+			moduleParsed(moduleInfo) {
+				parsedModules.push(moduleInfo);
+			},
+			buildEnd() {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(parsedModules)), [
+					{
+						ast: {
+							type: 'Program',
+							start: 0,
+							end: 34,
+							body: [
+								{
+									type: 'ExportNamedDeclaration',
+									start: 0,
+									end: 33,
+									declaration: null,
+									specifiers: [
+										{
+											type: 'ExportSpecifier',
+											start: 9,
+											end: 14,
+											local: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+											exported: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+										}
+									],
+									source: {
+										type: 'Literal',
+										start: 22,
+										end: 32,
+										value: './dep.js',
+										raw: "'./dep.js'"
+									}
+								}
+							],
+							sourceType: 'module'
+						},
+						code: "export { value } from './dep.js';\n",
+						dynamicallyImportedIds: [],
+						dynamicImporters: [],
+						hasModuleSideEffects: true,
+						id: ID_MAIN,
+						implicitlyLoadedAfterOneOf: [],
+						implicitlyLoadedBefore: [],
+						importedIds: [ID_DEP],
+						importers: [],
+						isEntry: true,
+						isExternal: false,
+						meta: {}
+					},
+					{
+						ast: {
+							type: 'Program',
+							start: 0,
+							end: 25,
+							body: [
+								{
+									type: 'ExportNamedDeclaration',
+									start: 0,
+									end: 24,
+									declaration: {
+										type: 'VariableDeclaration',
+										start: 7,
+										end: 24,
+										declarations: [
+											{
+												type: 'VariableDeclarator',
+												start: 13,
+												end: 23,
+												id: { type: 'Identifier', start: 13, end: 18, name: 'value' },
+												init: { type: 'Literal', start: 21, end: 23, value: 42, raw: '42' }
+											}
+										],
+										kind: 'const'
+									},
+									specifiers: [],
+									source: null
+								}
+							],
+							sourceType: 'module'
+						},
+						code: 'export const value = 42;\n',
+						dynamicallyImportedIds: [],
+						dynamicImporters: [],
+						hasModuleSideEffects: true,
+						id: ID_DEP,
+						implicitlyLoadedAfterOneOf: [],
+						implicitlyLoadedBefore: [],
+						importedIds: [],
+						importers: [ID_MAIN],
+						isEntry: false,
+						isExternal: false,
+						meta: {}
+					}
+				]);
+			}
+		}
+	}
+};

--- a/test/function/samples/module-parsed-hook/dep.js
+++ b/test/function/samples/module-parsed-hook/dep.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/function/samples/module-parsed-hook/main.js
+++ b/test/function/samples/module-parsed-hook/main.js
@@ -1,0 +1,1 @@
+export { value } from './dep.js';

--- a/test/function/samples/plugin-module-information/_config.js
+++ b/test/function/samples/plugin-module-information/_config.js
@@ -15,6 +15,8 @@ module.exports = {
 		plugins: {
 			load(id) {
 				assert.deepStrictEqual(this.getModuleInfo(id), {
+					ast: null,
+					code: null,
 					dynamicImporters: [],
 					dynamicallyImportedIds: [],
 					hasModuleSideEffects: true,
@@ -30,64 +32,318 @@ module.exports = {
 			},
 			renderStart() {
 				rendered = true;
-				assert.deepStrictEqual(Array.from(this.getModuleIds()), [
-					ID_MAIN,
-					ID_FOO,
-					ID_PATH,
-					ID_NESTED
-				]);
-				assert.deepStrictEqual(this.getModuleInfo(ID_MAIN), {
-					dynamicImporters: [],
-					dynamicallyImportedIds: [ID_NESTED, ID_PATH],
-					hasModuleSideEffects: true,
-					id: ID_MAIN,
-					implicitlyLoadedAfterOneOf: [],
-					implicitlyLoadedBefore: [],
-					importedIds: [ID_FOO],
-					importers: [],
-					isEntry: true,
-					isExternal: false,
-					meta: {}
-				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_FOO), {
-					dynamicImporters: [],
-					dynamicallyImportedIds: [],
-					hasModuleSideEffects: true,
-					id: ID_FOO,
-					implicitlyLoadedAfterOneOf: [],
-					implicitlyLoadedBefore: [],
-					importedIds: [ID_PATH],
-					importers: [ID_MAIN, ID_NESTED],
-					isEntry: false,
-					isExternal: false,
-					meta: {}
-				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_NESTED), {
-					dynamicImporters: [ID_MAIN],
-					dynamicallyImportedIds: [],
-					hasModuleSideEffects: true,
-					id: ID_NESTED,
-					implicitlyLoadedAfterOneOf: [],
-					implicitlyLoadedBefore: [],
-					importedIds: [ID_FOO],
-					importers: [],
-					isEntry: false,
-					isExternal: false,
-					meta: {}
-				});
-				assert.deepStrictEqual(this.getModuleInfo(ID_PATH), {
-					dynamicImporters: [ID_MAIN],
-					dynamicallyImportedIds: [],
-					hasModuleSideEffects: true,
-					id: ID_PATH,
-					implicitlyLoadedAfterOneOf: [],
-					implicitlyLoadedBefore: [],
-					importedIds: [],
-					importers: [ID_FOO],
-					isEntry: false,
-					isExternal: true,
-					meta: {}
-				});
+				assert.deepStrictEqual([...this.getModuleIds()], [ID_MAIN, ID_FOO, ID_PATH, ID_NESTED]);
+				assert.deepStrictEqual(
+					JSON.parse(JSON.stringify([...this.getModuleIds()].map(id => this.getModuleInfo(id)))),
+					[
+						{
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 159,
+								body: [
+									{
+										type: 'ExportNamedDeclaration',
+										start: 0,
+										end: 31,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 9,
+												end: 12,
+												local: { type: 'Identifier', start: 9, end: 12, name: 'foo' },
+												exported: { type: 'Identifier', start: 9, end: 12, name: 'foo' }
+											}
+										],
+										source: {
+											type: 'Literal',
+											start: 20,
+											end: 30,
+											value: './foo.js',
+											raw: "'./foo.js'"
+										}
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 32,
+										end: 80,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 39,
+											end: 80,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 45,
+													end: 79,
+													id: { type: 'Identifier', start: 45, end: 51, name: 'nested' },
+													init: {
+														type: 'ImportExpression',
+														start: 54,
+														end: 79,
+														source: {
+															type: 'Literal',
+															start: 61,
+															end: 78,
+															value: './nested/nested',
+															raw: "'./nested/nested'"
+														}
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 81,
+										end: 116,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 88,
+											end: 116,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 94,
+													end: 115,
+													id: { type: 'Identifier', start: 94, end: 98, name: 'path' },
+													init: {
+														type: 'ImportExpression',
+														start: 101,
+														end: 115,
+														source: {
+															type: 'Literal',
+															start: 108,
+															end: 114,
+															value: 'path',
+															raw: "'path'"
+														}
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 117,
+										end: 158,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 124,
+											end: 158,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 130,
+													end: 157,
+													id: { type: 'Identifier', start: 130, end: 139, name: 'pathAgain' },
+													init: {
+														type: 'ImportExpression',
+														start: 142,
+														end: 157,
+														source: { type: 'Identifier', start: 149, end: 156, name: 'thePath' }
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									}
+								],
+								sourceType: 'module'
+							},
+							code:
+								"export { foo } from './foo.js';\nexport const nested = import('./nested/nested');\nexport const path = import('path');\nexport const pathAgain = import(thePath);\n",
+							dynamicallyImportedIds: [ID_NESTED, ID_PATH],
+							dynamicImporters: [],
+							hasModuleSideEffects: true,
+							id: ID_MAIN,
+							implicitlyLoadedAfterOneOf: [],
+							implicitlyLoadedBefore: [],
+							importedIds: [ID_FOO],
+							importers: [],
+							isEntry: true,
+							isExternal: false,
+							meta: {}
+						},
+						{
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 66,
+								body: [
+									{
+										type: 'ImportDeclaration',
+										start: 0,
+										end: 24,
+										specifiers: [
+											{
+												type: 'ImportDefaultSpecifier',
+												start: 7,
+												end: 11,
+												local: { type: 'Identifier', start: 7, end: 11, name: 'path' }
+											}
+										],
+										source: { type: 'Literal', start: 17, end: 23, value: 'path', raw: "'path'" }
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 26,
+										end: 65,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 33,
+											end: 65,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 39,
+													end: 64,
+													id: { type: 'Identifier', start: 39, end: 42, name: 'foo' },
+													init: {
+														type: 'CallExpression',
+														start: 45,
+														end: 64,
+														callee: {
+															type: 'MemberExpression',
+															start: 45,
+															end: 57,
+															object: { type: 'Identifier', start: 45, end: 49, name: 'path' },
+															property: { type: 'Identifier', start: 50, end: 57, name: 'resolve' },
+															computed: false,
+															optional: false
+														},
+														arguments: [
+															{ type: 'Literal', start: 58, end: 63, value: 'foo', raw: "'foo'" }
+														],
+														optional: false
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									}
+								],
+								sourceType: 'module'
+							},
+							code: "import path from 'path';\n\nexport const foo = path.resolve('foo');\n",
+							dynamicallyImportedIds: [],
+							dynamicImporters: [],
+							hasModuleSideEffects: true,
+							id: ID_FOO,
+							implicitlyLoadedAfterOneOf: [],
+							implicitlyLoadedBefore: [],
+							importedIds: [ID_PATH],
+							importers: [ID_MAIN, ID_NESTED],
+							isEntry: false,
+							isExternal: false,
+							meta: {}
+						},
+						{
+							ast: null,
+							code: null,
+							dynamicallyImportedIds: [],
+							dynamicImporters: [ID_MAIN],
+							hasModuleSideEffects: true,
+							id: ID_PATH,
+							implicitlyLoadedAfterOneOf: [],
+							implicitlyLoadedBefore: [],
+							importedIds: [],
+							importers: [ID_FOO],
+							isEntry: false,
+							isExternal: true,
+							meta: {}
+						},
+						{
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 72,
+								body: [
+									{
+										type: 'ImportDeclaration',
+										start: 0,
+										end: 32,
+										specifiers: [
+											{
+												type: 'ImportSpecifier',
+												start: 9,
+												end: 12,
+												imported: { type: 'Identifier', start: 9, end: 12, name: 'foo' },
+												local: { type: 'Identifier', start: 9, end: 12, name: 'foo' }
+											}
+										],
+										source: {
+											type: 'Literal',
+											start: 20,
+											end: 31,
+											value: '../foo.js',
+											raw: "'../foo.js'"
+										}
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 34,
+										end: 71,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 41,
+											end: 71,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 47,
+													end: 70,
+													id: { type: 'Identifier', start: 47, end: 53, name: 'nested' },
+													init: {
+														type: 'BinaryExpression',
+														start: 56,
+														end: 70,
+														left: {
+															type: 'Literal',
+															start: 56,
+															end: 64,
+															value: 'nested',
+															raw: "'nested'"
+														},
+														operator: '+',
+														right: { type: 'Identifier', start: 67, end: 70, name: 'foo' }
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									}
+								],
+								sourceType: 'module'
+							},
+							code: "import { foo } from '../foo.js';\n\nexport const nested = 'nested' + foo;\n",
+							dynamicallyImportedIds: [],
+							dynamicImporters: [ID_MAIN],
+							hasModuleSideEffects: true,
+							id: ID_NESTED,
+							implicitlyLoadedAfterOneOf: [],
+							implicitlyLoadedBefore: [],
+							importedIds: [ID_FOO],
+							importers: [],
+							isEntry: false,
+							isExternal: false,
+							meta: {}
+						}
+					]
+				);
 			}
 		}
 	},


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This adds a new hook `moduleParsed` that is called for each module after the `transform` hook. This is needed to be notified once a cached module is available and will be useful to finally fix the caching for the commonjs plugin. Mainly, this hook will be used to resolve if a module is commonjs or ES both for cached and other modules.

#### `moduleParsed`
Type: `(moduleInfo: ModuleInfo) => void`<br>
Kind: `async, parallel`<br>
Previous Hook: [`transform`](guide/en/#transform) where the currently handled file was transformed.<br>
NextHook: [`resolveId`](guide/en/#resolveid) and [`resolveDynamicImport`](guide/en/#resolvedynamicimport) to resolve all discovered static and dynamic imports in parallel if present, otherwise [`buildEnd`](guide/en/#buildend).

This hook is called each time a module has been fully parsed by Rollup. See [`this.getModuleInfo`](guide/en/#thisgetmoduleinfomoduleid-string--moduleinfo--null) for what information is passed to this hook.

In contrast to the [`transform`](guide/en/#transform) hook, this hook is never cached and can be used to get information about both cached and other modules, including the final shape of the `meta` property, the `code` and the `ast`.

Note that information about imported modules is not yet available in this hook, and information about importing modules may be incomplete as additional importers could be discovered later. If you need this information, use the [`buildEnd`](guide/en/#buildend) hook.