### PR TITLE
Return hook result inside promise with async timer end

### DIFF
--- a/src/utils/timers.ts
+++ b/src/utils/timers.ts
@@ -108,7 +108,10 @@ function getPluginWithTimers(plugin: any, index: number): Plugin {
 				timeEnd(timerLabel, 4);
 				if (result && typeof result.then === 'function') {
 					timeStart(`${timerLabel} (async)`, 4);
-					result = result.then(() => timeEnd(`${timerLabel} (async)`, 4));
+					result = result.then((hookResult: any) => {
+						timeEnd(`${timerLabel} (async)`, 4);
+						return hookResult;
+					});
 				}
 				return result;
 			};


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

Fix after #4004

### Description

#4004 replace plugin hooks result promises, and forget to return original promises payload.
For this reason, rollup builds with `perf` option, and with `@rollup/plugin-typescript` for example, was broken - because `load` plugin hook can return modified input, and this input has been discarded.