### PR TITLE
Fix additional let/var init bugs

### DIFF
--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -1428,8 +1428,8 @@ Type: `boolean`<br>
 CLI: `--treeshake.correctVarValueBeforeDeclaration`/`--no-treeshake.correctVarValueBeforeDeclaration`<br>
 Default: `false`
 
-If a variable is assigned a value in its declaration and is never reassigned, Rollup can in some adge case scenarios assume the value to be constant, see below. This is not true if the variable is declared with `var`, however, as those variables can be accessed before their declaration where they will evaluate to `undefined`.
-Choosing `true` will make sure Rollup does not make any assumptions about the value of such variables. Note though that this can have a noticeable negative impact on tree-shaking results.
+In some edge cases if a variable is accessed before its declaration assignment and is not reassigned, then Rollup may incorrectly assume that variable is constant throughout the program, as in the example below. This is not true if the variable is declared with `var`, however, as those variables can be accessed before their declaration where they will evaluate to `undefined`.
+Choosing `true` will make sure Rollup does not make any assumptions about the value of variables declared with `var`. Note though that this can have a noticeable negative impact on tree-shaking results.
 
 ```js
 // everything will be tree-shaken unless treeshake.correctVarValueBeforeDeclaration === true

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -1431,22 +1431,6 @@ Default: `false`
 If a variable is assigned a value in its declaration and is never reassigned, Rollup sometimes assumes the value to be constant. This is not true if the variable is declared with `var`, however, as those variables can be accessed before their declaration where they will evaluate to `undefined`.
 Choosing `true` will make sure Rollup does not make (wrong) assumptions about the value of such variables. Note though that this can have a noticeable negative impact on tree-shaking results.
 
-```js
-// input
-if (Math.random() < 0.5) var x = true;
-if (!x) {
-  console.log('effect');
-}
-
-// no output with treeshake.correctVarValueBeforeDeclaration === false
-
-// output with treeshake.correctVarValueBeforeDeclaration === true
-if (Math.random() < 0.5) var x = true;
-if (!x) {
-  console.log('effect');
-}
-```
-
 **treeshake.moduleSideEffects**<br>
 Type: `boolean | "no-external" | string[] | (id: string, external: boolean) => boolean`<br>
 CLI: `--treeshake.moduleSideEffects`/`--no-treeshake.moduleSideEffects`/`--treeshake.moduleSideEffects no-external`<br>

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -1428,8 +1428,31 @@ Type: `boolean`<br>
 CLI: `--treeshake.correctVarValueBeforeDeclaration`/`--no-treeshake.correctVarValueBeforeDeclaration`<br>
 Default: `false`
 
-If a variable is assigned a value in its declaration and is never reassigned, Rollup sometimes assumes the value to be constant. This is not true if the variable is declared with `var`, however, as those variables can be accessed before their declaration where they will evaluate to `undefined`.
-Choosing `true` will make sure Rollup does not make (wrong) assumptions about the value of such variables. Note though that this can have a noticeable negative impact on tree-shaking results.
+If a variable is assigned a value in its declaration and is never reassigned, Rollup can in some adge case scenarios assume the value to be constant, see below. This is not true if the variable is declared with `var`, however, as those variables can be accessed before their declaration where they will evaluate to `undefined`.
+Choosing `true` will make sure Rollup does not make any assumptions about the value of such variables. Note though that this can have a noticeable negative impact on tree-shaking results.
+
+```js
+// everything will be tree-shaken unless treeshake.correctVarValueBeforeDeclaration === true
+let logBeforeDeclaration = false;
+
+function logIfEnabled() {
+  if (logBeforeDeclaration) {
+    log();
+  }
+
+  var value = true;
+
+  function log() {
+    if (!value) {
+      console.log('should be retained, value is undefined');
+    }
+  }
+};
+
+logIfEnabled(); // could be removed
+logBeforeDeclaration = true;
+logIfEnabled(); // needs to be retained as it displays a log
+```
 
 **treeshake.moduleSideEffects**<br>
 Type: `boolean | "no-external" | string[] | (id: string, external: boolean) => boolean`<br>

--- a/src/ast/scopes/TrackingScope.ts
+++ b/src/ast/scopes/TrackingScope.ts
@@ -14,6 +14,6 @@ export default class TrackingScope extends BlockScope {
 		isHoisted: boolean
 	): LocalVariable {
 		this.hoistedDeclarations.push(identifier);
-		return this.parent.addDeclaration(identifier, context, init, isHoisted);
+		return super.addDeclaration(identifier, context, init, isHoisted);
 	}
 }

--- a/test/cli/samples/treeshake-preset-override/_expected.js
+++ b/test/cli/samples/treeshake-preset-override/_expected.js
@@ -11,3 +11,17 @@ try {
 } catch {}
 
 unknownGlobal;
+
+let flag = true;
+
+function test() {
+	if (flag) var x = true;
+	if (x) {
+		return;
+	}
+	console.log('effect');
+}
+
+test();
+flag = false;
+test();

--- a/test/form/samples/tdz-common/_expected.js
+++ b/test/form/samples/tdz-common/_expected.js
@@ -41,3 +41,16 @@ class cls {}
 	console.log("C" );
 	console.log("D" );
 })();
+
+(function let_tdz() {
+	let flag = false;
+	function foo() {
+		if (flag) {
+			value; // TDZ
+		}
+		let value;
+	}
+	foo();
+	flag = true;
+	foo();
+})();

--- a/test/form/samples/tdz-common/main.js
+++ b/test/form/samples/tdz-common/main.js
@@ -55,3 +55,26 @@ class cls {}
 	console.log(C ? "C" : "!C");
 	console.log(D ? "D" : "!D");
 })();
+
+(function let_tdz() {
+	let flag = false;
+	function foo() {
+		if (flag) {
+			value; // TDZ
+		}
+		let value;
+	}
+	foo();
+	flag = true;
+	foo();
+})();
+
+// should be dropped
+(function() {
+	function foo() {
+		const access = () => value;
+		let value;
+		access();
+	};
+	foo();
+})();

--- a/test/form/samples/treeshake-presets/preset-with-override/_expected.js
+++ b/test/form/samples/treeshake-presets/preset-with-override/_expected.js
@@ -1,3 +1,17 @@
 console.log('main');
 
 unknownGlobal;
+
+let flag = true;
+
+function test() {
+	if (flag) var x = true;
+	if (x) {
+		return;
+	}
+	console.log('effect');
+}
+
+test();
+flag = false;
+test();

--- a/test/form/samples/treeshake-presets/recommended/_expected.js
+++ b/test/form/samples/treeshake-presets/recommended/_expected.js
@@ -11,3 +11,17 @@ console.log('main');
 try {
 	const noeffect = 1;
 } catch {}
+
+let flag = true;
+
+function test() {
+	if (flag) var x = true;
+	if (x) {
+		return;
+	}
+	console.log('effect');
+}
+
+test();
+flag = false;
+test();

--- a/test/form/samples/treeshake-presets/smallest/_expected.js
+++ b/test/form/samples/treeshake-presets/smallest/_expected.js
@@ -1,1 +1,15 @@
 console.log('main');
+
+let flag = true;
+
+function test() {
+	if (flag) var x = true;
+	if (x) {
+		return;
+	}
+	console.log('effect');
+}
+
+test();
+flag = false;
+test();

--- a/test/form/samples/treeshake-presets/true/_expected.js
+++ b/test/form/samples/treeshake-presets/true/_expected.js
@@ -13,3 +13,17 @@ try {
 } catch {}
 
 unknownGlobal;
+
+let flag = true;
+
+function test() {
+	if (flag) var x = true;
+	if (x) {
+		return;
+	}
+	console.log('effect');
+}
+
+test();
+flag = false;
+test();

--- a/test/function/samples/use-var-before-decl/main.js
+++ b/test/function/samples/use-var-before-decl/main.js
@@ -41,4 +41,21 @@ log(function() {
 	}
 })();
 
-assert.strictEqual(results.join(" "), "PASS1 PASS2 PASS3 PASS4 PASS5 PASS6 OFF ON");
+(function () {
+	var flag = false;
+
+	function foo() {
+		if (flag) {
+			if (!value) log(flag + "1");
+		}
+		var value = true;
+		log(flag + "2");
+	}
+
+	foo();
+
+	flag = true;
+	foo();
+})();
+
+assert.strictEqual(results.join(" "), "PASS1 PASS2 PASS3 PASS4 PASS5 PASS6 OFF ON false2 true1 true2");


### PR DESCRIPTION
Fix additional variable state change bugs including blockless `if` statement `var` declarations and `let`/`var` use before declaration within same function that do not cross function scopes.

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
<!--
Follow up to #4148
-->

### Description

Fixes several outstanding var/let init issues mentioned in #4148 without any code pessimization other than for previously incorrect rollup output, and with minimal overhead.