### PR TITLE
feat: Update documentation on configuring Babel

### DIFF
--- a/docs/07-tools.md
+++ b/docs/07-tools.md
@@ -166,14 +166,12 @@ Before Babel will actually compile your code, it needs to be configured. Create 
 ```json
 {
   "presets": [
-    ["@babel/env", {"modules": false}]
+    "@babel/env"
   ]
 }
 ```
 
-There are a few unusual elements to this setup. First, we're setting "modules": false, otherwise Babel will convert our modules to CommonJS before Rollup gets a chance to do its thing, causing it to fail.
-
-Secondly, we're putting our `.babelrc.json` file in `src`, rather than the project root. This allows us to have a different `.babelrc.json` for things like tests, if we need that later – See the [Babel documentation](https://babeljs.io/docs/en/config-files#project-wide-configuration) for more information on both project wide and file relative configuration. 
+We're putting our `.babelrc.json` file in `src`, rather than the project root. This allows us to have a different `.babelrc.json` for things like tests, if we need that later – See the [Babel documentation](https://babeljs.io/docs/en/config-files#project-wide-configuration) for more information on both project wide and file relative configuration. 
 
 Now, before we run rollup, we need to install
 [`babel-core`](https://babeljs.io/docs/en/babel-core)


### PR DESCRIPTION
Updated documentation on configuring Babel removing the section on passing '{"modules": false}' as that is no longer needed since Babel 7

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [X] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: #3717

### Description

I'm not sure if I should add some documentation on using `{"modules": false}` for Babel <7, what do you think?
