### PR TITLE
Do not fail when returning null or undefined from an async options hook

### DIFF
--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -122,13 +122,14 @@ function applyOptionHook(watchMode: boolean) {
 		inputOptions: Promise<GenericConfigObject>,
 		plugin: Plugin
 	): Promise<GenericConfigObject> => {
-		if (plugin.options)
+		if (plugin.options) {
 			return (
-				(plugin.options.call(
+				((await plugin.options.call(
 					{ meta: { rollupVersion, watchMode } },
 					await inputOptions
-				) as GenericConfigObject) || inputOptions
+				)) as GenericConfigObject) || inputOptions
 			);
+		}
 
 		return inputOptions;
 	};

--- a/test/function/samples/aync-options/_config.js
+++ b/test/function/samples/aync-options/_config.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'handles async plugin options',
+	options: {
+		preserveEntrySignatures: false,
+		plugins: [
+			{
+				options(options) {
+					assert.strictEqual(options.preserveEntrySignatures, false);
+					return Promise.resolve({ ...options, preserveEntrySignatures: 'strict' });
+				}
+			},
+			{
+				options(options) {
+					assert.strictEqual(options.preserveEntrySignatures, 'strict');
+					return Promise.resolve(null);
+				}
+			}
+		]
+	},
+	exports(exports) {
+		assert.strictEqual(exports.foo, 1);
+	}
+};

--- a/test/function/samples/aync-options/main.js
+++ b/test/function/samples/aync-options/main.js
@@ -1,0 +1,1 @@
+export const foo = 1;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4038 

### Description
Due to a missing `await`, async options hooks with false results were not handled correctly.