### PR TITLE
fix: export `rollup.defineConfig` at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:lint": "npm run lint:nofix",
     "ci:test": "npm run build:cjs && npm run build:bootstrap && npm run test:all",
     "ci:test:only": "npm run build:cjs && npm run build:bootstrap && npm run test:only",
-    "ci:coverage": "npm run build:cjs && nyc --reporter lcovonly mocha",
+    "ci:coverage": "npm run build:cjs && npm run build:bootstrap && nyc --reporter lcovonly mocha",
     "lint": "npx eslint . --fix --cache && npm run lint:markdown",
     "lint:nofix": "npx eslint . && npm run lint:markdown",
     "lint:markdown": "markdownlint --config markdownlint.json docs/**/*.md",

--- a/src/browser-entry.ts
+++ b/src/browser-entry.ts
@@ -1,2 +1,2 @@
-export { default as rollup } from './rollup/rollup';
+export { default as rollup, defineConfig } from './rollup/rollup';
 export { version as VERSION } from 'package.json';

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -1,3 +1,3 @@
-export { default as rollup } from './rollup/rollup';
+export { default as rollup, defineConfig } from './rollup/rollup';
 export { default as watch } from './watch/watch-proxy';
 export { version as VERSION } from 'package.json';

--- a/test/cli/samples/config-defineConfig-cjs/_config.js
+++ b/test/cli/samples/config-defineConfig-cjs/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'uses cjs config file which return config wrapped by defineConfig',
+	command: 'rollup --config rollup.config.js',
+	execute: true
+};

--- a/test/cli/samples/config-defineConfig-cjs/main.js
+++ b/test/cli/samples/config-defineConfig-cjs/main.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/cli/samples/config-defineConfig-cjs/rollup.config.js
+++ b/test/cli/samples/config-defineConfig-cjs/rollup.config.js
@@ -1,0 +1,8 @@
+const { defineConfig } = require("../../../../dist/rollup");
+
+module.exports = defineConfig({
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+});

--- a/test/cli/samples/config-defineConfig-mjs/_config.js
+++ b/test/cli/samples/config-defineConfig-mjs/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'uses mjs config file which return config wrapped by defineConfig',
+	command: 'rollup --config rollup.config.mjs',
+	minNodeVersion: 13,
+	execute: true
+};

--- a/test/cli/samples/config-defineConfig-mjs/main.js
+++ b/test/cli/samples/config-defineConfig-mjs/main.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/cli/samples/config-defineConfig-mjs/rollup.config.mjs
+++ b/test/cli/samples/config-defineConfig-mjs/rollup.config.mjs
@@ -1,0 +1,8 @@
+import { defineConfig } from "../../../../dist/es/rollup.js"
+
+export default defineConfig({
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
- #4133

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR fixes #4133.
I expose `defineConfig` from entrypoint([node-entry.ts](https://github.com/rollup/rollup/pull/4134/files#diff-11288f92b833075d1381a302bbcf49bd4c62b841c0e6f7ecee04868081f90d41R1), [browser-entry.ts](https://github.com/rollup/rollup/pull/4134/files#diff-591f02c4219ff2edf76baf1560952dfbc5c48a021d8391d1168a9624771b860aR1)).
As a result, [type definition](https://github.com/rollup/rollup/blob/master/src/rollup/types.d.ts#L887) and runtime correspond.