### PR TITLE
chore: remove unused rollup-plugin-typescript ambient module types

### DIFF
--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -45,7 +45,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 	}
 
 	bind(): void {
-		if (this.variable === null && isReference(this, this.parent as any)) {
+		if (this.variable === null && isReference(this, this.parent)) {
 			this.variable = this.scope.findVariable(this.name);
 			this.variable.addReference(this);
 		}

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -9,11 +9,6 @@ declare module 'rollup-plugin-string' {
 	export const string: import('rollup').PluginImpl;
 }
 
-declare module 'rollup-plugin-typescript' {
-	const typescript: import('rollup').PluginImpl;
-	export default typescript;
-}
-
 declare module 'acorn-walk' {
 	type WalkerCallback<TState> = (node: acorn.Node, state: TState) => void;
 	type RecursiveWalkerFn<TState> = (

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -24,7 +24,7 @@ declare module 'is-reference' {
 	export default function is_reference(
 		node: NodeWithFieldDefinition,
 		parent: NodeWithFieldDefinition
-	): unknown;
+	): boolean;
 	export type Node =
 		| import('estree').Identifier
 		| import('estree').SimpleLiteral


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

missed this during the **@rollup/plugin-typescript** bump.

also fixed the return type of **is_reference**.