### PR TITLE
fix: use `colorette` instead of `turbocolor` #3391

### DIFF
--- a/scripts/perf.js
+++ b/scripts/perf.js
@@ -2,8 +2,8 @@
 
 const fs = require('fs');
 const path = require('path');
+const colorette = require('colorette');
 const prettyBytes = require('pretty-bytes');
-const tc = require('turbocolor');
 const rollup = require('../dist/rollup.js');
 const { loadPerfConfig, targetDir } = require('./load-perf-config');
 
@@ -27,10 +27,10 @@ if (!(numberOfDiscardedResults >= 0) || !(numberOfDiscardedResults < numberOfRun
 	process.exit(1);
 }
 console.info(
-	tc.bold(
-		`Calculating the average of ${tc.cyan(numberOfRunsToAverage)} runs discarding the ${tc.cyan(
-			numberOfDiscardedResults
-		)} largest results.\n`
+	colorette.bold(
+		`Calculating the average of ${colorette.cyan(
+			numberOfRunsToAverage
+		)} runs discarding the ${colorette.cyan(numberOfDiscardedResults)} largest results.\n`
 	) + 'Run "npm run perf <number of runs> <number of discarded results>" to change that.'
 );
 
@@ -111,9 +111,9 @@ function printMeasurements(average, existingAverage, filter = /.*/) {
 	printedLabels.forEach(label => {
 		let color = text => text;
 		if (label[0] === '#') {
-			color = tc.bold;
+			color = colorette.bold;
 			if (label[1] !== '#') {
-				color = tc.underline;
+				color = colorette.underline;
 			}
 		}
 		console.info(
@@ -139,7 +139,9 @@ function getExistingTimings() {
 	try {
 		const timings = JSON.parse(fs.readFileSync(perfFile, 'utf8'));
 		console.info(
-			tc.bold(`Comparing with ${tc.cyan(perfFile)}. Delete this file to create a new base line.`)
+			colorette.bold(
+				`Comparing with ${colorette.cyan(perfFile)}. Delete this file to create a new base line.`
+			)
 		);
 		return timings;
 	} catch (e) {
@@ -151,10 +153,14 @@ function persistTimings(timings) {
 	try {
 		fs.writeFileSync(perfFile, JSON.stringify(timings, null, 2), 'utf8');
 		console.info(
-			tc.bold(`Saving performance information to new reference file ${tc.cyan(perfFile)}.`)
+			colorette.bold(
+				`Saving performance information to new reference file ${colorette.cyan(perfFile)}.`
+			)
 		);
 	} catch (e) {
-		console.error(tc.bold(`Could not persist performance information in ${tc.cyan(perfFile)}.`));
+		console.error(
+			colorette.bold(`Could not persist performance information in ${colorette.cyan(perfFile)}.`)
+		);
 		process.exit(1);
 	}
 }
@@ -173,7 +179,7 @@ function getFormattedTime(currentTime, persistedTime = currentTime) {
 			0
 		)}ms, ${sign}${relativeDeviation.toFixed(1)}%)`;
 		if (relativeDeviation > RELATIVE_DEVIATION_FOR_COLORING) {
-			color = currentTime >= persistedTime ? tc.red : tc.green;
+			color = currentTime >= persistedTime ? colorette.red : colorette.green;
 		}
 	}
 	return color(formattedTime);
@@ -187,7 +193,7 @@ function getFormattedMemory(currentMemory, persistedMemory = currentMemory) {
 	const relativeDeviation = 100 * (absoluteDeviation / persistedMemory);
 	if (relativeDeviation > RELATIVE_DEVIATION_FOR_COLORING) {
 		formattedMemory += ` (${sign}${relativeDeviation.toFixed(0)}%)`;
-		color = currentMemory >= persistedMemory ? tc.red : tc.green;
+		color = currentMemory >= persistedMemory ? colorette.red : colorette.green;
 	}
 	return color(formattedMemory);
 }


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

### Description

`turbocolor` has been replaced with `colorette` in https://github.com/rollup/rollup/pull/3391, for now it is still used in `perf.js` file
