### PR TITLE
Expose syntheticNamedExports to ModuleInfo

### DIFF
--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -647,6 +647,8 @@ Returns additional information about the module in question in the form
   implicitlyLoadedAfterOneOf: string[], // implicit relationships, declared via this.emitChunk
   implicitlyLoadedBefore: string[], // implicit relationships, declared via this.emitChunk
   hasModuleSideEffects: boolean | "no-treeshake" // are imports of this module included if nothing is imported from it
+  meta: {[plugin: string]: any} // custom module meta-data
+  syntheticNamedExports: boolean | string // final value of synthetic named exports
 }
 ```
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -241,7 +241,7 @@ export default class Chunk {
 				if (!chunkModules.has(importer)) {
 					this.dynamicEntryModules.push(module);
 					// Modules with synthetic exports need an artificial namespace for dynamic imports
-					if (module.syntheticNamedExports && !outputOptions.preserveModules) {
+					if (module.info.syntheticNamedExports && !outputOptions.preserveModules) {
 						includedNamespaces.add(module);
 						this.exports.add(module.namespace);
 					}
@@ -379,7 +379,7 @@ export default class Chunk {
 			}
 		}
 		for (const module of this.dynamicEntryModules) {
-			if (module.syntheticNamedExports) continue;
+			if (module.info.syntheticNamedExports) continue;
 			if (!this.facadeModule && this.canModuleBeFacade(module, exposedVariables)) {
 				this.facadeModule = module;
 				this.facadeChunkByModule.set(module, this);

--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -58,7 +58,8 @@ export default class ExternalModule {
 			},
 			isEntry: false,
 			isExternal: true,
-			meta
+			meta,
+			syntheticNamedExports: false
 		};
 	}
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -805,6 +805,7 @@ export default class Module {
 		}
 		if (syntheticNamedExports != null) {
 			this.syntheticNamedExports = syntheticNamedExports;
+			this.info.syntheticNamedExports = syntheticNamedExports;
 		}
 		if (meta != null) {
 			this.info.meta = { ...this.info.meta, ...meta };

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -285,7 +285,10 @@ export default class Module {
 			isEntry,
 			isExternal: false,
 			meta,
-			syntheticNamedExports
+			get syntheticNamedExports() {
+				//since it's public and not readonly, we should use getter to ensure value is always actual
+				return module.syntheticNamedExports;
+			}
 		};
 	}
 
@@ -805,7 +808,6 @@ export default class Module {
 		}
 		if (syntheticNamedExports != null) {
 			this.syntheticNamedExports = syntheticNamedExports;
-			this.info.syntheticNamedExports = syntheticNamedExports;
 		}
 		if (meta != null) {
 			this.info.meta = { ...this.info.meta, ...meta };

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -284,7 +284,8 @@ export default class Module {
 			},
 			isEntry,
 			isExternal: false,
-			meta
+			meta,
+			syntheticNamedExports
 		};
 	}
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -246,7 +246,7 @@ export default class Module {
 		private readonly options: NormalizedInputOptions,
 		isEntry: boolean,
 		hasModuleSideEffects: boolean | 'no-treeshake',
-		public syntheticNamedExports: boolean | string,
+		syntheticNamedExports: boolean | string,
 		meta: CustomPluginOptions
 	) {
 		this.excludeFromSourcemap = /\0/.test(id);
@@ -285,10 +285,7 @@ export default class Module {
 			isEntry,
 			isExternal: false,
 			meta,
-			get syntheticNamedExports() {
-				//since it's public and not readonly, we should use getter to ensure value is always actual
-				return module.syntheticNamedExports;
-			}
+			syntheticNamedExports
 		};
 	}
 
@@ -396,7 +393,7 @@ export default class Module {
 		}
 		const exportNamesByVariable: Map<Variable, string[]> = new Map();
 		for (const exportName of this.getAllExportNames()) {
-			if (exportName === this.syntheticNamedExports) continue;
+			if (exportName === this.info.syntheticNamedExports) continue;
 			let tracedVariable = this.getVariableForExportName(exportName);
 			if (tracedVariable instanceof ExportDefaultVariable) {
 				tracedVariable = tracedVariable.getOriginalVariable();
@@ -459,7 +456,9 @@ export default class Module {
 		if (this.syntheticNamespace === null) {
 			this.syntheticNamespace = undefined;
 			this.syntheticNamespace = this.getVariableForExportName(
-				typeof this.syntheticNamedExports === 'string' ? this.syntheticNamedExports : 'default'
+				typeof this.info.syntheticNamedExports === 'string'
+					? this.info.syntheticNamedExports
+					: 'default'
 			);
 		}
 		if (!this.syntheticNamespace) {
@@ -469,10 +468,11 @@ export default class Module {
 				message: `Module "${relativeId(
 					this.id
 				)}" that is marked with 'syntheticNamedExports: ${JSON.stringify(
-					this.syntheticNamedExports
+					this.info.syntheticNamedExports
 				)}' needs ${
-					typeof this.syntheticNamedExports === 'string' && this.syntheticNamedExports !== 'default'
-						? `an export named "${this.syntheticNamedExports}"`
+					typeof this.info.syntheticNamedExports === 'string' &&
+					this.info.syntheticNamedExports !== 'default'
+						? `an export named "${this.info.syntheticNamedExports}"`
 						: 'a default export'
 				}.`
 			});
@@ -542,7 +542,7 @@ export default class Module {
 		// we don't want to create shims when we are just
 		// probing export * modules for exports
 		if (!isExportAllSearch) {
-			if (this.syntheticNamedExports) {
+			if (this.info.syntheticNamedExports) {
 				let syntheticExport = this.syntheticExports.get(name);
 				if (!syntheticExport) {
 					const syntheticNamespace = this.getSyntheticNamespace();
@@ -584,7 +584,7 @@ export default class Module {
 		}
 
 		for (const exportName of this.getExports()) {
-			if (includeNamespaceMembers || exportName !== this.syntheticNamedExports) {
+			if (includeNamespaceMembers || exportName !== this.info.syntheticNamedExports) {
 				const variable = this.getVariableForExportName(exportName);
 				variable.deoptimizePath(UNKNOWN_PATH);
 				if (!variable.included) {
@@ -740,7 +740,7 @@ export default class Module {
 		};
 
 		this.scope = new ModuleScope(this.graph.scope, this.astContext);
-		this.namespace = new NamespaceVariable(this.astContext, this.syntheticNamedExports);
+		this.namespace = new NamespaceVariable(this.astContext, this.info.syntheticNamedExports);
 		this.ast = new Program(ast, { type: 'Module', context: this.astContext }, this.scope);
 		this.info.ast = ast;
 
@@ -761,7 +761,7 @@ export default class Module {
 			originalSourcemap: this.originalSourcemap,
 			resolvedIds: this.resolvedIds,
 			sourcemapChain: this.sourcemapChain,
-			syntheticNamedExports: this.syntheticNamedExports,
+			syntheticNamedExports: this.info.syntheticNamedExports,
 			transformDependencies: this.transformDependencies,
 			transformFiles: this.transformFiles
 		};
@@ -807,7 +807,7 @@ export default class Module {
 			this.info.hasModuleSideEffects = moduleSideEffects;
 		}
 		if (syntheticNamedExports != null) {
-			this.syntheticNamedExports = syntheticNamedExports;
+			this.info.syntheticNamedExports = syntheticNamedExports;
 		}
 		if (meta != null) {
 			this.info.meta = { ...this.info.meta, ...meta };
@@ -968,7 +968,7 @@ export default class Module {
 				externalVariable.include();
 				this.imports.add(externalVariable);
 				mergedNamespaces.push(externalVariable);
-			} else if (module.syntheticNamedExports) {
+			} else if (module.info.syntheticNamedExports) {
 				const syntheticNamespace = module.getSyntheticNamespace();
 				syntheticNamespace.include();
 				this.imports.add(syntheticNamespace);

--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -46,7 +46,7 @@ export default class NamespaceVariable extends Variable {
 		}
 		const memberVariables = Object.create(null);
 		for (const name of this.context.getExports().concat(this.context.getReexports())) {
-			if (name[0] !== '*' && name !== this.module.syntheticNamedExports) {
+			if (name[0] !== '*' && name !== this.module.info.syntheticNamedExports) {
 				memberVariables[name] = this.context.traceExport(name);
 			}
 		}

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -171,6 +171,7 @@ interface ModuleInfo {
 	isEntry: boolean;
 	isExternal: boolean;
 	meta: CustomPluginOptions;
+	syntheticNamedExports: boolean | string;
 }
 
 export type GetModuleInfo = (moduleId: string) => ModuleInfo | null;

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry/_config.js
@@ -80,7 +80,8 @@ module.exports = {
 					importers: [],
 					isEntry: true,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
 					ast: {
@@ -138,7 +139,8 @@ module.exports = {
 					importers: [],
 					isEntry: true,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 			},
 			generateBundle(options, bundle) {

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-entry/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-entry/_config.js
@@ -76,7 +76,8 @@ module.exports = {
 					importers: [],
 					isEntry: true,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
 					ast: {
@@ -134,7 +135,8 @@ module.exports = {
 					importers: [],
 					isEntry: true,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 			},
 			generateBundle(options, bundle) {

--- a/test/chunking-form/samples/implicit-dependencies/multiple-dependencies/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/multiple-dependencies/_config.js
@@ -125,7 +125,8 @@ module.exports = {
 					importers: [],
 					isEntry: true,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_MAIN2))), {
 					ast: {
@@ -219,7 +220,8 @@ module.exports = {
 					importers: [],
 					isEntry: true,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
 					ast: {
@@ -312,7 +314,8 @@ module.exports = {
 					importers: [],
 					isEntry: false,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 			}
 		}

--- a/test/chunking-form/samples/implicit-dependencies/single-dependency/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/single-dependency/_config.js
@@ -75,7 +75,8 @@ module.exports = {
 					importers: [],
 					isEntry: true,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
 					ast: {
@@ -133,7 +134,8 @@ module.exports = {
 					importers: [],
 					isEntry: false,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 			},
 			generateBundle(options, bundle) {

--- a/test/function/samples/deprecated/manual-chunks-info/_config.js
+++ b/test/function/samples/deprecated/manual-chunks-info/_config.js
@@ -111,7 +111,8 @@ module.exports = {
 							importers: [],
 							isEntry: true,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: null,
@@ -126,7 +127,8 @@ module.exports = {
 							importers: [getId('main')],
 							isEntry: false,
 							isExternal: true,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: {
@@ -154,7 +156,8 @@ module.exports = {
 							importers: [getId('dynamic'), getId('main')],
 							isEntry: false,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: {
@@ -226,7 +229,8 @@ module.exports = {
 							importers: [],
 							isEntry: false,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						}
 					]
 				);

--- a/test/function/samples/manual-chunks-info/_config.js
+++ b/test/function/samples/manual-chunks-info/_config.js
@@ -110,7 +110,8 @@ module.exports = {
 							importers: [],
 							isEntry: true,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: null,
@@ -125,7 +126,8 @@ module.exports = {
 							importers: [getId('main')],
 							isEntry: false,
 							isExternal: true,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: {
@@ -153,7 +155,8 @@ module.exports = {
 							importers: [getId('dynamic'), getId('main')],
 							isEntry: false,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: {
@@ -225,7 +228,8 @@ module.exports = {
 							importers: [],
 							isEntry: false,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						}
 					]
 				);

--- a/test/function/samples/module-parsed-hook/_config.js
+++ b/test/function/samples/module-parsed-hook/_config.js
@@ -58,7 +58,8 @@ module.exports = {
 						importers: [],
 						isEntry: true,
 						isExternal: false,
-						meta: {}
+						meta: {},
+						syntheticNamedExports: false
 					},
 					{
 						ast: {
@@ -102,7 +103,8 @@ module.exports = {
 						importers: [ID_MAIN],
 						isEntry: false,
 						isExternal: false,
-						meta: {}
+						meta: {},
+						syntheticNamedExports: false
 					}
 				]);
 			}

--- a/test/function/samples/plugin-module-information/_config.js
+++ b/test/function/samples/plugin-module-information/_config.js
@@ -27,7 +27,8 @@ module.exports = {
 					importers: [],
 					isEntry: id === ID_MAIN,
 					isExternal: false,
-					meta: {}
+					meta: {},
+					syntheticNamedExports: false
 				});
 			},
 			renderStart() {
@@ -172,7 +173,8 @@ module.exports = {
 							importers: [],
 							isEntry: true,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: {
@@ -247,7 +249,8 @@ module.exports = {
 							importers: [ID_MAIN, ID_NESTED],
 							isEntry: false,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: null,
@@ -262,7 +265,8 @@ module.exports = {
 							importers: [ID_FOO],
 							isEntry: false,
 							isExternal: true,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						},
 						{
 							ast: {
@@ -340,7 +344,8 @@ module.exports = {
 							importers: [],
 							isEntry: false,
 							isExternal: false,
-							meta: {}
+							meta: {},
+							syntheticNamedExports: false
 						}
 					]
 				);

--- a/test/function/samples/synthetic-named-exports/dynamic-import/_config.js
+++ b/test/function/samples/synthetic-named-exports/dynamic-import/_config.js
@@ -9,6 +9,11 @@ module.exports = {
 					if (id.endsWith('dep.js')) {
 						return { code, syntheticNamedExports: true };
 					}
+				},
+				moduleParsed({id, syntheticNamedExports}) {
+					if (id.endsWith('dep.js')) {
+						assert.strictEqual(syntheticNamedExports, true);
+					}
 				}
 			}
 		]

--- a/test/function/samples/synthetic-named-exports/non-default-export/_config.js
+++ b/test/function/samples/synthetic-named-exports/non-default-export/_config.js
@@ -9,6 +9,11 @@ module.exports = {
 					if (id.endsWith('dep.js')) {
 						return { code, syntheticNamedExports: '__synthetic' };
 					}
+				},
+				moduleParsed({id, syntheticNamedExports}) {
+					if (id.endsWith('dep.js')) {
+						assert.strictEqual(syntheticNamedExports, '__synthetic');
+					}
 				}
 			}
 		]


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

In [docs](https://rollupjs.org/guide/en/#load) there is line about `meta` and `syntheticNamedExports` in `ModuleInfo`:
![image](https://user-images.githubusercontent.com/4806617/97710985-4bb2c100-1ade-11eb-9a62-c5e0007414e2.png)