### PR TITLE
[v3.0] Run output plugins last

### DIFF
--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -105,7 +105,7 @@ export class PluginDriver {
 		this.finaliseAssets = this.fileEmitter.finaliseAssets.bind(this.fileEmitter);
 		this.setChunkInformation = this.fileEmitter.setChunkInformation.bind(this.fileEmitter);
 		this.setOutputBundle = this.fileEmitter.setOutputBundle.bind(this.fileEmitter);
-		this.plugins = userPlugins.concat(basePluginDriver ? basePluginDriver.plugins : []);
+		this.plugins = (basePluginDriver ? basePluginDriver.plugins : []).concat(userPlugins);
 		const existingPluginNames = new Set<string>();
 
 		this.pluginContexts = new Map(

--- a/test/form/samples/runs-output-plugins-last/_config.js
+++ b/test/form/samples/runs-output-plugins-last/_config.js
@@ -1,0 +1,23 @@
+module.exports = {
+	description: 'runs output plugins last',
+	options: {
+		plugins: [
+			{
+				name: 'input',
+				renderChunk(code) {
+					return `/* input */\n${code}\n/* input */`;
+				}
+			}
+		],
+		output: {
+			plugins: [
+				{
+					name: 'output',
+					renderChunk(code) {
+						return `/* output */\n${code}\n/* output */`;
+					}
+				}
+			]
+		}
+	}
+};

--- a/test/form/samples/runs-output-plugins-last/_expected.js
+++ b/test/form/samples/runs-output-plugins-last/_expected.js
@@ -1,0 +1,7 @@
+/* output */
+/* input */
+let foo = 'base';
+
+export { foo };
+/* input */
+/* output */

--- a/test/form/samples/runs-output-plugins-last/main.js
+++ b/test/form/samples/runs-output-plugins-last/main.js
@@ -1,0 +1,1 @@
+export let foo = 'base';

--- a/test/function/samples/options-in-renderstart/_config.js
+++ b/test/function/samples/options-in-renderstart/_config.js
@@ -22,10 +22,10 @@ module.exports = {
 	},
 	exports: () => {
 		assert.deepStrictEqual(checkedOptions, [
-			'output-plugin',
+			'input-plugin',
 			'cjs',
 			'global',
-			'input-plugin',
+			'output-plugin',
 			'cjs',
 			'global'
 		]);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:
- #3845 

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Output plugins will run after input plugins.

Technically a breaking change, but it wasn't documented, so maybe it could be released in a patch version?