### PR TITLE
Make sure the initializer of hoisted variables is deoptimized

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,6 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Run tests
-        run: npm test
+        run: npm run ci:test:only
         env:
           CI: true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "shx rm -rf dist && git rev-parse HEAD > .commithash && rollup --config rollup.config.ts --configPlugin typescript && shx cp src/rollup/types.d.ts dist/rollup.d.ts && shx chmod a+x dist/bin/rollup",
     "build:cjs": "shx rm -rf dist && rollup --config rollup.config.ts --configPlugin typescript --configTest && shx cp src/rollup/types.d.ts dist/rollup.d.ts && shx chmod a+x dist/bin/rollup",
-    "build:bootstrap": "dist/bin/rollup --config rollup.config.ts --configPlugin typescript && shx cp src/rollup/types.d.ts dist/rollup.d.ts && shx chmod a+x dist/bin/rollup",
+    "build:bootstrap": "node dist/bin/rollup --config rollup.config.ts --configPlugin typescript && shx cp src/rollup/types.d.ts dist/rollup.d.ts && shx chmod a+x dist/bin/rollup",
     "ci:lint": "npm run lint:nofix",
     "ci:test": "npm run build:cjs && npm run build:bootstrap && npm run test:all",
     "ci:test:only": "npm run build:cjs && npm run build:bootstrap && npm run test:only",

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -9,12 +9,13 @@ import { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import { NodeEvent } from '../NodeEvents';
 import FunctionScope from '../scopes/FunctionScope';
 import { EMPTY_PATH, ObjectPath, PathTracker } from '../utils/PathTracker';
+import { UNDEFINED_EXPRESSION } from '../values';
 import GlobalVariable from '../variables/GlobalVariable';
 import LocalVariable from '../variables/LocalVariable';
 import Variable from '../variables/Variable';
 import * as NodeType from './NodeType';
 import SpreadElement from './SpreadElement';
-import { ExpressionEntity, LiteralValueOrUnknown, UNKNOWN_EXPRESSION } from './shared/Expression';
+import { ExpressionEntity, LiteralValueOrUnknown } from './shared/Expression';
 import { ExpressionNode, NodeBase } from './shared/Node';
 import { PatternNode } from './shared/Pattern';
 
@@ -48,12 +49,11 @@ export default class Identifier extends NodeBase implements PatternNode {
 		const { treeshake } = this.context.options;
 		switch (kind) {
 			case 'var':
-				variable = this.scope.addDeclaration(
-					this,
-					this.context,
-					treeshake && treeshake.correctVarValueBeforeDeclaration ? UNKNOWN_EXPRESSION : init,
-					true
-				);
+				variable = this.scope.addDeclaration(this, this.context, init, true);
+				if (treeshake && treeshake.correctVarValueBeforeDeclaration) {
+					// Necessary to make sure the init is deoptimized. We cannot call deoptimizePath here.
+					this.scope.addDeclaration(this, this.context, UNDEFINED_EXPRESSION, true);
+				}
 				break;
 			case 'function':
 				// in strict mode, functions are only hoisted within a scope but not across block scopes

--- a/src/ast/scopes/BlockScope.ts
+++ b/src/ast/scopes/BlockScope.ts
@@ -13,9 +13,9 @@ export default class BlockScope extends ChildScope {
 		isHoisted: boolean
 	): LocalVariable {
 		if (isHoisted) {
-			// Necessary to make sure the init is deoptimized
-			this.parent.addDeclaration(identifier, context, UNDEFINED_EXPRESSION, isHoisted);
-			return this.parent.addDeclaration(identifier, context, init, isHoisted);
+			this.parent.addDeclaration(identifier, context, init, isHoisted);
+			// Necessary to make sure the init is deoptimized. We cannot call deoptimizePath here.
+			return this.parent.addDeclaration(identifier, context, UNDEFINED_EXPRESSION, isHoisted);
 		} else {
 			return super.addDeclaration(identifier, context, init, false);
 		}

--- a/src/ast/scopes/BlockScope.ts
+++ b/src/ast/scopes/BlockScope.ts
@@ -1,6 +1,7 @@
 import { AstContext } from '../../Module';
 import Identifier from '../nodes/Identifier';
-import { ExpressionEntity, UNKNOWN_EXPRESSION } from '../nodes/shared/Expression';
+import { ExpressionEntity } from '../nodes/shared/Expression';
+import { UNDEFINED_EXPRESSION } from '../values';
 import LocalVariable from '../variables/LocalVariable';
 import ChildScope from './ChildScope';
 
@@ -12,7 +13,9 @@ export default class BlockScope extends ChildScope {
 		isHoisted: boolean
 	): LocalVariable {
 		if (isHoisted) {
-			return this.parent.addDeclaration(identifier, context, UNKNOWN_EXPRESSION, isHoisted);
+			// Necessary to make sure the init is deoptimized
+			this.parent.addDeclaration(identifier, context, UNDEFINED_EXPRESSION, isHoisted);
+			return this.parent.addDeclaration(identifier, context, init, isHoisted);
 		} else {
 			return super.addDeclaration(identifier, context, init, false);
 		}

--- a/src/ast/scopes/CatchScope.ts
+++ b/src/ast/scopes/CatchScope.ts
@@ -16,8 +16,7 @@ export default class CatchScope extends ParameterScope {
 			existingParameter.addDeclaration(identifier, init);
 			return existingParameter;
 		}
-		// as parameters are handled differently, all remaining declarations are
-		// hoisted
+		// as parameters are handled differently, all remaining declarations are hoisted
 		return this.parent.addDeclaration(identifier, context, init, isHoisted);
 	}
 }

--- a/test/form/samples/deoptimize-var-in-hoisted-scopes/_config.js
+++ b/test/form/samples/deoptimize-var-in-hoisted-scopes/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimizes var variables in hoisted scopes'
+};

--- a/test/form/samples/deoptimize-var-in-hoisted-scopes/_expected.js
+++ b/test/form/samples/deoptimize-var-in-hoisted-scopes/_expected.js
@@ -1,0 +1,15 @@
+const obj1 = { flag: false };
+{
+	var foo = obj1;
+	foo.flag = true;
+}
+if (obj1.flag) console.log('retained');
+
+const obj2 = { flag: false };
+try {
+	throw new Error();
+} catch {
+	var foo = obj2;
+	foo.flag = true;
+}
+if (obj2.flag) console.log('retained');

--- a/test/form/samples/deoptimize-var-in-hoisted-scopes/main.js
+++ b/test/form/samples/deoptimize-var-in-hoisted-scopes/main.js
@@ -1,0 +1,15 @@
+const obj1 = { flag: false };
+{
+	var foo = obj1;
+	foo.flag = true;
+}
+if (obj1.flag) console.log('retained');
+
+const obj2 = { flag: false };
+try {
+	throw new Error();
+} catch {
+	var foo = obj2;
+	foo.flag = true;
+}
+if (obj2.flag) console.log('retained');

--- a/test/function/samples/correct-var-before-declaration-deopt/_config.js
+++ b/test/function/samples/correct-var-before-declaration-deopt/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'adds necessary deoptimizations when using treeshake.correctVarBeforeDeclaration',
+	options: {
+		treeshake: { correctVarValueBeforeDeclaration: true }
+	}
+};

--- a/test/function/samples/correct-var-before-declaration-deopt/_expected.js
+++ b/test/function/samples/correct-var-before-declaration-deopt/_expected.js
@@ -1,0 +1,15 @@
+const obj1 = { flag: false };
+{
+	var foo = obj1;
+	foo.flag = true;
+}
+if (obj1.flag) console.log('retained');
+
+const obj2 = { flag: false };
+try {
+	throw new Error();
+} catch {
+	var foo = obj2;
+	foo.flag = true;
+}
+if (obj2.flag) console.log('retained');

--- a/test/function/samples/correct-var-before-declaration-deopt/main.js
+++ b/test/function/samples/correct-var-before-declaration-deopt/main.js
@@ -1,0 +1,7 @@
+const obj = { flag: false };
+var foo = obj;
+foo.flag = true;
+assert.ok(obj.flag ? true : false, 'init deoptimization');
+
+assert.ok(bar ? false : true, 'value deoptimization');
+var bar = true;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4147 
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There was already a logic to deoptimize `var` variables that are defined in nested scopes. This logic deoptimized the value of such variables but forgot to also deoptimize the initializer of those variables. It also deoptimizes initializers when vars are deoptimized via `treeshake.correctVarValueBeforeDeclaration`.
While this is a bug fix, it may prove interesting to see if #4148 will offer a way to handle these things differently. This should not prevent release, however.