### PR TITLE
Fix import.meta.url inside web workers

### DIFF
--- a/src/ast/nodes/MetaProperty.ts
+++ b/src/ast/nodes/MetaProperty.ts
@@ -217,10 +217,10 @@ const relativeUrlMechanisms: Record<InternalModuleFormat, (relativePath: string)
 	iife: relativePath => getRelativeUrlFromDocument(relativePath),
 	system: relativePath => getResolveUrl(`'${relativePath}', module.meta.url`),
 	umd: relativePath =>
-		`(typeof document === 'undefined' ? ${getResolveUrl(
+		`(typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? ${getResolveUrl(
 			`'file:' + __dirname + '/${relativePath}'`,
 			`(require('u' + 'rl').URL)`
-		)} : ${getRelativeUrlFromDocument(relativePath)})`
+		)} : location.href) : ${getRelativeUrlFromDocument(relativePath)})`
 };
 
 const importMetaMechanisms: Record<string, (prop: string | null, chunkId: string) => string> = {
@@ -236,9 +236,9 @@ const importMetaMechanisms: Record<string, (prop: string | null, chunkId: string
 	system: prop => (prop === null ? `module.meta` : `module.meta.${prop}`),
 	umd: getGenericImportMetaMechanism(
 		chunkId =>
-			`(typeof document === 'undefined' ? ${getResolveUrl(
+			`(typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? ${getResolveUrl(
 				`'file:' + __filename`,
 				`(require('u' + 'rl').URL)`
-			)} : ${getUrlFromDocument(chunkId)})`
+			)} : location.href) : ${getUrlFromDocument(chunkId)})`
 	)
 };

--- a/src/ast/nodes/MetaProperty.ts
+++ b/src/ast/nodes/MetaProperty.ts
@@ -217,10 +217,10 @@ const relativeUrlMechanisms: Record<InternalModuleFormat, (relativePath: string)
 	iife: relativePath => getRelativeUrlFromDocument(relativePath),
 	system: relativePath => getResolveUrl(`'${relativePath}', module.meta.url`),
 	umd: relativePath =>
-		`(typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? ${getResolveUrl(
+		`(typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : ${getResolveUrl(
 			`'file:' + __dirname + '/${relativePath}'`,
 			`(require('u' + 'rl').URL)`
-		)} : location.href) : ${getRelativeUrlFromDocument(relativePath)})`
+		)}) : ${getRelativeUrlFromDocument(relativePath)})`
 };
 
 const importMetaMechanisms: Record<string, (prop: string | null, chunkId: string) => string> = {
@@ -236,9 +236,9 @@ const importMetaMechanisms: Record<string, (prop: string | null, chunkId: string
 	system: prop => (prop === null ? `module.meta` : `module.meta.${prop}`),
 	umd: getGenericImportMetaMechanism(
 		chunkId =>
-			`(typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? ${getResolveUrl(
+			`(typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : ${getResolveUrl(
 				`'file:' + __filename`,
 				`(require('u' + 'rl').URL)`
-			)} : location.href) : ${getUrlFromDocument(chunkId)})`
+			)}) : ${getUrlFromDocument(chunkId)})`
 	)
 };

--- a/src/ast/nodes/MetaProperty.ts
+++ b/src/ast/nodes/MetaProperty.ts
@@ -185,9 +185,11 @@ const accessedFileUrlGlobals = {
 
 const getResolveUrl = (path: string, URL = 'URL') => `new ${URL}(${path}).href`;
 
-const getRelativeUrlFromDocument = (relativePath: string) =>
+const getRelativeUrlFromDocument = (relativePath: string, umd = false) =>
 	getResolveUrl(
-		`'${relativePath}', document.currentScript && document.currentScript.src || document.baseURI`
+		`'${relativePath}', ${
+			umd ? `typeof document === 'undefined' ? location.href : ` : ''
+		}document.currentScript && document.currentScript.src || document.baseURI`
 	);
 
 const getGenericImportMetaMechanism =
@@ -200,8 +202,10 @@ const getGenericImportMetaMechanism =
 			: 'undefined';
 	};
 
-const getUrlFromDocument = (chunkId: string) =>
-	`(document.currentScript && document.currentScript.src || new URL('${chunkId}', document.baseURI).href)`;
+const getUrlFromDocument = (chunkId: string, umd = false) =>
+	`${
+		umd ? `typeof document === 'undefined' ? location.href : ` : ''
+	}(document.currentScript && document.currentScript.src || new URL('${chunkId}', document.baseURI).href)`;
 
 const relativeUrlMechanisms: Record<InternalModuleFormat, (relativePath: string) => string> = {
 	amd: relativePath => {
@@ -217,10 +221,10 @@ const relativeUrlMechanisms: Record<InternalModuleFormat, (relativePath: string)
 	iife: relativePath => getRelativeUrlFromDocument(relativePath),
 	system: relativePath => getResolveUrl(`'${relativePath}', module.meta.url`),
 	umd: relativePath =>
-		`(typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : ${getResolveUrl(
+		`(typeof document === 'undefined' && typeof location === 'undefined' ? ${getResolveUrl(
 			`'file:' + __dirname + '/${relativePath}'`,
 			`(require('u' + 'rl').URL)`
-		)}) : ${getRelativeUrlFromDocument(relativePath)})`
+		)} : ${getRelativeUrlFromDocument(relativePath, true)})`
 };
 
 const importMetaMechanisms: Record<string, (prop: string | null, chunkId: string) => string> = {
@@ -236,9 +240,9 @@ const importMetaMechanisms: Record<string, (prop: string | null, chunkId: string
 	system: prop => (prop === null ? `module.meta` : `module.meta.${prop}`),
 	umd: getGenericImportMetaMechanism(
 		chunkId =>
-			`(typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : ${getResolveUrl(
+			`(typeof document === 'undefined' && typeof location === 'undefined' ? ${getResolveUrl(
 				`'file:' + __filename`,
 				`(require('u' + 'rl').URL)`
-			)}) : ${getUrlFromDocument(chunkId)})`
+			)} : ${getUrlFromDocument(chunkId, true)})`
 	)
 };

--- a/test/form/samples/configure-file-url/_expected/umd.js
+++ b/test/form/samples/configure-file-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset3 = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : location.href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/configure-file-url/_expected/umd.js
+++ b/test/form/samples/configure-file-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset3 = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : new URL('assets/asset-unresolved-8dcd7fca.txt', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/configure-file-url/_expected/umd.js
+++ b/test/form/samples/configure-file-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : location.href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset3 = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
@@ -21,7 +21,7 @@
 
 	import('external').then(console.log);
 	exports['default'] = 0;
-	console.log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	console.log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 
 	function nested1() {
 		const _interopDefault = 1;
@@ -35,7 +35,7 @@
 
 		import('external').then(console.log);
 		exports['default'] = 1;
-		console.log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+		console.log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 	}
 
 	nested1();

--- a/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
@@ -21,7 +21,7 @@
 
 	import('external').then(console.log);
 	exports['default'] = 0;
-	console.log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	console.log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 
 	function nested1() {
 		const _interopDefault = 1;
@@ -35,7 +35,7 @@
 
 		import('external').then(console.log);
 		exports['default'] = 1;
-		console.log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+		console.log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 	}
 
 	nested1();

--- a/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
@@ -21,7 +21,7 @@
 
 	import('external').then(console.log);
 	exports['default'] = 0;
-	console.log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	console.log((typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : typeof document === 'undefined' ? location.href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 
 	function nested1() {
 		const _interopDefault = 1;
@@ -35,7 +35,7 @@
 
 		import('external').then(console.log);
 		exports['default'] = 1;
-		console.log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+		console.log((typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : typeof document === 'undefined' ? location.href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 	}
 
 	nested1();

--- a/test/form/samples/deprecated/configure-asset-url/_expected/umd.js
+++ b/test/form/samples/deprecated/configure-asset-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset3 = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : location.href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/deprecated/configure-asset-url/_expected/umd.js
+++ b/test/form/samples/deprecated/configure-asset-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset3 = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : new URL('assets/asset-unresolved-8dcd7fca.txt', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/deprecated/configure-asset-url/_expected/umd.js
+++ b/test/form/samples/deprecated/configure-asset-url/_expected/umd.js
@@ -7,7 +7,7 @@
 
 	var asset2 = 'resolved';
 
-	var asset3 = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href : location.href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset3 = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-unresolved-8dcd7fca.txt').href) : new URL('assets/asset-unresolved-8dcd7fca.txt', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1, asset2, asset3);
 

--- a/test/form/samples/deprecated/emit-asset/_expected/umd.js
+++ b/test/form/samples/deprecated/emit-asset/_expected/umd.js
@@ -3,7 +3,7 @@
 	factory();
 }((function () { 'use strict';
 
-	var logo = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : location.href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var logo = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/deprecated/emit-asset/_expected/umd.js
+++ b/test/form/samples/deprecated/emit-asset/_expected/umd.js
@@ -3,7 +3,7 @@
 	factory();
 }((function () { 'use strict';
 
-	var logo = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var logo = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : new URL('assets/logo-25585ac1.svg', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/deprecated/emit-asset/_expected/umd.js
+++ b/test/form/samples/deprecated/emit-asset/_expected/umd.js
@@ -3,7 +3,7 @@
 	factory();
 }((function () { 'use strict';
 
-	var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var logo = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : location.href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/emit-asset-file/_expected/umd.js
+++ b/test/form/samples/emit-asset-file/_expected/umd.js
@@ -3,7 +3,7 @@
 	factory();
 }((function () { 'use strict';
 
-	var logo = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : location.href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var logo = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/emit-asset-file/_expected/umd.js
+++ b/test/form/samples/emit-asset-file/_expected/umd.js
@@ -3,7 +3,7 @@
 	factory();
 }((function () { 'use strict';
 
-	var logo = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var logo = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : new URL('assets/logo-25585ac1.svg', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/emit-asset-file/_expected/umd.js
+++ b/test/form/samples/emit-asset-file/_expected/umd.js
@@ -3,7 +3,7 @@
 	factory();
 }((function () { 'use strict';
 
-	var logo = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var logo = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/logo-25585ac1.svg').href : location.href) : new URL('assets/logo-25585ac1.svg', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	function showImage(url) {
 		console.log(url);

--- a/test/form/samples/emit-uint8array-no-buffer/_expected/umd.js
+++ b/test/form/samples/emit-uint8array-no-buffer/_expected/umd.js
@@ -3,15 +3,15 @@
 	factory();
 }((function () { 'use strict';
 
-	var asset1a = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset1a = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : new URL('assets/asset-dc5cb674', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset1b = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset1b = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : new URL('assets/asset-dc5cb674', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset2a = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset2a = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : new URL('assets/asset-52cbd095', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset2b = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset2b = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : new URL('assets/asset-52cbd095', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset99a = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-c568a840').href) : new URL('assets/asset-c568a840', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset99a = (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-c568a840').href : new URL('assets/asset-c568a840', typeof document === 'undefined' ? location.href : document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1a, asset1b, asset2a, asset2b, asset99a);
 

--- a/test/form/samples/emit-uint8array-no-buffer/_expected/umd.js
+++ b/test/form/samples/emit-uint8array-no-buffer/_expected/umd.js
@@ -3,15 +3,15 @@
 	factory();
 }((function () { 'use strict';
 
-	var asset1a = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset1a = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : location.href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset1b = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset1b = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : location.href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset2a = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset2a = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : location.href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset2b = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset2b = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : location.href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset99a = (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-c568a840').href : new URL('assets/asset-c568a840', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset99a = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-c568a840').href : location.href) : new URL('assets/asset-c568a840', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1a, asset1b, asset2a, asset2b, asset99a);
 

--- a/test/form/samples/emit-uint8array-no-buffer/_expected/umd.js
+++ b/test/form/samples/emit-uint8array-no-buffer/_expected/umd.js
@@ -3,15 +3,15 @@
 	factory();
 }((function () { 'use strict';
 
-	var asset1a = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : location.href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset1a = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset1b = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href : location.href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset1b = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-dc5cb674').href) : new URL('assets/asset-dc5cb674', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset2a = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : location.href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset2a = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset2b = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href : location.href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset2b = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-52cbd095').href) : new URL('assets/asset-52cbd095', document.currentScript && document.currentScript.src || document.baseURI).href);
 
-	var asset99a = (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-c568a840').href : location.href) : new URL('assets/asset-c568a840', document.currentScript && document.currentScript.src || document.baseURI).href);
+	var asset99a = (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __dirname + '/assets/asset-c568a840').href) : new URL('assets/asset-c568a840', document.currentScript && document.currentScript.src || document.baseURI).href);
 
 	console.log(asset1a, asset1b, asset2a, asset2b, asset99a);
 

--- a/test/form/samples/import-meta-url/_expected/umd.js
+++ b/test/form/samples/import-meta-url/_expected/umd.js
@@ -11,6 +11,6 @@
 		}
 	}
 
-	log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 
 })));

--- a/test/form/samples/import-meta-url/_expected/umd.js
+++ b/test/form/samples/import-meta-url/_expected/umd.js
@@ -11,6 +11,6 @@
 		}
 	}
 
-	log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	log((typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : typeof document === 'undefined' ? location.href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 
 })));

--- a/test/form/samples/import-meta-url/_expected/umd.js
+++ b/test/form/samples/import-meta-url/_expected/umd.js
@@ -11,6 +11,6 @@
 		}
 	}
 
-	log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 
 })));

--- a/test/form/samples/import-meta/_expected/umd.js
+++ b/test/form/samples/import-meta/_expected/umd.js
@@ -3,6 +3,6 @@
 	factory();
 }((function () { 'use strict';
 
-	console.log(({ url: (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
+	console.log(({ url: (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
 
 })));

--- a/test/form/samples/import-meta/_expected/umd.js
+++ b/test/form/samples/import-meta/_expected/umd.js
@@ -3,6 +3,6 @@
 	factory();
 }((function () { 'use strict';
 
-	console.log(({ url: (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
+	console.log(({ url: (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : typeof document === 'undefined' ? location.href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
 
 })));

--- a/test/form/samples/import-meta/_expected/umd.js
+++ b/test/form/samples/import-meta/_expected/umd.js
@@ -3,6 +3,6 @@
 	factory();
 }((function () { 'use strict';
 
-	console.log(({ url: (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
+	console.log(({ url: (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
 
 })));

--- a/test/form/samples/resolve-import-meta-url/_expected/umd.js
+++ b/test/form/samples/resolve-import-meta-url/_expected/umd.js
@@ -7,9 +7,9 @@
 	console.log('resolved');
 	console.log('resolved');
 
-	console.log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	console.log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 	console.log(undefined);
-	console.log(({ url: (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
+	console.log(({ url: (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
 
 	console.log('url=umd.js:resolve-import-meta-url/main.js');
 	console.log('privateProp=umd.js:resolve-import-meta-url/main.js');

--- a/test/form/samples/resolve-import-meta-url/_expected/umd.js
+++ b/test/form/samples/resolve-import-meta-url/_expected/umd.js
@@ -7,9 +7,9 @@
 	console.log('resolved');
 	console.log('resolved');
 
-	console.log((typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	console.log((typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 	console.log(undefined);
-	console.log(({ url: (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
+	console.log(({ url: (typeof document === 'undefined' ? (typeof self === 'undefined' || typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : location.href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
 
 	console.log('url=umd.js:resolve-import-meta-url/main.js');
 	console.log('privateProp=umd.js:resolve-import-meta-url/main.js');

--- a/test/form/samples/resolve-import-meta-url/_expected/umd.js
+++ b/test/form/samples/resolve-import-meta-url/_expected/umd.js
@@ -7,9 +7,9 @@
 	console.log('resolved');
 	console.log('resolved');
 
-	console.log((typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
+	console.log((typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : typeof document === 'undefined' ? location.href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)));
 	console.log(undefined);
-	console.log(({ url: (typeof document === 'undefined' ? (typeof location !== 'undefined' ? location.href : new (require('u' + 'rl').URL)('file:' + __filename).href) : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
+	console.log(({ url: (typeof document === 'undefined' && typeof location === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __filename).href : typeof document === 'undefined' ? location.href : (document.currentScript && document.currentScript.src || new URL('umd.js', document.baseURI).href)) }));
 
 	console.log('url=umd.js:resolve-import-meta-url/main.js');
 	console.log('privateProp=umd.js:resolve-import-meta-url/main.js');


### PR DESCRIPTION
This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes
- [ ] no

Breaking Changes?
- [ ] yes
- [x] no

### Description

If I compile a library that uses `import.meta.url` internally using UMD, it will break if I try to use it inside web workers, that happens because today rollup compile `import.meta.url` to use nodejs require or browser document API, but both is unavailable inside web workers. This PR adds a check for it and try to use `location.href`, if available.