### PR TITLE
[types] add options hook to AsyncPluginHooks

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -347,7 +347,10 @@ export interface PluginHooks extends OutputPluginHooks {
 	buildStart: (this: PluginContext, options: NormalizedInputOptions) => Promise<void> | void;
 	load: LoadHook;
 	moduleParsed: ModuleParsedHook;
-	options: (this: MinimalPluginContext, options: InputOptions) => InputOptions | null | undefined;
+	options: (
+		this: MinimalPluginContext,
+		options: InputOptions
+	) => Promise<InputOptions | null | undefined> | InputOptions | null | undefined;
 	resolveDynamicImport: ResolveDynamicImportHook;
 	resolveId: ResolveIdHook;
 	transform: TransformHook;
@@ -391,6 +394,7 @@ interface OutputPluginHooks {
 }
 
 export type AsyncPluginHooks =
+	| 'options'
 	| 'buildEnd'
 	| 'buildStart'
 	| 'generateBundle'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

According to the docs, options hook is supposed to be [async](http://rollupjs.org/guide/en/#options), and I checked the [code](https://github.com/rollup/rollup/blob/1fa9374/src/rollup/rollup.ts#L101) as well.

This pull request fixes the corresponding types.
