### PR TITLE
Make sure uninitialised exports turn up via .hasOwnProperty for non-ES formats

### DIFF
--- a/src/ast/nodes/VariableDeclarator.ts
+++ b/src/ast/nodes/VariableDeclarator.ts
@@ -1,5 +1,6 @@
 import MagicString from 'magic-string';
 import { BLANK } from '../../utils/blank';
+import { isReassignedExportsMember } from '../../utils/reassignedExportsMember';
 import {
 	findFirstOccurrenceOutsideComment,
 	findNonWhiteSpace,
@@ -8,6 +9,7 @@ import {
 import { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import { ObjectPath } from '../utils/PathTracker';
 import { UNDEFINED_EXPRESSION } from '../values';
+import Identifier from './Identifier';
 import * as NodeType from './NodeType';
 import { ExpressionNode, IncludeChildren, NodeBase } from './shared/Node';
 import { PatternNode } from './shared/Pattern';
@@ -53,6 +55,12 @@ export default class VariableDeclarator extends NodeBase {
 				options,
 				renderId ? BLANK : { renderedParentType: NodeType.ExpressionStatement }
 			);
+		} else if (
+			this.id instanceof Identifier &&
+			isReassignedExportsMember(this.id.variable!, options.exportNamesByVariable)
+		) {
+			const _ = options.compact ? '' : ' ';
+			code.appendLeft(this.end, `${_}=${_}void 0`);
 		}
 	}
 }

--- a/src/utils/reassignedExportsMember.ts
+++ b/src/utils/reassignedExportsMember.ts
@@ -1,0 +1,10 @@
+import Variable from '../ast/variables/Variable';
+
+export function isReassignedExportsMember(
+	variable: Variable,
+	exportNamesByVariable: Map<Variable, string[]>
+): boolean {
+	return (
+		variable.renderBaseName !== null && exportNamesByVariable.has(variable) && variable.isReassigned
+	);
+}

--- a/test/form/samples/assignment-to-exports/_expected/amd.js
+++ b/test/form/samples/assignment-to-exports/_expected/amd.js
@@ -5,6 +5,7 @@ define(['exports'], function (exports) { 'use strict';
 
 	// Reassigned uninitialised export
 	exports.bar1 = 1;
+	exports.bar1 = void 0;
 
 	// Reassigned initialised export
 	exports.baz1 = 1;
@@ -14,7 +15,7 @@ define(['exports'], function (exports) { 'use strict';
 	var kept1, foo2, kept2;
 
 	// Reassigned uninitialised export
-	var kept1, kept2;
+	var kept1; exports.bar2 = void 0; var kept2;
 	exports.bar2 = 1;
 
 	// Reassigned initialised export

--- a/test/form/samples/assignment-to-exports/_expected/cjs.js
+++ b/test/form/samples/assignment-to-exports/_expected/cjs.js
@@ -7,6 +7,7 @@ var foo1;
 
 // Reassigned uninitialised export
 exports.bar1 = 1;
+exports.bar1 = void 0;
 
 // Reassigned initialised export
 exports.baz1 = 1;
@@ -16,7 +17,7 @@ exports.baz1 = 2;
 var kept1, foo2, kept2;
 
 // Reassigned uninitialised export
-var kept1, kept2;
+var kept1; exports.bar2 = void 0; var kept2;
 exports.bar2 = 1;
 
 // Reassigned initialised export

--- a/test/form/samples/assignment-to-exports/_expected/es.js
+++ b/test/form/samples/assignment-to-exports/_expected/es.js
@@ -3,7 +3,7 @@ var foo1;
 
 // Reassigned uninitialised export
 bar1 = 1;
-var bar1; // this will be removed for non ES6 bundles
+var bar1;
 
 // Reassigned initialised export
 var baz1 = 1;

--- a/test/form/samples/assignment-to-exports/_expected/iife.js
+++ b/test/form/samples/assignment-to-exports/_expected/iife.js
@@ -6,6 +6,7 @@ var bundle = (function (exports) {
 
 	// Reassigned uninitialised export
 	exports.bar1 = 1;
+	exports.bar1 = void 0;
 
 	// Reassigned initialised export
 	exports.baz1 = 1;
@@ -15,7 +16,7 @@ var bundle = (function (exports) {
 	var kept1, foo2, kept2;
 
 	// Reassigned uninitialised export
-	var kept1, kept2;
+	var kept1; exports.bar2 = void 0; var kept2;
 	exports.bar2 = 1;
 
 	// Reassigned initialised export

--- a/test/form/samples/assignment-to-exports/_expected/system.js
+++ b/test/form/samples/assignment-to-exports/_expected/system.js
@@ -15,7 +15,7 @@ System.register('bundle', [], function (exports) {
 
 			// Reassigned uninitialised export
 			bar1 = exports('bar1', 1);
-			var bar1; // this will be removed for non ES6 bundles
+			var bar1;
 
 			// Reassigned initialised export
 			var baz1 = exports('baz1', 1);

--- a/test/form/samples/assignment-to-exports/_expected/umd.js
+++ b/test/form/samples/assignment-to-exports/_expected/umd.js
@@ -9,6 +9,7 @@
 
 	// Reassigned uninitialised export
 	exports.bar1 = 1;
+	exports.bar1 = void 0;
 
 	// Reassigned initialised export
 	exports.baz1 = 1;
@@ -18,7 +19,7 @@
 	var kept1, foo2, kept2;
 
 	// Reassigned uninitialised export
-	var kept1, kept2;
+	var kept1; exports.bar2 = void 0; var kept2;
 	exports.bar2 = 1;
 
 	// Reassigned initialised export

--- a/test/form/samples/assignment-to-exports/main.js
+++ b/test/form/samples/assignment-to-exports/main.js
@@ -3,7 +3,7 @@ export var foo1;
 
 // Reassigned uninitialised export
 bar1 = 1;
-export var bar1; // this will be removed for non ES6 bundles
+export var bar1;
 
 // Reassigned initialised export
 export var baz1 = 1;

--- a/test/form/samples/render-named-export-declarations/_expected/amd.js
+++ b/test/form/samples/render-named-export-declarations/_expected/amd.js
@@ -1,9 +1,9 @@
 define(['exports'], function (exports) { 'use strict';
 
-	var aFoo;
+	var aFoo; exports.aBar = void 0;
 	exports.aBar = 2;
 
-	var bBar;
+	exports.bFoo = void 0; var bBar;
 	exports.bFoo = 2;
 
 	var cFoo; exports.cBar = 1;

--- a/test/form/samples/render-named-export-declarations/_expected/cjs.js
+++ b/test/form/samples/render-named-export-declarations/_expected/cjs.js
@@ -2,10 +2,10 @@
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
-var aFoo;
+var aFoo; exports.aBar = void 0;
 exports.aBar = 2;
 
-var bBar;
+exports.bFoo = void 0; var bBar;
 exports.bFoo = 2;
 
 var cFoo; exports.cBar = 1;

--- a/test/form/samples/render-named-export-declarations/_expected/iife.js
+++ b/test/form/samples/render-named-export-declarations/_expected/iife.js
@@ -1,10 +1,10 @@
 var bundle = (function (exports) {
 	'use strict';
 
-	var aFoo;
+	var aFoo; exports.aBar = void 0;
 	exports.aBar = 2;
 
-	var bBar;
+	exports.bFoo = void 0; var bBar;
 	exports.bFoo = 2;
 
 	var cFoo; exports.cBar = 1;

--- a/test/form/samples/render-named-export-declarations/_expected/umd.js
+++ b/test/form/samples/render-named-export-declarations/_expected/umd.js
@@ -4,10 +4,10 @@
 	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.bundle = {}));
 }(this, (function (exports) { 'use strict';
 
-	var aFoo;
+	var aFoo; exports.aBar = void 0;
 	exports.aBar = 2;
 
-	var bBar;
+	exports.bFoo = void 0; var bBar;
 	exports.bFoo = 2;
 
 	var cFoo; exports.cBar = 1;

--- a/test/function/samples/create-undefined-export-property-compact/_config.js
+++ b/test/function/samples/create-undefined-export-property-compact/_config.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'creates an export as an exports property even if is has no initializer',
+	options: { output: { compact: true } },
+	exports(exports) {
+		assert.strictEqual(exports.foo, undefined);
+		assert.strictEqual(exports.bar, undefined);
+		assert.strictEqual(exports.baz, undefined);
+		assert.ok(exports.hasOwnProperty('foo'));
+		assert.ok(exports.hasOwnProperty('bar'));
+		assert.ok(exports.hasOwnProperty('baz'));
+		exports.defineFooBar();
+		assert.strictEqual(exports.foo, 'defined');
+		assert.strictEqual(exports.bar, 'defined');
+	}
+};

--- a/test/function/samples/create-undefined-export-property-compact/main.js
+++ b/test/function/samples/create-undefined-export-property-compact/main.js
@@ -1,0 +1,6 @@
+export let foo;
+export let bar, quux = 3, baz;
+export function defineFooBar() {
+	foo = 'defined';
+	bar = 'defined';
+}

--- a/test/function/samples/create-undefined-export-property/_config.js
+++ b/test/function/samples/create-undefined-export-property/_config.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'creates an export as an exports property even if is has no initializer',
+	exports(exports) {
+		assert.strictEqual(exports.foo, undefined);
+		assert.strictEqual(exports.bar, undefined);
+		assert.strictEqual(exports.baz, undefined);
+		assert.ok(exports.hasOwnProperty('foo'));
+		assert.ok(exports.hasOwnProperty('bar'));
+		assert.ok(exports.hasOwnProperty('baz'));
+		exports.defineFooBar();
+		assert.strictEqual(exports.foo, 'defined');
+		assert.strictEqual(exports.bar, 'defined');
+	}
+};

--- a/test/function/samples/create-undefined-export-property/main.js
+++ b/test/function/samples/create-undefined-export-property/main.js
@@ -1,0 +1,6 @@
+export let foo;
+export let bar, quux = 3, baz;
+export function defineFooBar() {
+	foo = 'defined';
+	bar = 'defined';
+}

--- a/test/function/samples/destructuring-loop/_config.js
+++ b/test/function/samples/destructuring-loop/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles loops with destructuring declarations'
+};

--- a/test/function/samples/destructuring-loop/main.js
+++ b/test/function/samples/destructuring-loop/main.js
@@ -1,0 +1,11 @@
+let result;
+
+for (const [foo] of [['foo']]) {
+	result = foo;
+}
+assert.strictEqual(result, 'foo');
+
+for (const { bar } of [{ bar: 'bar' }]) {
+	result = bar;
+}
+assert.strictEqual(result, 'bar');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description
This will make sure that even uninitialised named exports will create properties on the exports object in CJS/IIFE/AMD/UMD formats so that checking for those properties via `.hasOwnProperty` or `Object.keys` works.
This is important for tools that rely on this for e.g. merging and forwarding namespaces.

This was already working properly for constant exports but was broken for exports that were assigned dynamically later, example:

https://rollupjs.org/repl/?version=2.38.5&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGxldCUyMGZvbyUzQiU1Q24lNUNuZXhwb3J0JTIwY29uc3QlMjB1cGRhdGVGb28lMjAlM0QlMjAoKSUyMCUzRCUzRSUyMGZvbyUyMCUzRCUyMCd1cGRhdGVkJyUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmNqcyUyMiUyQyUyMm5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmFtZCUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyJTIyJTdEJTJDJTIyZ2xvYmFscyUyMiUzQSU3QiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE

Note that when `updateFoo` is not run, the property `foo` will no exist.
