### PR TITLE
fix(utils): exclude invalid URL chars

### DIFF
--- a/src/utils/sanitizeFileName.ts
+++ b/src/utils/sanitizeFileName.ts
@@ -1,11 +1,12 @@
 // https://datatracker.ietf.org/doc/html/rfc2396
-const INVALID_CHAR_RE = /[?*:\x00-\x1f\x7f<>#"{}|\^[\]`]/g
+// eslint-disable-next-line no-control-regex
+const INVALID_CHAR_RE = /[?*:\x00-\x1f\x7f<>#"{}|\\^[\]`]/g;
 
-export function sanitizeFileName (name: string): string {
-	const match = /^[a-z]:/i.exec(name)
-	const driveLetter = match ? match[0] : ''
+export function sanitizeFileName(name: string): string {
+	const match = /^[a-z]:/i.exec(name);
+	const driveLetter = match ? match[0] : '';
 
 	// A `:` is only allowed as part of a windows drive letter (ex: C:\foo)
 	// Otherwise, avoid them because they can refer to NTFS alternate data streams.
-	return driveLetter + name.substr(driveLetter.length).replace(INVALID_CHAR_RE, '_')
+	return driveLetter + name.substr(driveLetter.length).replace(INVALID_CHAR_RE, '_');
 }

--- a/src/utils/sanitizeFileName.ts
+++ b/src/utils/sanitizeFileName.ts
@@ -1,6 +1,6 @@
 // https://datatracker.ietf.org/doc/html/rfc2396
 // eslint-disable-next-line no-control-regex
-const INVALID_CHAR_RE = /[?*:\x00-\x1f\x7f<>#"{}|\\^[\]`]/g;
+const INVALID_CHAR_RE = /[?*:\x00-\x1f\x7f<>#"{}|^[\]`]/g;
 
 export function sanitizeFileName(name: string): string {
 	const match = /^[a-z]:/i.exec(name);

--- a/src/utils/sanitizeFileName.ts
+++ b/src/utils/sanitizeFileName.ts
@@ -1,8 +1,11 @@
-export function sanitizeFileName(name: string): string {
-	const match = /^[a-z]:/i.exec(name);
-	const driveLetter = match ? match[0] : '';
+// https://datatracker.ietf.org/doc/html/rfc2396
+const INVALID_CHAR_RE = /[?*:\x00-\x1f\x7f<>#"{}|\^[\]`]/g
+
+export function sanitizeFileName (name: string): string {
+	const match = /^[a-z]:/i.exec(name)
+	const driveLetter = match ? match[0] : ''
 
 	// A `:` is only allowed as part of a windows drive letter (ex: C:\foo)
 	// Otherwise, avoid them because they can refer to NTFS alternate data streams.
-	return driveLetter + name.substr(driveLetter.length).replace(/[\0?*:]/g, '_');
+	return driveLetter + name.substr(driveLetter.length).replace(INVALID_CHAR_RE, '_')
 }

--- a/src/utils/sanitizeFileName.ts
+++ b/src/utils/sanitizeFileName.ts
@@ -1,6 +1,6 @@
 // https://datatracker.ietf.org/doc/html/rfc2396
 // eslint-disable-next-line no-control-regex
-const INVALID_CHAR_RE = /[?*:\x00-\x1f\x7f<>#"{}|^[\]`]/g;
+const INVALID_CHAR_RE = /[\x00-\x1F\x7F<>*#"{}|^[\]`;?:&=+$,]/g;
 
 export function sanitizeFileName(name: string): string {
 	const match = /^[a-z]:/i.exec(name);

--- a/test/chunking-form/samples/sanitize-chunk-names/_config.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_config.js
@@ -5,7 +5,7 @@ module.exports = {
 		plugins: [
 			{
 				options(options) {
-					options.input = ['\0virtual:entry-1', '\0virtual:entry-2'];
+					options.input = ['\0virtual:entry-1', '\0virtual:entry-2', 'another-[slug]-#result'];
 					return options;
 				},
 				resolveId(id) {

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/another-_slug_-_result.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/amd/another-_slug_-_result.js
@@ -1,0 +1,7 @@
+define((function () { 'use strict';
+
+	var another__slug___result = "another-[slug]-#result";
+
+	return another__slug___result;
+
+}));

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/another-_slug_-_result.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/cjs/another-_slug_-_result.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var another__slug___result = "another-[slug]-#result";
+
+module.exports = another__slug___result;

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/es/another-_slug_-_result.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/es/another-_slug_-_result.js
@@ -1,0 +1,3 @@
+var another__slug___result = "another-[slug]-#result";
+
+export { another__slug___result as default };

--- a/test/chunking-form/samples/sanitize-chunk-names/_expected/system/another-_slug_-_result.js
+++ b/test/chunking-form/samples/sanitize-chunk-names/_expected/system/another-_slug_-_result.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var another__slug___result = exports('default', "another-[slug]-#result");
+
+		})
+	};
+}));


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

resolves #4222
context: https://github.com/nuxt/framework/issues/1494

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR removes characters that are excluded from valid URLs (see [RFC 2396](https://datatracker.ietf.org/doc/html/rfc2396)). As rollup-produced files may be consumed by browsers, this is one approach to provide broader ecosystem safety without requiring URL encoding.

The context is [this issue](https://github.com/nuxt/framework/issues/1494). I'm aware we can simply sanitize downstream with [output.sanitizeFilename](https://rollupjs.org/guide/en/#outputsanitizefilename), but felt that RFC2396 might be a reasonable standards-based reasong for excluding these characters.

This PR also serves to solve the issue (solely replicable in ESM context) where `#` in filenames breaks imports: #4222.

In response to #4222, @lukastaegert observed:
> But this might break legitimate usages of the hash character for others (not sure how big the risk is, though).

I've marked this as non-breaking as I can't see how a chunk filename could be depended upon, but happily will defer. I'm also happy for this to be closed and to implement this instead with configuration with `output.sanitizeFilename`.