### PR TITLE
Do not count accessing members of an external namespace as side-effects.

### DIFF
--- a/src/ast/variables/ExternalVariable.ts
+++ b/src/ast/variables/ExternalVariable.ts
@@ -1,5 +1,6 @@
 import ExternalModule from '../../ExternalModule';
 import Identifier from '../nodes/Identifier';
+import { ObjectPath } from '../utils/PathTracker';
 import Variable from './Variable';
 
 export default class ExternalVariable extends Variable {
@@ -19,6 +20,10 @@ export default class ExternalVariable extends Variable {
 		if (this.name === 'default' || this.name === '*') {
 			this.module.suggestName(identifier.name);
 		}
+	}
+
+	hasEffectsWhenAccessedAtPath(path: ObjectPath) {
+		return path.length > (this.isNamespace ? 1 : 0);
 	}
 
 	include() {

--- a/test/form/samples/treeshake-namespace-access/_config.js
+++ b/test/form/samples/treeshake-namespace-access/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'does not count namespace property access as side-effect',
+	options: { external: 'external' }
+};

--- a/test/form/samples/treeshake-namespace-access/_expected/amd.js
+++ b/test/form/samples/treeshake-namespace-access/_expected/amd.js
@@ -1,0 +1,5 @@
+define(['external'], function (external) { 'use strict';
+
+	console.log('main');
+
+});

--- a/test/form/samples/treeshake-namespace-access/_expected/cjs.js
+++ b/test/form/samples/treeshake-namespace-access/_expected/cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require('external');
+
+console.log('main');

--- a/test/form/samples/treeshake-namespace-access/_expected/es.js
+++ b/test/form/samples/treeshake-namespace-access/_expected/es.js
@@ -1,0 +1,3 @@
+import 'external';
+
+console.log('main');

--- a/test/form/samples/treeshake-namespace-access/_expected/iife.js
+++ b/test/form/samples/treeshake-namespace-access/_expected/iife.js
@@ -1,0 +1,6 @@
+(function () {
+	'use strict';
+
+	console.log('main');
+
+}());

--- a/test/form/samples/treeshake-namespace-access/_expected/system.js
+++ b/test/form/samples/treeshake-namespace-access/_expected/system.js
@@ -1,0 +1,11 @@
+System.register(['external'], function () {
+	'use strict';
+	return {
+		setters: [function () {}],
+		execute: function () {
+
+			console.log('main');
+
+		}
+	};
+});

--- a/test/form/samples/treeshake-namespace-access/_expected/umd.js
+++ b/test/form/samples/treeshake-namespace-access/_expected/umd.js
@@ -1,0 +1,8 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(['external'], factory) :
+	factory();
+}((function () { 'use strict';
+
+	console.log('main');
+
+})));

--- a/test/form/samples/treeshake-namespace-access/main.js
+++ b/test/form/samples/treeshake-namespace-access/main.js
@@ -1,0 +1,4 @@
+import * as external from 'external';
+
+const unused = external.foo;
+console.log('main');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#3999

### Description
This solves a regression introduced in #3999 where accessing properties of external namespaces was considered side-effectful, preventing tree-shaking.