### PR TITLE
Forward bundle through watch error events

### DIFF
--- a/cli/run/watch-cli.ts
+++ b/cli/run/watch-cli.ts
@@ -129,13 +129,16 @@ export async function watch(command: any) {
 					if (event.result && event.result.getTimings) {
 						printTimings(event.result.getTimings());
 					}
-					event.result.close().catch(error => handleError(error, true));
 					break;
 
 				case 'END':
 					if (!silent && isTTY) {
 						stderr(`\n[${dateTime()}] waiting for changes...`);
 					}
+			}
+
+			if ('result' in event && event.result) {
+				event.result.close().catch(error => handleError(error, true));
 			}
 		});
 	}

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -196,11 +196,15 @@ watcher.on('event', event => {
   //   END          — finished building all bundles
   //   ERROR        — encountered an error while bundling
   //                  * event.error contains the error that was thrown
+  //                  * event.result is null for build errors and contains the
+  //                    bundle object for output generation errors. As with
+  //                    "BUNDLE_END", you should call "event.result.close()" if
+  //                    present once you are done.
 });
 
 // This will make sure that bundles are properly closed after each run
-watcher.on('event', ({ code, result }) => {
-  if (code === 'BUNDLE_END') {
+watcher.on('event', ({ result }) => {
+  if (result) {
   	result.close();
   }
 });

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -857,7 +857,7 @@ export type RollupWatcherEvent =
 			result: RollupBuild;
 	  }
 	| { code: 'END' }
-	| { code: 'ERROR'; error: RollupError };
+	| { code: 'ERROR'; error: RollupError; result: RollupBuild | null };
 
 export interface RollupWatcher
 	extends TypedEventEmitter<{

--- a/test/cli/samples/watch/close-on-generate-error/_config.js
+++ b/test/cli/samples/watch/close-on-generate-error/_config.js
@@ -1,0 +1,19 @@
+const { assertIncludes } = require('../../../../utils.js');
+
+module.exports = {
+	description: 'closes the bundle on generate errors',
+	command: 'rollup -cw',
+	abortOnStderr(data) {
+		if (data.includes('Bundle closed')) {
+			return true;
+		}
+	},
+	stderr(stderr) {
+		assertIncludes(
+			stderr,
+			'[!] Error: You must specify "output.file" or "output.dir" for the build.'
+		);
+		assertIncludes(stderr, 'Bundle closed');
+		return false;
+	}
+};

--- a/test/cli/samples/watch/close-on-generate-error/main.js
+++ b/test/cli/samples/watch/close-on-generate-error/main.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/cli/samples/watch/close-on-generate-error/rollup.config.js
+++ b/test/cli/samples/watch/close-on-generate-error/rollup.config.js
@@ -1,0 +1,14 @@
+export default {
+	input: 'main.js',
+	plugins: [
+		{
+			name: 'faulty-close',
+			closeBundle() {
+				console.error('Bundle closed')
+			}
+		}
+	],
+	output: {
+		format: "es"
+	}
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
One oversight from the previous PR #3883 was that when a bundle was successfully created but writing the files threw an error, then there was no way to close the bundle.

This is fixed now: In such a situation, the error event will also contain a reference to the created bundle. And the CLI will make sure, that the bundle is closed.