### PR TITLE
Track access side effects when using object spread operator

### DIFF
--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,5 +1,6 @@
+import { HasEffectsContext } from '../ExecutionContext';
 import { NodeEvent } from '../NodeEvents';
-import { ObjectPath, PathTracker, UnknownKey } from '../utils/PathTracker';
+import { ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
 import * as NodeType from './NodeType';
 import { ExpressionEntity } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
@@ -23,6 +24,13 @@ export default class SpreadElement extends NodeBase {
 				recursionTracker
 			);
 		}
+	}
+
+	hasEffects(context: HasEffectsContext): boolean {
+		return (
+			this.argument.hasEffects(context) ||
+			this.argument.hasEffectsWhenAccessedAtPath(UNKNOWN_PATH, context)
+		);
 	}
 
 	protected applyDeoptimizations(): void {

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -23,7 +23,7 @@ module.exports = {
                 format: 'es'
               }
             }),
-          500
+          1000
         );
       });
   		`

--- a/test/function/samples/object-spread-side-effect/_config.js
+++ b/test/function/samples/object-spread-side-effect/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'triggers getter side effects when spreading objects'
+};

--- a/test/function/samples/object-spread-side-effect/main.js
+++ b/test/function/samples/object-spread-side-effect/main.js
@@ -1,0 +1,9 @@
+let result = 'FAIL';
+const unused = {
+	...{
+		get prop() {
+			result = 'PASS';
+		}
+	}
+};
+assert.strictEqual(result, 'PASS');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4093 

### Description
This will additionally check for getter side effects when using the spread operator on an object.