### PR TITLE
Treeshake chained assignment expressions

### DIFF
--- a/test/form/samples/chained-assignments/_config.js
+++ b/test/form/samples/chained-assignments/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'treeshakes chained assignments'
+};

--- a/test/form/samples/chained-assignments/_expected.js
+++ b/test/form/samples/chained-assignments/_expected.js
@@ -1,0 +1,8 @@
+let a, d;
+a = 1;
+d = 2;
+console.log(a, d);
+
+let e = 'first', f = 'second';
+e += f += 'third';
+console.log(e);

--- a/test/form/samples/chained-assignments/main.js
+++ b/test/form/samples/chained-assignments/main.js
@@ -1,0 +1,8 @@
+let a, b, c, d;
+a = b = 1;
+c = d = 2;
+console.log(a, d);
+
+let e = 'first', f = 'second';
+e += f += 'third';
+console.log(e);

--- a/test/form/samples/nested-member-access/_expected.js
+++ b/test/form/samples/nested-member-access/_expected.js
@@ -6,9 +6,7 @@ const retainedResult2 = retained2.foo.bar;
 
 const retained3 = void {};
 const retainedResult3 = retained3.foo;
-
-let retained4a;
-const retained4b = retained4a = undefined;
+const retained4b = undefined;
 const retainedResult4 = retained4b.foo;
 
 const retained5 = 1 + 2;

--- a/test/form/samples/nested-member-access/main.js
+++ b/test/form/samples/nested-member-access/main.js
@@ -32,8 +32,8 @@ const retainedResult2 = retained2.foo.bar;
 const retained3 = void {};
 const retainedResult3 = retained3.foo;
 
-let retained4a;
-const retained4b = retained4a = undefined;
+let removed4a;
+const retained4b = removed4a = undefined;
 const retainedResult4 = retained4b.foo;
 
 const retained5 = 1 + 2;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This will allow tree-shaking parts of chained assignment expressions. Example:

```js
// input
let a, b, c, d;
a = b = 1;
c = d = 2;
console.log(a, d);

// output
let a, d;
a = 1;
d = 2;
console.log(a, d);
```

Special care is taken so that
- Non-"=" Assignment operators such as "+=" are not tree-shaken
- Side-effects on the left side are still observed

This will be helpful with some planned updates for the commonjs plugin as it will produce nicer output.