### PR TITLE
Stop recommending node-builtins

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -78,7 +78,7 @@ const immediateHandlers: {
 		stderr(
 			`Creating a browser bundle that depends on ${printQuotedStringList(
 				warning.modules!
-			)}. You might need to include https://github.com/ionic-team/rollup-plugin-node-polyfills`
+			)}. You might need to include https://github.com/snowpackjs/rollup-plugin-polyfill-node`
 		);
 	},
 

--- a/docs/08-troubleshooting.md
+++ b/docs/08-troubleshooting.md
@@ -91,7 +91,7 @@ export default {
 
 If you *do* want to include the module in your bundle, you need to tell Rollup how to find it. In most cases, this is a question of using [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/master/packages/node-resolve).
 
-Some modules, like `events` or `util`, are built in to Node.js. If you want to include those (for example, so that your bundle runs in the browser), you may need to include [rollup-plugin-node-polyfills](https://github.com/ionic-team/rollup-plugin-node-polyfills).
+Some modules, like `events` or `util`, are built in to Node.js. If you want to include those (for example, so that your bundle runs in the browser), you may need to include [rollup-plugin-polyfill-node](https://github.com/snowpackjs/rollup-plugin-polyfill-node).
 
 ### Error: "EMFILE: too many open files"
 

--- a/src/finalisers/shared/warnOnBuiltins.ts
+++ b/src/finalisers/shared/warnOnBuiltins.ts
@@ -38,7 +38,7 @@ export default function warnOnBuiltins(
 		code: 'MISSING_NODE_BUILTINS',
 		message: `Creating a browser bundle that depends on Node.js built-in modules (${printQuotedStringList(
 			externalBuiltins
-		)}). You might need to include https://github.com/ionic-team/rollup-plugin-node-polyfills`,
+		)}). You might need to include https://github.com/snowpackjs/rollup-plugin-polyfill-node`,
 		modules: externalBuiltins
 	});
 }

--- a/test/cli/samples/warn-multiple/_config.js
+++ b/test/cli/samples/warn-multiple/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Missing shims for Node.js built-ins\n' +
-				'Creating a browser bundle that depends on "url", "assert" and "path". You might need to include https://github.com/ionic-team/rollup-plugin-node-polyfills\n'
+				'Creating a browser bundle that depends on "url", "assert" and "path". You might need to include https://github.com/snowpackjs/rollup-plugin-polyfill-node\n'
 		);
 		assertIncludes(
 			stderr,

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -49,7 +49,7 @@ describe('misc', () => {
 				assert.equal(relevantWarnings.length, 1);
 				assert.equal(
 					relevantWarnings[0].message,
-					`Creating a browser bundle that depends on Node.js built-in modules ("util"). You might need to include https://github.com/ionic-team/rollup-plugin-node-polyfills`
+					`Creating a browser bundle that depends on Node.js built-in modules ("util"). You might need to include https://github.com/snowpackjs/rollup-plugin-polyfill-node`
 				);
 			});
 	});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [X] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [X] no

List any relevant issue numbers:

Resolves #2881

### Description

I recently went on a wild goose chase trying to figure out the best solution in the current Rollup ecosystem for polyfilling Node builtins. Long story short, this repository https://github.com/snowpackjs/rollup-plugin-polyfill-node looks to be, by far, the best alternative to the currently recommended repository, which has not been maintained for 2 years. I personally migrated to this package and it appears to work extremely well.

Related threads:

 * https://github.com/rollup/awesome/pull/92 - Discovery that the old package is not preferred.
 * https://github.com/rollup/awesome/pull/94 - Addition of the up to date package to the awesome list.
