### PR TITLE
Use correct import.meta.url in config files

### DIFF
--- a/cli/run/loadConfigFile.ts
+++ b/cli/run/loadConfigFile.ts
@@ -77,7 +77,20 @@ async function getDefaultFromTranspiledConfigFile(
 		output: [{ code }]
 	} = await bundle.generate({
 		exports: 'named',
-		format: 'cjs'
+		format: 'cjs',
+		plugins: [
+			{
+				name: 'transpile-import-meta',
+				resolveImportMeta(property, { moduleId }) {
+					if (property === 'url') {
+						return `'${pathToFileURL(moduleId).href}'`;
+					}
+					if (property == null) {
+						return `{url:'${pathToFileURL(moduleId).href}'}`
+					}
+				}
+			}
+		]
 	});
 	return loadConfigFromBundledFile(fileName, code);
 }

--- a/test/cli/samples/config-import-meta/_config.js
+++ b/test/cli/samples/config-import-meta/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'uses correct import.meta.url in config files',
+	command: 'rollup -c'
+};

--- a/test/cli/samples/config-import-meta/_expected.js
+++ b/test/cli/samples/config-import-meta/_expected.js
@@ -1,0 +1,3 @@
+var test = 'test text';
+
+console.log(test);

--- a/test/cli/samples/config-import-meta/main.js
+++ b/test/cli/samples/config-import-meta/main.js
@@ -1,0 +1,3 @@
+import test from 'test';
+
+console.log(test);

--- a/test/cli/samples/config-import-meta/plugin/plugin.js
+++ b/test/cli/samples/config-import-meta/plugin/plugin.js
@@ -1,0 +1,28 @@
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { readFileSync } from 'fs';
+import assert from 'assert';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const id = 'test';
+const fileName = `test.txt`;
+
+function validateImportMeta(importMeta) {
+	assert.strictEqual(importMeta.url, import.meta.url);
+}
+
+validateImportMeta(import.meta);
+assert.strictEqual(import.meta.foo, undefined);
+
+export default () => ({
+	resolveId(source) {
+		if (source === id) {
+			return source;
+		}
+	},
+	load(loadedId) {
+		if (loadedId === id) {
+			return `export default '${readFileSync(resolve(__dirname, fileName), 'utf8')}';`;
+		}
+	}
+});

--- a/test/cli/samples/config-import-meta/plugin/test.txt
+++ b/test/cli/samples/config-import-meta/plugin/test.txt
@@ -1,0 +1,1 @@
+test text

--- a/test/cli/samples/config-import-meta/rollup.config.js
+++ b/test/cli/samples/config-import-meta/rollup.config.js
@@ -1,0 +1,9 @@
+import plugin from './plugin/plugin.js';
+
+export default {
+	input: 'main.js',
+	output: {
+		format: 'es'
+	},
+	plugins: [plugin()]
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3758 

### Description
This will make sure `import.meta.url` behaves as expected inside plugins that are imported via relative paths. Previously, `import.meta.url` would be the file url of the config file instead.