### PR TITLE
Align batch warning for UNUSED_EXTERNAL_IMPORT to individual warning

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -239,9 +239,9 @@ const deferredHandlers: {
 		for (const warning of warnings) {
 			stderr(
 				warning.names +
-					' imported from external module ' +
+					" imported from external module '" +
 					warning.source +
-					' but never used in ' +
+					"' but never used in " +
 					printQuotedStringList((warning.sources as string[]).map(id => relativeId(id)))
 			);
 		}

--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -238,9 +238,10 @@ const deferredHandlers: {
 		title('Unused external imports');
 		for (const warning of warnings) {
 			stderr(
-				`${warning.names} imported from external module '${warning.source}' but never used in ${
-					printQuotedStringList((<string[]>warning.sources).map(id => relativeId(id)))
-				}`
+				`${warning.names} imported from external module '${warning.source}'
+				 but never used in ${printQuotedStringList(
+						(warning.sources as string[]).map(id => relativeId(id))
+					)}`
 			);
 		}
 	}

--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -239,9 +239,9 @@ const deferredHandlers: {
 		for (const warning of warnings) {
 			stderr(
 				warning.names +
-					" imported from external module '" +
+					' imported from external module "' +
 					warning.source +
-					"' but never used in " +
+					'" but never used in ' +
 					printQuotedStringList((warning.sources as string[]).map(id => relativeId(id)))
 			);
 		}

--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -238,10 +238,11 @@ const deferredHandlers: {
 		title('Unused external imports');
 		for (const warning of warnings) {
 			stderr(
-				`${warning.names} imported from external module '${warning.source}'
-				 but never used in ${printQuotedStringList(
-						(warning.sources as string[]).map(id => relativeId(id))
-					)}`
+				`${warning.names} imported from external module '${
+					warning.source
+				}' but never used in ${printQuotedStringList(
+					(warning.sources as string[]).map(id => relativeId(id))
+				)}`
 			);
 		}
 	}

--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -237,7 +237,13 @@ const deferredHandlers: {
 	UNUSED_EXTERNAL_IMPORT(warnings) {
 		title('Unused external imports');
 		for (const warning of warnings) {
-			stderr(`${warning.names} imported from external module '${warning.source}' but never used`);
+			stderr(
+				`${warning.names} imported from external module '${warning.source}' but never used${
+					warning.sources
+						? ' in ' + printQuotedStringList(warning.sources.map(id => relativeId(id)))
+						: ''
+				}`
+			);
 		}
 	}
 };

--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -238,10 +238,8 @@ const deferredHandlers: {
 		title('Unused external imports');
 		for (const warning of warnings) {
 			stderr(
-				`${warning.names} imported from external module '${warning.source}' but never used${
-					warning.sources
-						? ' in ' + printQuotedStringList(warning.sources.map(id => relativeId(id)))
-						: ''
+				`${warning.names} imported from external module '${warning.source}' but never used in ${
+					printQuotedStringList((<string[]>warning.sources).map(id => relativeId(id)))
 				}`
 			);
 		}

--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -238,11 +238,11 @@ const deferredHandlers: {
 		title('Unused external imports');
 		for (const warning of warnings) {
 			stderr(
-				`${warning.names} imported from external module '${
-					warning.source
-				}' but never used in ${printQuotedStringList(
-					(warning.sources as string[]).map(id => relativeId(id))
-				)}`
+				warning.names +
+					' imported from external module ' +
+					warning.source +
+					' but never used in ' +
+					printQuotedStringList((warning.sources as string[]).map(id => relativeId(id)))
 			);
 		}
 	}

--- a/test/cli/samples/warn-import-export/_config.js
+++ b/test/cli/samples/warn-import-export/_config.js
@@ -16,7 +16,7 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Unused external imports\n' +
-				`default imported from external module 'external' but never used in "main.js"\n`
+				`default imported from external module "external" but never used in "main.js"\n`
 		);
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-import-export/_config.js
+++ b/test/cli/samples/warn-import-export/_config.js
@@ -16,7 +16,7 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Unused external imports\n' +
-				"default imported from external module 'external' but never used\n"
+				`default imported from external module 'external' but never used in "main.js"\n`
 		);
 		assertIncludes(
 			stderr,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [X] other

Are tests included?
- [ ] yes (*bugfixes and features will not be merged without tests*)
- [X] no

Breaking Changes?
- [ ] yes (*breaking changes will not be merged unless absolutely necessary*)
- [X] no

List any relevant issue numbers:

The original issue which was closed is https://github.com/rollup/rollup/issues/4052. This finishes addressing that issue
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
PR https://github.com/rollup/rollup/pull/4054 improved the individual warning, but did not update the batch warning. When I build SvelteKit with Vite, which uses Rollup, I get a warning that I can't understand the origin of or how to fix

After using a locally modified copy, I was quickly able to track down the culprit: https://github.com/ampproject/amphtml/pull/35435