### PR TITLE
Do not partially tree-shake unused declarations in for loops

### DIFF
--- a/src/ast/nodes/ForStatement.ts
+++ b/src/ast/nodes/ForStatement.ts
@@ -40,7 +40,7 @@ export default class ForStatement extends StatementBase {
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren) {
 		this.included = true;
-		if (this.init) this.init.include(context, includeChildrenRecursively);
+		if (this.init) this.init.includeAllDeclaredVariables(context, includeChildrenRecursively);
 		if (this.test) this.test.include(context, includeChildrenRecursively);
 		const { brokenFlow } = context;
 		if (this.update) this.update.include(context, includeChildrenRecursively);

--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -87,6 +87,7 @@ export default class VariableDeclaration extends NodeBase {
 
 	render(code: MagicString, options: RenderOptions, nodeRenderOptions: NodeRenderOptions = BLANK) {
 		if (
+			nodeRenderOptions.isNoStatement ||
 			areAllDeclarationsIncludedAndNotExported(this.declarations, options.exportNamesByVariable)
 		) {
 			for (const declarator of this.declarations) {

--- a/src/ast/nodes/VariableDeclarator.ts
+++ b/src/ast/nodes/VariableDeclarator.ts
@@ -45,6 +45,9 @@ export default class VariableDeclarator extends NodeBase {
 	): void {
 		this.included = true;
 		this.id.include(context, includeChildrenRecursively);
+		if (this.init) {
+			this.init.include(context, includeChildrenRecursively);
+		}
 	}
 
 	render(code: MagicString, options: RenderOptions) {

--- a/test/function/samples/unused-for-loop-declaration/_config.js
+++ b/test/function/samples/unused-for-loop-declaration/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not partially tree-shake unused declarations with side-effects in for loops'
+};

--- a/test/function/samples/unused-for-loop-declaration/main.js
+++ b/test/function/samples/unused-for-loop-declaration/main.js
@@ -1,0 +1,9 @@
+let result;
+let reassigned;
+
+for (var a = (reassigned = 'reassigned'), b = 0; b < 2; b++) {
+	result = b;
+}
+
+assert.strictEqual(result, 1);
+assert.strictEqual(reassigned, 'reassigned');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3941 

### Description
This is a fix for an issue introduced by partial declaration tree-shaking in for-loops. The simple solution here is not to tree-shake declarations in the first argument of a for-loop. A more involved solution would be to always include ids here, but I was not sure if it was worth the effort.