### PR TITLE
fix: plugin warnings not showing warning.loc

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -189,15 +189,13 @@ const deferredHandlers: {
 				for (const warning of items) {
 					if (warning.url && warning.url !== lastUrl) info((lastUrl = warning.url));
 
-					if (warning.id) {
-						let loc = relativeId(warning.id);
+					const id = warning.id || warning.loc?.file;
+					if (id) {
+						let loc = relativeId(id);
 						if (warning.loc) {
 							loc += `: (${warning.loc.line}:${warning.loc.column})`;
 						}
 						stderr(bold(loc));
-					}
-					else if (warning.loc) {
-							info(yellow(`${rollup.relativeId(warning.loc.file)}:${warning.loc.line}:${warning.loc.column}`)+' error '+message);
 					}
 					if (warning.frame) info(warning.frame);
 				}

--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -196,6 +196,9 @@ const deferredHandlers: {
 						}
 						stderr(bold(loc));
 					}
+					else if (warning.loc) {
+							info(yellow(`${rollup.relativeId(warning.loc.file)}:${warning.loc.line}:${warning.loc.column}`)+' error '+message);
+					}
 					if (warning.frame) info(warning.frame);
 				}
 			}

--- a/test/cli/samples/warn-plugin-loc/_config.js
+++ b/test/cli/samples/warn-plugin-loc/_config.js
@@ -1,0 +1,17 @@
+const { assertIncludes } = require('../../../utils.js');
+
+module.exports = {
+	description: 'correctly adds locations to plugin warnings',
+	command: 'rollup -c',
+	stderr: stderr => {
+		assertIncludes(
+			stderr,
+			'(!) Plugin test: Warning with file and id\n' +
+				'file1: (1:2)\n' +
+				'(!) Plugin test: Warning with file\n' +
+				'file2: (2:3)\n' +
+				'(!) Plugin test: Warning with id\n' +
+				'file-id3: (3:4)\n'
+		);
+	}
+};

--- a/test/cli/samples/warn-plugin-loc/main.js
+++ b/test/cli/samples/warn-plugin-loc/main.js
@@ -1,0 +1,1 @@
+console.log("everyday I'm throwing");

--- a/test/cli/samples/warn-plugin-loc/rollup.config.js
+++ b/test/cli/samples/warn-plugin-loc/rollup.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+	plugins: [
+		{
+			name: 'test',
+			buildStart() {
+				this.warn({
+					message: 'Warning with file and id',
+					file: path.join(__dirname, 'file-id1'),
+					loc: { file: path.join(__dirname, 'file1'), line: 1, column: 2 }
+				});
+				this.warn({
+					message: 'Warning with file',
+					loc: { file: path.join(__dirname, 'file2'), line: 2, column: 3 }
+				});
+				this.warn({
+					message: 'Warning with id',
+					id: path.join(__dirname, 'file-id3'),
+					loc: { line: 3, column: 4 }
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
Plugin warnings without warning.id but with warning.loc were not emitting loc information
loc information emitting is fundamental for user experience (to locate the source of the error/warning)

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Plugin warnings without `warning.id `but with `warning.loc` were not emitting `warning.loc` information
`warning.loc` information emitting is fundamental for user experience (to locate the source of the error/warning)
added 3 lines, to emit the `warning.loc` info if present in a format amicable to IDEs problem matchers: file:line:col
