### PR TITLE
Detect async arrow thenable side effects

### DIFF
--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,3 +1,4 @@
+import { NormalizedTreeshakingOptions } from '../../rollup/types';
 import { HasEffectsContext } from '../ExecutionContext';
 import { NodeEvent } from '../NodeEvents';
 import { ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
@@ -27,9 +28,14 @@ export default class SpreadElement extends NodeBase {
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {
+		if (!this.deoptimized) this.applyDeoptimizations();
+		const { propertyReadSideEffects } = this.context.options
+			.treeshake as NormalizedTreeshakingOptions;
 		return (
 			this.argument.hasEffects(context) ||
-			this.argument.hasEffectsWhenAccessedAtPath(UNKNOWN_PATH, context)
+			(propertyReadSideEffects &&
+				(propertyReadSideEffects === 'always' ||
+					this.argument.hasEffectsWhenAccessedAtPath(UNKNOWN_PATH, context)))
 		);
 	}
 

--- a/test/form/samples/async-function-effects/_config.js
+++ b/test/form/samples/async-function-effects/_config.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 module.exports = {
 	description: 'tracks effects when awaiting thenables'
 };

--- a/test/form/samples/async-function-effects/_expected.js
+++ b/test/form/samples/async-function-effects/_expected.js
@@ -7,9 +7,45 @@
 })();
 
 (async function () {
+	return {
+		get then() {
+			console.log(2);
+			return () => {};
+		}
+	};
+})();
+
+(async function () {
+	return {
+		get then() {
+			return () => console.log(3);
+		}
+	};
+})();
+
+(async () => ({
+	then() {
+		console.log(4);
+	}
+}))();
+
+(async () => ({
+	get then() {
+		console.log(5);
+		return () => {};
+	}
+}))();
+
+(async () => ({
+	get then() {
+		return () => console.log(6);
+	}
+}))();
+
+(async function () {
 	await {
 		then: function () {
-			console.log(2);
+			console.log(7);
 		}
 	};
 	return { then() {} };
@@ -18,7 +54,7 @@
 (async function () {
 	await {
 		get then() {
-			console.log(3);
+			console.log(8);
 			return () => {};
 		}
 	};
@@ -28,7 +64,7 @@
 (async function () {
 	await {
 		get then() {
-			return () => console.log(4);
+			return () => console.log(9);
 		}
 	};
 	return { then() {} };
@@ -39,7 +75,7 @@
 		then(resolve) {
 			resolve({
 				then() {
-					console.log(5);
+					console.log(10);
 				}
 			});
 		}
@@ -53,13 +89,13 @@ async function asyncIdentity(x) {
 
 asyncIdentity({}); // no side effects - may be dropped
 
-const promise = asyncIdentity(6);
+const promise = asyncIdentity(11);
 
 promise.then(x => console.log(x));
 
 asyncIdentity({
 	then(success, fail) {
-		success(console.log(7));
+		success(console.log(12));
 	}
 });
 
@@ -67,7 +103,7 @@ asyncIdentity({
 	then(resolve) {
 		resolve({
 			then() {
-				console.log(8);
+				console.log(13);
 			}
 		});
 	}

--- a/test/form/samples/async-function-effects/main.js
+++ b/test/form/samples/async-function-effects/main.js
@@ -12,9 +12,66 @@
 })();
 
 (async function () {
+	return {
+		get then() {
+			console.log(2);
+			return () => {};
+		}
+	};
+})();
+
+(async function () {
+	return {
+		get then() {
+			return () => console.log(3);
+		}
+	};
+})();
+
+// removed
+(async function () {
+	return {
+		get then() {
+			return () => {};
+		}
+	};
+})();
+
+(async () => ({
+	then() {
+		console.log(4);
+	}
+}))();
+
+// removed
+(async () => ({
+	then() {}
+}))();
+
+(async () => ({
+	get then() {
+		console.log(5);
+		return () => {};
+	}
+}))();
+
+(async () => ({
+	get then() {
+		return () => console.log(6);
+	}
+}))();
+
+// removed
+(async () => ({
+	get then() {
+		return () => {};
+	}
+}))();
+
+(async function () {
 	await {
 		then: function () {
-			console.log(2);
+			console.log(7);
 		}
 	};
 	return { then() {} };
@@ -31,7 +88,7 @@
 (async function () {
 	await {
 		get then() {
-			console.log(3);
+			console.log(8);
 			return () => {};
 		}
 	};
@@ -41,7 +98,7 @@
 (async function () {
 	await {
 		get then() {
-			return () => console.log(4);
+			return () => console.log(9);
 		}
 	};
 	return { then() {} };
@@ -62,7 +119,7 @@
 		then(resolve) {
 			resolve({
 				then() {
-					console.log(5);
+					console.log(10);
 				}
 			});
 		}
@@ -76,13 +133,13 @@ async function asyncIdentity(x) {
 
 asyncIdentity({}); // no side effects - may be dropped
 
-const promise = asyncIdentity(6);
+const promise = asyncIdentity(11);
 
 promise.then(x => console.log(x));
 
 asyncIdentity({
 	then(success, fail) {
-		success(console.log(7));
+		success(console.log(12));
 	}
 });
 
@@ -90,7 +147,7 @@ asyncIdentity({
 	then(resolve) {
 		resolve({
 			then() {
-				console.log(8);
+				console.log(13);
 			}
 		});
 	}

--- a/test/form/samples/ignore-property-access-side-effects/main.js
+++ b/test/form/samples/ignore-property-access-side-effects/main.js
@@ -24,6 +24,22 @@ const foo5 = {
 };
 
 const foo6 = (async function () {
+	return {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+})();
+
+const foo7 = (async () => ({
+	get then() {
+		console.log('effect');
+		return () => {};
+	}
+}))();
+
+const foo8 = (async function () {
 	await {
 		get then() {
 			console.log('effect');

--- a/test/form/samples/ignore-property-access-side-effects/main.js
+++ b/test/form/samples/ignore-property-access-side-effects/main.js
@@ -1,6 +1,6 @@
 const getter = {
-	get foo () {
-		console.log( 'effect' );
+	get foo() {
+		console.log('effect');
 	}
 };
 const foo1 = getter.foo;
@@ -13,4 +13,22 @@ function accessArg(arg) {
 }
 accessArg(null);
 
-const foo4 = globalThis.globalThis.unknown.unknownProperty;
+const foo4 = globalThis.unknown.unknownProperty;
+
+const foo5 = {
+	...{
+		get prop() {
+			console.log('effect');
+		}
+	}
+};
+
+const foo6 = (async function () {
+	await {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+	return { then() {} };
+})();

--- a/test/form/samples/keep-property-access-side-effects/_expected.js
+++ b/test/form/samples/keep-property-access-side-effects/_expected.js
@@ -14,3 +14,21 @@ function accessArg(arg) {
 accessArg(null);
 
 globalThis.unknown.unknownProperty;
+
+({
+	...{
+		get prop() {
+			console.log('effect');
+		}
+	}
+});
+
+((async function () {
+	await {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+	return { then() {} };
+}))();

--- a/test/form/samples/keep-property-access-side-effects/_expected.js
+++ b/test/form/samples/keep-property-access-side-effects/_expected.js
@@ -1,6 +1,6 @@
 const getter = {
-	get foo () {
-		console.log( 'effect' );
+	get foo() {
+		console.log('effect');
 	}
 };
 getter.foo;
@@ -22,6 +22,22 @@ globalThis.unknown.unknownProperty;
 		}
 	}
 });
+
+((async function () {
+	return {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+}))();
+
+(async () => ({
+	get then() {
+		console.log('effect');
+		return () => {};
+	}
+}))();
 
 ((async function () {
 	await {

--- a/test/form/samples/keep-property-access-side-effects/main.js
+++ b/test/form/samples/keep-property-access-side-effects/main.js
@@ -1,6 +1,6 @@
 const getter = {
-	get foo () {
-		console.log( 'effect' );
+	get foo() {
+		console.log('effect');
 	}
 };
 const foo1 = getter.foo;
@@ -24,6 +24,22 @@ const foo5 = {
 };
 
 const foo6 = (async function () {
+	return {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+})();
+
+const foo7 = (async () => ({
+	get then() {
+		console.log('effect');
+		return () => {};
+	}
+}))();
+
+const foo8 = (async function () {
 	await {
 		get then() {
 			console.log('effect');

--- a/test/form/samples/keep-property-access-side-effects/main.js
+++ b/test/form/samples/keep-property-access-side-effects/main.js
@@ -14,3 +14,21 @@ function accessArg(arg) {
 accessArg(null);
 
 const foo4 = globalThis.unknown.unknownProperty;
+
+const foo5 = {
+	...{
+		get prop() {
+			console.log('effect');
+		}
+	}
+};
+
+const foo6 = (async function () {
+	await {
+		get then() {
+			console.log('effect');
+			return () => {};
+		}
+	};
+	return { then() {} };
+})();

--- a/test/function/samples/async-function-return/_config.js
+++ b/test/function/samples/async-function-return/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'uses the correct return value for async functions'
+};

--- a/test/function/samples/async-function-return/main.js
+++ b/test/function/samples/async-function-return/main.js
@@ -1,0 +1,9 @@
+const foo = async function () {
+	return false;
+};
+const fooResult = foo();
+assert.strictEqual(fooResult ? 'retained' : 'ignored', 'retained');
+
+const bar = async () => false;
+const barResult = bar();
+assert.strictEqual(barResult ? 'retained' : 'ignored', 'retained');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4116

### Description
This will also detect side effects from accessing the `then` property or calling it when executing an async arrow function.
