### PR TITLE
Accept `output.sourcemapFile` for inlined source map

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -754,7 +754,8 @@ export default class Chunk {
 			timeStart('sourcemap', 2);
 
 			let file: string;
-			if (options.file) file = resolve(options.sourcemapFile || options.file);
+			if (options.sourcemapFile) file = resolve(options.sourcemapFile);
+			else if (options.file) file = resolve(options.file);
 			else if (options.dir) file = resolve(options.dir, this.id);
 			else file = resolve(this.id);
 

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -46,7 +46,9 @@ runTestSuiteWithSamples('sourcemaps', path.resolve(__dirname, 'samples'), (dir, 
 });
 
 async function generateAndTestBundle(bundle, outputOptions, config, format, warnings) {
-	await bundle.write(outputOptions);
+	if (outputOptions.file) {
+		await bundle.write(outputOptions);
+	}
 	if (config.warnings) {
 		compareWarnings(warnings, config.warnings);
 	} else if (warnings.length) {

--- a/test/sourcemaps/samples/relative-paths-inline/_config.js
+++ b/test/sourcemaps/samples/relative-paths-inline/_config.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'source paths are relative to sourcemapFile for inlined sourcemap',
+	options: {
+		output: {
+			file: null,
+			name: 'Main',
+			sourcemap: 'inline',
+			sourcemapFile: 'dist/js/bundle.js'
+		}
+	},
+	test(code, map) {
+		assert.deepEqual(map.sources, ['../../main.js']);
+	}
+};

--- a/test/sourcemaps/samples/relative-paths-inline/main.js
+++ b/test/sourcemaps/samples/relative-paths-inline/main.js
@@ -1,0 +1,1 @@
+export default 42;


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

This is for plugins like `karma-rollup-preprocessor` which would use rollup API to generate a bundle, but do not use rollup API to write bundle. When generating the bundle with `sourcemap: 'inline'`, the generated source paths in the source map can be wrong. Without specify `output.file`, the source path will be relative to `this.id`, which is usually just basename of the `input`, which means if the manually written output file is not served under '/', the source paths are messed up.

Here is an example of what happens with `karma-rollup-preprocessor`. You can see that weird path `test/test/`, which should be `test/`.

```
FAILED TESTS:
  t1
    Fixture 1
      ✖ should return dependency signature
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected true to be false.
          at <Jasmine>
          at UserContext.<anonymous> (test/test/t1.js:11:20 <- test/t1.js:27:21)
          at <Jasmine>

  t4
    CommonJS Module in typescript
      ✖ Should be defined.
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected false to be true.
          at <Jasmine>
          at UserContext.<anonymous> (test/test/t4.ts:7:21 <- test/t4.js:77:23)
          at <Jasmine>
```


The fix I propose here is fairly simple: it's to allow option `options.sourcemapFile` to be interpreted as a location of where the caller intend to write the output, and use it as a base for source path even if `output.file` is not provided.

Why don't just specify `output.file` as calling `bundle.generate` won't actually write the file? The reason is that `karma-rollup-preprocessor` relies on the `fileName` from the bundle output to handle `ts` vs `js` extension, such that specify `output.file` would be difficult.

With this PR and a patch like this - https://github.com/jlmakes/karma-rollup-preprocessor/compare/master...ntkme:fix-sourcemap (I will submit later), the source paths are now fixed:

```
FAILED TESTS:
  t1
    Fixture 1
      ✖ should return dependency signature
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected true to be false.
          at <Jasmine>
          at UserContext.<anonymous> (test/t1.js:11:20 <- test/t1.js:27:21)
          at <Jasmine>

  t4
    CommonJS Module in typescript
      ✖ Should be defined.
        Chrome 87.0.4280 (Mac OS X 11.0.0)
      Error: Expected false to be true.
          at <Jasmine>
          at UserContext.<anonymous> (test/t4.ts:7:21 <- test/t4.js:77:23)
          at <Jasmine>
```