### PR TITLE
Restore labels after included try statement block

### DIFF
--- a/src/ast/nodes/TryStatement.ts
+++ b/src/ast/nodes/TryStatement.ts
@@ -12,6 +12,7 @@ export default class TryStatement extends StatementBase {
 	type!: NodeType.tTryStatement;
 
 	private directlyIncluded = false;
+	private includedLabelsAfterBlock: string[] | null = null;
 
 	hasEffects(context: HasEffectsContext): boolean {
 		return (
@@ -33,7 +34,14 @@ export default class TryStatement extends StatementBase {
 				context,
 				tryCatchDeoptimization ? INCLUDE_PARAMETERS : includeChildrenRecursively
 			);
+			if (context.includedLabels.size > 0) {
+				this.includedLabelsAfterBlock = [...context.includedLabels];
+			}
 			context.brokenFlow = brokenFlow;
+		} else if (this.includedLabelsAfterBlock) {
+			for (const label of this.includedLabelsAfterBlock) {
+				context.includedLabels.add(label);
+			}
 		}
 		if (this.handler !== null) {
 			this.handler.include(context, includeChildrenRecursively);

--- a/test/function/samples/conditional-catch/_config.js
+++ b/test/function/samples/conditional-catch/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles conditional catch blocks (#3869)'
+};

--- a/test/function/samples/conditional-catch/main.js
+++ b/test/function/samples/conditional-catch/main.js
@@ -1,0 +1,17 @@
+function g() {
+	var result;
+	g: {
+		try {
+			break g;
+		} catch (_) {}
+		return;
+	}
+	try {
+		throw 'Expected';
+	} catch (e) {
+		result = e;
+	}
+	assert.strictEqual(result, 'Expected');
+}
+
+g();


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3869

### Description
This solves a tricky issue in the interplay of the default deoptimization of try-catch blocks, see #3869. Basically what was happening is that while during the first tree-shaking run, the break statement with the label was correctly tracked, it was not tracked during the second run as it was nested in a try statement. And try statements are only evaluated once.

This PR fixes this by caching the labels that are used inside a try statement for subsequent runs.
