### PR TITLE
support loading ESM plugins from the CLI via `--plugin`

### DIFF
--- a/build-plugins/esm-dynamic-import.ts
+++ b/build-plugins/esm-dynamic-import.ts
@@ -13,7 +13,7 @@ export default function addBinShebangAndEsmImport(): Plugin {
 		name: 'esm-dynamic-import',
 		renderDynamicImport({ moduleId }) {
 			importFound = true;
-			if (moduleId.endsWith('loadConfigFile.ts')) {
+			if (moduleId.endsWith('commandPlugins.ts') || moduleId.endsWith('loadConfigFile.ts')) {
 				return { left: 'import(', right: ')' };
 			}
 		}

--- a/cli/run/index.ts
+++ b/cli/run/index.ts
@@ -92,5 +92,5 @@ async function getConfigs(
 		const { options, warnings } = await loadAndParseConfigFile(configFile, command);
 		return { options, warnings };
 	}
-	return loadConfigFromCommand(command);
+	return await loadConfigFromCommand(command);
 }

--- a/cli/run/loadConfigFile.ts
+++ b/cli/run/loadConfigFile.ts
@@ -27,11 +27,12 @@ export default async function loadAndParseConfigFile(
 	const configs = await loadConfigFile(fileName, commandOptions);
 	const warnings = batchWarnings();
 	try {
-		const normalizedConfigs = configs.map(config => {
+		const normalizedConfigs: MergedRollupOptions[] = [];
+		for (const config of configs) {
 			const options = mergeOptions(config, commandOptions, warnings.add);
-			addCommandPluginsToInputOptions(options, commandOptions);
-			return options;
-		});
+			await addCommandPluginsToInputOptions(options, commandOptions);
+			normalizedConfigs.push(options);
+		}
 		return { options: normalizedConfigs, warnings };
 	} catch (err) {
 		warnings.flush();
@@ -73,7 +74,7 @@ async function getDefaultFromTranspiledConfigFile(
 		plugins: [],
 		treeshake: false
 	};
-	addPluginsFromCommandOption(commandOptions.configPlugin, inputOptions);
+	await addPluginsFromCommandOption(commandOptions.configPlugin, inputOptions);
 	const bundle = await rollup.rollup(inputOptions);
 	if (!commandOptions.silent && warnings.count > 0) {
 		stderr(bold(`loaded ${relativeId(fileName)} with warnings`));

--- a/cli/run/loadConfigFromCommand.ts
+++ b/cli/run/loadConfigFromCommand.ts
@@ -4,15 +4,15 @@ import batchWarnings, { BatchWarnings } from './batchWarnings';
 import { addCommandPluginsToInputOptions } from './commandPlugins';
 import { stdinName } from './stdin';
 
-export default function loadConfigFromCommand(command: Record<string, any>): {
+export default async function loadConfigFromCommand(command: Record<string, any>): Promise<{
 	options: MergedRollupOptions[];
 	warnings: BatchWarnings;
-} {
+}> {
 	const warnings = batchWarnings();
 	if (!command.input && (command.stdin || !process.stdin.isTTY)) {
 		command.input = stdinName;
 	}
 	const options = mergeOptions({ input: [] }, command, warnings.add);
-	addCommandPluginsToInputOptions(options, command);
+	await addCommandPluginsToInputOptions(options, command);
 	return { options: [options], warnings };
 }

--- a/test/cli/samples/plugin/absolute-esm/_config.js
+++ b/test/cli/samples/plugin/absolute-esm/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'ESM CLI --plugin /absolute/path',
+	minNodeVersion: 12,
+	skipIfWindows: true,
+	command: `echo 'console.log(1 ? 2 : 3);' | rollup -p "\`pwd\`/my-esm-plugin.mjs={comment: 'Absolute ESM'}"`
+};

--- a/test/cli/samples/plugin/absolute-esm/_expected.js
+++ b/test/cli/samples/plugin/absolute-esm/_expected.js
@@ -1,0 +1,2 @@
+// Hello Absolute ESM
+console.log(2 );

--- a/test/cli/samples/plugin/absolute-esm/my-esm-plugin.mjs
+++ b/test/cli/samples/plugin/absolute-esm/my-esm-plugin.mjs
@@ -1,0 +1,8 @@
+export default function(options = {}) {
+	const {comment} = options;
+	return {
+		transform(code) {
+			return `// Hello ${comment}\n${code}`;
+		}
+	};
+};

--- a/test/cli/samples/plugin/advanced-esm/_config.js
+++ b/test/cli/samples/plugin/advanced-esm/_config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	description: 'load an ESM-only rollup plugin from node_modules as well as CJS plugins',
+	minNodeVersion: 12,
+	skipIfWindows: true,
+
+	// The NodeJS resolution rules for ESM modules are more restrictive than CJS.
+	// Must copy the ESM plugin into the main node_modules in order to use and test it.
+
+	command: `rm -rf ../../../../../node_modules/rollup-plugin-esm-test && cp -rp node_modules/rollup-plugin-esm-test ../../../../../node_modules/ && rollup -c -p node-resolve,commonjs,esm-test -p "terser={mangle: false, output: {beautify: true, indent_level: 2}}"`
+};

--- a/test/cli/samples/plugin/advanced-esm/_expected/cjs.js
+++ b/test/cli/samples/plugin/advanced-esm/_expected/cjs.js
@@ -1,0 +1,20 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: !0
+}), console.log("esm-test: node_modules/print/index.js");
+
+console.log("esm-test: node_modules/foo/index.js");
+
+var print = function(value) {
+  console.log(value);
+}, Foo = function() {
+  function Foo(x) {
+    this.x = x;
+  }
+  return Foo.prototype.output = function() {
+    print(this.x);
+  }, Foo;
+}();
+
+console.log("esm-test: main.js"), new Foo(123).output(), exports.Bar = Foo;

--- a/test/cli/samples/plugin/advanced-esm/_expected/es.js
+++ b/test/cli/samples/plugin/advanced-esm/_expected/es.js
@@ -1,0 +1,18 @@
+console.log("esm-test: node_modules/print/index.js");
+
+console.log("esm-test: node_modules/foo/index.js");
+
+var print = function(value) {
+  console.log(value);
+}, Foo = function() {
+  function Foo(x) {
+    this.x = x;
+  }
+  return Foo.prototype.output = function() {
+    print(this.x);
+  }, Foo;
+}();
+
+console.log("esm-test: main.js"), new Foo(123).output();
+
+export { Foo as Bar };

--- a/test/cli/samples/plugin/advanced-esm/main.js
+++ b/test/cli/samples/plugin/advanced-esm/main.js
@@ -1,0 +1,4 @@
+import {Foo} from "foo";
+var foo = new Foo(123);
+foo.output();
+export {Foo as Bar};

--- a/test/cli/samples/plugin/advanced-esm/node_modules/foo/index.js
+++ b/test/cli/samples/plugin/advanced-esm/node_modules/foo/index.js
@@ -1,0 +1,10 @@
+var print = require('print');
+
+exports.Foo = class {
+	constructor(x) {
+		this.x = x;
+	}
+	output() {
+		print(this.x);
+	}
+};

--- a/test/cli/samples/plugin/advanced-esm/node_modules/print/index.js
+++ b/test/cli/samples/plugin/advanced-esm/node_modules/print/index.js
@@ -1,0 +1,3 @@
+module.exports = function(value) {
+	console.log(value);
+};

--- a/test/cli/samples/plugin/advanced-esm/node_modules/rollup-plugin-esm-test/index.mjs
+++ b/test/cli/samples/plugin/advanced-esm/node_modules/rollup-plugin-esm-test/index.mjs
@@ -1,0 +1,9 @@
+export function esmTest() {
+	return {
+		transform(code, id) {
+			if (id.includes("\0")) return null;
+			const name = JSON.stringify(id.replace(/^.*\/advanced-esm\//, "esm-test: "));
+			return `console.log(${name});\n${code}`;
+		}
+	};
+}

--- a/test/cli/samples/plugin/advanced-esm/node_modules/rollup-plugin-esm-test/package.json
+++ b/test/cli/samples/plugin/advanced-esm/node_modules/rollup-plugin-esm-test/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "./index.mjs"
+}

--- a/test/cli/samples/plugin/advanced-esm/rollup.config.js
+++ b/test/cli/samples/plugin/advanced-esm/rollup.config.js
@@ -1,0 +1,18 @@
+const buble = require('@rollup/plugin-buble');
+
+export default {
+	input: 'main.js',
+	plugins: [
+		buble()
+	],
+	output: [
+		{
+			file: '_actual/cjs.js',
+			format: 'cjs'
+		},
+		{
+			file: '_actual/es.js',
+			format: 'esm'
+		}
+	]
+};

--- a/test/cli/samples/plugin/relative-esm/_config.js
+++ b/test/cli/samples/plugin/relative-esm/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'ESM CLI --plugin ../relative/path',
+	minNodeVersion: 12,
+	skipIfWindows: true,
+	command: `echo 'console.log(1 ? 2 : 3);' | rollup -p "../absolute-esm/my-esm-plugin.mjs={comment: 'Relative ESM'}"`
+};

--- a/test/cli/samples/plugin/relative-esm/_expected.js
+++ b/test/cli/samples/plugin/relative-esm/_expected.js
@@ -1,0 +1,2 @@
+// Hello Relative ESM
+console.log(2 );


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

n/a

### Description

Rollup presently only supports CJS plugins from the CLI via `--plugin`. This PR adds seamless ESM plugin support to the CLI. To maintain backwards compatibility rollup will still attempt to resolve the plugin via `require` first, and only upon error will it attempt to load the plugin via a dynamic `import()`. This is due to the different module resolution semantics of CJS and ESM modules in NodeJS.

The use of dynamic import to load ESM plugins works with Node v12+.  No rollup CLI functionality is lost on NodeJS versions that do not support loading ESM via dynamic `import`.