### PR TITLE
Do not create invalid code if a function argument is an empty object pattern

### DIFF
--- a/src/ast/scopes/ParameterScope.ts
+++ b/src/ast/scopes/ParameterScope.ts
@@ -64,12 +64,17 @@ export default class ParameterScope extends ChildScope {
 			const arg = args[index];
 			if (paramVars) {
 				calledFromTryStatement = false;
-				for (const variable of paramVars) {
-					if (variable.included) {
-						argIncluded = true;
-					}
-					if (variable.calledFromTryStatement) {
-						calledFromTryStatement = true;
+				if (paramVars.length === 0) {
+					// handle empty destructuring
+					argIncluded = true;
+				} else {
+					for (const variable of paramVars) {
+						if (variable.included) {
+							argIncluded = true;
+						}
+						if (variable.calledFromTryStatement) {
+							calledFromTryStatement = true;
+						}
 					}
 				}
 			}

--- a/test/function/samples/unused-parameter-side-effects/_config.js
+++ b/test/function/samples/unused-parameter-side-effects/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not tree-shake arguments where the corresponding parameters have side-effects'
+};

--- a/test/function/samples/unused-parameter-side-effects/main.js
+++ b/test/function/samples/unused-parameter-side-effects/main.js
@@ -1,0 +1,9 @@
+let sideEffects = 0;
+
+function destructured({}) {
+	sideEffects++;
+}
+
+destructured({});
+
+assert.strictEqual(sideEffects, 1);


### PR DESCRIPTION


<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3997 

### Description
When a function argument is an empty object pattern, Rollup would see that no variables are declared and falsely assume that it is not necessary. This fix adds special handling for that case (note that when even a single, even unused, variable was declared in the pattern, it was retained correctly).
