### PR TITLE
Respect propertyReadSideEffects in spread elements

### DIFF
--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,3 +1,4 @@
+import { NormalizedTreeshakingOptions } from '../../rollup/types';
 import { HasEffectsContext } from '../ExecutionContext';
 import { NodeEvent } from '../NodeEvents';
 import { ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
@@ -27,9 +28,14 @@ export default class SpreadElement extends NodeBase {
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {
+		if (!this.deoptimized) this.applyDeoptimizations();
+		const { propertyReadSideEffects } = this.context.options
+			.treeshake as NormalizedTreeshakingOptions;
 		return (
 			this.argument.hasEffects(context) ||
-			this.argument.hasEffectsWhenAccessedAtPath(UNKNOWN_PATH, context)
+			(propertyReadSideEffects &&
+				(propertyReadSideEffects === 'always' ||
+					this.argument.hasEffectsWhenAccessedAtPath(UNKNOWN_PATH, context)))
 		);
 	}
 

--- a/test/form/samples/ignore-property-access-side-effects/main.js
+++ b/test/form/samples/ignore-property-access-side-effects/main.js
@@ -1,6 +1,6 @@
 const getter = {
-	get foo () {
-		console.log( 'effect' );
+	get foo() {
+		console.log('effect');
 	}
 };
 const foo1 = getter.foo;
@@ -13,4 +13,22 @@ function accessArg(arg) {
 }
 accessArg(null);
 
-const foo4 = globalThis.globalThis.unknown.unknownProperty;
+const foo4 = globalThis.unknown.unknownProperty;
+
+const foo5 = {
+	...{
+		get prop() {
+			console.log('effect');
+		}
+	}
+};
+
+const foo6 = (async function () {
+	await {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+	return { then() {} };
+})();

--- a/test/form/samples/keep-property-access-side-effects/_expected.js
+++ b/test/form/samples/keep-property-access-side-effects/_expected.js
@@ -14,3 +14,21 @@ function accessArg(arg) {
 accessArg(null);
 
 globalThis.unknown.unknownProperty;
+
+({
+	...{
+		get prop() {
+			console.log('effect');
+		}
+	}
+});
+
+((async function () {
+	await {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+	return { then() {} };
+}))();

--- a/test/form/samples/keep-property-access-side-effects/main.js
+++ b/test/form/samples/keep-property-access-side-effects/main.js
@@ -14,3 +14,21 @@ function accessArg(arg) {
 accessArg(null);
 
 const foo4 = globalThis.unknown.unknownProperty;
+
+const foo5 = {
+	...{
+		get prop() {
+			console.log('effect');
+		}
+	}
+};
+
+const foo6 = (async function () {
+	await {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+	return { then() {} };
+})();


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
#4113

### Description
In #4113, we introduced a check for property access side effects when using spread operators. This check was always applied. This PR changes this by respecting `treeshake.propertyReadSideEffects: false`.