### PR TITLE
Fix crash when using inlineDynamicImports with no-treeshake

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -362,17 +362,18 @@ export default class Module {
 			}
 			necessaryDependencies.add(variable.module!);
 		}
-		if (this.options.treeshake && this.info.hasModuleSideEffects !== 'no-treeshake') {
-			this.addRelevantSideEffectDependencies(
-				relevantDependencies,
-				necessaryDependencies,
-				alwaysCheckedDependencies
-			);
-		} else {
+		if (!this.options.treeshake || this.info.hasModuleSideEffects === 'no-treeshake') {
 			for (const dependency of this.dependencies) {
-				relevantDependencies.add(dependency);
+				if (dependency instanceof ExternalModule || dependency.isIncluded()) {
+					relevantDependencies.add(dependency);
+				}
 			}
 		}
+		this.addRelevantSideEffectDependencies(
+			relevantDependencies,
+			necessaryDependencies,
+			alwaysCheckedDependencies
+		);
 		for (const dependency of necessaryDependencies) {
 			relevantDependencies.add(dependency);
 		}

--- a/test/function/samples/inline-dynamic-no-treeshake/_config.js
+++ b/test/function/samples/inline-dynamic-no-treeshake/_config.js
@@ -1,0 +1,29 @@
+const MAGIC_ENTRY = 'main';
+
+module.exports = {
+	description: 'handles inlining dynamic imports when treeshaking is disabled for modules (#4098)',
+	options: {
+		input: MAGIC_ENTRY,
+		output: {
+			inlineDynamicImports: true
+		},
+		plugins: [
+			{
+				name: 'magic-modules',
+				buildStart() {
+					this.emitFile({ type: 'chunk', id: './dep.js' });
+				},
+				async resolveId(source) {
+					if (source === MAGIC_ENTRY) {
+						return { id: source, moduleSideEffects: 'no-treeshake' };
+					}
+					return null;
+				},
+				async load(id) {
+					if (id !== MAGIC_ENTRY) return null;
+					return `import {foo} from './reexport.js';assert.strictEqual(foo, 1);`;
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/inline-dynamic-no-treeshake/dep.js
+++ b/test/function/samples/inline-dynamic-no-treeshake/dep.js
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/test/function/samples/inline-dynamic-no-treeshake/reexport.js
+++ b/test/function/samples/inline-dynamic-no-treeshake/reexport.js
@@ -1,0 +1,1 @@
+export * from './dep.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4098 

### Description
This resolves a crash when
* inlineDynamicImports is used
* A module is set to "no-treeshake"
* That module has a dependency that is completely tree-shaken