### PR TITLE
Make sure default exports snapshot synthetic named exports

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -199,7 +199,7 @@ function getAndExtendSideEffectModules(variable: Variable, module: Module): Set<
 		if (!currentVariable || referencedVariables.has(currentVariable)) {
 			break;
 		}
-		referencedVariables.add(variable);
+		referencedVariables.add(currentVariable);
 		sideEffectModules.add(importingModule);
 		const originalSideEffects = importingModule.sideEffectDependenciesByVariable.get(
 			currentVariable

--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -55,7 +55,9 @@ export default class ExportDefaultVariable extends LocalVariable {
 			(this.hasId ||
 				!(
 					this.originalId.variable.isReassigned ||
-					this.originalId.variable instanceof UndefinedVariable
+					this.originalId.variable instanceof UndefinedVariable ||
+					// this avoids a circular dependency
+					'syntheticNamespace' in this.originalId.variable
 				))
 			? this.originalId.variable
 			: null;

--- a/src/ast/variables/SyntheticNamedExportVariable.ts
+++ b/src/ast/variables/SyntheticNamedExportVariable.ts
@@ -1,5 +1,4 @@
 import Module, { AstContext } from '../../Module';
-import { error, errSyntheticNamedExportsNeedNamespaceExport } from '../../utils/error';
 import { RESERVED_NAMES } from '../../utils/reservedNames';
 import ExportDefaultVariable from './ExportDefaultVariable';
 import Variable from './Variable';
@@ -21,12 +20,10 @@ export default class SyntheticNamedExportVariable extends Variable {
 	getBaseVariable(): Variable {
 		if (this.baseVariable) return this.baseVariable;
 		let baseVariable = this.syntheticNamespace;
-		const checkedVariables = new Set<Variable>();
 		while (
 			baseVariable instanceof ExportDefaultVariable ||
 			baseVariable instanceof SyntheticNamedExportVariable
 		) {
-			checkedVariables.add(baseVariable);
 			if (baseVariable instanceof ExportDefaultVariable) {
 				const original = baseVariable.getOriginalVariable();
 				if (original === baseVariable) break;
@@ -34,14 +31,6 @@ export default class SyntheticNamedExportVariable extends Variable {
 			}
 			if (baseVariable instanceof SyntheticNamedExportVariable) {
 				baseVariable = baseVariable.syntheticNamespace;
-			}
-			if (checkedVariables.has(baseVariable)) {
-				return error(
-					errSyntheticNamedExportsNeedNamespaceExport(
-						this.module.id,
-						this.module.info.syntheticNamedExports
-					)
-				);
 			}
 		}
 		return (this.baseVariable = baseVariable);

--- a/test/chunking-form/samples/synthetic-named-exports/chained-default-reexport/lib-reexport.js
+++ b/test/chunking-form/samples/synthetic-named-exports/chained-default-reexport/lib-reexport.js
@@ -1,3 +1,3 @@
 import { named } from './lib-reexport2.js';
 console.log('side-effect', named);
-export default named;
+export { named as default };

--- a/test/chunking-form/samples/synthetic-named-exports/chained-default-reexport/lib-reexport2.js
+++ b/test/chunking-form/samples/synthetic-named-exports/chained-default-reexport/lib-reexport2.js
@@ -1,3 +1,3 @@
 import { named } from './lib.js';
 console.log('side-effect', named);
-export default named;
+export { named as default };

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports/_config.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports/_config.js
@@ -12,9 +12,10 @@ module.exports = {
 			}
 		]
 	},
-	generateError: {
+	error: {
 		code: 'SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT',
 		id: path.join(__dirname, 'main.js'),
-		message: `Module "main.js" that is marked with 'syntheticNamedExports: "__synthetic"' needs an export named "__synthetic" that does not reexport an unresolved named export of the same module.`
+		message: `Module "main.js" that is marked with 'syntheticNamedExports: "__synthetic"' needs an export named "__synthetic" that does not reexport an unresolved named export of the same module.`,
+		watchFiles: [path.join(__dirname, 'main.js'), path.join(__dirname, 'dep.js')]
 	}
 };

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports/dep.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports/dep.js
@@ -1,2 +1,1 @@
-import { foo } from './main.js';
-export default foo;
+export { foo as default } from './main.js';

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/_config.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/_config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	description: 'handles circular synthetic exports',
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			cycle: ['dep1.js', 'dep2.js', 'dep1.js'],
+			importer: 'dep1.js',
+			message: 'Circular dependency: dep1.js -> dep2.js -> dep1.js'
+		}
+	]
+};

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/dep1.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/dep1.js
@@ -1,0 +1,2 @@
+import dep2 from './dep2';
+export default dep2;

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/dep2.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/dep2.js
@@ -1,0 +1,2 @@
+import dep1 from './dep1';
+export default dep1;

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/main.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/main.js
@@ -1,0 +1,2 @@
+import dep1 from './dep1';
+assert.strictEqual(dep1, undefined);

--- a/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/_config.js
+++ b/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/_config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	description: 'makes sure default exports of synthetic named exports are snapshots',
+	options: {
+		plugins: {
+			transform() {
+				return { syntheticNamedExports: '__synthetic' };
+			}
+		}
+	}
+};

--- a/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/dep.js
+++ b/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/dep.js
@@ -1,0 +1,2 @@
+import { foo } from './synthetic';
+export default foo;

--- a/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/main.js
+++ b/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/main.js
@@ -1,0 +1,6 @@
+import foo from './dep';
+import { update } from './synthetic';
+
+assert.strictEqual(foo, 'original');
+update();
+assert.strictEqual(foo, 'original');

--- a/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/synthetic.js
+++ b/test/function/samples/synthetic-named-exports/synthetic-named-export-as-default/synthetic.js
@@ -1,0 +1,2 @@
+export const __synthetic = { foo: 'original' };
+export const update = () => (__synthetic.foo = 'reassigned');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
rollup/plugins#658

### Description
This is an inconsistency that turned up when looking into https://github.com/rollup/plugins/pull/658#issuecomment-770284420. Basically the following situation:

```js
// main.js
import foo from './dep';
import { update } from './synthetic';

assert.strictEqual(foo, 'original');
update();
// This would fail
assert.strictEqual(foo, 'original');

// dep.js
import { foo } from './synthetic';
// This default export should produce a snapshot of the current value of foo
export default foo;

// synthetic.js
// This should be the synthetic namespace
export const __synthetic = { foo: 'original' };
export const update = () => (__synthetic.foo = 'reassigned');
```

So in short we have a synthetic named export foo that is "reexported" via an export default declaration which is evaluated before and after the synthetic namespace is updated. This should not change the result as the default export declaration should snapshot. Previously, though, the following output was generated:

```js
const __synthetic = { foo: 'original' };
const update = () => (__synthetic.foo = 'reassigned');
    
assert.strictEqual(__synthetic.foo, 'original');
update();
assert.strictEqual(__synthetic.foo, 'original');
```

which did in fact live-bind where it should not. This is fixed now:

```js
const __synthetic = { foo: 'original' };
const update = () => (__synthetic.foo = 'reassigned');

// This is the new snapshot
var foo = __synthetic.foo;
    
assert.strictEqual(foo, 'original');
update();
assert.strictEqual(foo, 'original');
```
