### PR TITLE
Correctly handle catch declarations

### DIFF
--- a/src/ast/nodes/CatchClause.ts
+++ b/src/ast/nodes/CatchClause.ts
@@ -17,20 +17,16 @@ export default class CatchClause extends NodeBase {
 		this.scope = new CatchScope(parentScope, this.context);
 	}
 
-	initialise(): void {
-		if (this.param) {
-			this.param.declare('parameter', UNKNOWN_EXPRESSION);
-		}
-	}
-
 	parseNode(esTreeNode: GenericEsTreeNode): void {
-		this.body = new this.context.nodeConstructors.BlockStatement(
-			esTreeNode.body,
-			this,
-			this.scope
-		) as BlockStatement;
+		// Parameters need to be declared first as the logic is that hoisted body
+		// variables are associated with outside vars unless there is a parameter,
+		// in which case they are associated with the parameter
+		const { param } = esTreeNode;
+		if (param) {
+			(this.param as GenericEsTreeNode) = new (this.context.nodeConstructors[param.type] ||
+				this.context.nodeConstructors.UnknownNode)(param, this, this.scope);
+			this.param!.declare('parameter', UNKNOWN_EXPRESSION);
+		}
 		super.parseNode(esTreeNode);
 	}
 }
-
-CatchClause.prototype.preventChildBlockScope = true;

--- a/src/ast/scopes/CatchScope.ts
+++ b/src/ast/scopes/CatchScope.ts
@@ -11,10 +11,14 @@ export default class CatchScope extends ParameterScope {
 		init: ExpressionEntity | null,
 		isHoisted: boolean
 	): LocalVariable {
+		const existingParameter = this.variables.get(identifier.name) as LocalVariable;
+		if (existingParameter) {
+			existingParameter.addDeclaration(identifier, init);
+			return existingParameter;
+		}
 		if (isHoisted) {
 			return this.parent.addDeclaration(identifier, context, init, isHoisted);
-		} else {
-			return super.addDeclaration(identifier, context, init, false);
 		}
+		return super.addDeclaration(identifier, context, init, false);
 	}
 }

--- a/src/ast/scopes/CatchScope.ts
+++ b/src/ast/scopes/CatchScope.ts
@@ -16,9 +16,8 @@ export default class CatchScope extends ParameterScope {
 			existingParameter.addDeclaration(identifier, init);
 			return existingParameter;
 		}
-		if (isHoisted) {
-			return this.parent.addDeclaration(identifier, context, init, isHoisted);
-		}
-		return super.addDeclaration(identifier, context, init, false);
+		// as parameters are handled differently, all remaining declarations are
+		// hoisted
+		return this.parent.addDeclaration(identifier, context, init, isHoisted);
 	}
 }

--- a/test/function/samples/catch-block-scope/_config.js
+++ b/test/function/samples/catch-block-scope/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'uses correct scope in catch blocks'
+};

--- a/test/function/samples/catch-block-scope/main.js
+++ b/test/function/samples/catch-block-scope/main.js
@@ -1,0 +1,17 @@
+try {
+	throw 'FAIL';
+} catch (t) {
+	var t = 'PASS';
+	assert.strictEqual(t, 'PASS');
+}
+
+let a = 1;
+let def = 'PASS2';
+try {
+	throw ['FAIL2', 'PASS1'];
+} catch ({ [a]: b, 3: d = def }) {
+	let a = 0,
+		def = 'FAIL3';
+	assert.strictEqual(b, 'PASS1');
+	assert.strictEqual(d, 'PASS2');
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4096 
Resolves #4106 

### Description
There was a scoping issue in catch scopes that could lead to incorrect variable associations, see the linked issues. The implemented logic now works like this:
* The body of a catch clause now receives a block scope so that block scoped declarations do not seep into surrounding scopes, including the parameter scope
* Hoisted declarations inside the catch clause that do not match a parameter name will be hoisted to the surrounding scope (as before)
* Hoisted declarations that DO match a parameter will instead be associated with the parameter and are not hoisted to the outside (this is new and indeed correct)