### PR TITLE
Docs: fix code snippet

### DIFF
--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -144,7 +144,7 @@ Next Hook: [`load`](guide/en/#load) if the resolved id that has not yet been loa
 Defines a custom resolver. A resolver can be useful for e.g. locating third-party dependencies. Here `source` is the importee exactly as it is written in the import statement, i.e. for
 
 ```js
-import { foo } from '../bar,js';
+import { foo } from '../bar.js';
 ```
 
 the source will be `"../bar.js""`. 


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Fixes a typo:

    import { foo } from '../bar,js';

is now

    import { foo } from '../bar.js';