### PR TITLE
Prioritize manual chunk name over dynamic entry id

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -187,6 +187,7 @@ export default class Chunk {
 	private dependencies = new Set<ExternalModule | Chunk>();
 	private dynamicDependencies = new Set<ExternalModule | Chunk>();
 	private dynamicEntryModules: Module[] = [];
+	private dynamicName: string | null = null;
 	private exportNamesByVariable = new Map<Variable, string[]>();
 	private exports = new Set<Variable>();
 	private exportsByName: Record<string, Variable> = Object.create(null);
@@ -384,7 +385,7 @@ export default class Chunk {
 				this.facadeModule = module;
 				this.facadeChunkByModule.set(module, this);
 				this.strictFacade = true;
-				this.assignFacadeName({}, module);
+				this.dynamicName = getChunkNameFromModule(module);
 			} else if (
 				this.facadeModule === module &&
 				!this.strictFacade &&
@@ -815,9 +816,7 @@ export default class Chunk {
 		if (fileName) {
 			this.fileName = fileName;
 		} else {
-			this.name = sanitizeFileName(
-				name || facadedModule.chunkName || getAliasName(facadedModule.id)
-			);
+			this.name = sanitizeFileName(name || getChunkNameFromModule(facadedModule));
 		}
 	}
 
@@ -1079,6 +1078,9 @@ export default class Chunk {
 	private getFallbackChunkName(): string {
 		if (this.manualChunkAlias) {
 			return this.manualChunkAlias;
+		}
+		if (this.dynamicName) {
+			return this.dynamicName;
 		}
 		if (this.fileName) {
 			return getAliasName(this.fileName);
@@ -1369,4 +1371,8 @@ export default class Chunk {
 			}
 		}
 	}
+}
+
+function getChunkNameFromModule(module: Module): string {
+	return module.chunkName || getAliasName(module.id);
 }

--- a/test/chunking-form/samples/single-file-manual-chunk/_config.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	description: 'chunk aliasing with extensions',
+	options: {
+		output: {
+			manualChunks(id) {
+				if (id.endsWith('main.js')) return;
+				if (id.endsWith('a.js')) return 'first';
+				return 'second';
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/amd/generated-first.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/amd/generated-first.js
@@ -1,0 +1,5 @@
+define(function () { 'use strict';
+
+	console.log('a');
+
+});

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/amd/generated-second.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/amd/generated-second.js
@@ -1,0 +1,18 @@
+define(['exports'], function (exports) { 'use strict';
+
+	console.log('b');
+
+	var b = /*#__PURE__*/Object.freeze({
+		__proto__: null
+	});
+
+	console.log('c');
+
+	var c = /*#__PURE__*/Object.freeze({
+		__proto__: null
+	});
+
+	exports.b = b;
+	exports.c = c;
+
+});

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/amd/main.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/amd/main.js
@@ -1,0 +1,7 @@
+define(['require'], function (require) { 'use strict';
+
+	new Promise(function (resolve, reject) { require(['./generated-first'], resolve, reject) });
+	new Promise(function (resolve, reject) { require(['./generated-second'], resolve, reject) }).then(function (n) { return n.b; });
+	new Promise(function (resolve, reject) { require(['./generated-second'], resolve, reject) }).then(function (n) { return n.c; });
+
+});

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/cjs/generated-first.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/cjs/generated-first.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('a');

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/cjs/generated-second.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/cjs/generated-second.js
@@ -1,0 +1,16 @@
+'use strict';
+
+console.log('b');
+
+var b = /*#__PURE__*/Object.freeze({
+	__proto__: null
+});
+
+console.log('c');
+
+var c = /*#__PURE__*/Object.freeze({
+	__proto__: null
+});
+
+exports.b = b;
+exports.c = c;

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/cjs/main.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/cjs/main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+Promise.resolve().then(function () { return require('./generated-first.js'); });
+Promise.resolve().then(function () { return require('./generated-second.js'); }).then(function (n) { return n.b; });
+Promise.resolve().then(function () { return require('./generated-second.js'); }).then(function (n) { return n.c; });

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/es/generated-first.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/es/generated-first.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/es/generated-second.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/es/generated-second.js
@@ -1,0 +1,13 @@
+console.log('b');
+
+var b = /*#__PURE__*/Object.freeze({
+	__proto__: null
+});
+
+console.log('c');
+
+var c = /*#__PURE__*/Object.freeze({
+	__proto__: null
+});
+
+export { b, c };

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/es/main.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/es/main.js
@@ -1,0 +1,3 @@
+import('./generated-first.js');
+import('./generated-second.js').then(function (n) { return n.b; });
+import('./generated-second.js').then(function (n) { return n.c; });

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/system/generated-first.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/system/generated-first.js
@@ -1,0 +1,10 @@
+System.register([], function () {
+	'use strict';
+	return {
+		execute: function () {
+
+			console.log('a');
+
+		}
+	};
+});

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/system/generated-second.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/system/generated-second.js
@@ -1,0 +1,22 @@
+System.register([], function (exports) {
+	'use strict';
+	return {
+		execute: function () {
+
+			console.log('b');
+
+			var b = /*#__PURE__*/Object.freeze({
+				__proto__: null
+			});
+			exports('b', b);
+
+			console.log('c');
+
+			var c = /*#__PURE__*/Object.freeze({
+				__proto__: null
+			});
+			exports('c', c);
+
+		}
+	};
+});

--- a/test/chunking-form/samples/single-file-manual-chunk/_expected/system/main.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/_expected/system/main.js
@@ -1,0 +1,12 @@
+System.register([], function (exports, module) {
+	'use strict';
+	return {
+		execute: function () {
+
+			module.import('./generated-first.js');
+			module.import('./generated-second.js').then(function (n) { return n.b; });
+			module.import('./generated-second.js').then(function (n) { return n.c; });
+
+		}
+	};
+});

--- a/test/chunking-form/samples/single-file-manual-chunk/a.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/a.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/test/chunking-form/samples/single-file-manual-chunk/b.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/b.js
@@ -1,0 +1,1 @@
+console.log('b');

--- a/test/chunking-form/samples/single-file-manual-chunk/c.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/c.js
@@ -1,0 +1,1 @@
+console.log('c');

--- a/test/chunking-form/samples/single-file-manual-chunk/main.js
+++ b/test/chunking-form/samples/single-file-manual-chunk/main.js
@@ -1,0 +1,3 @@
+import('./a.js');
+import('./b.js');
+import('./c.js');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #3973

### Description
If a manual chunk only contains a single dynamic entry point, the manual chunk name would be overridden by the name derived from the dynamic entry. As this is not in the user's interest, this will change the priorities to prefer the user-given name.
Now the only situation where a manual chunk will not receive the expected name is if there is a single explicitly defined entry point in the chunk (which is an optimisation to reduce the number of chunks).