### PR TITLE
Deduplicate acorn import

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,7 +49,8 @@ const moduleAliases = {
 	resolve: ['.js', '.json', '.md'],
 	entries: [
 		{ find: 'help.md', replacement: path.resolve('cli/help.md') },
-		{ find: 'package.json', replacement: path.resolve('package.json') }
+		{ find: 'package.json', replacement: path.resolve('package.json') },
+		{ find: 'acorn', replacement: path.resolve('node_modules/acorn/dist/acorn.mjs') }
 	]
 };
 

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -1,3 +1,4 @@
+import * as acorn from 'acorn';
 import injectClassFields from 'acorn-class-fields';
 import injectStaticClassFeatures from 'acorn-static-class-features';
 import {

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -1,5 +1,4 @@
 // internal
-declare module 'rollup';
 declare module 'help.md' {
 	const str: string;
 	export default str;
@@ -12,16 +11,6 @@ declare module 'acorn-static-class-features' {
 }
 
 declare module 'acorn-class-fields' {
-	const plugin: (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
-	export default plugin;
-}
-
-declare module 'acorn-import-meta' {
-	const plugin: (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
-	export default plugin;
-}
-
-declare module 'acorn-export-ns-from' {
 	const plugin: (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
 	export default plugin;
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
When switching to latest rollup-plugin-node-resolve, we suddenly had two copies of acorn in the build as acorn does not use `module` in its export conditions. This fixes it, noticeably reducing file size again.