### PR TITLE
Move pure comment annotation to Graph.contextParse

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -17,6 +17,7 @@ import { BuildPhase } from './utils/buildPhase';
 import { errImplicitDependantIsNotIncluded, error } from './utils/error';
 import { analyseModuleExecution } from './utils/executionOrder';
 import { PluginDriver } from './utils/PluginDriver';
+import { markPureCallExpressions } from './utils/pureComments';
 import relativeId from './utils/relativeId';
 import { timeEnd, timeStart } from './utils/timers';
 import { markModuleAndImpureDependenciesAsExecuted } from './utils/traverseStaticDependencies';
@@ -45,7 +46,6 @@ function normalizeEntryModules(
 export default class Graph {
 	acornParser: typeof acorn.Parser;
 	cachedModules: Map<string, ModuleJSON>;
-	contextParse: (code: string, acornOptions?: acorn.Options) => acorn.Node;
 	deoptimizationTracker: PathTracker;
 	entryModules: Module[] = [];
 	moduleLoader: ModuleLoader;
@@ -77,11 +77,6 @@ export default class Graph {
 				for (const key of Object.keys(cache)) cache[key][0]++;
 			}
 		}
-		this.contextParse = (code: string, options: Partial<acorn.Options> = {}) =>
-			this.acornParser.parse(code, {
-				...(this.options.acorn as acorn.Options),
-				...options
-			});
 
 		if (watcher) {
 			this.watchMode = true;
@@ -115,6 +110,37 @@ export default class Graph {
 		timeEnd('mark included statements', 2);
 
 		this.phase = BuildPhase.GENERATE;
+	}
+
+	contextParse(code: string, options: Partial<acorn.Options> = {}) {
+		const onCommentOrig = options.onComment;
+		const comments: acorn.Comment[] = [];
+
+		if (onCommentOrig && typeof onCommentOrig == 'function') {
+			options.onComment = (block, text, start, end, ...args) => {
+				comments.push({type: block ? "Block" : "Line", value: text, start, end});
+				return onCommentOrig.call(options, block, text, start, end, ...args);
+			}
+		} else {
+			options.onComment = comments;
+		}
+
+		const ast = this.acornParser.parse(code, {
+			...(this.options.acorn as acorn.Options),
+			...options
+		});
+
+		if (typeof onCommentOrig == 'object') {
+			onCommentOrig.push(...comments);
+		}
+
+		options.onComment = onCommentOrig;
+
+		markPureCallExpressions(comments.map((cmt) => {
+			return {...cmt, block: cmt.type == "Block", text: cmt.value};
+		}), ast);
+
+		return ast;
 	}
 
 	getCache(): RollupCache {

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -136,9 +136,7 @@ export default class Graph {
 
 		options.onComment = onCommentOrig;
 
-		markPureCallExpressions(comments.map((cmt) => {
-			return {...cmt, block: cmt.type == "Block", text: cmt.value};
-		}), ast);
+		markPureCallExpressions(comments, ast);
 
 		return ast;
 	}

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -122,35 +122,6 @@ export interface AstContext {
 	warn: (warning: RollupWarning, pos: number) => void;
 }
 
-function tryParse(
-	module: Module,
-	Parser: typeof acorn.Parser,
-	acornOptions: acorn.Options
-): acorn.Node {
-	try {
-		return Parser.parse(module.info.code!, {
-			...acornOptions,
-			onComment: (block: boolean, text: string, start: number, end: number) =>
-				module.comments.push({ block, text, start, end })
-		});
-	} catch (err) {
-		let message = err.message.replace(/ \(\d+:\d+\)$/, '');
-		if (module.id.endsWith('.json')) {
-			message += ' (Note that you need @rollup/plugin-json to import JSON files)';
-		} else if (!module.id.endsWith('.js')) {
-			message += ' (Note that you need plugins to import files that are not JavaScript)';
-		}
-		return module.error(
-			{
-				code: 'PARSE_ERROR',
-				message,
-				parserError: err
-			},
-			err.pos
-		);
-	}
-}
-
 const MISSING_EXPORT_SHIM_DESCRIPTION: ExportDescription = {
 	identifier: null,
 	localName: MISSING_EXPORT_SHIM_VARIABLE
@@ -719,13 +690,12 @@ export default class Module {
 
 		this.alwaysRemovedCode = alwaysRemovedCode || [];
 		if (!ast) {
-			ast = tryParse(this, this.graph.acornParser, this.options.acorn as acorn.Options);
+			ast = this.tryParse();
 			for (const comment of this.comments) {
 				if (!comment.block && SOURCEMAPPING_URL_RE.test(comment.text)) {
 					this.alwaysRemovedCode.push([comment.start, comment.end]);
 				}
 			}
-			markPureCallExpressions(this.comments, ast);
 		}
 
 		timeEnd('generate ast', 3);
@@ -833,6 +803,32 @@ export default class Module {
 
 		return null;
 	}
+
+	tryParse(): acorn.Node {
+		try {
+			return this.graph.contextParse(this.info.code!, {
+				onComment: (block: boolean, text: string, start: number, end: number) =>
+					this.comments.push({ block, text, start, end })
+			});
+		} catch (err) {
+			let message = err.message.replace(/ \(\d+:\d+\)$/, '');
+			if (this.id.endsWith('.json')) {
+				message += ' (Note that you need @rollup/plugin-json to import JSON files)';
+			} else if (!this.id.endsWith('.js')) {
+				message += ' (Note that you need plugins to import files that are not JavaScript)';
+			}
+			console.log(err);
+			return this.error(
+				{
+					code: 'PARSE_ERROR',
+					message,
+					parserError: err
+				},
+				err.pos
+			);
+		}
+	}
+	
 
 	updateOptions({
 		meta,

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -58,7 +58,6 @@ import { getOrCreate } from './utils/getOrCreate';
 import { getOriginalLocation } from './utils/getOriginalLocation';
 import { makeLegal } from './utils/identifierHelpers';
 import { basename, extname } from './utils/path';
-import { markPureCallExpressions } from './utils/pureComments';
 import relativeId from './utils/relativeId';
 import { RenderOptions } from './utils/renderHelpers';
 import { SOURCEMAPPING_URL_RE } from './utils/sourceMappingURL';

--- a/src/ast/keys.ts
+++ b/src/ast/keys.ts
@@ -9,7 +9,7 @@ export const keys: {
 
 export function getAndCreateKeys(esTreeNode: GenericEsTreeNode) {
 	keys[esTreeNode.type] = Object.keys(esTreeNode).filter(
-		key => typeof esTreeNode[key] === 'object'
+		key => key !== '_rollupAnnotations' && typeof esTreeNode[key] === 'object'
 	);
 	return keys[esTreeNode.type];
 }

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -21,12 +21,11 @@ import Identifier from './Identifier';
 import MemberExpression from './MemberExpression';
 import * as NodeType from './NodeType';
 import { ExpressionEntity } from './shared/Expression';
-import { ExpressionNode, IncludeChildren, INCLUDE_PARAMETERS, NodeBase } from './shared/Node';
+import { Annotation, ExpressionNode, IncludeChildren, INCLUDE_PARAMETERS, NodeBase } from './shared/Node';
 import SpreadElement from './SpreadElement';
 import Super from './Super';
 
 export default class CallExpression extends NodeBase implements DeoptimizableEntity {
-	annotatedPure?: boolean;
 	arguments!: (ExpressionNode | SpreadElement)[];
 	callee!: ExpressionNode | Super;
 	optional!: boolean;
@@ -157,7 +156,7 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 		}
 		if (
 			(this.context.options.treeshake as NormalizedTreeshakingOptions).annotations &&
-			this.annotatedPure
+			this.annotations?.some((a: Annotation) => a.pure)
 		)
 			return false;
 		return (

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -3,10 +3,9 @@ import { CallOptions } from '../CallOptions';
 import { HasEffectsContext } from '../ExecutionContext';
 import { EMPTY_PATH, ObjectPath, UNKNOWN_PATH } from '../utils/PathTracker';
 import * as NodeType from './NodeType';
-import { ExpressionNode, NodeBase } from './shared/Node';
+import { Annotation, ExpressionNode, NodeBase } from './shared/Node';
 
 export default class NewExpression extends NodeBase {
-	annotatedPure?: boolean;
 	arguments!: ExpressionNode[];
 	callee!: ExpressionNode;
 	type!: NodeType.tNewExpression;
@@ -27,7 +26,7 @@ export default class NewExpression extends NodeBase {
 		}
 		if (
 			(this.context.options.treeshake as NormalizedTreeshakingOptions).annotations &&
-			this.annotatedPure
+			this.annotations?.some((a: Annotation) => a.pure)
 		)
 			return false;
 		return (

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -1,7 +1,7 @@
 import * as acorn from 'acorn';
 import { locate } from 'locate-character';
 import MagicString from 'magic-string';
-import { AstContext, CommentDescription } from '../../../Module';
+import { AstContext } from '../../../Module';
 import { NodeRenderOptions, RenderOptions } from '../../../utils/renderHelpers';
 import { CallOptions } from '../../CallOptions';
 import { DeoptimizableEntity } from '../../DeoptimizableEntity';
@@ -28,7 +28,7 @@ export const INCLUDE_PARAMETERS: 'variables' = 'variables';
 export type IncludeChildren = boolean | typeof INCLUDE_PARAMETERS;
 
 export interface Node extends Entity {
-	annotations?: CommentDescription[];
+	annotations?: acorn.Comment[];
 	context: AstContext;
 	end: number;
 	esTreeNode: GenericEsTreeNode;

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -235,11 +235,7 @@ export class NodeBase implements ExpressionNode {
 			if (this.hasOwnProperty(key)) continue;
 			const value = esTreeNode[key];
 			if (key === '_rollupAnnotations') {
-				if (this.annotations) {
-					this.annotations.push(...value);
-				} else {
-					this.annotations = value;
-				}
+				this.annotations = value;
 			} else if (typeof value !== 'object' || value === null) {
 				(this as GenericEsTreeNode)[key] = value;
 			} else if (Array.isArray(value)) {

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -128,7 +128,7 @@ export class NodeBase implements ExpressionNode {
 	bind() {
 		for (const key of this.keys) {
 			const value = (this as GenericEsTreeNode)[key];
-			if (value === null || key === 'annotations') continue;
+			if (value === null) continue;
 			if (Array.isArray(value)) {
 				for (const child of value) {
 					if (child !== null) child.bind();
@@ -167,7 +167,7 @@ export class NodeBase implements ExpressionNode {
 	hasEffects(context: HasEffectsContext): boolean {
 		for (const key of this.keys) {
 			const value = (this as GenericEsTreeNode)[key];
-			if (value === null || key === 'annotations') continue;
+			if (value === null) continue;
 			if (Array.isArray(value)) {
 				for (const child of value) {
 					if (child !== null && child.hasEffects(context)) return true;
@@ -197,7 +197,7 @@ export class NodeBase implements ExpressionNode {
 		this.included = true;
 		for (const key of this.keys) {
 			const value = (this as GenericEsTreeNode)[key];
-			if (value === null || key === 'annotations') continue;
+			if (value === null) continue;
 			if (Array.isArray(value)) {
 				for (const child of value) {
 					if (child !== null) child.include(context, includeChildrenRecursively);
@@ -262,7 +262,7 @@ export class NodeBase implements ExpressionNode {
 	render(code: MagicString, options: RenderOptions) {
 		for (const key of this.keys) {
 			const value = (this as GenericEsTreeNode)[key];
-			if (value === null || key === 'annotations') continue;
+			if (value === null) continue;
 			if (Array.isArray(value)) {
 				for (const child of value) {
 					if (child !== null) child.render(code, options);

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -26,9 +26,10 @@ export interface GenericEsTreeNode extends acorn.Node {
 
 export const INCLUDE_PARAMETERS: 'variables' = 'variables';
 export type IncludeChildren = boolean | typeof INCLUDE_PARAMETERS;
+export interface Annotation {comment?: acorn.Comment, pure?: boolean}
 
 export interface Node extends Entity {
-	annotations?: acorn.Comment[];
+	annotations?: Annotation[];
 	context: AstContext;
 	end: number;
 	esTreeNode: GenericEsTreeNode;
@@ -88,6 +89,7 @@ export interface StatementNode extends Node {}
 export interface ExpressionNode extends ExpressionEntity, Node {}
 
 export class NodeBase implements ExpressionNode {
+	annotations?: Annotation[];
 	context: AstContext;
 	end!: number;
 	esTreeNode: acorn.Node;
@@ -232,7 +234,13 @@ export class NodeBase implements ExpressionNode {
 			// That way, we can override this function to add custom initialisation and then call super.parseNode
 			if (this.hasOwnProperty(key)) continue;
 			const value = esTreeNode[key];
-			if (typeof value !== 'object' || value === null || key === 'annotations') {
+			if (key === '_rollupAnnotations') {
+				if (this.annotations) {
+					this.annotations.push(...value);
+				} else {
+					this.annotations = value;
+				}
+			} else if (typeof value !== 'object' || value === null) {
 				(this as GenericEsTreeNode)[key] = value;
 			} else if (Array.isArray(value)) {
 				(this as GenericEsTreeNode)[key] = [];

--- a/src/utils/PluginContext.ts
+++ b/src/utils/PluginContext.ts
@@ -156,7 +156,7 @@ export function getPluginContexts(
 				const moduleIds = graph.modulesById.keys();
 				return wrappedModuleIds();
 			},
-			parse: graph.contextParse,
+			parse: graph.contextParse.bind(graph),
 			resolve(source, importer, { custom, skipSelf } = BLANK) {
 				return graph.moduleLoader.resolveId(source, importer, custom, skipSelf ? pidx : null);
 			},

--- a/src/utils/pureComments.ts
+++ b/src/utils/pureComments.ts
@@ -1,6 +1,7 @@
 import * as acorn from 'acorn';
 import { base as basicWalker, BaseWalker } from 'acorn-walk';
 import { CallExpression, ExpressionStatement, NewExpression } from '../ast/nodes/NodeType';
+import { Annotation } from '../ast/nodes/shared/Node';
 
 // patch up acorn-walk until class-fields are officially supported
 basicWalker.PropertyDefinition = function (node: any, st: any, c: any) {
@@ -33,19 +34,23 @@ function handlePureAnnotationsOfNode(
 }
 
 function markPureNode(
-	node: acorn.Node & { annotations?: acorn.Comment[] },
+	node: acorn.Node & { _rollupAnnotations?: Annotation[] },
 	comment: acorn.Comment
 ) {
-	if (node.annotations) {
-		node.annotations.push(comment);
+	if (node._rollupAnnotations) {
+		node._rollupAnnotations.push({comment});
 	} else {
-		node.annotations = [comment];
+		node._rollupAnnotations = [{comment}];
 	}
 	if (node.type === ExpressionStatement) {
 		node = (node as any).expression;
 	}
 	if (node.type === CallExpression || node.type === NewExpression) {
-		(node as any).annotatedPure = true;
+		if (node._rollupAnnotations) {
+			node._rollupAnnotations.push({pure: true});
+		} else {
+			node._rollupAnnotations = [{pure: true}];
+		}
 	}
 }
 

--- a/src/utils/pureComments.ts
+++ b/src/utils/pureComments.ts
@@ -1,7 +1,6 @@
 import * as acorn from 'acorn';
 import { base as basicWalker, BaseWalker } from 'acorn-walk';
 import { CallExpression, ExpressionStatement, NewExpression } from '../ast/nodes/NodeType';
-import { CommentDescription } from '../Module';
 
 // patch up acorn-walk until class-fields are officially supported
 basicWalker.PropertyDefinition = function (node: any, st: any, c: any) {
@@ -15,7 +14,7 @@ basicWalker.PropertyDefinition = function (node: any, st: any, c: any) {
 
 interface CommentState {
 	commentIndex: number;
-	commentNodes: CommentDescription[];
+	commentNodes: acorn.Comment[];
 }
 
 function handlePureAnnotationsOfNode(
@@ -34,8 +33,8 @@ function handlePureAnnotationsOfNode(
 }
 
 function markPureNode(
-	node: acorn.Node & { annotations?: CommentDescription[] },
-	comment: CommentDescription
+	node: acorn.Node & { annotations?: acorn.Comment[] },
+	comment: acorn.Comment
 ) {
 	if (node.annotations) {
 		node.annotations.push(comment);
@@ -51,9 +50,9 @@ function markPureNode(
 }
 
 const pureCommentRegex = /[@#]__PURE__/;
-const isPureComment = (comment: CommentDescription) => pureCommentRegex.test(comment.text);
+const isPureComment = (comment: acorn.Comment) => pureCommentRegex.test(comment.value);
 
-export function markPureCallExpressions(comments: CommentDescription[], esTreeAst: acorn.Node) {
+export function markPureCallExpressions(comments: acorn.Comment[], esTreeAst: acorn.Node) {
 	handlePureAnnotationsOfNode(esTreeAst, {
 		commentIndex: 0,
 		commentNodes: comments.filter(isPureComment)

--- a/src/utils/treeshakeNode.ts
+++ b/src/utils/treeshakeNode.ts
@@ -6,8 +6,11 @@ export function treeshakeNode(node: Node, code: MagicString, start: number, end:
 	code.remove(start, end);
 	if (node.annotations) {
 		for (const annotation of node.annotations) {
-			if (annotation.start < start) {
-				code.remove(annotation.start, annotation.end);
+			if (!annotation.comment) {
+				continue;
+			}
+			if (annotation.comment.start < start) {
+				code.remove(annotation.comment.start, annotation.comment.end);
 			} else {
 				return;
 			}
@@ -21,7 +24,10 @@ export function removeAnnotations(node: Node, code: MagicString) {
 	}
 	if (node.annotations) {
 		for (const annotation of node.annotations) {
-			code.remove(annotation.start, annotation.end);
+			if (!annotation.comment) {
+				continue;
+			}
+			code.remove(annotation.comment.start, annotation.comment.end);
 		}
 	}
 }

--- a/src/utils/treeshakeNode.ts
+++ b/src/utils/treeshakeNode.ts
@@ -23,11 +23,8 @@ export function removeAnnotations(node: Node, code: MagicString) {
 		node = node.parent as Node;
 	}
 	if (node.annotations) {
-		for (const annotation of node.annotations) {
-			if (!annotation.comment) {
-				continue;
-			}
-			code.remove(annotation.comment.start, annotation.comment.end);
+		for (const annotation of node.annotations.filter((a) => a.comment)) {
+			code.remove(annotation.comment!.start, annotation.comment!.end);
 		}
 	}
 }

--- a/test/function/samples/call-marked-pure-with-plugin-parse-ast/_config.js
+++ b/test/function/samples/call-marked-pure-with-plugin-parse-ast/_config.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'external function calls marked with pure comment do not have effects and should be removed even if parsed by PluginContext.parse method',
+	options: {
+		external: ['socks'],
+		plugins:[{
+			transform(code, _id) {
+				const ast = this.parse(code);
+				return {ast, code, map: null};
+			},
+		}],
+	},
+	context: {
+		require(id) {
+			if (id === 'socks') {
+				return () => {
+					throw new Error('Not all socks were removed.');
+				};
+			}
+		}
+	},
+	code(code) {
+		assert.ok(code.search(/socks\(\)/) === -1);
+	}
+};

--- a/test/function/samples/call-marked-pure-with-plugin-parse-ast/_config.js
+++ b/test/function/samples/call-marked-pure-with-plugin-parse-ast/_config.js
@@ -6,7 +6,11 @@ module.exports = {
 		external: ['socks'],
 		plugins:[{
 			transform(code, _id) {
-				const ast = this.parse(code);
+				const comments = [];
+				const ast = this.parse(code, {onComment: comments});
+				if (comments.length != 5 || comments.some(({value}) => !value.includes('PURE'))) {
+					throw new Error('failed to get comments');
+				}
 				return {ast, code, map: null};
 			},
 		}],

--- a/test/function/samples/call-marked-pure-with-plugin-parse-ast/main.js
+++ b/test/function/samples/call-marked-pure-with-plugin-parse-ast/main.js
@@ -1,0 +1,8 @@
+import socks from 'socks';
+
+/*#__PURE__*/ socks();
+/* #__PURE__*/ socks();
+/*#__PURE__ */ socks();
+/* #__PURE__ */ socks();
+// #__PURE__
+socks();


### PR DESCRIPTION
If a plugin calls `PluginContext.parse` method to parse the AST of the module
rollup ignored the `PURE` annotations. This commit fixes the issue by moving
the annotation functionality to a central location - the `contextParse` method.

Resolves #3979

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

Resolve #3979 

### Description

Move pure comment annotation to Graph.contextParse

If a plugin calls `PluginContext.parse` method to parse the AST of the module
rollup ignored the `PURE` annotations. This commit fixes the issue by moving
the annotation functionality to a central location - the `contextParse` method.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
