### PR TITLE
fix: prevent UnhandledPromiseRejectionWarning when module resolution/parsing fails

### DIFF
--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -341,12 +341,11 @@ export class ModuleLoader {
 		Promise.all([
 			...(resolveStaticDependencyPromises as Promise<never>[]),
 			...(resolveDynamicImportPromises as Promise<never>[])
-		]).then(
-			() => this.pluginDriver.hookParallel('moduleParsed', [module.info]),
-			() => {
+		])
+			.then(() => this.pluginDriver.hookParallel('moduleParsed', [module.info]))
+			.catch(() => {
 				/* rejections thrown here are also handled within PluginDriver - they are safe to ignore */
-			}
-		);
+			});
 		await Promise.all([
 			this.fetchStaticDependencies(module, resolveStaticDependencyPromises),
 			this.fetchDynamicDependencies(module, resolveDynamicImportPromises)

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -341,7 +341,12 @@ export class ModuleLoader {
 		Promise.all([
 			...(resolveStaticDependencyPromises as Promise<never>[]),
 			...(resolveDynamicImportPromises as Promise<never>[])
-		]).then(() => this.pluginDriver.hookParallel('moduleParsed', [module.info]));
+		]).then(
+			() => this.pluginDriver.hookParallel('moduleParsed', [module.info]),
+			() => {
+				/* rejections thrown here are also handled within PluginDriver - they are safe to ignore */
+			}
+		);
 		await Promise.all([
 			this.fetchStaticDependencies(module, resolveStaticDependencyPromises),
 			this.fetchDynamicDependencies(module, resolveDynamicImportPromises)

--- a/test/function/samples/es5-class-called-without-new/main.js
+++ b/test/function/samples/es5-class-called-without-new/main.js
@@ -2,6 +2,4 @@ import { Foo, Bar } from './foo';
 
 assert.equal( new Foo(5).value, 5 );
 
-assert.throws( function () {
-	Bar(5);
-}, /^TypeError: Cannot set property 'value' of undefined$/ );
+assert.throws(() => Bar(5), /^TypeError: Cannot set propert.*'value'.*$/ );

--- a/test/function/samples/object-deep-access-effect/_config.js
+++ b/test/function/samples/object-deep-access-effect/_config.js
@@ -1,5 +1,3 @@
-const assert = require('assert');
-
 module.exports = {
 	description: 'throws when an nested property of an unknown object property is accessed',
 	context: {
@@ -9,11 +7,5 @@ module.exports = {
 	},
 	options: {
 		external: ['external']
-	},
-	exports({ expectError }) {
-		assert.throws(expectError, {
-			name: 'TypeError',
-			message: "Cannot read property 'prop' of undefined"
-		});
 	}
 };

--- a/test/function/samples/object-deep-access-effect/main.js
+++ b/test/function/samples/object-deep-access-effect/main.js
@@ -1,6 +1,6 @@
 import { unknown } from 'external';
 
-export function expectError() {
+assert.throws(() => {
 	const obj = {};
 	obj[unknown].prop;
-}
+}, /^TypeError: Cannot read propert.*'prop'.*$/ );

--- a/test/function/samples/warn-on-top-level-this/_config.js
+++ b/test/function/samples/warn-on-top-level-this/_config.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
 const path = require('path');
+const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'warns on top-level this (#770)',
@@ -24,6 +24,7 @@ module.exports = {
 		}
 	],
 	runtimeError: err => {
-		assert.equal(err.message, `Cannot set property 'foo' of undefined`);
+		assertIncludes(err.message, 'Cannot set propert');
+		assertIncludes(err.message, "'foo'");
 	}
 };


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes
- [x] no (_see description_)

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

resolves #4217

### Description

This fixes an instance where rollup can cause an unhandled rejection during normal programmatic usage. There isn't a simple way to test this since as of Node 15, a test would amount to ensuring that the process doesn't exit when you force a module resolution error.

I temporarily enabled `@typescript-eslint/no-floating-promises` with parserServices to check if there were any other places that had floating promises outside of `ModuleLoader.ts` and saw the following:

```console
❯ npx eslint src --cache

/Users/kherock/Workspaces/rollup/src/ModuleLoader.ts
  341:3  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/Users/kherock/Workspaces/rollup/src/utils/queue.ts
  14:4  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/Users/kherock/Workspaces/rollup/src/watch/fileWatcher.ts
  19:3  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  21:4  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
  30:4  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/Users/kherock/Workspaces/rollup/src/watch/watch-proxy.ts
  31:2  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

/Users/kherock/Workspaces/rollup/src/watch/watch.ts
  97:4  error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises

✖ 7 problems (7 errors, 0 warnings)
```

I didn't notice anything else that seemed dangerous, all the other cases were either already handled imperatively or were innocuous `.close()` calls that would only marginally benefit from a handler which logs a warning.