### PR TITLE
Tree-shake pure call expressions with optional chaining

### DIFF
--- a/src/utils/pureComments.ts
+++ b/src/utils/pureComments.ts
@@ -1,6 +1,11 @@
 import * as acorn from 'acorn';
 import { base as basicWalker, BaseWalker } from 'acorn-walk';
-import { CallExpression, ExpressionStatement, NewExpression } from '../ast/nodes/NodeType';
+import {
+	CallExpression,
+	ChainExpression,
+	ExpressionStatement,
+	NewExpression
+} from '../ast/nodes/NodeType';
 import { Annotation } from '../ast/nodes/shared/Node';
 
 // patch up acorn-walk until class-fields are officially supported
@@ -38,18 +43,18 @@ function markPureNode(
 	comment: acorn.Comment
 ) {
 	if (node._rollupAnnotations) {
-		node._rollupAnnotations.push({comment});
+		node._rollupAnnotations.push({ comment });
 	} else {
-		node._rollupAnnotations = [{comment}];
+		node._rollupAnnotations = [{ comment }];
 	}
-	if (node.type === ExpressionStatement) {
+	while (node.type === ExpressionStatement || node.type === ChainExpression) {
 		node = (node as any).expression;
 	}
 	if (node.type === CallExpression || node.type === NewExpression) {
 		if (node._rollupAnnotations) {
-			node._rollupAnnotations.push({pure: true});
+			node._rollupAnnotations.push({ pure: true });
 		} else {
-			node._rollupAnnotations = [{pure: true}];
+			node._rollupAnnotations = [{ pure: true }];
 		}
 	}
 }

--- a/test/form/samples/tree-shake-pure-optional-chaining/_config.js
+++ b/test/form/samples/tree-shake-pure-optional-chaining/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'tree-shake pure call expressions involving optional chaining'
+};

--- a/test/form/samples/tree-shake-pure-optional-chaining/_expected.js
+++ b/test/form/samples/tree-shake-pure-optional-chaining/_expected.js
@@ -1,0 +1,3 @@
+foo.bar();
+foo?.bar();
+foo.bar?.();

--- a/test/form/samples/tree-shake-pure-optional-chaining/main.js
+++ b/test/form/samples/tree-shake-pure-optional-chaining/main.js
@@ -1,0 +1,6 @@
+foo.bar();
+foo?.bar();
+foo.bar?.();
+/*#__PURE__*/foo.bar();
+/*#__PURE__*/foo?.bar();
+/*#__PURE__*/foo.bar?.();


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4006 

### Description
Not really a bug fix but rather an oversight: Since optional chaining call expressions are wrapped in a "ChainExpression" node, the existing logic for marking pure call expressions was skipping it. This is fixed now.