### PR TITLE
also removeExtensionFromRelativeAmdId in UMD finaliser

### DIFF
--- a/src/finalisers/amd.ts
+++ b/src/finalisers/amd.ts
@@ -3,17 +3,8 @@ import { NormalizedOutputOptions } from '../rollup/types';
 import { FinaliserOptions } from './index';
 import { getExportBlock, getNamespaceMarkers } from './shared/getExportBlock';
 import getInteropBlock from './shared/getInteropBlock';
+import removeExtensionFromRelativeAmdId from './shared/removeExtensionFromRelativeAmdId';
 import warnOnBuiltins from './shared/warnOnBuiltins';
-
-// AMD resolution will only respect the AMD baseUrl if the .js extension is omitted.
-// The assumption is that this makes sense for all relative ids:
-// https://requirejs.org/docs/api.html#jsfiles
-function removeExtensionFromRelativeAmdId(id: string) {
-	if (id[0] === '.' && id.endsWith('.js')) {
-		return id.slice(0, -3);
-	}
-	return id;
-}
 
 export default function amd(
 	magicString: MagicStringBundle,

--- a/src/finalisers/shared/removeExtensionFromRelativeAmdId.ts
+++ b/src/finalisers/shared/removeExtensionFromRelativeAmdId.ts
@@ -1,0 +1,9 @@
+// AMD resolution will only respect the AMD baseUrl if the .js extension is omitted.
+// The assumption is that this makes sense for all relative ids:
+// https://requirejs.org/docs/api.html#jsfiles
+export default function removeExtensionFromRelativeAmdId(id: string) {
+	if (id[0] === '.' && id.endsWith('.js')) {
+		return id.slice(0, -3);
+	}
+	return id;
+}

--- a/src/finalisers/umd.ts
+++ b/src/finalisers/umd.ts
@@ -4,6 +4,7 @@ import { error } from '../utils/error';
 import { FinaliserOptions } from './index';
 import { getExportBlock, getNamespaceMarkers } from './shared/getExportBlock';
 import getInteropBlock from './shared/getInteropBlock';
+import removeExtensionFromRelativeAmdId from './shared/removeExtensionFromRelativeAmdId';
 import { keypath, property } from './shared/sanitize';
 import { assignToDeepVariable } from './shared/setupNamespace';
 import trimEmptyImports from './shared/trimEmptyImports';
@@ -66,7 +67,7 @@ export default function umd(
 
 	warnOnBuiltins(warn, dependencies);
 
-	const amdDeps = dependencies.map(m => `'${m.id}'`);
+	const amdDeps = dependencies.map(m => `'${removeExtensionFromRelativeAmdId(m.id)}'`);
 	const cjsDeps = dependencies.map(m => `require('${m.id}')`);
 
 	const trimmedImports = trimEmptyImports(dependencies);

--- a/test/form/samples/guessed-global-names/_expected/umd.js
+++ b/test/form/samples/guessed-global-names/_expected/umd.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('unchanged'), require('changed'), require('special-character'), require('with/slash'), require('./relative.js')) :
-	typeof define === 'function' && define.amd ? define(['unchanged', 'changed', 'special-character', 'with/slash', './relative.js'], factory) :
+	typeof define === 'function' && define.amd ? define(['unchanged', 'changed', 'special-character', 'with/slash', './relative'], factory) :
 	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.unchanged, global.changedName, global.specialCharacter, global.slash, global.relative_js));
 }(this, (function (unchanged, changedName, specialCharacter, slash, relative_js) { 'use strict';
 

--- a/test/form/samples/relative-external-with-global/_expected/umd.js
+++ b/test/form/samples/relative-external-with-global/_expected/umd.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('./lib/throttle.js')) :
-	typeof define === 'function' && define.amd ? define(['./lib/throttle.js'], factory) :
+	typeof define === 'function' && define.amd ? define(['./lib/throttle'], factory) :
 	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.Lib.throttle));
 }(this, (function (throttle) { 'use strict';
 


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (updated existing)
- [ ] no

Breaking Changes?
- [ ] yes
- [x] no

### Description
I noticed in the UMD finialiser the AMD ids are not run through `removeExtensionFromRelativeAmdId` when in the AMD one they are.

Should't they work the same way?