### PR TITLE
Change removal of sourcemap comment

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -688,15 +688,12 @@ export default class Module {
 
 		let sourcemappingUrlMatch;
 		while (sourcemappingUrlMatch = SOURCEMAPPING_URL_COMMENT_RE.exec(this.info.code)) {
-			const found = findNodeAround(ast, sourcemappingUrlMatch.index);
+			const foundState = findNodeAround(ast, sourcemappingUrlMatch.index);
 
-			// if no node contains this string - it's surely a comment
-			if (!found || !found.node) {
-				continue;
-			}
-
-			// if this regex is part of a literal or expression
-			if (!(found?.node as GenericEsTreeNode).body) {
+			/* the AST matches the code therefore there must be a node that
+			 * encloses the position within the code.
+			 */
+			if (!(foundState!.node as GenericEsTreeNode).body) {
 				continue;
 			}
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -182,7 +182,6 @@ export default class Module {
 	ast: Program | null = null;
 	chunkFileNames = new Set<string>();
 	chunkName: string | null = null;
-	comments: acorn.Comment[] = [];
 	cycles = new Set<Symbol>();
 	dependencies = new Set<Module | ExternalModule>();
 	dynamicDependencies = new Set<Module | ExternalModule>();
@@ -808,10 +807,7 @@ export default class Module {
 
 	tryParse(): acorn.Node {
 		try {
-			return this.graph.contextParse(this.info.code!, {
-				onComment: (block: boolean, text: string, start: number, end: number) =>
-					this.comments.push({ type: block ? "Block" : "Line", value: text, start, end })
-			});
+			return this.graph.contextParse(this.info.code!);
 		} catch (err) {
 			let message = err.message.replace(/ \(\d+:\d+\)$/, '');
 			if (this.id.endsWith('.json')) {

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -123,7 +123,7 @@ function findSourceMappingURLComments(ast: acorn.Node, code: string): [number, n
 	let lastStmtEnd = 0;
 	const ranges = [];
 
-	for (let stmt of (ast as GenericEsTreeNode).body) {
+	for (const stmt of (ast as GenericEsTreeNode).body) {
 		if (lastStmtEnd != stmt.start) {
 			ranges.push([lastStmtEnd, stmt.start]);
 		}
@@ -134,7 +134,7 @@ function findSourceMappingURLComments(ast: acorn.Node, code: string): [number, n
 	}
 
 	const ret: [number, number][] = [];
-	for (let [start, end] of ranges) {
+	for (const [start, end] of ranges) {
 		let sourcemappingUrlMatch;
 		while (sourcemappingUrlMatch = SOURCEMAPPING_URL_COMMENT_RE.exec(code.slice(start, end))) {
 			ret.push([start + sourcemappingUrlMatch.index, start + SOURCEMAPPING_URL_COMMENT_RE.lastIndex]);

--- a/src/utils/sourceMappingURL.ts
+++ b/src/utils/sourceMappingURL.ts
@@ -2,7 +2,11 @@
 // this for an actual sourceMappingURL
 let SOURCEMAPPING_URL = 'sourceMa';
 SOURCEMAPPING_URL += 'ppingURL';
+const whiteSpaceNoNewline = '[ \\f\\r\\t\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]';
 
-const SOURCEMAPPING_URL_RE = new RegExp(`^#\\s+${SOURCEMAPPING_URL}=.+\\n?`);
+const SOURCEMAPPING_URL_LINE_COMMENT_RE = `//#${whiteSpaceNoNewline}+${SOURCEMAPPING_URL}=.+`;
+const SOURCEMAPPING_URL_BLOCK_COMMENT_RE = `/\\*#${whiteSpaceNoNewline}+${SOURCEMAPPING_URL}=.+\\*/`;
+const SOURCEMAPPING_URL_COMMENT_RE = new RegExp(
+  `(${SOURCEMAPPING_URL_LINE_COMMENT_RE})|(${SOURCEMAPPING_URL_BLOCK_COMMENT_RE})`, 'g');
 
-export { SOURCEMAPPING_URL, SOURCEMAPPING_URL_RE };
+export { SOURCEMAPPING_URL, SOURCEMAPPING_URL_COMMENT_RE};

--- a/test/function/samples/plugin-parse-ast-receives-comments/_config.js
+++ b/test/function/samples/plugin-parse-ast-receives-comments/_config.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+const comments = [];
+
+module.exports = {
+	description: 'plugin parse ast receives comments',
+	options: {
+		plugins:[{
+			transform(code, _id) {
+				const ast = this.parse(code, {
+					onComment(...args) {
+						comments.push(args);
+					},
+				});
+				return {ast, code, map: null};
+			},
+		}],
+	},
+	after() {
+		assert.ok(comments.length > 0);
+	},
+};

--- a/test/function/samples/plugin-parse-ast-receives-comments/main.js
+++ b/test/function/samples/plugin-parse-ast-receives-comments/main.js
@@ -1,0 +1,4 @@
+/* this is a comment */
+export function main() {
+	// this is also a comment
+}

--- a/test/function/samples/plugin-parse-ast-remove-sourcemapping/_config.js
+++ b/test/function/samples/plugin-parse-ast-remove-sourcemapping/_config.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'remove source mapping comment even if code is parsed by PluginContext.parse method',
+	options: {
+		plugins:[{
+			transform(code, _id) {
+				const ast = this.parse(code);
+				return {ast, code, map: null};
+			},
+		}],
+	},
+	code(code) {
+		assert.ok(code.search(/sourceMappingURL/) === -1);
+	}
+};

--- a/test/function/samples/plugin-parse-ast-remove-sourcemapping/main.js
+++ b/test/function/samples/plugin-parse-ast-remove-sourcemapping/main.js
@@ -1,0 +1,3 @@
+export function main() {
+  //# sourceMappingURL=http://example.com/path/to/your/sourcemap.map
+}

--- a/test/function/samples/plugin-parse-ast-remove-sourcemapping/main.js
+++ b/test/function/samples/plugin-parse-ast-remove-sourcemapping/main.js
@@ -1,3 +1,11 @@
 export function main() {
-  //# sourceMappingURL=http://example.com/path/to/your/sourcemap.map
+
 }
+
+//# sourceMappingURL=http://example.com/path/to/your/sourcemap.map
+
+export function foo() {
+  
+}
+
+/*# sourceMappingURL=http://example.com/path/to/your/sourcemap.map */


### PR DESCRIPTION
Do the removal without relying on the module parsing the code. This way even if
a plugin uses the `parse` method in the PluginContext the comments are removed.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
 #3982

### Description
This PR moves the removal of sourceMappingURL comments away from code parsing. This means that even if a plugin parses the ast, the comment will still be removed.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
