### PR TITLE
Correctly create outside variable when shadowed by catch parameter

### DIFF
--- a/src/ast/nodes/CatchClause.ts
+++ b/src/ast/nodes/CatchClause.ts
@@ -18,9 +18,9 @@ export default class CatchClause extends NodeBase {
 	}
 
 	parseNode(esTreeNode: GenericEsTreeNode): void {
-		// Parameters need to be declared first as the logic is that hoisted body
-		// variables are associated with outside vars unless there is a parameter,
-		// in which case they are associated with the parameter
+		// Parameters need to be declared first as the logic is that initializers
+		// of hoisted body variables are associated with parameters of the same
+		// name instead of the variable
 		const { param } = esTreeNode;
 		if (param) {
 			(this.param as GenericEsTreeNode) = new (this.context.nodeConstructors[param.type] ||

--- a/src/ast/scopes/CatchScope.ts
+++ b/src/ast/scopes/CatchScope.ts
@@ -1,6 +1,7 @@
 import { AstContext } from '../../Module';
 import Identifier from '../nodes/Identifier';
 import { ExpressionEntity } from '../nodes/shared/Expression';
+import { UNDEFINED_EXPRESSION } from '../values';
 import LocalVariable from '../variables/LocalVariable';
 import ParameterScope from './ParameterScope';
 
@@ -13,10 +14,13 @@ export default class CatchScope extends ParameterScope {
 	): LocalVariable {
 		const existingParameter = this.variables.get(identifier.name) as LocalVariable;
 		if (existingParameter) {
+			// While we still create a hoisted declaration, the initializer goes to
+			// the parameter. Note that technically, the declaration now belongs to
+			// two variables, which is not correct but should not cause issues.
+			this.parent.addDeclaration(identifier, context, UNDEFINED_EXPRESSION, isHoisted);
 			existingParameter.addDeclaration(identifier, init);
 			return existingParameter;
 		}
-		// as parameters are handled differently, all remaining declarations are hoisted
 		return this.parent.addDeclaration(identifier, context, init, isHoisted);
 	}
 }

--- a/test/function/samples/catch-scope-shadowing/_config.js
+++ b/test/function/samples/catch-scope-shadowing/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'correctly associates shadowed variables in catch scopes'
+};

--- a/test/function/samples/catch-scope-shadowing/main.js
+++ b/test/function/samples/catch-scope-shadowing/main.js
@@ -1,0 +1,23 @@
+var e = 'failed1',
+	x = 'value';
+
+(function () {
+	try {
+		// empty
+	} catch (e) {
+		var e = 'failed2';
+	}
+
+	assert.strictEqual(e, undefined);
+	assert.strictEqual(x, undefined);
+	x = 'failed3';
+	return;
+
+	try {
+		not_reached();
+	} catch (x) {
+		var x = 'failed4';
+	}
+})();
+
+assert.strictEqual(x, 'value');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4176
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Apparently, a `var` declared in a catch clause will always create a hoisted variable, even if the variable name matches the clause parameter. If that is the case, then the initializer goes to the parameter instead of the variable...
This handles this correctly by always creating a hoisted variable while deoptimizing the catch parameter if there is a conflict.
