### PR TITLE
Make array and object prototype singletons immutable for now

### DIFF
--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -79,10 +79,14 @@ export default class ArrayExpression extends NodeBase {
 		const properties: ObjectProperty[] = [
 			{ key: 'length', kind: 'init', property: UNKNOWN_LITERAL_NUMBER }
 		];
+		let hasSpread = false;
 		for (let index = 0; index < this.elements.length; index++) {
 			const element = this.elements[index];
-			if (element instanceof SpreadElement) {
-				properties.unshift({ key: UnknownInteger, kind: 'init', property: element });
+			if (element instanceof SpreadElement || hasSpread) {
+				if (element) {
+					hasSpread = true;
+					properties.unshift({ key: UnknownInteger, kind: 'init', property: element });
+				}
 			} else if (!element) {
 				properties.push({ key: String(index), kind: 'init', property: UNDEFINED_EXPRESSION });
 			} else {

--- a/src/ast/nodes/shared/ArrayPrototype.ts
+++ b/src/ast/nodes/shared/ArrayPrototype.ts
@@ -148,5 +148,6 @@ export const ARRAY_PROTOTYPE = new ObjectEntity(
 		unshift: METHOD_MUTATES_SELF_RETURNS_NUMBER,
 		values: METHOD_DEOPTS_SELF_RETURNS_UNKNOWN
 	} as unknown as PropertyMap,
-	OBJECT_PROTOTYPE
+	OBJECT_PROTOTYPE,
+	true
 );

--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -137,9 +137,6 @@ export class ObjectEntity extends ExpressionEntity {
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		if (path.length === 0) {
-			return;
-		}
 		const [key, ...subPath] = path;
 
 		if (
@@ -288,7 +285,9 @@ export class ObjectEntity extends ExpressionEntity {
 				return false;
 			}
 			for (const getter of this.unmatchableGetters) {
-				if (getter.hasEffectsWhenAccessedAtPath(subPath, context)) return true;
+				if (getter.hasEffectsWhenAccessedAtPath(subPath, context)) {
+					return true;
+				}
 			}
 		} else {
 			for (const getters of Object.values(this.gettersByKey).concat([this.unmatchableGetters])) {
@@ -320,6 +319,7 @@ export class ObjectEntity extends ExpressionEntity {
 		}
 
 		if (this.hasUnknownDeoptimizedProperty) return true;
+		// We do not need to test for unknown properties as in that case, hasUnknownDeoptimizedProperty is true
 		if (typeof key === 'string') {
 			if (this.propertiesAndSettersByKey[key]) {
 				const setters = this.settersByKey[key];
@@ -331,12 +331,8 @@ export class ObjectEntity extends ExpressionEntity {
 				return false;
 			}
 			for (const property of this.unmatchableSetters) {
-				if (property.hasEffectsWhenAssignedAtPath(subPath, context)) return true;
-			}
-		} else {
-			for (const setters of Object.values(this.settersByKey).concat([this.unmatchableSetters])) {
-				for (const setter of setters) {
-					if (setter.hasEffectsWhenAssignedAtPath(subPath, context)) return true;
+				if (property.hasEffectsWhenAssignedAtPath(subPath, context)) {
+					return true;
 				}
 			}
 		}

--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -400,11 +400,6 @@ export class ObjectEntity extends ExpressionEntity {
 					}
 					if (!propertiesAndGettersByKey[key]) {
 						propertiesAndGettersByKey[key] = [property, ...unmatchablePropertiesAndGetters];
-						if (INTEGER_REG_EXP.test(key)) {
-							for (const integerProperty of unknownIntegerProps) {
-								propertiesAndGettersByKey[key].push(integerProperty);
-							}
-						}
 					}
 				}
 			}

--- a/src/ast/nodes/shared/ObjectPrototype.ts
+++ b/src/ast/nodes/shared/ObjectPrototype.ts
@@ -15,5 +15,6 @@ export const OBJECT_PROTOTYPE = new ObjectEntity(
 		toString: METHOD_RETURNS_STRING,
 		valueOf: METHOD_RETURNS_UNKNOWN
 	} as unknown as PropertyMap,
-	null
+	null,
+	true
 );

--- a/test/form/samples/object-expression/reassign-prop-without-proto/_config.js
+++ b/test/form/samples/object-expression/reassign-prop-without-proto/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'correctly deoptimizes when there is no proto'
+};

--- a/test/form/samples/object-expression/reassign-prop-without-proto/_expected.js
+++ b/test/form/samples/object-expression/reassign-prop-without-proto/_expected.js
@@ -1,0 +1,7 @@
+const obj = { __proto__: null };
+
+obj.flag = true;
+
+if (obj.flag) {
+	console.log('mutated');
+}

--- a/test/form/samples/object-expression/reassign-prop-without-proto/main.js
+++ b/test/form/samples/object-expression/reassign-prop-without-proto/main.js
@@ -1,0 +1,7 @@
+const obj = { __proto__: null };
+
+obj.flag = true;
+
+if (obj.flag) {
+	console.log('mutated');
+}

--- a/test/form/samples/object-expression/unknown-getter-no-side-effect/_config.js
+++ b/test/form/samples/object-expression/unknown-getter-no-side-effect/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'removes unknown getter access without side effect',
+	options: { external: ['external'] }
+};

--- a/test/form/samples/object-expression/unknown-getter-no-side-effect/_expected.js
+++ b/test/form/samples/object-expression/unknown-getter-no-side-effect/_expected.js
@@ -1,0 +1,1 @@
+import 'external';

--- a/test/form/samples/object-expression/unknown-getter-no-side-effect/main.js
+++ b/test/form/samples/object-expression/unknown-getter-no-side-effect/main.js
@@ -1,0 +1,7 @@
+import { unknown } from 'external';
+
+const obj = {
+	get [unknown]() {}
+};
+
+obj.prop;

--- a/test/form/samples/object-expression/unknown-setter-no-side-effect/_config.js
+++ b/test/form/samples/object-expression/unknown-setter-no-side-effect/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'removes unknown setter access without side effect',
+	options: { external: ['external'] }
+};

--- a/test/form/samples/object-expression/unknown-setter-no-side-effect/_expected.js
+++ b/test/form/samples/object-expression/unknown-setter-no-side-effect/_expected.js
@@ -1,0 +1,1 @@
+import 'external';

--- a/test/form/samples/object-expression/unknown-setter-no-side-effect/main.js
+++ b/test/form/samples/object-expression/unknown-setter-no-side-effect/main.js
@@ -1,0 +1,7 @@
+import { unknown } from 'external';
+
+const obj = {
+	set [unknown](value) {}
+};
+
+obj.prop = true;

--- a/test/function/samples/array-double-spread/_config.js
+++ b/test/function/samples/array-double-spread/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'correctly deoptimizes when there is no proto'
+};

--- a/test/function/samples/array-double-spread/main.js
+++ b/test/function/samples/array-double-spread/main.js
@@ -1,0 +1,19 @@
+const a = [false, , true];
+const b = [false, , true, ...a, false, , true, ...a];
+
+let count = 0;
+
+b[0] ? count+= 10: count++;
+b[1] ? count+= 10: count++;
+b[2] ? count+= 10: count++;
+b[3] ? count+= 10: count++;
+b[4] ? count+= 10: count++;
+b[5] ? count+= 10: count++;
+b[6] ? count+= 10: count++;
+b[7] ? count+= 10: count++;
+b[8] ? count+= 10: count++;
+b[9] ? count+= 10: count++;
+b[10] ? count+= 10: count++;
+b[11] ? count+= 10: count++;
+
+assert.strictEqual(count, 48);

--- a/test/function/samples/modify-this-via-getter/unknown-prop-getter/_config.js
+++ b/test/function/samples/modify-this-via-getter/unknown-prop-getter/_config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	description: 'handles unknown getters that modify "this"',
 	context: {
-		require(id) {
+		require() {
 			return { unknown: 'prop' };
 		}
 	},

--- a/test/function/samples/object-deep-access-effect/_config.js
+++ b/test/function/samples/object-deep-access-effect/_config.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'throws when an nested property of an unknown object property is accessed',
+	context: {
+		require() {
+			return { unknown: 'prop' };
+		}
+	},
+	options: {
+		external: ['external']
+	},
+	exports({ expectError }) {
+		assert.throws(expectError, {
+			name: 'TypeError',
+			message: "Cannot read property 'prop' of undefined"
+		});
+	}
+};

--- a/test/function/samples/object-deep-access-effect/main.js
+++ b/test/function/samples/object-deep-access-effect/main.js
@@ -1,0 +1,6 @@
+import { unknown } from 'external';
+
+export function expectError() {
+	const obj = {};
+	obj[unknown].prop;
+}

--- a/test/function/samples/returned-array-mutation/_config.js
+++ b/test/function/samples/returned-array-mutation/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'tracks array mutations'
+};

--- a/test/function/samples/returned-array-mutation/main.js
+++ b/test/function/samples/returned-array-mutation/main.js
@@ -1,0 +1,13 @@
+let push = false;
+
+const getArray = () => {
+	const array = [];
+	if (push) {
+		array.push(true);
+	}
+	return array;
+};
+
+assert.strictEqual(getArray()[0] || false, false);
+push = true;
+assert.strictEqual(getArray()[0] || false, true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4140 

### Description
Currently, Rollup treats the Array and Object prototypes as singletons. This is problematic as we are still using a stateful helper class to implement this, which can lead to a memory leak when used in watch mode. This hopefully improves the situation. Note that in the future, we might rework this again if we ever get to the point that we track mutations of globals.