### PR TITLE
Improved watcher hooks

### DIFF
--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -243,12 +243,12 @@ See [custom module meta-data](guide/en/#custom-module-meta-data) for how to use 
 You can use [`this.getModuleInfo`](guide/en/#thisgetmoduleinfomoduleid-string--moduleinfo--null) to find out the previous values of `moduleSideEffects`, `syntheticNamedExports` and `meta` inside this hook.
 
 #### `watchChange`
-Type: `(id: string, isDeleted: boolean) => void`<br>
+Type: `watchChange: (id: string, change: {event: 'create' | 'update' | 'delete'}) => void`<br>
 Kind: `sync, sequential`<br>
 Previous/Next Hook: This hook can be triggered at any time both during the build and the output generation phases. If that is the case, the current build will still proceed but a new build will be scheduled to start once the current build has completed, starting again with [`options`](guide/en/#options).
 
 Notifies a plugin whenever rollup has detected a change to a monitored file in `--watch` mode. This hook cannot be used by output plugins.
-Second argument will be `true` if file deleted.  
+Second argument contains additional details of change event.  
 
 ### Output Generation Hooks
 

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -72,7 +72,9 @@ To interact with the build process, your plugin object includes 'hooks'. Hooks a
 * `sequential`: If several plugins implement this hook, all of them will be run in the specified plugin order. If a hook is async, subsequent hooks of this kind will wait until the current hook is resolved.
 * `parallel`: If several plugins implement this hook, all of them will be run in the specified plugin order. If a hook is async, subsequent hooks of this kind will be run in parallel and not wait for the current hook.
 
-Build hooks are run during the build phase, which is triggered by `rollup.rollup(inputOptions)`. They are mainly concerned with locating, providing and transforming input files before they are processed by Rollup. The first hook of the build phase is [options](guide/en/#options), the last one is always [buildEnd](guide/en/#buildend). Additionally in watch mode, the [watchChange](guide/en/#watchchange) hook can be triggered at any time to notify a new run will be triggered once the current run has generated its outputs.
+Build hooks are run during the build phase, which is triggered by `rollup.rollup(inputOptions)`. They are mainly concerned with locating, providing and transforming input files before they are processed by Rollup. The first hook of the build phase is [options](guide/en/#options), the last one is always [buildEnd](guide/en/#buildend).
+
+Additionally, in watch mode the [watchChange](guide/en/#watchchange) hook can be triggered at any time to notify a new run will be triggered once the current run has generated its outputs. Also, when watcher closes, the [closeWatcher](guide/en/#closewatcher) hook will be triggered.
 
 See [Output Generation Hooks](guide/en/#output-generation-hooks) for hooks that run during the output generation phase to modify the generated output.
 

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -92,6 +92,13 @@ Next Hook: [`resolveId`](guide/en/#resolveid) to resolve each entry point in par
 
 Called on each `rollup.rollup` build. This is the recommended hook to use when you need access to the options passed to `rollup.rollup()` as it takes the transformations by all [`options`](guide/en/#options) hooks into account and also contains the right default values for unset options.
 
+#### `closeWatcher`
+Type: `() => void`<br>
+Kind: `sync, sequential`<br>
+Previous/Next Hook: This hook can be triggered at any time both during the build and the output generation phases. If that is the case, the current build will still proceed but no new [`watchChange`](guide/en/#watchChange) events will be triggered ever.
+
+Notifies a plugin when watcher process closes and all open resources should be closed too. This hook cannot be used by output plugins.
+
 #### `load`
 Type: `(id: string) => string | null | {code: string, map?: string | SourceMap, ast? : ESTree.Program, moduleSideEffects?: boolean | "no-treeshake" | null, syntheticNamedExports?: boolean | string | null, meta?: {[plugin: string]: any} | null}`<br>
 Kind: `async, first`<br>
@@ -236,11 +243,12 @@ See [custom module meta-data](guide/en/#custom-module-meta-data) for how to use 
 You can use [`this.getModuleInfo`](guide/en/#thisgetmoduleinfomoduleid-string--moduleinfo--null) to find out the previous values of `moduleSideEffects`, `syntheticNamedExports` and `meta` inside this hook.
 
 #### `watchChange`
-Type: `(id: string) => void`<br>
+Type: `(id: string, isDeleted: boolean) => void`<br>
 Kind: `sync, sequential`<br>
 Previous/Next Hook: This hook can be triggered at any time both during the build and the output generation phases. If that is the case, the current build will still proceed but a new build will be scheduled to start once the current build has completed, starting again with [`options`](guide/en/#options).
 
 Notifies a plugin whenever rollup has detected a change to a monitored file in `--watch` mode. This hook cannot be used by output plugins.
+Second argument will be `true` if file deleted.  
 
 ### Output Generation Hooks
 
@@ -654,6 +662,11 @@ During the build, this object represents currently available information about t
  the `importedIds` are not yet resolved or additional `importers` are discovered.
  
 Returns `null` if the module id cannot be found.
+
+#### `this.getWatchFiles() => string[]`
+
+Get ids of the files which has been watched previously. Include both files added by plugins with `this.addWatchFile`
+ and files added implicitly by rollup during the build.
 
 #### `this.meta: {rollupVersion: string, watchMode: boolean}`
 

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -247,8 +247,7 @@ Type: `watchChange: (id: string, change: {event: 'create' | 'update' | 'delete'}
 Kind: `sync, sequential`<br>
 Previous/Next Hook: This hook can be triggered at any time both during the build and the output generation phases. If that is the case, the current build will still proceed but a new build will be scheduled to start once the current build has completed, starting again with [`options`](guide/en/#options).
 
-Notifies a plugin whenever rollup has detected a change to a monitored file in `--watch` mode. This hook cannot be used by output plugins.
-Second argument contains additional details of change event.  
+Notifies a plugin whenever rollup has detected a change to a monitored file in `--watch` mode. This hook cannot be used by output plugins. Second argument contains additional details of change event.  
 
 ### Output Generation Hooks
 
@@ -665,8 +664,7 @@ Returns `null` if the module id cannot be found.
 
 #### `this.getWatchFiles() => string[]`
 
-Get ids of the files which has been watched previously. Include both files added by plugins with `this.addWatchFile`
- and files added implicitly by rollup during the build.
+Get ids of the files which has been watched previously. Include both files added by plugins with `this.addWatchFile` and files added implicitly by rollup during the build.
 
 #### `this.meta: {rollupVersion: string, watchMode: boolean}`
 

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -84,10 +84,13 @@ export default class Graph {
 
 		if (watcher) {
 			this.watchMode = true;
-			const handleChange = (id: string) => this.pluginDriver.hookSeqSync('watchChange', [id]);
+			const handleChange = (id: string, del: boolean) => this.pluginDriver.hookSeqSync('watchChange', [id, del]);
+			const handleClose = () => this.pluginDriver.hookSeqSync('closeWatcher', []);
 			watcher.on('change', handleChange);
+			watcher.on('close', handleClose);
 			watcher.once('restart', () => {
 				watcher.removeListener('change', handleChange);
+				watcher.removeListener('close', handleClose);
 			});
 		}
 		this.pluginDriver = new PluginDriver(this, options, options.plugins, this.pluginCache);

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -10,7 +10,8 @@ import {
 	NormalizedInputOptions,
 	RollupCache,
 	RollupWatcher,
-	SerializablePluginCache
+	SerializablePluginCache,
+	WatchChangeHook
 } from './rollup/types';
 import { BuildPhase } from './utils/buildPhase';
 import { errImplicitDependantIsNotIncluded, error } from './utils/error';
@@ -84,7 +85,7 @@ export default class Graph {
 
 		if (watcher) {
 			this.watchMode = true;
-			const handleChange = (id: string, del: boolean) => this.pluginDriver.hookSeqSync('watchChange', [id, del]);
+			const handleChange: WatchChangeHook = (...args) => this.pluginDriver.hookSeqSync('watchChange', args);
 			const handleClose = () => this.pluginDriver.hookSeqSync('closeWatcher', []);
 			watcher.on('change', handleChange);
 			watcher.on('close', handleClose);

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -822,7 +822,7 @@ export type RollupWatcherEvent =
 
 export interface RollupWatcher
 	extends TypedEventEmitter<{
-		change: WatchChangeHook;
+		change: (id: string, change: {event: ChangeEvent}) => void;
 		close: () => void;
 		event: (event: RollupWatcherEvent) => void;
 		restart: () => void;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -319,6 +319,9 @@ export type ResolveFileUrlHook = (
 export type AddonHookFunction = (this: PluginContext) => string | Promise<string>;
 export type AddonHook = string | AddonHookFunction;
 
+export type ChangeEvent = 'create' | 'update' | 'delete'
+export type WatchChangeHook = (this: PluginContext, id: string, change: {event: ChangeEvent}) => void
+
 /**
  * use this type for plugin annotation
  * @example
@@ -353,7 +356,7 @@ export interface PluginHooks extends OutputPluginHooks {
 	resolveDynamicImport: ResolveDynamicImportHook;
 	resolveId: ResolveIdHook;
 	transform: TransformHook;
-	watchChange: (this: PluginContext, id: string, isDeleted: boolean) => void;
+	watchChange: WatchChangeHook;
 }
 
 interface OutputPluginHooks {
@@ -786,9 +789,9 @@ export interface RollupWatchOptions extends InputOptions {
 	watch?: WatcherOptions | false;
 }
 
-interface TypedEventEmitter<T> {
+interface TypedEventEmitter<T extends {[event: string]: (...args: any) => any}> {
 	addListener<K extends keyof T>(event: K, listener: T[K]): this;
-	emit<K extends keyof T>(event: K, ...args: any[]): boolean;
+	emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): boolean;
 	eventNames(): Array<keyof T>;
 	getMaxListeners(): number;
 	listenerCount(type: keyof T): number;
@@ -806,11 +809,11 @@ interface TypedEventEmitter<T> {
 
 export type RollupWatcherEvent =
 	| { code: 'START' }
-	| { code: 'BUNDLE_START'; input: InputOption; output: readonly string[] }
+	| { code: 'BUNDLE_START'; input?: InputOption; output: readonly string[] }
 	| {
 			code: 'BUNDLE_END';
 			duration: number;
-			input: InputOption;
+			input?: InputOption;
 			output: readonly string[];
 			result: RollupBuild;
 	  }
@@ -819,7 +822,7 @@ export type RollupWatcherEvent =
 
 export interface RollupWatcher
 	extends TypedEventEmitter<{
-		change: (id: string, isDeleted: boolean) => void;
+		change: WatchChangeHook;
 		close: () => void;
 		event: (event: RollupWatcherEvent) => void;
 		restart: () => void;

--- a/src/utils/PluginContext.ts
+++ b/src/utils/PluginContext.ts
@@ -126,6 +126,7 @@ export function getPluginContexts(
 			getFileName: fileEmitter.getFileName,
 			getModuleIds: () => graph.modulesById.keys(),
 			getModuleInfo: graph.getModuleInfo,
+			getWatchFiles: () => Object.keys(graph.watchFiles),
 			isExternal: getDeprecatedContextHandler(
 				(id: string, parentId: string | undefined, isResolved = false) =>
 					options.external(id, parentId, isResolved),

--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -47,6 +47,7 @@ const inputHookNames: {
 } = {
 	buildEnd: 1,
 	buildStart: 1,
+	closeWatcher: 1,
 	load: 1,
 	moduleParsed: 1,
 	options: 1,

--- a/src/watch/fileWatcher.ts
+++ b/src/watch/fileWatcher.ts
@@ -45,7 +45,7 @@ export class FileWatcher {
 		const task = this.task;
 		const isLinux = platform() === 'linux';
 		const isTransformDependency = transformWatcherId !== null;
-		const handleChange = (id: string) => {
+		const handleChange = (id: string, _: unknown, isDeleted = false) => {
 			const changedId = transformWatcherId || id;
 			if (isLinux) {
 				// unwatching and watching fixes an issue with chokidar where on certain systems,
@@ -54,13 +54,13 @@ export class FileWatcher {
 				watcher.unwatch(changedId);
 				watcher.add(changedId);
 			}
-			task.invalidate(changedId, isTransformDependency);
+			task.invalidate(changedId, isTransformDependency, isDeleted);
 		};
 		const watcher = chokidar
 			.watch([], this.chokidarOptions)
 			.on('add', handleChange)
 			.on('change', handleChange)
-			.on('unlink', handleChange);
+			.on('unlink', id => handleChange(id, null, true));
 		return watcher;
 	}
 }

--- a/src/watch/fileWatcher.ts
+++ b/src/watch/fileWatcher.ts
@@ -1,6 +1,6 @@
 import chokidar, { FSWatcher } from 'chokidar';
 import { platform } from 'os';
-import { ChokidarOptions } from '../rollup/types';
+import { ChangeEvent, ChokidarOptions } from '../rollup/types';
 import { Task } from './watch';
 
 export class FileWatcher {
@@ -45,7 +45,7 @@ export class FileWatcher {
 		const task = this.task;
 		const isLinux = platform() === 'linux';
 		const isTransformDependency = transformWatcherId !== null;
-		const handleChange = (id: string, _: unknown, isDeleted = false) => {
+		const handleChange = (id: string, event: ChangeEvent) => {
 			const changedId = transformWatcherId || id;
 			if (isLinux) {
 				// unwatching and watching fixes an issue with chokidar where on certain systems,
@@ -54,13 +54,13 @@ export class FileWatcher {
 				watcher.unwatch(changedId);
 				watcher.add(changedId);
 			}
-			task.invalidate(changedId, isTransformDependency, isDeleted);
+			task.invalidate(changedId, {isTransformDependency, event});
 		};
 		const watcher = chokidar
 			.watch([], this.chokidarOptions)
-			.on('add', handleChange)
-			.on('change', handleChange)
-			.on('unlink', id => handleChange(id, null, true));
+			.on('add', id => handleChange(id, 'create'))
+			.on('change', id => handleChange(id, 'update'))
+			.on('unlink', id => handleChange(id, 'delete'));
 		return watcher;
 	}
 }

--- a/src/watch/fsevents-importer.ts
+++ b/src/watch/fsevents-importer.ts
@@ -2,7 +2,6 @@ let fsEvents: any;
 let fsEventsImportError: any;
 
 export function loadFsEvents() {
-	// @ts-ignore
 	return import('fsevents')
 		.then(namespace => {
 			fsEvents = namespace.default;

--- a/src/watch/fsevents-importer.ts
+++ b/src/watch/fsevents-importer.ts
@@ -2,6 +2,7 @@ let fsEvents: any;
 let fsEventsImportError: any;
 
 export function loadFsEvents() {
+	// @ts-ignore
 	return import('fsevents')
 		.then(namespace => {
 			fsEvents = namespace.default;

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import createFilter from 'rollup-pluginutils/src/createFilter';
 import { rollupInternal } from '../rollup/rollup';
 import {
+	ChangeEvent,
 	MergedRollupOptions,
 	OutputOptions,
 	RollupBuild,
@@ -13,13 +14,30 @@ import { mergeOptions } from '../utils/options/mergeOptions';
 import { GenericConfigObject } from '../utils/options/options';
 import { FileWatcher } from './fileWatcher';
 
+const eventsRewrites: Record<ChangeEvent, Record<ChangeEvent, ChangeEvent | 'buggy' | null>> = {
+	create: {
+		create: 'buggy',
+		delete: null,			//delete file from map
+		update: 'create',
+	},
+	delete: {
+		create: 'update',
+		delete: 'buggy',
+		update: 'buggy',
+	},
+	update: {
+		create: 'buggy',
+		delete: 'delete',
+		update: 'update',
+	}
+}
+
 export class Watcher {
 	emitter: RollupWatcher;
 
 	private buildDelay = 0;
 	private buildTimeout: NodeJS.Timer | null = null;
-	private deletedIds: Set<string> = new Set();
-	private invalidatedIds: Set<string> = new Set();
+	private invalidatedIds: Map<string, ChangeEvent> = new Map();
 	private rerun = false;
 	private running: boolean;
 	private tasks: Task[];
@@ -44,21 +62,25 @@ export class Watcher {
 		for (const task of this.tasks) {
 			task.close();
 		}
-		this.emit('close')
+		this.emitter.emit('close');
 		this.emitter.removeAllListeners();
 	}
 
-	emit(event: string, ...args: unknown[]) {
-		this.emitter.emit(event as any, ...args);
-	}
+	invalidate(file?: {event: ChangeEvent, id: string}) {
+		if (file) {
+			const prevEvent = this.invalidatedIds.get(file.id);
+			const event = prevEvent
+				? eventsRewrites[prevEvent][file.event]
+				: file.event;
 
-	invalidate(id?: string, isDeleted?: boolean) {
-		if (id) {
-			this.invalidatedIds.add(id);
-			if (isDeleted)
-				this.deletedIds.add(id);
-			else
-				this.deletedIds.delete(id)
+			if (event === 'buggy') {
+				//TODO: throws or warn? Currently just ignore, uses new event
+				this.invalidatedIds.set(file.id, file.event);
+			} else if (event === null) {
+				this.invalidatedIds.delete(file.id);
+			} else {
+				this.invalidatedIds.set(file.id, event);
+			}
 		}
 		if (this.running) {
 			this.rerun = true;
@@ -69,12 +91,11 @@ export class Watcher {
 
 		this.buildTimeout = setTimeout(() => {
 			this.buildTimeout = null;
-			for (const id of this.invalidatedIds) {
-				this.emit('change', id, this.deletedIds.has(id));
+			for (const [id, event] of this.invalidatedIds.entries()) {
+				this.emitter.emit('change', id, {event});
 			}
 			this.invalidatedIds.clear();
-			this.deletedIds.clear();
-			this.emit('restart');
+			this.emitter.emit('restart');
 			this.run();
 		}, this.buildDelay);
 	}
@@ -82,7 +103,7 @@ export class Watcher {
 	private async run() {
 		this.running = true;
 
-		this.emit('event', {
+		this.emitter.emit('event', {
 			code: 'START'
 		});
 
@@ -91,12 +112,12 @@ export class Watcher {
 				await task.run();
 			}
 			this.running = false;
-			this.emit('event', {
+			this.emitter.emit('event', {
 				code: 'END'
 			});
 		} catch (error) {
 			this.running = false;
-			this.emit('event', {
+			this.emitter.emit('event', {
 				code: 'ERROR',
 				error
 			});
@@ -151,16 +172,16 @@ export class Task {
 		this.fileWatcher.close();
 	}
 
-	invalidate(id: string, isTransformDependency: boolean | undefined, isDeleted: boolean) {
+	invalidate(id: string, details: {event: ChangeEvent, isTransformDependency?: boolean}) {
 		this.invalidated = true;
-		if (isTransformDependency) {
+		if (details.isTransformDependency) {
 			for (const module of this.cache.modules) {
 				if (module.transformDependencies.indexOf(id) === -1) continue;
 				// effective invalidation
 				module.originalCode = null as any;
 			}
 		}
-		this.watcher.invalidate(id, isDeleted);
+		this.watcher.invalidate({id, event: details.event});
 	}
 
 	async run() {
@@ -174,7 +195,7 @@ export class Task {
 
 		const start = Date.now();
 
-		this.watcher.emit('event', {
+		this.watcher.emitter.emit('event', {
 			code: 'BUNDLE_START',
 			input: this.options.input,
 			output: this.outputFiles
@@ -187,7 +208,7 @@ export class Task {
 			}
 			this.updateWatchedFiles(result);
 			this.skipWrite || (await Promise.all(this.outputs.map(output => result.write(output))));
-			this.watcher.emit('event', {
+			this.watcher.emitter.emit('event', {
 				code: 'BUNDLE_END',
 				duration: Date.now() - start,
 				input: this.options.input,

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -237,6 +237,134 @@ describe('rollup.watch', () => {
 			});
 	});
 
+	it('passes isDeleted parameter to the watchChange plugin hook', () => {
+		const deleted = [];
+		let ids;
+		const expectedIds = ['test/_tmp/input/watched', path.resolve('test/_tmp/input/main.js')];
+		return sander
+			.copydir('test/watch/samples/watch-files')
+			.to('test/_tmp/input')
+			.then(() => {
+				watcher = rollup.watch({
+					input: 'test/_tmp/input/main.js',
+					output: {
+						file: 'test/_tmp/output/bundle.js',
+						format: 'cjs',
+						exports: 'auto'
+					},
+					plugins: {
+						buildStart() {
+							this.addWatchFile('test/_tmp/input/watched');
+						},
+						watchChange(id, isDeleted) {
+							assert.strictEqual(id, 'test/_tmp/input/watched');
+							deleted.push(isDeleted);
+						},
+						buildEnd() {
+							ids = this.getWatchFiles();
+						}
+					}
+				});
+
+				return sequence(watcher, [
+					'START',
+					'BUNDLE_START',
+					'BUNDLE_END',
+					'END',
+					() => {
+						assert.strictEqual(run('../_tmp/output/bundle.js'), 42);
+						assert.deepStrictEqual(deleted, []);
+						assert.deepStrictEqual(ids, expectedIds);
+						sander.writeFileSync('test/_tmp/input/watched', 'another');
+					},
+					'START',
+					'BUNDLE_START',
+					'BUNDLE_END',
+					'END',
+					() => {
+						assert.strictEqual(run('../_tmp/output/bundle.js'), 42);
+						assert.deepStrictEqual(deleted, [false]);
+						assert.deepStrictEqual(ids, expectedIds);
+						sander.rimrafSync('test/_tmp/input/watched');
+					},
+					'START',
+					'BUNDLE_START',
+					'BUNDLE_END',
+					'END',
+					() => {
+						assert.strictEqual(run('../_tmp/output/bundle.js'), 42);
+						assert.deepStrictEqual(deleted, [false, true]);
+						assert.deepStrictEqual(ids, expectedIds);
+						sander.writeFileSync('test/_tmp/input/watched', 'third');
+					},
+					'START',
+					'BUNDLE_START',
+					'BUNDLE_END',
+					'END',
+					() => {
+						assert.strictEqual(run('../_tmp/output/bundle.js'), 42);
+						assert.deepStrictEqual(deleted, [false, true, false]);
+						assert.deepStrictEqual(ids, expectedIds);
+					}
+				]);
+			});
+	});
+
+	it('calls closeWatcher plugin hook', () => {
+		let calls = 0;
+		let ctx1;
+		let ctx2;
+		return sander
+			.copydir('test/watch/samples/basic')
+			.to('test/_tmp/input')
+			.then(() => {
+				watcher = rollup.watch({
+					input: 'test/_tmp/input/main.js',
+					output: {
+						file: 'test/_tmp/output/bundle.js',
+						format: 'cjs',
+						exports: 'auto'
+					},
+					plugins: [
+						{
+							buildStart() {
+								ctx1 = this;
+							},
+							closeWatcher() {
+								assert.strictEqual(ctx1, this);
+								calls++;
+							}
+						},
+						{
+							buildStart() {
+								ctx2 = this;
+							},
+							closeWatcher() {
+								assert.strictEqual(ctx2, this);
+								calls++;
+							}
+						},
+					]
+				});
+
+				return sequence(watcher, [
+					'START',
+					'BUNDLE_START',
+					'BUNDLE_END',
+					'END',
+					() => {
+						assert.strictEqual(run('../_tmp/output/bundle.js'), 42);
+						assert.ok(ctx1);
+						assert.ok(ctx2);
+						watcher.once('close', () => {
+							assert.strictEqual(calls, 2);
+						});
+						watcher.close();
+					},
+				]);
+			});
+	});
+
 	it('watches a file in code-splitting mode', () => {
 		return sander
 			.copydir('test/watch/samples/code-splitting')

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -310,8 +310,7 @@ describe('rollup.watch', () => {
 			});
 	});
 
-	it('correctly rewrites change event during build delay', function() {
-		this.timeout(3000);
+	it('correctly rewrites change event during build delay', () => {
 		let e;
 		return sander
 			.copydir('test/watch/samples/watch-files')
@@ -325,7 +324,10 @@ describe('rollup.watch', () => {
 						exports: 'auto'
 					},
 					watch: {
-						buildDelay: 300,
+						buildDelay: 100,
+						chokidar: {
+							atomic: true,
+						}
 					},
 					plugins: {
 						buildStart() {
@@ -347,8 +349,7 @@ describe('rollup.watch', () => {
 						assert.strictEqual(run('../_tmp/output/bundle.js'), 42);
 						assert.strictEqual(e, undefined);
 						sander.writeFileSync('test/_tmp/input/watched', 'another');
-						//default chokidar timeout for waiting is 100, so we waiting 150
-						setTimeout(() => sander.rimrafSync('test/_tmp/input/watched'), 150);
+						setTimeout(() => sander.rimrafSync('test/_tmp/input/watched'), 10);
 					},
 					'START',
 					'BUNDLE_START',
@@ -357,7 +358,7 @@ describe('rollup.watch', () => {
 					() => {
 						assert.strictEqual(e, 'delete');
 						sander.writeFileSync('test/_tmp/input/watched', '123');
-						setTimeout(() => sander.writeFileSync('test/_tmp/input/watched', 'asd'), 150);
+						setTimeout(() => sander.writeFileSync('test/_tmp/input/watched', 'asd'), 10);
 					},
 					'START',
 					'BUNDLE_START',

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -310,7 +310,8 @@ describe('rollup.watch', () => {
 			});
 	});
 
-	it('correctly rewrites change event during build delay', () => {
+	it('correctly rewrites change event during build delay', function() {
+		this.timeout(3000);
 		let e;
 		return sander
 			.copydir('test/watch/samples/watch-files')
@@ -324,9 +325,9 @@ describe('rollup.watch', () => {
 						exports: 'auto'
 					},
 					watch: {
-						buildDelay: 100,
+						buildDelay: 150,
 						chokidar: {
-							atomic: true,
+							atomic: 30,
 						}
 					},
 					plugins: {
@@ -349,7 +350,7 @@ describe('rollup.watch', () => {
 						assert.strictEqual(run('../_tmp/output/bundle.js'), 42);
 						assert.strictEqual(e, undefined);
 						sander.writeFileSync('test/_tmp/input/watched', 'another');
-						setTimeout(() => sander.rimrafSync('test/_tmp/input/watched'), 10);
+						setTimeout(() => sander.rimrafSync('test/_tmp/input/watched'), 50);
 					},
 					'START',
 					'BUNDLE_START',
@@ -357,8 +358,18 @@ describe('rollup.watch', () => {
 					'END',
 					() => {
 						assert.strictEqual(e, 'delete');
+						e = undefined;
 						sander.writeFileSync('test/_tmp/input/watched', '123');
-						setTimeout(() => sander.writeFileSync('test/_tmp/input/watched', 'asd'), 10);
+						setTimeout(() => sander.rimrafSync('test/_tmp/input/watched'), 50);
+					},
+					'START',
+					'BUNDLE_START',
+					'BUNDLE_END',
+					'END',
+					() => {
+						assert.strictEqual(e, undefined);
+						sander.writeFileSync('test/_tmp/input/watched', '123');
+						setTimeout(() => sander.writeFileSync('test/_tmp/input/watched', 'asd'), 50);
 					},
 					'START',
 					'BUNDLE_START',

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -30,3 +30,7 @@ declare module 'acorn-numeric-separator' {
 	const plugin: (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
 	export default plugin;
 }
+
+declare module 'fsevents' {
+	export default {};
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Closes #3821

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
1. Implemented `closeWatcher` hook
2. Added `getWatchFiles` method to `PluginContext`
3. Extended `watchChange` hook to get `isDeleted` parameter
4. Also added `this: PluginContext` for `watchChange`
