### PR TITLE
Break infinite loops in this.resolve

### DIFF
--- a/browser/resolveId.ts
+++ b/browser/resolveId.ts
@@ -1,4 +1,4 @@
-import { CustomPluginOptions } from '../src/rollup/types';
+import { CustomPluginOptions, Plugin } from '../src/rollup/types';
 import { PluginDriver } from '../src/utils/PluginDriver';
 import { throwNoFileSystem } from './error';
 
@@ -7,7 +7,7 @@ export async function resolveId(
 	importer: string | undefined,
 	_preserveSymlinks: boolean,
 	pluginDriver: PluginDriver,
-	skip: number | null,
+	skip: Plugin | null,
 	customOptions: CustomPluginOptions | undefined
 ) {
 	const pluginResult = await pluginDriver.hookFirst(

--- a/browser/resolveId.ts
+++ b/browser/resolveId.ts
@@ -1,5 +1,6 @@
-import { CustomPluginOptions, Plugin } from '../src/rollup/types';
+import { CustomPluginOptions, Plugin, ResolvedId } from '../src/rollup/types';
 import { PluginDriver } from '../src/utils/PluginDriver';
+import { resolveIdViaPlugins } from '../src/utils/resolveIdViaPlugins';
 import { throwNoFileSystem } from './error';
 
 export async function resolveId(
@@ -7,15 +8,16 @@ export async function resolveId(
 	importer: string | undefined,
 	_preserveSymlinks: boolean,
 	pluginDriver: PluginDriver,
-	skip: Plugin | null,
+	moduleLoaderResolveId: (
+		source: string,
+		importer: string | undefined,
+		customOptions: CustomPluginOptions | undefined,
+		skip: { importer: string | undefined; plugin: Plugin; source: string }[] | null
+	) => Promise<ResolvedId | null>,
+	skip: { importer: string | undefined; plugin: Plugin; source: string }[] | null,
 	customOptions: CustomPluginOptions | undefined
 ) {
-	const pluginResult = await pluginDriver.hookFirst(
-		'resolveId',
-		[source, importer, { custom: customOptions }],
-		null,
-		skip
-	);
+	const pluginResult = await resolveIdViaPlugins(source, importer,pluginDriver, moduleLoaderResolveId, skip, customOptions);
 	if (pluginResult == null) {
 		throwNoFileSystem('path.resolve');
 	}

--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -697,7 +697,7 @@ Use Rollup's internal acorn instance to parse code to an AST.
 #### `this.resolve(source: string, importer?: string, options?: {skipSelf?: boolean, custom?: {[plugin: string]: any}}) => Promise<{id: string, external: boolean, moduleSideEffects: boolean | 'no-treeshake', syntheticNamedExports: boolean | string, meta: {[plugin: string]: any}} | null>`
 Resolve imports to module ids (i.e. file names) using the same plugins that Rollup uses, and determine if an import should be external. If `null` is returned, the import could not be resolved by Rollup or any plugin but was not explicitly marked as external by the user.
 
-If you pass `skipSelf: true`, then the `resolveId` hook of the plugin from which `this.resolve` is called will be skipped when resolving.
+If you pass `skipSelf: true`, then the `resolveId` hook of the plugin from which `this.resolve` is called will be skipped when resolving. When other plugins themselves also call `this.resolve` in their `resolveId` hooks with the *exact same `source` and `importer`* while handling the original `this.resolve` call, then the `resolveId` hook of the original plugin will be skipped for those calls as well. The rationale here is that the plugin already stated that it "does not know" how to resolve this particular combination of `source` and `importer` at this point in time. If you do not want this behaviour, do not use `skipSelf` but implement your own infinite loop prevention mechanism if necessary.
 
 You can also pass an object of plugin-specific options via the `custom` option, see [custom resolver options](guide/en/#custom-resolver-options) for details.
 

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -8,6 +8,7 @@ import {
 	HasModuleSideEffects,
 	NormalizedInputOptions,
 	PartialResolvedId,
+	Plugin,
 	ResolvedId,
 	ResolveIdResult,
 	SourceDescription
@@ -139,7 +140,7 @@ export class ModuleLoader {
 		source: string,
 		importer: string | undefined,
 		customOptions: CustomPluginOptions | undefined,
-		skip: number | null = null
+		skip: Plugin | null = null
 	): Promise<ResolvedId | null> {
 		return this.addDefaultsToResolvedId(
 			this.getNormalizedResolvedIdWithoutDefaults(

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -136,12 +136,12 @@ export class ModuleLoader {
 		return module;
 	}
 
-	async resolveId(
+	resolveId = async (
 		source: string,
 		importer: string | undefined,
 		customOptions: CustomPluginOptions | undefined,
-		skip: Plugin | null = null
-	): Promise<ResolvedId | null> {
+		skip: { importer: string | undefined; plugin: Plugin; source: string }[] | null = null
+	): Promise<ResolvedId | null> => {
 		return this.addDefaultsToResolvedId(
 			this.getNormalizedResolvedIdWithoutDefaults(
 				this.options.external(source, importer, false)
@@ -151,6 +151,7 @@ export class ModuleLoader {
 							importer,
 							this.options.preserveSymlinks,
 							this.pluginDriver,
+							this.resolveId,
 							skip,
 							customOptions
 					  ),
@@ -445,6 +446,7 @@ export class ModuleLoader {
 			importer,
 			this.options.preserveSymlinks,
 			this.pluginDriver,
+			this.resolveId,
 			null,
 			EMPTY_OBJECT
 		);

--- a/src/utils/PluginContext.ts
+++ b/src/utils/PluginContext.ts
@@ -153,32 +153,37 @@ export function getPluginContext(
 				yield* moduleIds;
 			}
 
-			const moduleIds = graph.modulesById.keys();
-			return wrappedModuleIds();
-		},
-		parse: graph.contextParse.bind(graph),
-		resolve(source, importer, { custom, skipSelf } = BLANK) {
-			return graph.moduleLoader.resolveId(source, importer, custom, skipSelf ? plugin : null);
-		},
-		resolveId: getDeprecatedContextHandler(
-			(source: string, importer: string | undefined) =>
-				graph.moduleLoader
-					.resolveId(source, importer, BLANK)
-					.then(resolveId => resolveId && resolveId.id),
-			'resolveId',
-			'resolve',
-			plugin.name,
-			true,
-			options
-		),
-		setAssetSource: fileEmitter.setAssetSource,
-		warn(warning) {
-			if (typeof warning === 'string') warning = { message: warning } as RollupWarning;
-			if (warning.code) warning.pluginCode = warning.code;
-			warning.code = 'PLUGIN_WARNING';
-			warning.plugin = plugin.name;
-			options.onwarn(warning);
-		}
-	};
-	return context;
+				const moduleIds = graph.modulesById.keys();
+				return wrappedModuleIds();
+			},
+			parse: graph.contextParse.bind(graph),
+			resolve(source, importer, { custom, skipSelf } = BLANK) {
+				return graph.moduleLoader.resolveId(
+					source,
+					importer,
+					custom,
+					skipSelf ? [{ importer, plugin, source }] : null
+				);
+			},
+			resolveId: getDeprecatedContextHandler(
+				(source: string, importer: string | undefined) =>
+					graph.moduleLoader
+						.resolveId(source, importer, BLANK)
+						.then(resolveId => resolveId && resolveId.id),
+				'resolveId',
+				'resolve',
+				plugin.name,
+				true,
+				options
+			),
+			setAssetSource: fileEmitter.setAssetSource,
+			warn(warning) {
+				if (typeof warning === 'string') warning = { message: warning } as RollupWarning;
+				if (warning.code) warning.pluginCode = warning.code;
+				warning.code = 'PLUGIN_WARNING';
+				warning.plugin = plugin.name;
+				options.onwarn(warning);
+			}
+		};
+		return context;
 }

--- a/src/utils/PluginContext.ts
+++ b/src/utils/PluginContext.ts
@@ -44,142 +44,141 @@ function getDeprecatedContextHandler<H extends Function>(
 	}) as unknown) as H;
 }
 
-export function getPluginContexts(
+export function getPluginContext(
+	plugin: Plugin,
 	pluginCache: Record<string, SerializablePluginCache> | void,
 	graph: Graph,
 	options: NormalizedInputOptions,
-	fileEmitter: FileEmitter
-): (plugin: Plugin, pluginIndex: number) => PluginContext {
-	const existingPluginNames = new Set<string>();
-	return (plugin, pidx) => {
-		let cacheable = true;
-		if (typeof plugin.cacheKey !== 'string') {
-			if (
-				plugin.name.startsWith(ANONYMOUS_PLUGIN_PREFIX) ||
-				plugin.name.startsWith(ANONYMOUS_OUTPUT_PLUGIN_PREFIX) ||
-				existingPluginNames.has(plugin.name)
-			) {
-				cacheable = false;
-			} else {
-				existingPluginNames.add(plugin.name);
-			}
-		}
-
-		let cacheInstance: PluginCache;
-		if (!pluginCache) {
-			cacheInstance = NO_CACHE;
-		} else if (cacheable) {
-			const cacheKey = plugin.cacheKey || plugin.name;
-			cacheInstance = createPluginCache(
-				pluginCache[cacheKey] || (pluginCache[cacheKey] = Object.create(null))
-			);
+	fileEmitter: FileEmitter,
+	existingPluginNames: Set<string>
+): PluginContext {
+	let cacheable = true;
+	if (typeof plugin.cacheKey !== 'string') {
+		if (
+			plugin.name.startsWith(ANONYMOUS_PLUGIN_PREFIX) ||
+			plugin.name.startsWith(ANONYMOUS_OUTPUT_PLUGIN_PREFIX) ||
+			existingPluginNames.has(plugin.name)
+		) {
+			cacheable = false;
 		} else {
-			cacheInstance = getCacheForUncacheablePlugin(plugin.name);
+			existingPluginNames.add(plugin.name);
 		}
+	}
 
-		const context: PluginContext = {
-			addWatchFile(id) {
-				if (graph.phase >= BuildPhase.GENERATE) {
-					return this.error(errInvalidRollupPhaseForAddWatchFile());
-				}
-				graph.watchFiles[id] = true;
-			},
-			cache: cacheInstance,
-			emitAsset: getDeprecatedContextHandler(
-				(name: string, source?: string | Uint8Array) =>
-					fileEmitter.emitFile({ type: 'asset', name, source }),
-				'emitAsset',
-				'emitFile',
-				plugin.name,
-				true,
-				options
-			),
-			emitChunk: getDeprecatedContextHandler(
-				(id: string, options?: { name?: string }) =>
-					fileEmitter.emitFile({ type: 'chunk', id, name: options && options.name }),
-				'emitChunk',
-				'emitFile',
-				plugin.name,
-				true,
-				options
-			),
-			emitFile: fileEmitter.emitFile,
-			error(err): never {
-				return throwPluginError(err, plugin.name);
-			},
-			getAssetFileName: getDeprecatedContextHandler(
-				fileEmitter.getFileName,
-				'getAssetFileName',
-				'getFileName',
-				plugin.name,
-				true,
-				options
-			),
-			getChunkFileName: getDeprecatedContextHandler(
-				fileEmitter.getFileName,
-				'getChunkFileName',
-				'getFileName',
-				plugin.name,
-				true,
-				options
-			),
-			getFileName: fileEmitter.getFileName,
-			getModuleIds: () => graph.modulesById.keys(),
-			getModuleInfo: graph.getModuleInfo,
-			getWatchFiles: () => Object.keys(graph.watchFiles),
-			isExternal: getDeprecatedContextHandler(
-				(id: string, parentId: string | undefined, isResolved = false) =>
-					options.external(id, parentId, isResolved),
-				'isExternal',
-				'resolve',
-				plugin.name,
-				true,
-				options
-			),
-			meta: {
-				rollupVersion,
-				watchMode: graph.watchMode
-			},
-			get moduleIds() {
-				function* wrappedModuleIds() {
-					warnDeprecation(
-						{
-							message: `Accessing "this.moduleIds" on the plugin context by plugin ${plugin.name} is deprecated. The "this.getModuleIds" plugin context function should be used instead.`,
-							plugin: plugin.name
-						},
-						false,
-						options
-					);
-					yield* moduleIds;
-				}
+	let cacheInstance: PluginCache;
+	if (!pluginCache) {
+		cacheInstance = NO_CACHE;
+	} else if (cacheable) {
+		const cacheKey = plugin.cacheKey || plugin.name;
+		cacheInstance = createPluginCache(
+			pluginCache[cacheKey] || (pluginCache[cacheKey] = Object.create(null))
+		);
+	} else {
+		cacheInstance = getCacheForUncacheablePlugin(plugin.name);
+	}
 
-				const moduleIds = graph.modulesById.keys();
-				return wrappedModuleIds();
-			},
-			parse: graph.contextParse.bind(graph),
-			resolve(source, importer, { custom, skipSelf } = BLANK) {
-				return graph.moduleLoader.resolveId(source, importer, custom, skipSelf ? pidx : null);
-			},
-			resolveId: getDeprecatedContextHandler(
-				(source: string, importer: string | undefined) =>
-					graph.moduleLoader
-						.resolveId(source, importer, BLANK)
-						.then(resolveId => resolveId && resolveId.id),
-				'resolveId',
-				'resolve',
-				plugin.name,
-				true,
-				options
-			),
-			setAssetSource: fileEmitter.setAssetSource,
-			warn(warning) {
-				if (typeof warning === 'string') warning = { message: warning } as RollupWarning;
-				if (warning.code) warning.pluginCode = warning.code;
-				warning.code = 'PLUGIN_WARNING';
-				warning.plugin = plugin.name;
-				options.onwarn(warning);
+	const context: PluginContext = {
+		addWatchFile(id) {
+			if (graph.phase >= BuildPhase.GENERATE) {
+				return this.error(errInvalidRollupPhaseForAddWatchFile());
 			}
-		};
-		return context;
+			graph.watchFiles[id] = true;
+		},
+		cache: cacheInstance,
+		emitAsset: getDeprecatedContextHandler(
+			(name: string, source?: string | Uint8Array) =>
+				fileEmitter.emitFile({ type: 'asset', name, source }),
+			'emitAsset',
+			'emitFile',
+			plugin.name,
+			true,
+			options
+		),
+		emitChunk: getDeprecatedContextHandler(
+			(id: string, options?: { name?: string }) =>
+				fileEmitter.emitFile({ type: 'chunk', id, name: options && options.name }),
+			'emitChunk',
+			'emitFile',
+			plugin.name,
+			true,
+			options
+		),
+		emitFile: fileEmitter.emitFile,
+		error(err): never {
+			return throwPluginError(err, plugin.name);
+		},
+		getAssetFileName: getDeprecatedContextHandler(
+			fileEmitter.getFileName,
+			'getAssetFileName',
+			'getFileName',
+			plugin.name,
+			true,
+			options
+		),
+		getChunkFileName: getDeprecatedContextHandler(
+			fileEmitter.getFileName,
+			'getChunkFileName',
+			'getFileName',
+			plugin.name,
+			true,
+			options
+		),
+		getFileName: fileEmitter.getFileName,
+		getModuleIds: () => graph.modulesById.keys(),
+		getModuleInfo: graph.getModuleInfo,
+		getWatchFiles: () => Object.keys(graph.watchFiles),
+		isExternal: getDeprecatedContextHandler(
+			(id: string, parentId: string | undefined, isResolved = false) =>
+				options.external(id, parentId, isResolved),
+			'isExternal',
+			'resolve',
+			plugin.name,
+			true,
+			options
+		),
+		meta: {
+			rollupVersion,
+			watchMode: graph.watchMode
+		},
+		get moduleIds() {
+			function* wrappedModuleIds() {
+				warnDeprecation(
+					{
+						message: `Accessing "this.moduleIds" on the plugin context by plugin ${plugin.name} is deprecated. The "this.getModuleIds" plugin context function should be used instead.`,
+						plugin: plugin.name
+					},
+					false,
+					options
+				);
+				yield* moduleIds;
+			}
+
+			const moduleIds = graph.modulesById.keys();
+			return wrappedModuleIds();
+		},
+		parse: graph.contextParse.bind(graph),
+		resolve(source, importer, { custom, skipSelf } = BLANK) {
+			return graph.moduleLoader.resolveId(source, importer, custom, skipSelf ? plugin : null);
+		},
+		resolveId: getDeprecatedContextHandler(
+			(source: string, importer: string | undefined) =>
+				graph.moduleLoader
+					.resolveId(source, importer, BLANK)
+					.then(resolveId => resolveId && resolveId.id),
+			'resolveId',
+			'resolve',
+			plugin.name,
+			true,
+			options
+		),
+		setAssetSource: fileEmitter.setAssetSource,
+		warn(warning) {
+			if (typeof warning === 'string') warning = { message: warning } as RollupWarning;
+			if (warning.code) warning.pluginCode = warning.code;
+			warning.code = 'PLUGIN_WARNING';
+			warning.plugin = plugin.name;
+			options.onwarn(warning);
+		}
 	};
+	return context;
 }

--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -21,7 +21,7 @@ import {
 } from '../rollup/types';
 import { errInputHookInOutputPlugin, error } from './error';
 import { FileEmitter } from './FileEmitter';
-import { getPluginContexts } from './PluginContext';
+import { getPluginContext } from './PluginContext';
 import { throwPluginError, warnDeprecatedHooks } from './pluginUtils';
 
 /**
@@ -80,7 +80,7 @@ export class PluginDriver {
 
 	private fileEmitter: FileEmitter;
 	private pluginCache: Record<string, SerializablePluginCache> | undefined;
-	private pluginContexts: PluginContext[];
+	private pluginContexts = new Map<Plugin, PluginContext>();
 	private plugins: Plugin[];
 
 	constructor(
@@ -102,9 +102,13 @@ export class PluginDriver {
 		this.finaliseAssets = this.fileEmitter.assertAssetsFinalized;
 		this.setOutputBundle = this.fileEmitter.setOutputBundle;
 		this.plugins = userPlugins.concat(basePluginDriver ? basePluginDriver.plugins : []);
-		this.pluginContexts = this.plugins.map(
-			getPluginContexts(pluginCache, graph, options, this.fileEmitter)
-		);
+		const existingPluginNames = new Set<string>();
+		for (const plugin of this.plugins) {
+			this.pluginContexts.set(
+				plugin,
+				getPluginContext(plugin, pluginCache, graph, options, this.fileEmitter, existingPluginNames)
+			);
+		}
 		if (basePluginDriver) {
 			for (const plugin of userPlugins) {
 				for (const hook of inputHooks) {
@@ -125,14 +129,14 @@ export class PluginDriver {
 		hookName: H,
 		args: Parameters<PluginHooks[H]>,
 		replaceContext?: ReplaceContext | null,
-		skip?: number | null
+		skip?: Plugin | null
 	): EnsurePromise<ReturnType<PluginHooks[H]>> {
 		let promise: EnsurePromise<ReturnType<PluginHooks[H]>> = Promise.resolve(undefined as any);
-		for (let i = 0; i < this.plugins.length; i++) {
-			if (skip === i) continue;
+		for (const plugin of this.plugins) {
+			if (skip === plugin) continue;
 			promise = promise.then(result => {
 				if (result != null) return result;
-				return this.runHook(hookName, args, i, false, replaceContext);
+				return this.runHook(hookName, args, plugin, false, replaceContext);
 			});
 		}
 		return promise;
@@ -144,8 +148,8 @@ export class PluginDriver {
 		args: Parameters<PluginHooks[H]>,
 		replaceContext?: ReplaceContext
 	): ReturnType<PluginHooks[H]> {
-		for (let i = 0; i < this.plugins.length; i++) {
-			const result = this.runHookSync(hookName, args, i, replaceContext);
+		for (const plugin of this.plugins) {
+			const result = this.runHookSync(hookName, args, plugin, replaceContext);
 			if (result != null) return result;
 		}
 		return null as any;
@@ -158,8 +162,8 @@ export class PluginDriver {
 		replaceContext?: ReplaceContext
 	): Promise<void> {
 		const promises: Promise<void>[] = [];
-		for (let i = 0; i < this.plugins.length; i++) {
-			const hookPromise = this.runHook(hookName, args, i, false, replaceContext);
+		for (const plugin of this.plugins) {
+			const hookPromise = this.runHook(hookName, args, plugin, false, replaceContext);
 			if (!hookPromise) continue;
 			promises.push(hookPromise);
 		}
@@ -178,13 +182,13 @@ export class PluginDriver {
 		replaceContext?: ReplaceContext
 	): Promise<Arg0<H>> {
 		let promise = Promise.resolve(arg0);
-		for (let i = 0; i < this.plugins.length; i++) {
+		for (const plugin of this.plugins) {
 			promise = promise.then(arg0 => {
 				const args = [arg0, ...rest] as Parameters<PluginHooks[H]>;
-				const hookPromise = this.runHook(hookName, args, i, false, replaceContext);
+				const hookPromise = this.runHook(hookName, args, plugin, false, replaceContext);
 				if (!hookPromise) return arg0;
 				return hookPromise.then(result =>
-					reduce.call(this.pluginContexts[i], arg0, result, this.plugins[i])
+					reduce.call(this.pluginContexts.get(plugin), arg0, result, plugin)
 				);
 			});
 		}
@@ -198,10 +202,10 @@ export class PluginDriver {
 		reduce: (reduction: Arg0<H>, result: ReturnType<PluginHooks[H]>, plugin: Plugin) => Arg0<H>,
 		replaceContext?: ReplaceContext
 	): Arg0<H> {
-		for (let i = 0; i < this.plugins.length; i++) {
+		for (const plugin of this.plugins) {
 			const args = [arg0, ...rest] as Parameters<PluginHooks[H]>;
-			const result = this.runHookSync(hookName, args, i, replaceContext);
-			arg0 = reduce.call(this.pluginContexts[i], arg0, result, this.plugins[i]);
+			const result = this.runHookSync(hookName, args, plugin, replaceContext);
+			arg0 = reduce.call(this.pluginContexts.get(plugin), arg0, result, plugin);
 		}
 		return arg0;
 	}
@@ -219,12 +223,12 @@ export class PluginDriver {
 		replaceContext?: ReplaceContext
 	): Promise<T> {
 		let promise = Promise.resolve(initialValue);
-		for (let i = 0; i < this.plugins.length; i++) {
+		for (const plugin of this.plugins) {
 			promise = promise.then(value => {
-				const hookPromise = this.runHook(hookName, args, i, true, replaceContext);
+				const hookPromise = this.runHook(hookName, args, plugin, true, replaceContext);
 				if (!hookPromise) return value;
 				return hookPromise.then(result =>
-					reduce.call(this.pluginContexts[i], value, result, this.plugins[i])
+					reduce.call(this.pluginContexts.get(plugin), value, result, plugin)
 				);
 			});
 		}
@@ -240,9 +244,9 @@ export class PluginDriver {
 		replaceContext?: ReplaceContext
 	): T {
 		let acc = initialValue;
-		for (let i = 0; i < this.plugins.length; i++) {
-			const result = this.runHookSync(hookName, args, i, replaceContext);
-			acc = reduce.call(this.pluginContexts[i], acc, result, this.plugins[i]);
+		for (const plugin of this.plugins) {
+			const result = this.runHookSync(hookName, args, plugin, replaceContext);
+			acc = reduce.call(this.pluginContexts.get(plugin), acc, result, plugin);
 		}
 		return acc;
 	}
@@ -254,9 +258,9 @@ export class PluginDriver {
 		replaceContext?: ReplaceContext
 	): Promise<void> {
 		let promise = Promise.resolve();
-		for (let i = 0; i < this.plugins.length; i++) {
+		for (const plugin of this.plugins) {
 			promise = promise.then(
-				() => this.runHook(hookName, args, i, false, replaceContext) as Promise<void>
+				() => this.runHook(hookName, args, plugin, false, replaceContext) as Promise<void>
 			);
 		}
 		return promise;
@@ -268,8 +272,8 @@ export class PluginDriver {
 		args: Parameters<PluginHooks[H]>,
 		replaceContext?: ReplaceContext
 	): void {
-		for (let i = 0; i < this.plugins.length; i++) {
-			this.runHookSync(hookName, args, i, replaceContext);
+		for (const plugin of this.plugins) {
+			this.runHookSync(hookName, args, plugin, replaceContext);
 		}
 	}
 
@@ -277,36 +281,35 @@ export class PluginDriver {
 	 * Run an async plugin hook and return the result.
 	 * @param hookName Name of the plugin hook. Must be either in `PluginHooks` or `OutputPluginValueHooks`.
 	 * @param args Arguments passed to the plugin hook.
-	 * @param pluginIndex Index of the plugin inside `this.plugins[]`.
+	 * @param plugin The actual pluginObject to run.
 	 * @param permitValues If true, values can be passed instead of functions for the plugin hook.
 	 * @param hookContext When passed, the plugin context can be overridden.
 	 */
 	private runHook<H extends PluginValueHooks>(
 		hookName: H,
 		args: Parameters<AddonHookFunction>,
-		pluginIndex: number,
+		plugin: Plugin,
 		permitValues: true,
 		hookContext?: ReplaceContext | null
 	): EnsurePromise<ReturnType<AddonHookFunction>>;
 	private runHook<H extends AsyncPluginHooks>(
 		hookName: H,
 		args: Parameters<PluginHooks[H]>,
-		pluginIndex: number,
+		plugin: Plugin,
 		permitValues: false,
 		hookContext?: ReplaceContext | null
 	): EnsurePromise<ReturnType<PluginHooks[H]>>;
 	private runHook<H extends AsyncPluginHooks>(
 		hookName: H,
 		args: Parameters<PluginHooks[H]>,
-		pluginIndex: number,
+		plugin: Plugin,
 		permitValues: boolean,
 		hookContext?: ReplaceContext | null
 	): EnsurePromise<ReturnType<PluginHooks[H]>> {
-		const plugin = this.plugins[pluginIndex];
 		const hook = plugin[hookName];
 		if (!hook) return undefined as any;
 
-		let context = this.pluginContexts[pluginIndex];
+		let context = this.pluginContexts.get(plugin)!;
 		if (hookContext) {
 			context = hookContext(context, plugin);
 		}
@@ -327,20 +330,19 @@ export class PluginDriver {
 	 * Run a sync plugin hook and return the result.
 	 * @param hookName Name of the plugin hook. Must be in `PluginHooks`.
 	 * @param args Arguments passed to the plugin hook.
-	 * @param pluginIndex Index of the plugin inside `this.plugins[]`.
+	 * @param plugin The acutal plugin
 	 * @param hookContext When passed, the plugin context can be overridden.
 	 */
 	private runHookSync<H extends SyncPluginHooks>(
 		hookName: H,
 		args: Parameters<PluginHooks[H]>,
-		pluginIndex: number,
+		plugin: Plugin,
 		hookContext?: ReplaceContext
 	): ReturnType<PluginHooks[H]> {
-		const plugin = this.plugins[pluginIndex];
 		const hook = plugin[hookName];
 		if (!hook) return undefined as any;
 
-		let context = this.pluginContexts[pluginIndex];
+		let context = this.pluginContexts.get(plugin)!;
 		if (hookContext) {
 			context = hookContext(context, plugin);
 		}

--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -59,7 +59,7 @@ const inputHookNames: {
 };
 const inputHooks = Object.keys(inputHookNames);
 
-type ReplaceContext = (context: PluginContext, plugin: Plugin) => PluginContext;
+export type ReplaceContext = (context: PluginContext, plugin: Plugin) => PluginContext;
 
 function throwInvalidHookError(hookName: string, pluginName: string) {
 	return error({
@@ -129,11 +129,11 @@ export class PluginDriver {
 		hookName: H,
 		args: Parameters<PluginHooks[H]>,
 		replaceContext?: ReplaceContext | null,
-		skip?: Plugin | null
+		skipped?: Set<Plugin> | null
 	): EnsurePromise<ReturnType<PluginHooks[H]>> {
 		let promise: EnsurePromise<ReturnType<PluginHooks[H]>> = Promise.resolve(undefined as any);
 		for (const plugin of this.plugins) {
-			if (skip === plugin) continue;
+			if (skipped && skipped.has(plugin)) continue;
 			promise = promise.then(result => {
 				if (result != null) return result;
 				return this.runHook(hookName, args, plugin, false, replaceContext);

--- a/src/utils/resolveId.ts
+++ b/src/utils/resolveId.ts
@@ -1,4 +1,4 @@
-import { CustomPluginOptions } from '../rollup/types';
+import { CustomPluginOptions, Plugin } from '../rollup/types';
 import { lstatSync, readdirSync, realpathSync } from './fs';
 import { basename, dirname, isAbsolute, resolve } from './path';
 import { PluginDriver } from './PluginDriver';
@@ -8,7 +8,7 @@ export async function resolveId(
 	importer: string | undefined,
 	preserveSymlinks: boolean,
 	pluginDriver: PluginDriver,
-	skip: number | null,
+	skip: Plugin | null,
 	customOptions: CustomPluginOptions | undefined
 ) {
 	const pluginResult = await pluginDriver.hookFirst(

--- a/src/utils/resolveId.ts
+++ b/src/utils/resolveId.ts
@@ -1,21 +1,30 @@
-import { CustomPluginOptions, Plugin } from '../rollup/types';
+import { CustomPluginOptions, Plugin, ResolvedId } from '../rollup/types';
 import { lstatSync, readdirSync, realpathSync } from './fs';
 import { basename, dirname, isAbsolute, resolve } from './path';
 import { PluginDriver } from './PluginDriver';
+import { resolveIdViaPlugins } from './resolveIdViaPlugins';
 
 export async function resolveId(
 	source: string,
 	importer: string | undefined,
 	preserveSymlinks: boolean,
 	pluginDriver: PluginDriver,
-	skip: Plugin | null,
+	moduleLoaderResolveId: (
+		source: string,
+		importer: string | undefined,
+		customOptions: CustomPluginOptions | undefined,
+		skip: { importer: string | undefined; plugin: Plugin; source: string }[] | null
+	) => Promise<ResolvedId | null>,
+	skip: { importer: string | undefined; plugin: Plugin; source: string }[] | null,
 	customOptions: CustomPluginOptions | undefined
 ) {
-	const pluginResult = await pluginDriver.hookFirst(
-		'resolveId',
-		[source, importer, { custom: customOptions }],
-		null,
-		skip
+	const pluginResult = await resolveIdViaPlugins(
+		source,
+		importer,
+		pluginDriver,
+		moduleLoaderResolveId,
+		skip,
+		customOptions
 	);
 	if (pluginResult != null) return pluginResult;
 

--- a/src/utils/resolveIdViaPlugins.ts
+++ b/src/utils/resolveIdViaPlugins.ts
@@ -1,0 +1,45 @@
+import { CustomPluginOptions, Plugin, PluginContext, ResolvedId } from '../rollup/types';
+import { BLANK } from './blank';
+import { PluginDriver, ReplaceContext } from './PluginDriver';
+
+export function resolveIdViaPlugins(
+	source: string,
+	importer: string | undefined,
+	pluginDriver: PluginDriver,
+	moduleLoaderResolveId: (
+		source: string,
+		importer: string | undefined,
+		customOptions: CustomPluginOptions | undefined,
+		skip: { importer: string | undefined; plugin: Plugin; source: string }[] | null
+	) => Promise<ResolvedId | null>,
+	skip: { importer: string | undefined; plugin: Plugin; source: string }[] | null,
+	customOptions: CustomPluginOptions | undefined
+) {
+	let skipped: Set<Plugin> | null = null;
+	let replaceContext: ReplaceContext | null = null;
+	if (skip) {
+		skipped = new Set();
+		for (const skippedCall of skip) {
+			if (source === skippedCall.source && importer === skippedCall.importer) {
+				skipped.add(skippedCall.plugin);
+			}
+		}
+		replaceContext = (pluginContext, plugin): PluginContext => ({
+			...pluginContext,
+			resolve: (source, importer, { custom, skipSelf } = BLANK) => {
+				return moduleLoaderResolveId(
+					source,
+					importer,
+					custom,
+					skipSelf ? [...skip, { importer, plugin, source }] : skip
+				);
+			}
+		});
+	}
+	return pluginDriver.hookFirst(
+		'resolveId',
+		[source, importer, { custom: customOptions }],
+		replaceContext,
+		skipped
+	);
+}

--- a/test/function/samples/prevent-context-resolve-loop/_config.js
+++ b/test/function/samples/prevent-context-resolve-loop/_config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+const ID_OTHER_1 = path.join(__dirname, 'other1.js');
+const ID_OTHER_2 = path.join(__dirname, 'other2.js');
+const ID_OTHER_3 = path.join(__dirname, 'other3.js');
+
+module.exports = {
+	description: 'prevents infinite loops when several plugins are calling this.resolve in resolveId',
+	options: {
+		plugins: [
+			{
+				name: 'first',
+				async resolveId(source, importer) {
+					const { id } = await this.resolve(source, importer, { skipSelf: true });
+					if (id === ID_OTHER_2) {
+						return ID_OTHER_3;
+					}
+				}
+			},
+			{
+				name: 'second',
+				async resolveId(source, importer) {
+					const { id } = await this.resolve(source, importer, { skipSelf: true });
+					if (id === ID_OTHER_1) {
+						return ID_OTHER_2;
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/prevent-context-resolve-loop/_config.js
+++ b/test/function/samples/prevent-context-resolve-loop/_config.js
@@ -3,6 +3,9 @@ const path = require('path');
 const ID_OTHER_1 = path.join(__dirname, 'other1.js');
 const ID_OTHER_2 = path.join(__dirname, 'other2.js');
 const ID_OTHER_3 = path.join(__dirname, 'other3.js');
+const ID_OTHER_4 = path.join(__dirname, 'other4.js');
+
+const thirdPluginCalls = new Set();
 
 module.exports = {
 	description: 'prevents infinite loops when several plugins are calling this.resolve in resolveId',
@@ -12,8 +15,8 @@ module.exports = {
 				name: 'first',
 				async resolveId(source, importer) {
 					const { id } = await this.resolve(source, importer, { skipSelf: true });
-					if (id === ID_OTHER_2) {
-						return ID_OTHER_3;
+					if (id === ID_OTHER_1) {
+						return ID_OTHER_4;
 					}
 				}
 			},
@@ -21,8 +24,26 @@ module.exports = {
 				name: 'second',
 				async resolveId(source, importer) {
 					const { id } = await this.resolve(source, importer, { skipSelf: true });
-					if (id === ID_OTHER_1) {
-						return ID_OTHER_2;
+					if (id === ID_OTHER_2) {
+						// To make this more interesting
+						await this.resolve('./other1', importer, { skipSelf: true });
+						await this.resolve(source, ID_OTHER_1, { skipSelf: true });
+						return ID_OTHER_4;
+					}
+				}
+			},
+			{
+				name: 'third',
+				async resolveId(source, importer) {
+					const hash = `${source}:${importer}`;
+					if (thirdPluginCalls.has(hash)) {
+						return null;
+					}
+					thirdPluginCalls.add(hash);
+					const { id } = await this.resolve(source, importer);
+					thirdPluginCalls.delete(hash);
+					if (id === ID_OTHER_3) {
+						return ID_OTHER_4;
 					}
 				}
 			}

--- a/test/function/samples/prevent-context-resolve-loop/dep.js
+++ b/test/function/samples/prevent-context-resolve-loop/dep.js
@@ -1,0 +1,3 @@
+import third from './other3.js';
+
+assert.strictEqual(third, 4);

--- a/test/function/samples/prevent-context-resolve-loop/main.js
+++ b/test/function/samples/prevent-context-resolve-loop/main.js
@@ -1,0 +1,5 @@
+import first from './other1.js';
+import second from './other2.js';
+
+assert.strictEqual(first, 3);
+assert.strictEqual(second, 3);

--- a/test/function/samples/prevent-context-resolve-loop/main.js
+++ b/test/function/samples/prevent-context-resolve-loop/main.js
@@ -1,5 +1,6 @@
 import first from './other1.js';
 import second from './other2.js';
+import './dep.js';
 
-assert.strictEqual(first, 3);
-assert.strictEqual(second, 3);
+assert.strictEqual(first, 4);
+assert.strictEqual(second, 4);

--- a/test/function/samples/prevent-context-resolve-loop/other1.js
+++ b/test/function/samples/prevent-context-resolve-loop/other1.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/function/samples/prevent-context-resolve-loop/other2.js
+++ b/test/function/samples/prevent-context-resolve-loop/other2.js
@@ -1,0 +1,1 @@
+export default 2;

--- a/test/function/samples/prevent-context-resolve-loop/other3.js
+++ b/test/function/samples/prevent-context-resolve-loop/other3.js
@@ -1,0 +1,1 @@
+export default 3;

--- a/test/function/samples/prevent-context-resolve-loop/other4.js
+++ b/test/function/samples/prevent-context-resolve-loop/other4.js
@@ -1,0 +1,1 @@
+export default 4;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no
- [x] technically yes, but I would consider the previous behaviour as very hard to handle anyway and would push this in a minor release 

List any relevant issue numbers:

### Description
This will change the logic when using `skipSelf` in `this.resolve`. With this patch, this will not only skip the current plugin for this call of `this.resolve` but when one of the other plugins calls `this.resolve` again from its resolveId hook with the exact same source and importer, the initial plugin will be skipped as well.


Example:

```js
plugins: [
  {
    name: 'first',
    async resolveId(source, importer) {
      const resolved = await this.resolve(source, importer, {skipSelf: true});
      if (resolved.id === 'foo1') return 'bar1';
    }
  },
  {
    name: 'second',
    async resolveId(source, importer) {
      const resolved = await this.resolve(source, importer, {skipSelf: true});
      if (resolved.id === 'foo2') return 'bar2';
    }
  }
]
```


What would happen without this patch is that when a pair of (source, importer) is resolved, it is passed to the first plugin, which calls `this.resolve` to pass it to the second plugin, which again calls `this.resolve` to pass it back to the first plugin.

With this patch, the pair of (source, importer) is passed to the first plugin, which calls `this.resolve` to pass it to the second plugin (the first is skipped by `skipSelf`) and core. As the call of `this.resolve` in the second plugin uses the same `source` and `importer` as the call the first plugin wanted skipped, this is skipping now both plugins, passing it directly to Rollup core.