### PR TITLE
fix `sourcemap` reference in docs

### DIFF
--- a/docs/08-troubleshooting.md
+++ b/docs/08-troubleshooting.md
@@ -64,9 +64,9 @@ There are occasional valid reasons for `this` to mean something else. If you're 
 
 ### Warning: "Sourcemap is likely to be incorrect"
 
-You'll see this warning if you generate a sourcemap with your bundle (`sourceMap: true` or `sourceMap: 'inline'`) but you're using one or more plugins that transformed code without generating a sourcemap for the transformation.
+You'll see this warning if you generate a sourcemap with your bundle (`sourcemap: true` or `sourcemap: 'inline'`) but you're using one or more plugins that transformed code without generating a sourcemap for the transformation.
 
-Usually, a plugin will only omit the sourcemap if it (the plugin, not the bundle) was configured with `sourceMap: false` – so all you need to do is change that. If the plugin doesn't generate a sourcemap, consider raising an issue with the plugin author.
+Usually, a plugin will only omit the sourcemap if it (the plugin, not the bundle) was configured with `sourcemap: false` – so all you need to do is change that. If the plugin doesn't generate a sourcemap, consider raising an issue with the plugin author.
 
 
 ### Warning: "Treating [module] as external dependency"


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

### Description
It's lowercase in the config.

>Usually, a plugin will only omit the sourcemap if it (the plugin, not the bundle) was configured with `sourcemap: false`

Looks like the [commmonjs plugin uses `sourceMap`](https://github.com/rollup/plugins/tree/master/packages/commonjs#sourcemap) 🙈, so not sure if the line about plugins should be left as is, or maybe CommonJS should also accept `sourcemap` to be more inline with rollup itself?