### PR TITLE
Disable pessimistic object deoptimization for calls when the called function doesn't ref this

### DIFF
--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -98,6 +98,10 @@ export default class ArrowFunctionExpression extends NodeBase {
 		}
 	}
 
+	mayModifyThisWhenCalledAtPath() {
+		return false;
+	}
+
 	parseNode(esTreeNode: GenericEsTreeNode) {
 		if (esTreeNode.body.type === NodeType.BlockStatement) {
 			this.body = new this.context.nodeConstructors.BlockStatement(

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -65,7 +65,8 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 		// ensure the returnExpression is set for the tree-shaking passes
 		this.getReturnExpression(SHARED_RECURSION_TRACKER);
 		// This deoptimizes "this" for non-namespace calls until we have a better solution
-		if (this.callee instanceof MemberExpression && !this.callee.variable) {
+		if (this.callee instanceof MemberExpression && !this.callee.variable &&
+		    this.callee.mayModifyThisWhenCalledAtPath([])) {
 			this.callee.object.deoptimizePath(UNKNOWN_PATH);
 		}
 		for (const argument of this.arguments) {

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -141,6 +141,12 @@ export default class Identifier extends NodeBase implements PatternNode {
 		this.variable!.includeCallArguments(context, args);
 	}
 
+	mayModifyThisWhenCalledAtPath(
+		path: ObjectPath
+	) {
+		return this.variable ? this.variable.mayModifyThisWhenCalledAtPath(path) : true
+	}
+
 	render(
 		code: MagicString,
 		_options: RenderOptions,

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -233,6 +233,15 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		this.propertyKey = getResolvablePropertyKey(this);
 	}
 
+	mayModifyThisWhenCalledAtPath(
+		path: ObjectPath
+	) {
+		if (this.variable) {
+			return this.variable.mayModifyThisWhenCalledAtPath(path);
+		}
+		return this.object.mayModifyThisWhenCalledAtPath([this.propertyKey as ObjectPathKey].concat(path));
+	}
+
 	render(
 		code: MagicString,
 		options: RenderOptions,

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -256,6 +256,16 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 		return false;
 	}
 
+	mayModifyThisWhenCalledAtPath(
+		path: ObjectPath
+	) {
+		if (!path.length || typeof path[0] !== "string") {
+			return true;
+		}
+		const property = this.getPropertyMap()[path[0]]?.exactMatchRead;
+		return property ? property.value.mayModifyThisWhenCalledAtPath(path.slice(1)) : true;
+	}
+
 	render(
 		code: MagicString,
 		options: RenderOptions,

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -4,6 +4,7 @@ import ModuleScope from '../scopes/ModuleScope';
 import { ObjectPath } from '../utils/PathTracker';
 import ThisVariable from '../variables/ThisVariable';
 import * as NodeType from './NodeType';
+import FunctionNode from './shared/FunctionNode';
 import { NodeBase } from './shared/Node';
 
 export default class ThisExpression extends NodeBase {
@@ -37,6 +38,12 @@ export default class ThisExpression extends NodeBase {
 				},
 				this.start
 			);
+		}
+		for (let parent = this.parent; parent instanceof NodeBase; parent = parent.parent) {
+			if (parent instanceof FunctionNode) {
+				parent.referencesThis = true;
+				break;
+			}
 		}
 	}
 

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -33,4 +33,7 @@ export interface ExpressionEntity extends WritableEntity {
 	): boolean;
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void;
 	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void;
+	mayModifyThisWhenCalledAtPath(
+		path: ObjectPath
+	): boolean;
 }

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -23,9 +23,6 @@ export default class FunctionNode extends NodeBase {
 
 	createScope(parentScope: FunctionScope) {
 		this.scope = new FunctionScope(parentScope, this.context);
-		// Initialized here because child nodes will update it before
-		// `this.initialize` even runs.
-		this.referencesThis = false;
 	}
 
 	deoptimizePath(path: ObjectPath) {
@@ -131,6 +128,7 @@ export default class FunctionNode extends NodeBase {
 	}
 
 	parseNode(esTreeNode: GenericEsTreeNode) {
+		this.referencesThis = false;
 		this.body = new this.context.nodeConstructors.BlockStatement(
 			esTreeNode.body,
 			this,

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -16,12 +16,16 @@ export default class FunctionNode extends NodeBase {
 	id!: IdentifierWithVariable | null;
 	params!: PatternNode[];
 	preventChildBlockScope!: true;
+	referencesThis!: boolean;
 	scope!: FunctionScope;
 
 	private isPrototypeDeoptimized = false;
 
 	createScope(parentScope: FunctionScope) {
 		this.scope = new FunctionScope(parentScope, this.context);
+		// Initialized here because child nodes will update it before
+		// `this.initialize` even runs.
+		this.referencesThis = false;
 	}
 
 	deoptimizePath(path: ObjectPath) {
@@ -118,6 +122,12 @@ export default class FunctionNode extends NodeBase {
 			this.params[this.params.length - 1] instanceof RestElement
 		);
 		this.body.addImplicitReturnExpressionToScope();
+	}
+
+	mayModifyThisWhenCalledAtPath(
+		path: ObjectPath
+	) {
+		return path.length ? true : this.referencesThis
 	}
 
 	parseNode(esTreeNode: GenericEsTreeNode) {

--- a/src/ast/nodes/shared/MultiExpression.ts
+++ b/src/ast/nodes/shared/MultiExpression.ts
@@ -73,4 +73,8 @@ export class MultiExpression implements ExpressionEntity {
 	}
 
 	includeCallArguments(): void {}
+
+	mayModifyThisWhenCalledAtPath(path: ObjectPath) {
+		return this.expressions.some(e => e.mayModifyThisWhenCalledAtPath(path));
+	}
 }

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -229,6 +229,12 @@ export class NodeBase implements ExpressionNode {
 		}
 	}
 
+	mayModifyThisWhenCalledAtPath(
+		_path: ObjectPath
+	) {
+		return true
+	}
+
 	parseNode(esTreeNode: GenericEsTreeNode) {
 		for (const key of Object.keys(esTreeNode)) {
 			// That way, we can override this function to add custom initialisation and then call super.parseNode

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -68,8 +68,6 @@ abstract class ValueBase implements ExpressionEntity {
 	includeCallArguments(_context: InclusionContext, _args: (ExpressionNode | SpreadElement)[]) {}
 
 	mayModifyThisWhenCalledAtPath() { return true; }
-
-	abstract toString(): string
 }
 
 function includeAll(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]) {
@@ -82,16 +80,11 @@ export const UNKNOWN_EXPRESSION: ExpressionEntity = new class extends ValueBase 
 	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void {
 		includeAll(context, args);
 	}
-	toString() { return '[[UNKNOWN]]' }
 };
 
 export const UNDEFINED_EXPRESSION: ExpressionEntity = new class extends ValueBase {
 	getLiteralValueAtPath() {
 		return undefined;
-	}
-
-	toString() {
-		return 'undefined'
 	}
 };
 
@@ -145,10 +138,6 @@ export class UnknownArrayExpression extends ValueBase {
 
 	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void {
 		includeAll(context, args);
-	}
-
-	toString() {
-		return '[[UNKNOWN ARRAY]]';
 	}
 }
 
@@ -205,7 +194,6 @@ const UNKNOWN_LITERAL_BOOLEAN: ExpressionEntity = new class extends ValueBase {
 	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void {
 		includeAll(context, args);
 	}
-	toString() { return '[[UNKNOWN BOOLEAN]]' }
 };
 
 const returnsBoolean: RawMemberDescription = {
@@ -243,7 +231,6 @@ const UNKNOWN_LITERAL_NUMBER: ExpressionEntity = new class extends ValueBase {
 	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void {
 		includeAll(context, args);
 	}
-	toString() { return '[[UNKNOWN NUMBER]]'; }
 };
 
 const returnsNumber: RawMemberDescription = {
@@ -292,7 +279,6 @@ const UNKNOWN_LITERAL_STRING: ExpressionEntity = new class extends ValueBase {
 	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void {
 		includeAll(context, args);
 	}
-	toString() { return '[[UNKNOWN STRING]]' }
 };
 
 const returnsString: RawMemberDescription = {
@@ -339,10 +325,6 @@ export class UnknownObjectExpression extends ValueBase {
 
 	includeCallArguments(context: InclusionContext, args: (ExpressionNode | SpreadElement)[]): void {
 		includeAll(context, args);
-	}
-
-	toString() {
-		return '[[UNKNOWN OBJECT]]';
 	}
 }
 

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -45,6 +45,7 @@ export const UNKNOWN_EXPRESSION: ExpressionEntity = {
 		}
 	},
 	included: true,
+	mayModifyThisWhenCalledAtPath: () => true,
 	toString: () => '[[UNKNOWN]]'
 };
 
@@ -58,6 +59,7 @@ export const UNDEFINED_EXPRESSION: ExpressionEntity = {
 	include: () => {},
 	includeCallArguments(): void {},
 	included: true,
+	mayModifyThisWhenCalledAtPath: () => true,
 	toString: () => 'undefined'
 };
 
@@ -119,6 +121,10 @@ export class UnknownArrayExpression implements ExpressionEntity {
 		for (const arg of args) {
 			arg.include(context, false);
 		}
+	}
+
+	mayModifyThisWhenCalledAtPath(_path: ObjectPath) {
+		return true;
 	}
 
 	toString() {
@@ -184,6 +190,7 @@ const UNKNOWN_LITERAL_BOOLEAN: ExpressionEntity = {
 		}
 	},
 	included: true,
+	mayModifyThisWhenCalledAtPath: () => true,
 	toString: () => '[[UNKNOWN BOOLEAN]]'
 };
 
@@ -229,6 +236,7 @@ const UNKNOWN_LITERAL_NUMBER: ExpressionEntity = {
 		}
 	},
 	included: true,
+	mayModifyThisWhenCalledAtPath: () => true,
 	toString: () => '[[UNKNOWN NUMBER]]'
 };
 
@@ -281,6 +289,7 @@ const UNKNOWN_LITERAL_STRING: ExpressionEntity = {
 		}
 	},
 	included: true,
+	mayModifyThisWhenCalledAtPath: () => true,
 	toString: () => '[[UNKNOWN STRING]]'
 };
 
@@ -336,6 +345,10 @@ export class UnknownObjectExpression implements ExpressionEntity {
 		for (const arg of args) {
 			arg.include(context, false);
 		}
+	}
+
+	mayModifyThisWhenCalledAtPath(_path: ObjectPath) {
+		return true;
 	}
 
 	toString() {

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -188,4 +188,13 @@ export default class LocalVariable extends Variable {
 	markCalledFromTryStatement() {
 		this.calledFromTryStatement = true;
 	}
+
+	mayModifyThisWhenCalledAtPath(
+		path: ObjectPath
+	) {
+		if (this.isReassigned || !this.init || path.length > MAX_PATH_DEPTH) {
+			return true;
+		}
+		return this.init.mayModifyThisWhenCalledAtPath(path);
+	}
 }

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -96,6 +96,12 @@ export default class Variable implements ExpressionEntity {
 
 	markCalledFromTryStatement() {}
 
+	mayModifyThisWhenCalledAtPath(
+		_path: ObjectPath
+	) {
+		return true
+	}
+
 	setRenderNames(baseName: string | null, name: string | null) {
 		this.renderBaseName = baseName;
 		this.renderName = name;

--- a/test/form/samples/getter-return-values/_expected.js
+++ b/test/form/samples/getter-return-values/_expected.js
@@ -9,12 +9,6 @@
 		return {};
 	}
 }).foo.bar.baz;
-
-({
-	get foo () {
-		return () => {};
-	}
-}).foo();
 ({
 	get foo () {
 		console.log( 'effect' );
@@ -26,12 +20,6 @@
 		return () => console.log( 'effect' );
 	}
 }).foo();
-
-({
-	get foo () {
-		return () => () => {};
-	}
-}).foo()();
 ({
 	get foo () {
 		console.log( 'effect' );

--- a/test/form/samples/object-expression/method-side-effects/_expected.js
+++ b/test/form/samples/object-expression/method-side-effects/_expected.js
@@ -1,12 +1,3 @@
-const x = {
-	[globalThis.unknown]() {
-		console.log('effect');
-	},
-	a() {}
-};
-
-x.a();
-
 const y = {
 	a() {},
 	[globalThis.unknown]() {

--- a/test/form/samples/object-expression/method-side-effects/_expected.js
+++ b/test/form/samples/object-expression/method-side-effects/_expected.js
@@ -1,15 +1,17 @@
 const y = {
 	a() {},
+	b: () => {},
 	[globalThis.unknown]() {
 		console.log('effect');
 	}
 };
 
 y.a();
+y.b();
 
 const z = {
 	[globalThis.unknown]() {}
 };
 
 z.a();
-z.hasOwnProperty('a'); // removed
+z.hasOwnProperty('a');

--- a/test/form/samples/object-expression/method-side-effects/main.js
+++ b/test/form/samples/object-expression/method-side-effects/main.js
@@ -2,23 +2,27 @@ const x = {
 	[globalThis.unknown]() {
 		console.log('effect');
 	},
-	a() {}
+	a() {},
+	b: () => {}
 };
 
 x.a();
+x.b();
 
 const y = {
 	a() {},
+	b: () => {},
 	[globalThis.unknown]() {
 		console.log('effect');
 	}
 };
 
 y.a();
+y.b();
 
 const z = {
 	[globalThis.unknown]() {}
 };
 
 z.a();
-z.hasOwnProperty('a'); // removed
+z.hasOwnProperty('a');

--- a/test/form/samples/object-expression/return-expressions/_expected.js
+++ b/test/form/samples/object-expression/return-expressions/_expected.js
@@ -1,10 +1,3 @@
-const x = {
-	[globalThis.unknown]: () => () => console.log('effect'),
-	a: () => () => {}
-};
-
-x.a()();
-
 const y = {
 	a: () => () => {},
 	[globalThis.unknown]: () => () => console.log('effect')

--- a/test/form/samples/object-literal-property-overwrites/_expected.js
+++ b/test/form/samples/object-literal-property-overwrites/_expected.js
@@ -1,23 +1,3 @@
-const removed1 = {
-	foo: () => {},
-	foo: () => {},
-	['f' + 'oo']: () => {}
-};
-removed1.foo();
-
-const removed2 = {
-	foo: () => console.log( 'effect' ),
-	foo: () => {}
-};
-removed2.foo();
-
-const removed3 = {
-	['fo' + 'o']: function () {this.x = 1;},
-	['f' + 'oo']: () => console.log( 'effect' ),
-	foo: () => {}
-};
-removed3.foo();
-
 const retained1 = {
 	foo: () => {},
 	foo: function () {this.x = 1;}

--- a/test/form/samples/property-setters-and-getters/early-access-getter-return/_expected.js
+++ b/test/form/samples/property-setters-and-getters/early-access-getter-return/_expected.js
@@ -1,16 +1,7 @@
 function getReturnExpressionBeforeInit() {
-	const bar = {
-		[foo.value()]: true
-	};
-	if (bar.baz) {
+	{
 		console.log('retained');
 	}
 }
-
-const foo = {
-	get value() {
-		return () => 'baz';
-	}
-};
 
 getReturnExpressionBeforeInit();

--- a/test/form/samples/recursive-calls/_expected.js
+++ b/test/form/samples/recursive-calls/_expected.js
@@ -1,13 +1,6 @@
 const removed4 = () => globalThis.unknown ? removed4() : { x: () => {} };
 removed4().x();
 
-const removed6 = {
-	get x () {
-		return globalThis.unknown ? removed6.x : () => {};
-	}
-};
-removed6.x();
-
 const removed8 = {
 	get x () {
 		return globalThis.unknown ? removed8.x : { y: () => {} };

--- a/test/form/samples/side-effects-object-literal-calls/_expected.js
+++ b/test/form/samples/side-effects-object-literal-calls/_expected.js
@@ -1,9 +1,3 @@
-const removed1 = { x: () => {} };
-removed1.x();
-
-const removed2 = { x: { y: () => {} } };
-removed2.x.y();
-
 const retained1 = { x: () => {} };
 retained1.y();
 


### PR DESCRIPTION
Adds a `referencesThis` flag to `FunctionNode` and uses it to avoid the deoptimization around method calls, as discussed in #3989

Instead of new tests, this reverts some of the test changes made by 3e0aa46d723cac0ac.

Let me know if the `FunctionNode.createScope` kludge is within the limits of kludginess accepted in this project. We could also do a conditional initialization of the property in `initialize`, but that'll lead to different object shapes for no real good reason.

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] kinda
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: #3989