### PR TITLE
Retain TDZ violations in common scenarios and fix similar `var` bugs

### DIFF
--- a/test/form/samples/tdz-common/_config.js
+++ b/test/form/samples/tdz-common/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'preserve common TDZ violations'
+};

--- a/test/form/samples/tdz-common/_expected.js
+++ b/test/form/samples/tdz-common/_expected.js
@@ -1,0 +1,29 @@
+console.log(function() {
+	if (x) return "HELLO"; // TDZ
+	const x = 1;           // keep
+}());
+
+const C = 1 + C + 2; // TDZ
+let L = L;           // TDZ
+var V = V;           // TODO: uncommon scenario, but should be dropped
+console.log("X+" ); // optimize
+
+console.log(Y ? "Y+" : "Y-"); // TDZ
+const Y = 2;                  // keep
+
+console.log(Z ? "Z+" : "Z-"); // TDZ
+const Z = 3;                  // keep
+console.log("Z+" ); // keep
+
+console.log(obj.x.y ? 1 : 2); // TDZ
+const obj = {                 // keep
+	x: {
+		y: true
+	}
+};
+console.log(3 ); // keep
+
+L2;              // TDZ for L2
+L3 = 20;    // TDZ for L3
+let L2, L3;  // keep L2, L3
+L3 = 30;             // keep

--- a/test/form/samples/tdz-common/_expected.js
+++ b/test/form/samples/tdz-common/_expected.js
@@ -27,3 +27,14 @@ L2;              // TDZ for L2
 L3 = 20;    // TDZ for L3
 let L2, L3;  // keep L2, L3
 L3 = 30;             // keep
+
+// Note that typical var/const/let use is still optimized
+(function() {
+	console.log(A ? "A" : "!A");
+	var A = 1;
+	console.log("A" );
+	console.log("B");
+	console.log("B" );
+	console.log("C" );
+	console.log("D" );
+})();

--- a/test/form/samples/tdz-common/main.js
+++ b/test/form/samples/tdz-common/main.js
@@ -1,0 +1,39 @@
+console.log(function() {
+	if (x) return "HELLO"; // TDZ
+	const x = 1;           // keep
+	return "WORLD";        // not reached
+}());
+
+const unused1 = 1;   // drop
+let unused2 = 2;     // drop
+var unused3 = 3;     // drop
+
+const C = 1 + C + 2; // TDZ
+let L = L;           // TDZ
+var V = V;           // TODO: uncommon scenario, but should be dropped
+
+const X = 1;                  // drop
+console.log(X ? "X+" : "X-"); // optimize
+
+console.log(Y ? "Y+" : "Y-"); // TDZ
+const Y = 2;                  // keep
+
+console.log(Z ? "Z+" : "Z-"); // TDZ
+const Z = 3;                  // keep
+console.log(Z ? "Z+" : "Z-"); // keep
+
+console.log(obj.x.y ? 1 : 2); // TDZ
+const obj = {                 // keep
+	x: {
+		y: true
+	}
+};
+console.log(obj.x.y ? 3 : 4); // keep
+
+V2, L2;              // TDZ for L2
+var V2;              // drop
+V3 = 10, L3 = 20;    // TDZ for L3
+let L1, L2, L3, L4;  // keep L2, L3
+var V3;              // drop
+L3 = 30;             // keep
+L4 = 40;             // drop

--- a/test/form/samples/tdz-common/main.js
+++ b/test/form/samples/tdz-common/main.js
@@ -37,3 +37,17 @@ let L1, L2, L3, L4;  // keep L2, L3
 var V3;              // drop
 L3 = 30;             // keep
 L4 = 40;             // drop
+
+// Note that typical var/const/let use is still optimized
+(function() {
+	console.log(A ? "A" : "!A");
+	var A = 1, B = 2;
+	const C = 3;
+	let D = 4;
+	console.log(A ? "A" : "!A");
+	if (B) console.log("B");
+	else console.log("!B");
+	console.log(B ? "B" : "!B");
+	console.log(C ? "C" : "!C");
+	console.log(D ? "D" : "!D");
+})();

--- a/test/function/samples/use-var-before-decl/_config.js
+++ b/test/function/samples/use-var-before-decl/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'exercise `var` variables before their declarations'
+};

--- a/test/function/samples/use-var-before-decl/main.js
+++ b/test/function/samples/use-var-before-decl/main.js
@@ -36,4 +36,12 @@ log(c ? "PASS5" : "FAIL5");
 })();
 */
 
+/* TODO: previously existing bug still fails, but in a different way
+	log(function() {
+		if (x) return "HELLO";
+		var x = 1;
+		return "WORLD";
+	}());
+*/
+
 assert.strictEqual(results.join(" "), "PASS1 PASS2 PASS3 PASS4 PASS5");

--- a/test/function/samples/use-var-before-decl/main.js
+++ b/test/function/samples/use-var-before-decl/main.js
@@ -1,0 +1,39 @@
+var results = [], log = x => results.push(x);
+
+(function () {
+	var a = "PASS1";
+	for (var b = 2; --b >= 0; ) {
+		(function() {
+			var c = function() {
+				return 1;
+			}(c && (a = "FAIL1"));
+		})();
+	}
+	log(a);
+})();
+
+log(a ? "FAIL2" : "PASS2");
+var a = 1;
+
+var b = 2;
+log(b ? "PASS3" : "FAIL3");
+
+log(c ? "FAIL4" : "PASS4");
+var c = 3;
+log(c ? "PASS5" : "FAIL5");
+
+/* TODO: multi-scope var-use-before-defined bug to be addressed in a future PR
+(function () {
+	var first = state();
+	var on = true;
+	var obj = {
+		state: state
+	};
+	log(first, obj.state());
+	function state() {
+		return on ? "ON" : "OFF";
+	}
+})();
+*/
+
+assert.strictEqual(results.join(" "), "PASS1 PASS2 PASS3 PASS4 PASS5");


### PR DESCRIPTION
Retain TDZ violations in some common scenarios and fix similar `var` bugs.

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:

Fixes most scenarios in #4101 except for `bug1`, which is a more complex multi-scope problem involving function calls. It will be addressed in a future PR.

### Description

Rollup used to silently mask code related to TDZ violations for `let` and `const` variables, which would produce different runtime behavior without warning. This PR retains the TDZ violating code in many common scenarios to attempt to be bug compatible with the source input. Not coincidentally, the same TDZ logic also fixes a number of bugs related to using `var` variables before their declarations.