### PR TITLE
Actually set the prototype when using a __proto__ property

### DIFF
--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -17,12 +17,7 @@ import Literal from './Literal';
 import * as NodeType from './NodeType';
 import Property from './Property';
 import SpreadElement from './SpreadElement';
-import {
-	ExpressionEntity,
-	LiteralValueOrUnknown,
-	UNKNOWN_EXPRESSION,
-	UnknownValue
-} from './shared/Expression';
+import { ExpressionEntity, LiteralValueOrUnknown, UnknownValue } from './shared/Expression';
 import { NodeBase } from './shared/Node';
 import { ObjectEntity, ObjectProperty } from './shared/ObjectEntity';
 import { OBJECT_PROTOTYPE } from './shared/ObjectPrototype';
@@ -112,6 +107,7 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 		if (this.objectEntity !== null) {
 			return this.objectEntity;
 		}
+		let prototype: ExpressionEntity | null = OBJECT_PROTOTYPE;
 		const properties: ObjectProperty[] = [];
 		for (const property of this.properties) {
 			if (property instanceof SpreadElement) {
@@ -137,12 +133,15 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 						? property.key.name
 						: String((property.key as Literal).value);
 				if (key === '__proto__' && property.kind === 'init') {
-					properties.unshift({ key: UnknownKey, kind: 'init', property: UNKNOWN_EXPRESSION });
+					prototype =
+						property.value instanceof Literal && property.value.value === null
+							? null
+							: property.value;
 					continue;
 				}
 			}
 			properties.push({ key, kind: property.kind, property });
 		}
-		return (this.objectEntity = new ObjectEntity(properties, OBJECT_PROTOTYPE));
+		return (this.objectEntity = new ObjectEntity(properties, prototype));
 	}
 }

--- a/test/form/samples/proto-null/_config.js
+++ b/test/form/samples/proto-null/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles getters and setters on __proto__ properties'
+};

--- a/test/form/samples/proto-null/_expected.js
+++ b/test/form/samples/proto-null/_expected.js
@@ -1,0 +1,2 @@
+console.log('retained');
+console.log('retained');

--- a/test/form/samples/proto-null/main.js
+++ b/test/form/samples/proto-null/main.js
@@ -1,0 +1,5 @@
+const a = { __proto__: null };
+if (a.hasOwnProperty) console.log('removed');
+else console.log('retained');
+if (a.foo) console.log('removed');
+else console.log('retained');

--- a/test/function/samples/proto-accessors/_config.js
+++ b/test/function/samples/proto-accessors/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles getters and setters on __proto__ properties'
+};

--- a/test/function/samples/proto-accessors/main.js
+++ b/test/function/samples/proto-accessors/main.js
@@ -1,0 +1,21 @@
+let getter_effect = 'FAIL';
+let setter_effect = 'FAIL';
+let proto = {
+	get foo() {
+		getter_effect = 'PASS';
+	},
+	set bar(value) {
+		setter_effect = 'PASS';
+	}
+};
+let obj1 = {
+	__proto__: proto
+};
+let obj2 = {
+	__proto__: proto
+};
+let unused = obj1.foo;
+obj2.bar = 0;
+
+assert.strictEqual(getter_effect, 'PASS');
+assert.strictEqual(setter_effect, 'PASS');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4094 

### Description
This replaces the clunky logic that was previously used for `__proto__` object literal properties by actually setting the prototype when such a property is encountered. This will immediately add support for accessors on the new prototype. There is special handling for the case where the property is the literal `null`. Only in this case, a prototype-free object will be created: [REPL](https://rollupjs.org/repl/?pr=4112&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmNvbnN0JTIwZm9vJTIwJTNEJTIwJTdCX19wcm90b19fJTNBJTIwbnVsbCU3RCUzQiU1Q25pZiUyMChmb28uaGFzT3duUHJvcGVydHkpJTIwY29uc29sZS5sb2coJ2dvbmUnKSUzQiU1Q24lNUNuY29uc3QlMjBiYXIlMjAlM0QlMjAlN0IlN0QlM0IlNUNuaWYlMjAoYmFyLmhhc093blByb3BlcnR5KSUyMGNvbnNvbGUubG9nKCdyZXRhaW5lZCcpJTNCJTIyJTJDJTIyaXNFbnRyeSUyMiUzQXRydWUlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyZm9ybWF0JTIyJTNBJTIyZXMlMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlMkMlMjJhbWQlMjIlM0ElN0IlMjJpZCUyMiUzQSUyMiUyMiU3RCUyQyUyMmdsb2JhbHMlMjIlM0ElN0IlN0QlN0QlMkMlMjJleGFtcGxlJTIyJTNBbnVsbCU3RA==)

In all other cases, the expression given is used as prototype. As far as I can see, this should only lead to unnecessary but harmless deoptimizations in cases when e.g. `undefined` is provided (as then all prototype property accesses should just be treated as side effects).