### PR TITLE
Generates namespace objects when not tree-shaking

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -621,6 +621,7 @@ export default class Module {
 
 	includeAllInBundle(): void {
 		this.ast!.include(createInclusionContext(), true);
+		this.includeAllExports(false);
 	}
 
 	isIncluded(): boolean {

--- a/test/form/samples/no-treeshake-namespace-object/_config.js
+++ b/test/form/samples/no-treeshake-namespace-object/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'generates namespace objects when not tree-shaking',
+	options: {
+		treeshake: false
+	}
+};

--- a/test/form/samples/no-treeshake-namespace-object/_expected.js
+++ b/test/form/samples/no-treeshake-namespace-object/_expected.js
@@ -1,0 +1,11 @@
+function foo() {}
+
+var namespace = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	foo: foo
+});
+
+const a = 1;
+const b = 2;
+
+export { a, b, namespace as ns1, namespace as ns2 };

--- a/test/form/samples/no-treeshake-namespace-object/main.js
+++ b/test/form/samples/no-treeshake-namespace-object/main.js
@@ -1,0 +1,8 @@
+import * as ns1 from './namespace';
+
+export { ns1 };
+
+export * as ns2 from './namespace';
+
+export const a = 1;
+export const b = 2;

--- a/test/form/samples/no-treeshake-namespace-object/namespace.js
+++ b/test/form/samples/no-treeshake-namespace-object/namespace.js
@@ -1,0 +1,1 @@
+export function foo() {}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
resolves #4174 
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When tree shaking was turned off, sometimes namespace objects were not generated. This is fixed here.