### PR TITLE
Deoptimize return values of async functions

### DIFF
--- a/src/ast/nodes/AwaitExpression.ts
+++ b/src/ast/nodes/AwaitExpression.ts
@@ -34,5 +34,6 @@ export default class AwaitExpression extends NodeBase {
 	protected applyDeoptimizations(): void {
 		this.deoptimized = true;
 		this.argument.deoptimizePath(UNKNOWN_PATH);
+		this.context.requestTreeshakingPass();
 	}
 }

--- a/test/function/samples/track-async-arrow-function-return-value/_config.js
+++ b/test/function/samples/track-async-arrow-function-return-value/_config.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'tracks object mutations of async arrow function return values',
+	async exports(exports) {
+		assert.strictEqual(exports.toggled, false);
+		await exports.test();
+		assert.strictEqual(exports.toggled, true);
+	}
+};

--- a/test/function/samples/track-async-arrow-function-return-value/main.js
+++ b/test/function/samples/track-async-arrow-function-return-value/main.js
@@ -1,4 +1,4 @@
-function fn() {
+const fn = async () => {
 	const obj = {
 		test() {
 			if (typeof obj.testfn === 'function') {
@@ -7,12 +7,13 @@ function fn() {
 		}
 	};
 	return obj;
-}
+};
 
 export let toggled = false;
 
 export const test = async function () {
-	const obj = await fn();
-	obj.testfn = () => (toggled = true);
-	obj.test();
+	const obj1 = await fn();
+	const obj2 = await fn();
+	obj1.testfn = () => (toggled = true);
+	obj1.test();
 };

--- a/test/function/samples/track-async-function-return-value/_config.js
+++ b/test/function/samples/track-async-function-return-value/_config.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'tracks object mutations of async function return values',
+	async exports(exports) {
+		assert.strictEqual(exports.toggled, false);
+		await exports.test();
+		assert.strictEqual(exports.toggled, true);
+	}
+};

--- a/test/function/samples/track-async-function-return-value/main.js
+++ b/test/function/samples/track-async-function-return-value/main.js
@@ -1,4 +1,4 @@
-function fn() {
+async function fn() {
 	const obj = {
 		test() {
 			if (typeof obj.testfn === 'function') {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This is a follow-up to #4161 resolving https://github.com/rollup/rollup/issues/4161#issuecomment-872168183. The problem is that for async functions, we were not properly deoptimizing the return value, which is fixed here.