### PR TITLE
Use SIGTERM instead of SIGINT to kill test child processes

### DIFF
--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -124,10 +124,10 @@ runTestSuiteWithSamples(
 					if (config.abortOnStderr) {
 						try {
 							if (await config.abortOnStderr(data)) {
-								childProcess.kill('SIGINT');
+								childProcess.kill('SIGTERM');
 							}
 						} catch (err) {
-							childProcess.kill('SIGINT');
+							childProcess.kill('SIGTERM');
 							done(err);
 						}
 					}


### PR DESCRIPTION

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

Since SIGINT fails to actually kill them on some platforms under some circumstances,
leading to a whole lot of watch tests sitting around for 40 seconds until they
time out.

See derail in the discussion for issue #3989
