### PR TITLE
Ignore invalid trailing pure annotations

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -136,7 +136,7 @@ export default class Graph {
 
 		options.onComment = onCommentOrig;
 
-		markPureCallExpressions(comments, ast);
+		markPureCallExpressions(comments, ast, code);
 
 		return ast;
 	}

--- a/test/form/samples/pure-comment-line-break/_expected.js
+++ b/test/form/samples/pure-comment-line-break/_expected.js
@@ -6,7 +6,7 @@ console.log('should remain impure');
 console.log('code');
 console.log('should remain impure');
 
-console.log('code');
+console.log('code')/*@__PURE__*/;
 console.log('should remain impure');
 console.log('should remain impure');
 
@@ -16,7 +16,7 @@ console.log('should remain impure');
 console.log('code'),
 console.log('should remain impure');
 
-console.log('code'),
+console.log('code')/*@__PURE__*/,
 console.log('should remain impure');
 
 console.log('should remain impure');
@@ -35,3 +35,21 @@ console.log('should remain impure', x);
 {
 	console.log('should remain impure');
 }
+keep1() /*@__PURE__*/ ; keep2();
+keep3() ; 
+keep4() /*@__PURE__*/ ; /* other comment */ keep5();
+keep6() /*@__PURE__*/ ; // other comment
+keep7();
+keep8() /*@__PURE__*/ && keep9();
+
+/*@__PURE__*/ Drop1(), // FIXME: unrelated issue
+Keep1() /*@__PURE__*/ , Keep2(),
+Keep3() , 
+Keep4() /*@__PURE__*/ , /* other comment */ Keep5(),
+Keep6() /*@__PURE__*/ , // other comment
+Keep7(),
+Keep8() /*@__PURE__*/ && Keep9();
+
+// FIXME: unrelated issue
+/*@__PURE__*/ Drop10(),
+/*@__PURE__*/ Drop13();

--- a/test/form/samples/pure-comment-line-break/main.js
+++ b/test/form/samples/pure-comment-line-break/main.js
@@ -42,3 +42,31 @@ console.log('should remain impure', code);
 if (true) {
 	console.log('should remain impure');
 }
+
+/*@__PURE__*/ drop1();
+/*@__PURE__*/
+drop2();
+keep1() /*@__PURE__*/ ; keep2();
+keep3() ; /*@__PURE__*/
+drop3();
+keep4() /*@__PURE__*/ ; /* other comment */ keep5();
+keep6() /*@__PURE__*/ ; // other comment
+keep7();
+keep8() /*@__PURE__*/ && keep9();
+
+/*@__PURE__*/ Drop1(), // FIXME: unrelated issue
+/*@__PURE__*/
+Drop2(),
+Keep1() /*@__PURE__*/ , Keep2(),
+Keep3() , /*@__PURE__*/
+Drop3(),
+Keep4() /*@__PURE__*/ , /* other comment */ Keep5(),
+Keep6() /*@__PURE__*/ , // other comment
+Keep7(),
+Keep8() /*@__PURE__*/ && Keep9();
+
+// FIXME: unrelated issue
+/*@__PURE__*/ Drop10(),
+/*@__PURE__*/ Drop11(),
+/*@__PURE__*/ Drop12(),
+/*@__PURE__*/ Drop13();

--- a/test/form/samples/pure-comments-disabled/_expected.js
+++ b/test/form/samples/pure-comments-disabled/_expected.js
@@ -2,5 +2,27 @@
 /*@__PURE__*/ a();
 /*@__PURE__*/ new a();
 
-console.log('code');
+console.log('code')/*@__PURE__*/;
 console.log('should remain impure');
+
+/*@__PURE__*/ drop1();
+/*@__PURE__*/
+drop2();
+keep1() /*@__PURE__*/ ; keep2();
+keep3() ; /*@__PURE__*/
+drop3();
+keep4() /*@__PURE__*/ ; /* other comment */ keep5();
+keep6() /*@__PURE__*/ ; // other comment
+keep7();
+keep8() /*@__PURE__*/ && keep9();
+
+/*@__PURE__*/ Drop1(),
+/*@__PURE__*/
+Drop2(),
+Keep1() /*@__PURE__*/ , Keep2(),
+Keep3() , /*@__PURE__*/
+Drop3(),
+Keep4() /*@__PURE__*/ , /* other comment */ Keep5(),
+Keep6() /*@__PURE__*/ , // other comment
+Keep7(),
+Keep8() /*@__PURE__*/ && Keep9();

--- a/test/form/samples/pure-comments-disabled/main.js
+++ b/test/form/samples/pure-comments-disabled/main.js
@@ -5,3 +5,25 @@
 console.log('code')/*@__PURE__*/;
 /*@__PURE__*/(() => {})();
 console.log('should remain impure');
+
+/*@__PURE__*/ drop1();
+/*@__PURE__*/
+drop2();
+keep1() /*@__PURE__*/ ; keep2();
+keep3() ; /*@__PURE__*/
+drop3();
+keep4() /*@__PURE__*/ ; /* other comment */ keep5();
+keep6() /*@__PURE__*/ ; // other comment
+keep7();
+keep8() /*@__PURE__*/ && keep9();
+
+/*@__PURE__*/ Drop1(),
+/*@__PURE__*/
+Drop2(),
+Keep1() /*@__PURE__*/ , Keep2(),
+Keep3() , /*@__PURE__*/
+Drop3(),
+Keep4() /*@__PURE__*/ , /* other comment */ Keep5(),
+Keep6() /*@__PURE__*/ , // other comment
+Keep7(),
+Keep8() /*@__PURE__*/ && Keep9();


### PR DESCRIPTION
Ignore invalid trailing pure annotations that were incorrectly associated with subsequent calls.

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

fixes #4062

### Description

Ignore invalid trailing pure annotations that were incorrectly associated with subsequent calls causing those calls to be erroneously dropped.

A valid pure annotation comment must precede a call or new expression and only whitespace characters may appear between the annotation comment and the following call.