### PR TITLE
RFC: Rollup static build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/tmp
 test/typescript/typings
 perf/
 .nyc_output/
+dist-static/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "shx rm -rf dist && git rev-parse HEAD > .commithash && rollup --config rollup.config.ts --configPlugin typescript && shx cp src/rollup/types.d.ts dist/rollup.d.ts && shx chmod a+x dist/bin/rollup",
     "build:cjs": "shx rm -rf dist && rollup --config rollup.config.ts --configPlugin typescript --configTest && shx cp src/rollup/types.d.ts dist/rollup.d.ts && shx chmod a+x dist/bin/rollup",
     "build:bootstrap": "node dist/bin/rollup --config rollup.config.ts --configPlugin typescript && shx cp src/rollup/types.d.ts dist/rollup.d.ts && shx chmod a+x dist/bin/rollup",
+    "build:static": "shx rm -rf dist-static && git rev-parse HEAD > .commithash && rollup --config rollup.config.static.ts --configPlugin typescript && shx chmod a+x dist-static/rollup",
     "ci:lint": "npm run lint:nofix",
     "ci:test": "npm run build:cjs && npm run build:bootstrap && npm run test:all",
     "ci:test:only": "npm run build:cjs && npm run build:bootstrap && npm run test:only",

--- a/rollup.config.static.ts
+++ b/rollup.config.static.ts
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import path from 'path';
+import alias from '@rollup/plugin-alias';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
+import { RollupOptions, WarningHandlerWithDefault } from 'rollup';
+import { string } from 'rollup-plugin-string';
+import typescript from 'rollup-plugin-typescript';
+import conditionalFsEventsImport from './build-plugins/conditional-fsevents-import';
+import emitModulePackageFile from './build-plugins/emit-module-package-file';
+import esmDynamicImport from './build-plugins/esm-dynamic-import';
+import getLicenseHandler from './build-plugins/generate-license-file';
+import pkg from './package.json';
+
+const commitHash = (function () {
+	try {
+		return fs.readFileSync('.commithash', 'utf-8');
+	} catch (err) {
+		return 'unknown';
+	}
+})();
+
+const now = new Date(
+	process.env.SOURCE_DATE_EPOCH
+		? 1000 * parseInt(process.env.SOURCE_DATE_EPOCH)
+		: new Date().getTime()
+).toUTCString();
+
+const banner = `#! /usr/bin/env node
+/*
+  @license
+	Rollup.js v${pkg.version}
+	${now} - commit ${commitHash}
+
+	https://github.com/rollup/rollup
+
+	Released under the MIT License.
+*/`;
+
+const onwarn: WarningHandlerWithDefault = warning => {
+	// eslint-disable-next-line no-console
+	console.error(
+		'Building Rollup produced warnings that need to be resolved. ' +
+			'Please keep in mind that the browser build may never have external dependencies!'
+	);
+	throw new Error(warning.message);
+};
+
+const moduleAliases = {
+	entries: [
+		{ find: 'help.md', replacement: path.resolve('cli/help.md') },
+		{ find: 'package.json', replacement: path.resolve('package.json') },
+		{ find: 'acorn', replacement: path.resolve('node_modules/acorn/dist/acorn.mjs') }
+	],
+	resolve: ['.js', '.json', '.md']
+};
+
+const treeshake = {
+	moduleSideEffects: false,
+	propertyReadSideEffects: false,
+	tryCatchDeoptimization: false
+};
+
+const nodePlugins = [
+	alias(moduleAliases),
+	resolve(),
+	json(),
+	conditionalFsEventsImport(),
+	string({ include: '**/*.md' }),
+	commonjs({ include: 'node_modules/**' }),
+	typescript()
+];
+
+export default (command: Record<string, unknown>): RollupOptions | RollupOptions[] => {
+	const { collectLicenses, writeLicense } = getLicenseHandler();
+	const commonJSBuild: RollupOptions = {
+		// fsevents is a dependency of chokidar that cannot be bundled as it contains binary code
+		external: [
+			'buffer',
+			'@rollup/plugin-typescript',
+			'assert',
+			'crypto',
+			'events',
+			'fs',
+			'fsevents',
+			'module',
+			'path',
+			'os',
+			'stream',
+			'url',
+			'util'
+		],
+		input: 'cli/cli.ts',
+		onwarn,
+		output: {
+			banner,
+			// TODO Only loadConfigFile is using default exports mode; this should be changed in Rollup@3
+			exports: 'auto',
+			externalLiveBindings: false,
+			file: 'dist-static/rollup',
+			format: 'cjs',
+			freeze: false,
+			inlineDynamicImports: true,
+			interop: id => {
+				if (id === 'fsevents') {
+					return 'defaultOnly';
+				}
+				return 'default';
+			},
+			sourcemap: false
+		},
+		plugins: [
+			...nodePlugins,
+			esmDynamicImport(),
+			// TODO this relied on an unpublished type update
+			(!command.configTest && collectLicenses()) as Plugin
+		],
+		strictDeprecations: true,
+		treeshake
+	};
+
+	return [commonJSBuild];
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no
- [x] maybe ?

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Hey folks !

I'm having a preliminary look at integrating rollup into a monorepo build system, that is using please (https://please.build). And in this build system, it's common to include rules to automatically fetches the tools required to build. In that case it'd be quite useful to have a single file bundle of rollup available somewhere to fetch it and allow building static node binaries.

To be honest, I'm quite bad at javascript and mostly unaware of the ecosystem, so I open this MR as an humble request for comment about the usage of rollup in build system to allow reproducible builds of "static" node builds.

Any thoughts ?
