### PR TITLE
Fixed unhandled promise rejections

### DIFF
--- a/src/utils/timers.ts
+++ b/src/utils/timers.ts
@@ -104,11 +104,11 @@ function getPluginWithTimers(plugin: any, index: number): Plugin {
 			timerLabel += ` - ${hook}`;
 			timedPlugin[hook] = function() {
 				timeStart(timerLabel, 4);
-				const result = plugin[hook].apply(this === timedPlugin ? plugin : this, arguments);
+				let result = plugin[hook].apply(this === timedPlugin ? plugin : this, arguments);
 				timeEnd(timerLabel, 4);
 				if (result && typeof result.then === 'function') {
 					timeStart(`${timerLabel} (async)`, 4);
-					result.then(() => timeEnd(`${timerLabel} (async)`, 4));
+					result = result.then(() => timeEnd(`${timerLabel} (async)`, 4));
 				}
 				return result;
 			};


### PR DESCRIPTION
when perf mode is activated and a plugin hooks throws.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no (reproduction repo is attached to #3876 but I'm not sure the issue warrants a unit test which I'd expect to be pretty convoluted)

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

Fixes #3876

### Description

This PR ensures the timerEnd promise isn't left unhandled (if the plugin throws - i.e `result` promise is rejected, the combined promise `result.then(...)` needs to be handled).
