### PR TITLE
fixed: ModuleInfo.importedIds will return null if resolvedIds[source] is undefined

### DIFF
--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -122,7 +122,7 @@ This hook is called each time a module has been fully parsed by Rollup. See [`th
 
 In contrast to the [`transform`](guide/en/#transform) hook, this hook is never cached and can be used to get information about both cached and other modules, including the final shape of the `meta` property, the `code` and the `ast`.
 
-Note that information about imported modules is not yet available in this hook, and information about importing modules may be incomplete as additional importers could be discovered later. If you need this information, use the [`buildEnd`](guide/en/#buildend) hook.
+This hook will wait until all imports are resolved so that the information in `moduleInfo.importedIds` and `moduleInfo.dynamicallyImportedIds` is complete and accurate. Note however that information about importing modules may be incomplete as additional importers could be discovered later. If you need this information, use the [`buildEnd`](guide/en/#buildend) hook.
 
 #### `options`
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -116,6 +116,13 @@ export interface AstContext {
 	warn: (warning: RollupWarning, pos: number) => void;
 }
 
+export interface DynamicImport {
+	argument: string | ExpressionNode;
+	id: string | null;
+	node: ImportExpression;
+	resolution: Module | ExternalModule | string | null;
+}
+
 const MISSING_EXPORT_SHIM_DESCRIPTION: ExportDescription = {
 	identifier: null,
 	localName: MISSING_EXPORT_SHIM_VARIABLE
@@ -187,11 +194,7 @@ export default class Module {
 	dependencies = new Set<Module | ExternalModule>();
 	dynamicDependencies = new Set<Module | ExternalModule>();
 	dynamicImporters: string[] = [];
-	dynamicImports: {
-		argument: string | ExpressionNode;
-		node: ImportExpression;
-		resolution: Module | ExternalModule | string | null;
-	}[] = [];
+	dynamicImports: DynamicImport[] = [];
 	excludeFromSourcemap: boolean;
 	execIndex = Infinity;
 	exportAllSources = new Set<string>();
@@ -256,9 +259,9 @@ export default class Module {
 			code: null,
 			get dynamicallyImportedIds() {
 				const dynamicallyImportedIds: string[] = [];
-				for (const { resolution } of module.dynamicImports) {
-					if (resolution instanceof Module || resolution instanceof ExternalModule) {
-						dynamicallyImportedIds.push(resolution.id);
+				for (const { id } of module.dynamicImports) {
+					if (id) {
+						dynamicallyImportedIds.push(id);
 					}
 				}
 				return dynamicallyImportedIds;
@@ -275,7 +278,7 @@ export default class Module {
 				return Array.from(module.implicitlyLoadedBefore, getId);
 			},
 			get importedIds() {
-				return Array.from(module.sources, source => module.resolvedIds[source]? module.resolvedIds[source].id : null);
+				return Array.from(module.sources, source => module.resolvedIds[source].id);
 			},
 			get importers() {
 				return module.importers.sort();
@@ -846,7 +849,7 @@ export default class Module {
 		} else if (argument instanceof Literal && typeof argument.value === 'string') {
 			argument = argument.value;
 		}
-		this.dynamicImports.push({ argument, node, resolution: null });
+		this.dynamicImports.push({ argument, id: null, node, resolution: null });
 	}
 
 	private addExport(

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -275,7 +275,7 @@ export default class Module {
 				return Array.from(module.implicitlyLoadedBefore, getId);
 			},
 			get importedIds() {
-				return Array.from(module.sources, source => module.resolvedIds[source].id);
+				return Array.from(module.sources, source => module.resolvedIds[source]? module.resolvedIds[source].id : null);
 			},
 			get importers() {
 				return module.importers.sort();

--- a/test/function/samples/module-parsed-imported-ids/_config.js
+++ b/test/function/samples/module-parsed-imported-ids/_config.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const path = require('path');
+
+module.exports = {
+	description: 'supports importedIds in the moduleParsed hook',
+	options: {
+		plugins: [
+			{
+				name: 'test-plugin',
+				moduleParsed({ dynamicallyImportedIds, id, importedIds }) {
+					if (id.endsWith('main.js')) {
+						assert.deepStrictEqual(importedIds, [path.join(__dirname, 'static.js')]);
+						assert.deepStrictEqual(dynamicallyImportedIds, [path.join(__dirname, 'dynamic.js')]);
+					}
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/module-parsed-imported-ids/_config.js
+++ b/test/function/samples/module-parsed-imported-ids/_config.js
@@ -2,15 +2,27 @@ const assert = require('assert');
 const path = require('path');
 
 module.exports = {
-	description: 'supports importedIds in the moduleParsed hook',
+	description: 'provides full importedIds and dynamicallyImportedIds in the moduleParsed hook',
 	options: {
 		plugins: [
 			{
-				name: 'test-plugin',
+				load(id) {
+					const { dynamicallyImportedIds, importedIds } = this.getModuleInfo(id);
+					assert.deepStrictEqual(importedIds, []);
+					assert.deepStrictEqual(dynamicallyImportedIds, []);
+				},
+				transform(code, id) {
+					const { dynamicallyImportedIds, importedIds } = this.getModuleInfo(id);
+					assert.deepStrictEqual(importedIds, []);
+					assert.deepStrictEqual(dynamicallyImportedIds, []);
+				},
 				moduleParsed({ dynamicallyImportedIds, id, importedIds }) {
 					if (id.endsWith('main.js')) {
 						assert.deepStrictEqual(importedIds, [path.join(__dirname, 'static.js')]);
 						assert.deepStrictEqual(dynamicallyImportedIds, [path.join(__dirname, 'dynamic.js')]);
+					} else {
+						assert.deepStrictEqual(importedIds, []);
+						assert.deepStrictEqual(dynamicallyImportedIds, []);
 					}
 				}
 			}

--- a/test/function/samples/module-parsed-imported-ids/dynamic.js
+++ b/test/function/samples/module-parsed-imported-ids/dynamic.js
@@ -1,0 +1,1 @@
+export const bar = 'dynamic';

--- a/test/function/samples/module-parsed-imported-ids/main.js
+++ b/test/function/samples/module-parsed-imported-ids/main.js
@@ -1,0 +1,3 @@
+import { foo } from './static.js';
+
+export const result = [foo, import('./dynamic.js')];

--- a/test/function/samples/module-parsed-imported-ids/static.js
+++ b/test/function/samples/module-parsed-imported-ids/static.js
@@ -1,0 +1,1 @@
+export const foo = 'static';


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no


### Description

I get error (TypeError: Cannot read property 'id' of undefined) when use `moduleInfo.importedIds` in moduleParsed of rollup plugin

after check importedIds source code, fin not compatible `undefined`.

