### PR TITLE
Always request a new tree-shaking pass when deoptimizations are performed

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -109,6 +109,7 @@ export interface AstContext {
 	moduleContext: string;
 	nodeConstructors: { [name: string]: typeof NodeBase };
 	options: NormalizedInputOptions;
+	requestTreeshakingPass: () => void;
 	traceExport: (name: string) => Variable | null;
 	traceVariable: (name: string) => Variable | null;
 	usesTopLevelAwait: boolean;
@@ -726,6 +727,7 @@ export default class Module {
 			moduleContext: this.context,
 			nodeConstructors,
 			options: this.options,
+			requestTreeshakingPass: () => (this.graph.needsTreeshakingPass = true),
 			traceExport: this.getVariableForExportName.bind(this),
 			traceVariable: this.traceVariable.bind(this),
 			usesTopLevelAwait: false,

--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -126,5 +126,6 @@ export default class AssignmentExpression extends NodeBase {
 		this.deoptimized = true;
 		this.left.deoptimizePath(EMPTY_PATH);
 		this.right.deoptimizePath(UNKNOWN_PATH);
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -48,5 +48,6 @@ export default class AssignmentPattern extends NodeBase implements PatternNode {
 		this.deoptimized = true;
 		this.left.deoptimizePath(EMPTY_PATH);
 		this.right.deoptimizePath(UNKNOWN_PATH);
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -298,6 +298,7 @@ export default class CallExpression extends NodeBase implements DeoptimizableEnt
 			// This will make sure all properties of parameters behave as "unknown"
 			argument.deoptimizePath(UNKNOWN_PATH);
 		}
+		this.context.requestTreeshakingPass();
 	}
 
 	private getReturnExpression(

--- a/src/ast/nodes/ForInStatement.ts
+++ b/src/ast/nodes/ForInStatement.ts
@@ -65,5 +65,6 @@ export default class ForInStatement extends StatementBase {
 	protected applyDeoptimizations(): void {
 		this.deoptimized = true;
 		this.left.deoptimizePath(EMPTY_PATH);
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/src/ast/nodes/ForOfStatement.ts
+++ b/src/ast/nodes/ForOfStatement.ts
@@ -50,5 +50,6 @@ export default class ForOfStatement extends StatementBase {
 	protected applyDeoptimizations(): void {
 		this.deoptimized = true;
 		this.left.deoptimizePath(EMPTY_PATH);
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -178,6 +178,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 		this.deoptimized = true;
 		if (this.variable !== null && this.variable instanceof LocalVariable) {
 			this.variable.consolidateInitializers();
+			this.context.requestTreeshakingPass();
 		}
 	}
 

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -329,6 +329,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 					SHARED_RECURSION_TRACKER
 				);
 			}
+			this.context.requestTreeshakingPass();
 		}
 	}
 

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -46,5 +46,6 @@ export default class NewExpression extends NodeBase {
 			// This will make sure all properties of parameters behave as "unknown"
 			argument.deoptimizePath(UNKNOWN_PATH);
 		}
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -46,6 +46,7 @@ export default class Property extends MethodBase implements PatternNode {
 		this.deoptimized = true;
 		if (this.declarationInit !== null) {
 			this.declarationInit.deoptimizePath([UnknownKey, UnknownKey]);
+			this.context.requestTreeshakingPass();
 		}
 	}
 }

--- a/src/ast/nodes/RestElement.ts
+++ b/src/ast/nodes/RestElement.ts
@@ -37,6 +37,7 @@ export default class RestElement extends NodeBase implements PatternNode {
 		this.deoptimized = true;
 		if (this.declarationInit !== null) {
 			this.declarationInit.deoptimizePath([UnknownKey, UnknownKey]);
+			this.context.requestTreeshakingPass();
 		}
 	}
 }

--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -30,5 +30,6 @@ export default class SpreadElement extends NodeBase {
 		// Only properties of properties of the argument could become subject to reassignment
 		// This will also reassign the return values of iterators
 		this.argument.deoptimizePath([UnknownKey, UnknownKey]);
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/src/ast/nodes/UnaryExpression.ts
+++ b/src/ast/nodes/UnaryExpression.ts
@@ -59,6 +59,7 @@ export default class UnaryExpression extends NodeBase {
 		this.deoptimized = true;
 		if (this.operator === 'delete') {
 			this.argument.deoptimizePath(EMPTY_PATH);
+			this.context.requestTreeshakingPass();
 		}
 	}
 }

--- a/src/ast/nodes/UpdateExpression.ts
+++ b/src/ast/nodes/UpdateExpression.ts
@@ -87,5 +87,6 @@ export default class UpdateExpression extends NodeBase {
 			const variable = this.scope.findVariable(this.argument.name);
 			variable.isReassigned = true;
 		}
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/src/ast/nodes/YieldExpression.ts
+++ b/src/ast/nodes/YieldExpression.ts
@@ -30,6 +30,10 @@ export default class YieldExpression extends NodeBase {
 
 	protected applyDeoptimizations(): void {
 		this.deoptimized = true;
-		this.argument?.deoptimizePath(UNKNOWN_PATH);
+		const { argument } = this;
+		if (argument) {
+			argument.deoptimizePath(UNKNOWN_PATH);
+			this.context.requestTreeshakingPass();
+		}
 	}
 }

--- a/test/function/samples/deoptimize-request-treeshaking-pass/_config.js
+++ b/test/function/samples/deoptimize-request-treeshaking-pass/_config.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const result = { value: 0 };
+
+module.exports = {
+	description: 'makes sure to request additional passes when a variable is deoptimized',
+	context: { result },
+	exports() {
+		assert.strictEqual(result.value, 2);
+	}
+};

--- a/test/function/samples/deoptimize-request-treeshaking-pass/main.js
+++ b/test/function/samples/deoptimize-request-treeshaking-pass/main.js
@@ -1,0 +1,17 @@
+function heisenbug() {
+	var a = false;
+	function f(b) {
+		if (a) a === b.c ? result.value++ : result.value--;
+		a = b.c;
+	}
+	function g() {}
+	function h() {
+		f({
+			c: g
+		});
+	}
+	h();
+	h();
+}
+heisenbug();
+heisenbug();


### PR DESCRIPTION
… are first included

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4097

### Description
Now that all deoptimizations happen lazily, there is a now class of issues that can arise, notably when during a tree-shaking pass, no new variables are included but some nodes perform deoptimizations for the first time.
Previously, new passes were only triggered when new variables were included. This has been changed to also trigger new passes when deoptimizations are applied.
