### PR TITLE
Always respect synthetic namespaces in namespace reexports

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -539,24 +539,24 @@ export default class Module {
 			}
 		}
 
+		if (this.info.syntheticNamedExports) {
+			let syntheticExport = this.syntheticExports.get(name);
+			if (!syntheticExport) {
+				const syntheticNamespace = this.getSyntheticNamespace();
+				syntheticExport = new SyntheticNamedExportVariable(
+					this.astContext,
+					name,
+					syntheticNamespace
+				);
+				this.syntheticExports.set(name, syntheticExport);
+				return syntheticExport;
+			}
+			return syntheticExport;
+		}
+
 		// we don't want to create shims when we are just
 		// probing export * modules for exports
 		if (!isExportAllSearch) {
-			if (this.info.syntheticNamedExports) {
-				let syntheticExport = this.syntheticExports.get(name);
-				if (!syntheticExport) {
-					const syntheticNamespace = this.getSyntheticNamespace();
-					syntheticExport = new SyntheticNamedExportVariable(
-						this.astContext,
-						name,
-						syntheticNamespace
-					);
-					this.syntheticExports.set(name, syntheticExport);
-					return syntheticExport;
-				}
-				return syntheticExport;
-			}
-
 			if (this.options.shimMissingExports) {
 				this.shimMissingExport(name);
 				return this.exportShimVariable;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -527,6 +527,7 @@ export default class Module {
 		}
 
 		if (name !== 'default') {
+			let foundSyntheticDeclaration: SyntheticNamedExportVariable | null = null;
 			for (const module of this.exportAllModules) {
 				const declaration = getVariableForExportNameRecursive(
 					module,
@@ -535,7 +536,17 @@ export default class Module {
 					searchedNamesAndModules
 				);
 
-				if (declaration) return declaration;
+				if (declaration) {
+					if (!(declaration instanceof SyntheticNamedExportVariable)) {
+						return declaration;
+					}
+					if (!foundSyntheticDeclaration) {
+						foundSyntheticDeclaration = declaration;
+					}
+				}
+			}
+			if (foundSyntheticDeclaration) {
+				return foundSyntheticDeclaration;
 			}
 		}
 
@@ -623,7 +634,7 @@ export default class Module {
 		this.addModulesToImportDescriptions(this.importDescriptions);
 		this.addModulesToImportDescriptions(this.reexportDescriptions);
 		for (const name in this.exports) {
-			if (name !== 'default') {
+			if (name !== 'default' && name !== this.info.syntheticNamedExports) {
 				this.exportsAll[name] = this.id;
 			}
 		}

--- a/test/function/samples/reexport-from-synthetic/_config.js
+++ b/test/function/samples/reexport-from-synthetic/_config.js
@@ -3,10 +3,8 @@ module.exports = {
 	options: {
 		plugins: [
 			{
-				transform(code, id) {
-					if (id.endsWith('synthetic.js')) {
-						return { syntheticNamedExports: '__synth' };
-					}
+				transform() {
+					return { syntheticNamedExports: '__synth' };
 				}
 			}
 		]

--- a/test/function/samples/reexport-from-synthetic/_config.js
+++ b/test/function/samples/reexport-from-synthetic/_config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	description: 'handles reexporting a synthetic namespace from a non-synthetic module',
+	options: {
+		plugins: [
+			{
+				transform(code, id) {
+					if (id.endsWith('synthetic.js')) {
+						return { syntheticNamedExports: '__synth' };
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/reexport-from-synthetic/main.js
+++ b/test/function/samples/reexport-from-synthetic/main.js
@@ -1,2 +1,4 @@
-import { q } from './reexport.js';
-assert.equal(q, 42);
+import { synth, explicit1, explicit2 } from './reexport.js';
+assert.strictEqual(synth, 1);
+assert.strictEqual(explicit1, 2);
+assert.strictEqual(explicit2, 4);

--- a/test/function/samples/reexport-from-synthetic/main.js
+++ b/test/function/samples/reexport-from-synthetic/main.js
@@ -1,0 +1,2 @@
+import { q } from './reexport.js';
+assert.equal(q, 42);

--- a/test/function/samples/reexport-from-synthetic/reexport.js
+++ b/test/function/samples/reexport-from-synthetic/reexport.js
@@ -1,1 +1,2 @@
-export * from './synthetic.js';
+export * from './synthetic1.js';
+export * from './synthetic2.js';

--- a/test/function/samples/reexport-from-synthetic/reexport.js
+++ b/test/function/samples/reexport-from-synthetic/reexport.js
@@ -1,0 +1,1 @@
+export * from './synthetic.js';

--- a/test/function/samples/reexport-from-synthetic/synthetic.js
+++ b/test/function/samples/reexport-from-synthetic/synthetic.js
@@ -1,1 +1,0 @@
-export const __synth = { q: 42 };

--- a/test/function/samples/reexport-from-synthetic/synthetic.js
+++ b/test/function/samples/reexport-from-synthetic/synthetic.js
@@ -1,0 +1,1 @@
+export const __synth = { q: 42 };

--- a/test/function/samples/reexport-from-synthetic/synthetic1.js
+++ b/test/function/samples/reexport-from-synthetic/synthetic1.js
@@ -1,0 +1,2 @@
+export const __synth = { synth: 1 };
+export const explicit1 = 2;

--- a/test/function/samples/reexport-from-synthetic/synthetic2.js
+++ b/test/function/samples/reexport-from-synthetic/synthetic2.js
@@ -1,0 +1,2 @@
+export const __synth = { synth: 3 };
+export const explicit2 = 4;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#3857
resolves #3928 

### Description
This will treat synthetic namespaces as containing "all named exports" also when handling namespace reexports, i.e.

```js
// main.js
import {foo} from './reexport.js';
console.log(foo);

// reexport.js
export * from './synthetic.js';

// synthetic.js
// we assume this is marked as the synthetic namespace
export const __synth = {foo: 'bar'};
```

should work now.