### PR TITLE
Upgrade chokidar and fsevents for Apple M1 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -873,14 +873,14 @@
       }
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1881,9 +1881,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
       "optional": true
     },
     "function-bind": {
@@ -3195,6 +3195,15 @@
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
             "readdirp": "~3.5.0"
+          },
+          "dependencies": {
+            "fsevents": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+              "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+              "dev": true,
+              "optional": true
+            }
           }
         },
         "debug": {
@@ -3990,6 +3999,15 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.1.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "rollup-plugin-license": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://rollupjs.org/",
   "optionalDependencies": {
-    "fsevents": "~2.1.2"
+    "fsevents": "~2.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.1",
@@ -75,7 +75,7 @@
     "acorn-static-class-features": "^0.2.4",
     "acorn-walk": "^8.0.1",
     "buble": "^0.20.0",
-    "chokidar": "^3.4.3",
+    "chokidar": "^3.5.1",
     "codecov": "^3.8.1",
     "colorette": "^1.2.1",
     "core-js": "^3.8.2",


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: -NA-

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR updates `chokidar` and `fsevents` in package.json.

`fsevents` ~2.1.2 was deprecated, and mentions to use 2.2 or 2.3 instead. This is the message you see when installing rollup as a dependency: `rollup > fsevents@2.1.3: "Please update to latest v2.3 or v2.2"`. The [commits](https://github.com/fsevents/fsevents/commits/master) there imply it's for Apple M1 compatibility.

`chokidar` also updated to that version of `fsevents`, so I updated that here too.

If you see package-lock.json, you'll see the older version of 2.1.3 got added to mocha's dependencies. They use the older version, and haven't released a new version yet.
