### PR TITLE
Prevent invalid code when removing assignment target of side-effectful object expression

### DIFF
--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -1,7 +1,9 @@
 import MagicString from 'magic-string';
+import { BLANK } from '../../utils/blank';
 import {
 	findFirstOccurrenceOutsideComment,
 	findNonWhiteSpace,
+	NodeRenderOptions,
 	RenderOptions
 } from '../../utils/renderHelpers';
 import { getSystemExportFunctionLeft } from '../../utils/systemJsRendering';
@@ -62,11 +64,18 @@ export default class AssignmentExpression extends NodeBase {
 		this.right.include(context, includeChildrenRecursively);
 	}
 
-	render(code: MagicString, options: RenderOptions) {
-		this.right.render(code, options);
+	render(
+		code: MagicString,
+		options: RenderOptions,
+		{ renderedParentType }: NodeRenderOptions = BLANK
+	) {
 		if (this.left.included) {
 			this.left.render(code, options);
+			this.right.render(code, options);
 		} else {
+			this.right.render(code, options, {
+				renderedParentType: renderedParentType || this.parent.type
+			});
 			code.remove(this.start, this.right.start);
 		}
 		if (options.format === 'system') {

--- a/test/function/samples/tree-shake-object-expression-assignment/_config.js
+++ b/test/function/samples/tree-shake-object-expression-assignment/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description:
+		'renders valid code when the target of an object expression with side-effects is tree-shaken'
+};

--- a/test/function/samples/tree-shake-object-expression-assignment/main.js
+++ b/test/function/samples/tree-shake-object-expression-assignment/main.js
@@ -1,0 +1,6 @@
+const result = {};
+
+let foo;
+foo = { [(result.x = 1)]: (result.y = 2) };
+
+assert.deepStrictEqual(result, { x: 1, y: 2 });


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3920 

### Description
As with all "simplification" type optimizations, this adds the necessary information so that when e.g. an object expression becomes an expression statement, it is wrapped in parentheses to avoid being misinterpreted as a block statement. Should also solve similar issues for sequence expressions.