### PR TITLE
Revert "Don't allow `:` in file names. (#3972)"

### DIFF
--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -1320,6 +1320,14 @@ Default: `false`
 
 Generate `const` declarations for exports rather than `var` declarations.
 
+#### output.sanitizeFileName
+Type: `boolean | (string) => string`<br>
+Default: `true`
+
+Set to `false` to disable all chunk name sanitizations (removal of `\0`, `?` and `*` characters).
+
+Alternatively set to a function to allow custom chunk name sanitization.
+
 #### output.strict
 Type: `boolean`<br>
 CLI: `--strict`/`--no-strict`<br>

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -430,6 +430,14 @@ export default class Chunk {
 		);
 	}
 
+	sanitizeFileName (id: string) {
+		if (this.outputOptions.sanitizeFileName === false)
+			return id;
+		else if (typeof this.outputOptions.sanitizeFileName === 'function')
+			return this.outputOptions.sanitizeFileName(id);
+		return sanitizeFileName(id);
+	}
+
 	generateIdPreserveModules(
 		preserveModulesRelativeDir: string,
 		options: NormalizedOutputOptions,
@@ -437,7 +445,7 @@ export default class Chunk {
 		unsetOptions: Set<string>
 	): string {
 		const id = this.orderedModules[0].id;
-		const sanitizedId = sanitizeFileName(id);
+		const sanitizedId = this.sanitizeFileName(id);
 		let path: string;
 		if (isAbsolute(id)) {
 			const extension = extname(id);
@@ -501,7 +509,7 @@ export default class Chunk {
 	}
 
 	getChunkName(): string {
-		return this.name || (this.name = sanitizeFileName(this.getFallbackChunkName()));
+		return this.name || (this.name = this.sanitizeFileName(this.getFallbackChunkName()));
 	}
 
 	getExportNames(): string[] {
@@ -816,7 +824,7 @@ export default class Chunk {
 		if (fileName) {
 			this.fileName = fileName;
 		} else {
-			this.name = sanitizeFileName(name || getChunkNameFromModule(facadedModule));
+			this.name = this.sanitizeFileName(name || getChunkNameFromModule(facadedModule));
 		}
 	}
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -693,6 +693,7 @@ export interface NormalizedOutputOptions {
 	preferConst: boolean;
 	preserveModules: boolean;
 	preserveModulesRoot: string | undefined;
+	sanitizeFileName: boolean | ((string) => string);
 	sourcemap: boolean | 'inline' | 'hidden';
 	sourcemapExcludeSources: boolean;
 	sourcemapFile: string | undefined;

--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -66,6 +66,7 @@ export function normalizeOutputOptions(
 		preferConst: (config.preferConst as boolean | undefined) || false,
 		preserveModules,
 		preserveModulesRoot: getPreserveModulesRoot(config),
+		sanitizeFileName: config.sanitizeFileName as NormalizedOutputOptions['sanitizeFileName'] ?? true,
 		sourcemap: (config.sourcemap as boolean | 'inline' | 'hidden' | undefined) || false,
 		sourcemapExcludeSources: (config.sourcemapExcludeSources as boolean | undefined) || false,
 		sourcemapFile: config.sourcemapFile as string | undefined,

--- a/src/utils/sanitizeFileName.ts
+++ b/src/utils/sanitizeFileName.ts
@@ -1,8 +1,3 @@
 export function sanitizeFileName(name: string): string {
-	const match = /^[a-z]:/i.exec(name);
-	const driveLetter = match ? match[0] : "";
-
-	// A `:` is only allowed as part of a windows drive letter (ex: C:\foo)
-	// Otherwise, avoid them because they can refer to NTFS alternate data streams.
-	return driveLetter + name.substr(driveLetter.length).replace(/[\0?*:]/g, '_');
+	return name.replace(/[\0?*]/g, '_');
 }

--- a/test/chunking-form/samples/sanitize-chunk-names/_config.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 		plugins: [
 			{
 				options(options) {
-					options.input = ['\0virtual:entry-1', '\0virtual:entry-2'];
+					options.input = ['\0virtual-entry-1', '\0virtual-entry-2'];
 					return options;
 				},
 				resolveId(id) {

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual-entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual-entry-1.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var _virtualEntry1 = "\u0000virtual-entry-1";
+
+	return _virtualEntry1;
+
+});

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual-entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual-entry-2.js
@@ -1,0 +1,7 @@
+define(function () { 'use strict';
+
+	var _virtualEntry2 = "\u0000virtual-entry-2";
+
+	return _virtualEntry2;
+
+});

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual_entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual_entry-1.js
@@ -1,7 +1,0 @@
-define(function () { 'use strict';
-
-	var _virtual_entry1 = "\u0000virtual:entry-1";
-
-	return _virtual_entry1;
-
-});

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual_entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/_virtual_entry-2.js
@@ -1,7 +1,0 @@
-define(function () { 'use strict';
-
-	var _virtual_entry2 = "\u0000virtual:entry-2";
-
-	return _virtual_entry2;
-
-});

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual-entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual-entry-1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var _virtualEntry1 = "\u0000virtual-entry-1";
+
+module.exports = _virtualEntry1;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual-entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual-entry-2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var _virtualEntry2 = "\u0000virtual-entry-2";
+
+module.exports = _virtualEntry2;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual_entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual_entry-1.js
@@ -1,5 +1,0 @@
-'use strict';
-
-var _virtual_entry1 = "\u0000virtual:entry-1";
-
-module.exports = _virtual_entry1;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual_entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/_virtual_entry-2.js
@@ -1,5 +1,0 @@
-'use strict';
-
-var _virtual_entry2 = "\u0000virtual:entry-2";
-
-module.exports = _virtual_entry2;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual-entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual-entry-1.js
@@ -1,0 +1,3 @@
+var _virtualEntry1 = "\u0000virtual-entry-1";
+
+export default _virtualEntry1;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual-entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual-entry-2.js
@@ -1,0 +1,3 @@
+var _virtualEntry2 = "\u0000virtual-entry-2";
+
+export default _virtualEntry2;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual_entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual_entry-1.js
@@ -1,3 +1,0 @@
-var _virtual_entry1 = "\u0000virtual:entry-1";
-
-export default _virtual_entry1;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual_entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/es/_virtual_entry-2.js
@@ -1,3 +1,0 @@
-var _virtual_entry2 = "\u0000virtual:entry-2";
-
-export default _virtual_entry2;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual-entry-1.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual-entry-1.js
@@ -3,7 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			var _virtual_entry2 = exports('default', "\u0000virtual:entry-2");
+			var _virtualEntry1 = exports('default', "\u0000virtual-entry-1");
 
 		}
 	};

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual-entry-2.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/system/_virtual-entry-2.js
@@ -3,7 +3,7 @@ System.register([], function (exports) {
 	return {
 		execute: function () {
 
-			var _virtual_entry1 = exports('default', "\u0000virtual:entry-1");
+			var _virtualEntry2 = exports('default', "\u0000virtual-entry-2");
 
 		}
 	};

--- a/test/form/samples/no-sanitize/_config.js
+++ b/test/form/samples/no-sanitize/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'supports disabling sanitization',
+	options: {
+		sanitizeFileName: false
+	}
+};

--- a/test/form/samples/no-sanitize/_expected/amd.js
+++ b/test/form/samples/no-sanitize/_expected/amd.js
@@ -1,0 +1,9 @@
+define(['?do-not-sanitize'], function (external) { 'use strict';
+
+	function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+	var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
+
+	console.log(external__default['default']);
+
+});

--- a/test/form/samples/no-sanitize/_expected/cjs.js
+++ b/test/form/samples/no-sanitize/_expected/cjs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var external = require('\0do-not-sanitize');
+
+function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
+
+console.log(external__default['default']);

--- a/test/form/samples/no-sanitize/_expected/es.js
+++ b/test/form/samples/no-sanitize/_expected/es.js
@@ -1,0 +1,3 @@
+import external from '\0do-not-sanitize';
+
+console.log(external);

--- a/test/form/samples/no-sanitize/_expected/iife.js
+++ b/test/form/samples/no-sanitize/_expected/iife.js
@@ -1,0 +1,10 @@
+(function (external) {
+	'use strict';
+
+	function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+	var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
+
+	console.log(external__default['default']);
+
+}(external));

--- a/test/form/samples/no-sanitize/_expected/system.js
+++ b/test/form/samples/no-sanitize/_expected/system.js
@@ -1,0 +1,14 @@
+System.register(['\0do-not-sanitize'], function () {
+	'use strict';
+	var external;
+	return {
+		setters: [function (module) {
+			external = module.default;
+		}],
+		execute: function () {
+
+			console.log(external);
+
+		}
+	};
+});

--- a/test/form/samples/no-sanitize/_expected/umd.js
+++ b/test/form/samples/no-sanitize/_expected/umd.js
@@ -1,0 +1,13 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require(':do-not-sanitize')) :
+	typeof define === 'function' && define.amd ? define([':do-not-sanitize'], factory) :
+	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.external));
+}(this, (function (external) { 'use strict';
+
+	function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
+
+	var external__default = /*#__PURE__*/_interopDefaultLegacy(external);
+
+	console.log(external__default['default']);
+
+})));

--- a/test/form/samples/no-sanitize/main.js
+++ b/test/form/samples/no-sanitize/main.js
@@ -1,0 +1,3 @@
+import external from ':do-not-sanitize';
+
+console.log(external);


### PR DESCRIPTION
This reverts commit 85304f2c3cdd476b73e91af21855eece5bc94ee0.

Modules are URLs in Node.js and on the Web. RollupJS outputs relative paths which are relative URLs.

Banning relative URLs that contain `:` is thus banning valid URL usages, and this breaks support for eg JSPM builds which rely on relative paths like `'../npm:pkg@version'` to be possible to build.

@NfNitLoop perhaps you could ban `:` at the readFile level when assuming a path rather? I think there would be more flexibility for RollupJS to keep it open for the internal format to be fully URL compatible (eg building URLs in future as well for eg Deno workflows).

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
