### PR TITLE
Correctly simplify assignments with parentheses

### DIFF
--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -76,7 +76,8 @@ export default class AssignmentExpression extends NodeBase {
 			this.right.render(code, options, {
 				renderedParentType: renderedParentType || this.parent.type
 			});
-			code.remove(this.start, this.right.start);
+			const operatorPos = findFirstOccurrenceOutsideComment(code.original, '=', this.left.end);
+			code.remove(this.start, findNonWhiteSpace(code.original, operatorPos + 1));
 		}
 		if (options.format === 'system') {
 			const exportNames =

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -50,11 +50,12 @@ export function findFirstOccurrenceOutsideComment(code: string, searchString: st
 	}
 }
 
-const WHITESPACE = /\s/;
+const NON_WHITESPACE = /\S/g;
 
 export function findNonWhiteSpace(code: string, index: number) {
-	while (index < code.length && WHITESPACE.test(code[index])) index++;
-	return index;
+	NON_WHITESPACE.lastIndex = index;
+	const result = NON_WHITESPACE.exec(code)!;
+	return result.index;
 }
 
 // This assumes "code" only contains white-space and comments

--- a/test/function/samples/unused-parenthesed-assignment/_config.js
+++ b/test/function/samples/unused-parenthesed-assignment/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'correctly simplifies assignments with right-hand-sides in parentheses (#3924)',
+	context: {
+		someObject: { isTrue: true }
+	}
+};

--- a/test/function/samples/unused-parenthesed-assignment/main.js
+++ b/test/function/samples/unused-parenthesed-assignment/main.js
@@ -1,0 +1,2 @@
+let unused = false;
+unused = (someObject.isTrue === true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3924

### Description
This fixes an issue where Rollup would incorrectly simplify assignment right-hand-sides with parentheses. Also, this improves performance of the non-white-space detection function by using a stateful regular expression instead of a loop.