### PR TITLE
Properly handle double reexports from external namespaces

### DIFF
--- a/test/function/samples/double-namespace-reexport/_config.js
+++ b/test/function/samples/double-namespace-reexport/_config.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'handles chained namespace reexports from externals',
+	options: {
+		external: 'external'
+	},
+	context: {
+		require(id) {
+			assert.strictEqual(id, 'external');
+			return { foo: 42 };
+		}
+	},
+	exports({ foo }) {
+		assert.strictEqual(foo, 42);
+	}
+};

--- a/test/function/samples/double-namespace-reexport/first.js
+++ b/test/function/samples/double-namespace-reexport/first.js
@@ -1,0 +1,1 @@
+export * from './second.js';

--- a/test/function/samples/double-namespace-reexport/main.js
+++ b/test/function/samples/double-namespace-reexport/main.js
@@ -1,0 +1,1 @@
+export { foo } from './first.js';

--- a/test/function/samples/double-namespace-reexport/second.js
+++ b/test/function/samples/double-namespace-reexport/second.js
@@ -1,0 +1,1 @@
+export * from 'external';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4158 
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This fixes an issue with the new logic that prefers local namespace reexports over external ones. Basically what was happening that the logic to detect cycles was preventing proper resolution of external namespace reexports if the reexports went over several steps.