### PR TITLE
package.json: update exports for node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,6 @@
       },
       "default": "./dist/es/rollup.browser.js"
     },
-    "./dist/": "./dist/"
+    "./dist/*": "./dist/*"
   }
 }


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no
- [x] maybe 

List any relevant issue numbers:

### Description

node 16 shows a deprecationWarning when using ./dist/ as exports field:

```
DeprecationWarning: Use of deprecated folder mapping "./dist/" in the "exports" field module resolution 
of the package at /{cwd}/node_modules/rollup/package.json imported from /{cwd}/build/tasks/rollup.js.
Update this package.json to use a subpath pattern like "./dist/*".
```

node 12, 13 and 14 seem to work fine with the change, node 14 works fine in my codebase that has node >= 14 as requirement.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
