### PR TITLE
Move long path recursion prevention to MemberExpression

### DIFF
--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -34,6 +34,9 @@ import {
 } from './shared/Expression';
 import { ExpressionNode, IncludeChildren, NodeBase } from './shared/Node';
 
+// To avoid infinite recursions
+const MAX_PATH_DEPTH = 7;
+
 function getResolvablePropertyKey(memberExpression: MemberExpression): string | null {
 	return memberExpression.computed
 		? getResolvableComputedPropertyKey(memberExpression.property)
@@ -124,7 +127,9 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.variable) {
 			this.variable.deoptimizePath(path);
 		} else if (!this.replacement) {
-			this.object.deoptimizePath([this.getPropertyKey(), ...path]);
+			if (path.length <= MAX_PATH_DEPTH) {
+				this.object.deoptimizePath([this.getPropertyKey(), ...path]);
+			}
 		}
 	}
 
@@ -137,12 +142,16 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.variable) {
 			this.variable.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
 		} else if (!this.replacement) {
-			this.object.deoptimizeThisOnEventAtPath(
-				event,
-				[this.getPropertyKey(), ...path],
-				thisParameter,
-				recursionTracker
-			);
+			if (path.length <= MAX_PATH_DEPTH) {
+				this.object.deoptimizeThisOnEventAtPath(
+					event,
+					[this.getPropertyKey(), ...path],
+					thisParameter,
+					recursionTracker
+				);
+			} else {
+				thisParameter.deoptimizePath(UNKNOWN_PATH);
+			}
 		}
 	}
 
@@ -158,11 +167,14 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			return UnknownValue;
 		}
 		this.expressionsToBeDeoptimized.push(origin);
-		return this.object.getLiteralValueAtPath(
-			[this.getPropertyKey(), ...path],
-			recursionTracker,
-			origin
-		);
+		if (path.length <= MAX_PATH_DEPTH) {
+			return this.object.getLiteralValueAtPath(
+				[this.getPropertyKey(), ...path],
+				recursionTracker,
+				origin
+			);
+		}
+		return UnknownValue;
 	}
 
 	getReturnExpressionWhenCalledAtPath(
@@ -183,12 +195,15 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			return UNKNOWN_EXPRESSION;
 		}
 		this.expressionsToBeDeoptimized.push(origin);
-		return this.object.getReturnExpressionWhenCalledAtPath(
-			[this.getPropertyKey(), ...path],
-			callOptions,
-			recursionTracker,
-			origin
-		);
+		if (path.length <= MAX_PATH_DEPTH) {
+			return this.object.getReturnExpressionWhenCalledAtPath(
+				[this.getPropertyKey(), ...path],
+				callOptions,
+				recursionTracker,
+				origin
+			);
+		}
+		return UNKNOWN_EXPRESSION;
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {
@@ -217,7 +232,10 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.replacement) {
 			return true;
 		}
-		return this.object.hasEffectsWhenAccessedAtPath([this.getPropertyKey(), ...path], context);
+		if (path.length <= MAX_PATH_DEPTH) {
+			return this.object.hasEffectsWhenAccessedAtPath([this.getPropertyKey(), ...path], context);
+		}
+		return true;
 	}
 
 	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
@@ -227,7 +245,10 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.replacement) {
 			return true;
 		}
-		return this.object.hasEffectsWhenAssignedAtPath([this.getPropertyKey(), ...path], context);
+		if (path.length <= MAX_PATH_DEPTH) {
+			return this.object.hasEffectsWhenAssignedAtPath([this.getPropertyKey(), ...path], context);
+		}
+		return true;
 	}
 
 	hasEffectsWhenCalledAtPath(
@@ -241,11 +262,14 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.replacement) {
 			return true;
 		}
-		return this.object.hasEffectsWhenCalledAtPath(
-			[this.getPropertyKey(), ...path],
-			callOptions,
-			context
-		);
+		if (path.length <= MAX_PATH_DEPTH) {
+			return this.object.hasEffectsWhenCalledAtPath(
+				[this.getPropertyKey(), ...path],
+				callOptions,
+				context
+			);
+		}
+		return true;
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -127,7 +127,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.variable) {
 			this.variable.deoptimizePath(path);
 		} else if (!this.replacement) {
-			if (path.length <= MAX_PATH_DEPTH) {
+			if (path.length < MAX_PATH_DEPTH) {
 				this.object.deoptimizePath([this.getPropertyKey(), ...path]);
 			}
 		}
@@ -142,7 +142,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.variable) {
 			this.variable.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
 		} else if (!this.replacement) {
-			if (path.length <= MAX_PATH_DEPTH) {
+			if (path.length < MAX_PATH_DEPTH) {
 				this.object.deoptimizeThisOnEventAtPath(
 					event,
 					[this.getPropertyKey(), ...path],
@@ -167,7 +167,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			return UnknownValue;
 		}
 		this.expressionsToBeDeoptimized.push(origin);
-		if (path.length <= MAX_PATH_DEPTH) {
+		if (path.length < MAX_PATH_DEPTH) {
 			return this.object.getLiteralValueAtPath(
 				[this.getPropertyKey(), ...path],
 				recursionTracker,
@@ -195,7 +195,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			return UNKNOWN_EXPRESSION;
 		}
 		this.expressionsToBeDeoptimized.push(origin);
-		if (path.length <= MAX_PATH_DEPTH) {
+		if (path.length < MAX_PATH_DEPTH) {
 			return this.object.getReturnExpressionWhenCalledAtPath(
 				[this.getPropertyKey(), ...path],
 				callOptions,
@@ -232,7 +232,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.replacement) {
 			return true;
 		}
-		if (path.length <= MAX_PATH_DEPTH) {
+		if (path.length < MAX_PATH_DEPTH) {
 			return this.object.hasEffectsWhenAccessedAtPath([this.getPropertyKey(), ...path], context);
 		}
 		return true;
@@ -245,7 +245,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.replacement) {
 			return true;
 		}
-		if (path.length <= MAX_PATH_DEPTH) {
+		if (path.length < MAX_PATH_DEPTH) {
 			return this.object.hasEffectsWhenAssignedAtPath([this.getPropertyKey(), ...path], context);
 		}
 		return true;
@@ -262,7 +262,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (this.replacement) {
 			return true;
 		}
-		if (path.length <= MAX_PATH_DEPTH) {
+		if (path.length < MAX_PATH_DEPTH) {
 			return this.object.hasEffectsWhenCalledAtPath(
 				[this.getPropertyKey(), ...path],
 				callOptions,

--- a/src/ast/nodes/shared/ObjectMember.ts
+++ b/src/ast/nodes/shared/ObjectMember.ts
@@ -20,7 +20,12 @@ export class ObjectMember extends ExpressionEntity {
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.object.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
+		this.object.deoptimizeThisOnEventAtPath(
+			event,
+			[this.key, ...path],
+			thisParameter,
+			recursionTracker
+		);
 	}
 
 	getLiteralValueAtPath(

--- a/test/form/samples/deep-properties-access/_config.js
+++ b/test/form/samples/deep-properties-access/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'handles deeply nested property accesses'
+};

--- a/test/form/samples/deep-properties-access/_expected.js
+++ b/test/form/samples/deep-properties-access/_expected.js
@@ -1,0 +1,2 @@
+var obj = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+console.log(obj.obj.obj.obj.obj.obj.obj.obj.obj.foo);

--- a/test/form/samples/deep-properties-access/main.js
+++ b/test/form/samples/deep-properties-access/main.js
@@ -1,0 +1,2 @@
+var obj = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+console.log(obj.obj.obj.obj.obj.obj.obj.obj.obj.foo);

--- a/test/form/samples/deep-properties/_config.js
+++ b/test/form/samples/deep-properties/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'handles deeply nested properties',
+	options: {
+		treeshake: { propertyReadSideEffects: false }
+	}
+};

--- a/test/form/samples/deep-properties/_expected.js
+++ b/test/form/samples/deep-properties/_expected.js
@@ -1,0 +1,11 @@
+var obj1 = obj1;
+console.log(obj1.foo());
+
+var obj2 = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+obj2.obj.obj.obj.obj.obj.obj.obj.foo();
+
+var obj3 = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+if (obj3.obj.obj.obj.obj.obj.obj.obj.obj.foo) console.log('nested');
+
+var obj4 = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+obj4.obj.obj.obj.obj.obj.obj.obj.foo = 'nested';

--- a/test/form/samples/deep-properties/main.js
+++ b/test/form/samples/deep-properties/main.js
@@ -1,0 +1,11 @@
+var obj1 = obj1;
+console.log(obj1.foo());
+
+var obj2 = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+obj2.obj.obj.obj.obj.obj.obj.obj.foo();
+
+var obj3 = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+if (obj3.obj.obj.obj.obj.obj.obj.obj.obj.foo) console.log('nested');
+
+var obj4 = { obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {obj: {}}}}}}}}}}};
+obj4.obj.obj.obj.obj.obj.obj.obj.foo = 'nested';

--- a/test/form/samples/recursive-property-call/_config.js
+++ b/test/form/samples/recursive-property-call/_config.js
@@ -1,3 +1,0 @@
-module.exports = {
-	description: 'handles calls to properties of recursively defined variables'
-};

--- a/test/form/samples/recursive-property-call/_expected.js
+++ b/test/form/samples/recursive-property-call/_expected.js
@@ -1,9 +1,0 @@
-var obj1 = obj1;
-console.log(obj1.foo());
-
-var obj2 = {foo: () => {}};
-var obj2 = {foo: log};
-obj2.foo();
-
-var obj3 = {obj: obj3};
-obj3.obj.obj.obj.obj.obj.obj.obj.obj.obj.foo();

--- a/test/form/samples/recursive-property-call/main.js
+++ b/test/form/samples/recursive-property-call/main.js
@@ -1,9 +1,0 @@
-var obj1 = obj1;
-console.log(obj1.foo());
-
-var obj2 = {foo: () => {}};
-var obj2 = {foo: log};
-obj2.foo();
-
-var obj3 = {obj: obj3}
-obj3.obj.obj.obj.obj.obj.obj.obj.obj.obj.foo()

--- a/test/form/samples/static-method-deoptimization/_config.js
+++ b/test/form/samples/static-method-deoptimization/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'avoids infinite recursions when deoptimizing "this" context'
+};

--- a/test/form/samples/static-method-deoptimization/_expected.js
+++ b/test/form/samples/static-method-deoptimization/_expected.js
@@ -1,0 +1,13 @@
+class Foo {
+	static echo(message) {
+		this.prototype.echo(message);
+	}
+	echo(message) {
+		console.log(message);
+	}
+}
+
+class Bar extends Foo {}
+
+global.baz = 'PASS';
+Bar.echo(baz);

--- a/test/form/samples/static-method-deoptimization/main.js
+++ b/test/form/samples/static-method-deoptimization/main.js
@@ -1,0 +1,13 @@
+class Foo {
+	static echo(message) {
+		this.prototype.echo(message);
+	}
+	echo(message) {
+		console.log(message);
+	}
+}
+
+class Bar extends Foo {}
+
+global.baz = 'PASS';
+Bar.echo(baz);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [x] no

List any relevant issue numbers:
Resolves #4184
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This resolves a regression reported when calling class methods that themselves call methods on "this". Here it was possible that Rollup was trying to deoptimize an infinite object path (basically `.prototype.prototype.prototype...`). This is resolved by moving the logic to prevent these things from the LocalVariable class to the MemberExpression class as the latter is actually the one responsible for the issue.
