### PR TITLE
Deoptimize ObjectExpression when a __proto__ property is present

### DIFF
--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -54,6 +54,16 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 		super.bind();
 		// ensure the propertyMap is set for the tree-shaking passes
 		this.getPropertyMap();
+		if (
+			!this.hasUnknownDeoptimizedProperty &&
+			this.properties.some(prop => {
+				if (prop instanceof SpreadElement || prop.computed) return false;
+				if (prop.key instanceof Identifier) return prop.key.name == "__proto__";
+				return String((prop.key as Literal).value) == "__proto__";
+			})
+		) {
+			this.deoptimizeAllProperties();
+		}
 	}
 
 	// We could also track this per-property but this would quickly become much more complex

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -307,7 +307,7 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 			}
 			const isWrite = property.kind !== 'get';
 			const isRead = property.kind !== 'set';
-			let key;
+			let key: string;
 			let unmatchable = false;
 			if (property.computed) {
 				const keyValue = property.key.getLiteralValueAtPath(
@@ -322,13 +322,13 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 			} else {
 				key = String((property.key as Literal).value);
 			}
-            if (key === '__proto__' && !property.computed || unmatchable) {
-					if (isRead) {
-						this.unmatchablePropertiesRead.push(property);
-					} else {
-						this.unmatchablePropertiesWrite.push(property);
-					}
-					continue;
+			if (unmatchable || (key === '__proto__' && !property.computed)) {
+				if (isRead) {
+					this.unmatchablePropertiesRead.push(property);
+				} else {
+					this.unmatchablePropertiesWrite.push(property);
+				}
+				continue;
 			}
 			const propertyMapProperty = propertyMap[key];
 			if (!propertyMapProperty) {

--- a/test/form/samples/object-expression/proto-property/_config.js
+++ b/test/form/samples/object-expression/proto-property/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Deoptimize when __proto__ is used'
+};

--- a/test/form/samples/object-expression/proto-property/_expected.js
+++ b/test/form/samples/object-expression/proto-property/_expected.js
@@ -1,0 +1,13 @@
+let proto = {
+  get a() { log(); }
+};
+
+let plainProto = {
+  __proto__: proto
+};
+if (plainProto.a) log("plainProto");
+
+let quotedProto = {
+  "__proto__": proto
+};
+if (quotedProto.a) log("quotedProto");

--- a/test/form/samples/object-expression/proto-property/main.js
+++ b/test/form/samples/object-expression/proto-property/main.js
@@ -1,0 +1,18 @@
+let basic = {
+  a: false
+};
+if (basic.a) log("basic");
+
+let proto = {
+  get a() { log(); }
+};
+
+let plainProto = {
+  __proto__: proto
+};
+if (plainProto.a) log("plainProto");
+
+let quotedProto = {
+  "__proto__": proto
+};
+if (quotedProto.a) log("quotedProto");


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers: #4014

### Description

Works around issues with effect tracking in object literals with a prototype (specified with a `__proto__` or `"__proto__"` property) by completely deoptimizing nodes with such a property.