### PR TITLE
Replace deprecated folder export with pattern export

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
       },
       "default": "./dist/es/rollup.browser.js"
     },
-    "./dist/": "./dist/"
+    "./dist/*": "./dist/*"
   },
   "dependencies": {
     "fsevents": "~2.1.2"


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3890 

### Description
This follows official Node (14) guidance to prefer a pattern export over a folder export.