### PR TITLE
remove manual wrapping in bug issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -40,15 +40,10 @@ body:
       description: |
         Issues without minimal reproductions will be closed! Please provide a link to one by:
         1. Using the REPL at https://rollupjs.org/repl/, or
-        2. Using the REPL.it reproduction template at https://repl.it/@rollup/rollup-repro
-          (allows full use of all rollup options and plugins), or
-        3. Provide a minimal repository link (Read https://git.io/fNzHA for instructions).
-          These may take more time to triage than the other options.
+        2. Using the REPL.it reproduction template at https://repl.it/@rollup/rollup-repro (allows full use of all rollup options and plugins), or
+        3. Provide a minimal repository link (Read https://git.io/fNzHA for instructions). These may take more time to triage than the other options.
           
-        For some bugs it this may seem like overkill but believe us, very often what seems like a
-        "clear issue" is actually specific to some details of your setup. Having a runnable
-        reproduction not only "proves" your bug to us but also allows us to spend all our effort
-        fixing the bug instead of struggling to understand your issue.
+        For some bugs it this may seem like overkill but believe us, very often what seems like a "clear issue" is actually specific to some details of your setup. Having a runnable reproduction not only "proves" your bug to us but also allows us to spend all our effort fixing the bug instead of struggling to understand your issue.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [x] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

### Description
Super minor thing I just noticed after the merge. We shouldn't line wrap manually so that it fills the space better in the actual form.