### PR TITLE
Only run REPL build on internal branches or when specific label is set

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -50,5 +50,6 @@
 	{ "name": "x⁴ ⋅ hold", "color": "#CFD8DC" },
 	{ "name": "x⁵ ⋅ in progress", "color": "#4CAF50" },
 	{ "name": "x⁶ ⋅ invalid", "color": "#CFD8DC" },
-	{ "name": "x⁷ ⋅ wontfix", "color": "#CFD8DC" }
+	{ "name": "x⁷ ⋅ wontfix", "color": "#CFD8DC" },
+	{ "name": "x8 ⚙️ build repl artefacts", "color": "#4CAF50" }
 ]

--- a/.github/workflows/repl-artefacts.yml
+++ b/.github/workflows/repl-artefacts.yml
@@ -2,9 +2,11 @@ name: Upload REPL artefacts
 
 on:
   pull_request_target:
+    types: [synchronize, opened, reopened, labeled]
 
 jobs:
   upload:
+    if: ${{ github.event.pull_request.head.repo.full_name == 'rollup/rollup' || contains( toJson(github.event.pull_request.labels), 'x8 ⚙️ build repl artefacts' ) }}
     runs-on: ubuntu-latest
     name: Upload
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
 
 jobs:
-  linux14:
+  linux16:
     runs-on: ubuntu-latest
-    name: Node 14 + Coverage (Linux)
+    name: Node 16 + Coverage (Linux)
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Run tests with coverage
@@ -29,16 +29,16 @@ jobs:
         with:
           commit_parent: ${{ github.event.pull_request.head.sha }}
 
-  linux12:
+  linux14:
     runs-on: ubuntu-latest
-    name: Node 12 + Extra Tests (Linux)
+    name: Node 14 + Extra Tests (Linux)
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v2
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '14'
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Lint
@@ -50,16 +50,19 @@ jobs:
         env:
           CI: true
 
-  linux10:
+  linux:
     runs-on: ubuntu-latest
-    name: Node 10 (Linux)
+    strategy:
+      matrix:
+        node: ['10', '12']
+    name: Node ${{ matrix.node }} (Linux)
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v2
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Run tests
@@ -71,7 +74,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node: ['10', '12', '14', '16']
+        node: ['10', '16']
     name: Node ${{ matrix.node }} (Windows)
     steps:
       - name: Configure git line-breaks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+    types: [synchronize, opened, reopened]
 
 jobs:
   linux16:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This will protect the REPL build workflow by only running it on forks if a specific label `x8 ⚙️ build repl artefacts` has been set on a pull request.
