### PR TITLE
Correctly include functions with side effects from side-effect-free modules

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1061,14 +1061,16 @@ export default class Module {
 			variable.include();
 			this.graph.needsTreeshakingPass = true;
 			const variableModule = variable.module;
-			if (variableModule && variableModule !== this && variableModule instanceof Module) {
+			if (variableModule && variableModule instanceof Module) {
 				if (!variableModule.isExecuted) {
 					markModuleAndImpureDependenciesAsExecuted(variableModule);
 				}
-				const sideEffectModules = getAndExtendSideEffectModules(variable, this);
-				for (const module of sideEffectModules) {
-					if (!module.isExecuted) {
-						markModuleAndImpureDependenciesAsExecuted(module);
+				if (variableModule !== this) {
+					const sideEffectModules = getAndExtendSideEffectModules(variable, this);
+					for (const module of sideEffectModules) {
+						if (!module.isExecuted) {
+							markModuleAndImpureDependenciesAsExecuted(module);
+						}
 					}
 				}
 			}

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -286,5 +286,5 @@ export function locateNode(node: Node) {
 }
 
 export function logNode(node: Node) {
-	console.log(node.context.code.slice(node.start, node.end));
+	return node.context.code.slice(node.start, node.end);
 }

--- a/test/function/samples/side-effect-free-module-function/_config.js
+++ b/test/function/samples/side-effect-free-module-function/_config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	description:
+		'correctly include functions with side effects from side-effect-free modules (#3942)',
+	options: {
+		plugins: {
+			transform() {
+				return { moduleSideEffects: false };
+			}
+		}
+	}
+};

--- a/test/function/samples/side-effect-free-module-function/curry.js
+++ b/test/function/samples/side-effect-free-module-function/curry.js
@@ -1,0 +1,4 @@
+export function curry(fn, args = []) {
+	return (..._args) =>
+		(rest => (rest.length >= fn.length ? fn(...rest) : curry(fn, rest)))([...args, ..._args]);
+}

--- a/test/function/samples/side-effect-free-module-function/main.js
+++ b/test/function/samples/side-effect-free-module-function/main.js
@@ -1,0 +1,11 @@
+import { curry } from './curry';
+let result;
+
+function foo() {
+	result = 'foo';
+}
+
+var fooc = curry(foo);
+fooc();
+
+assert.strictEqual(result, 'foo');


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3942 

### Description
There was an issue with the inclusion logic for variables in modules without side effects that is fixed here.