### PR TITLE
feat: add support for import assertions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -52,6 +52,13 @@ Repository: https://github.com/acornjs/acorn.git
 
 ---------------------------------------
 
+## acorn-import-assertions
+License: MIT
+By: Sven Sauleau
+Repository: https://github.com/xtuc/acorn-import-assertions
+
+---------------------------------------
+
 ## acorn-walk
 License: MIT
 By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,6 +876,12 @@
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
       "dev": true
     },
+    "acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "dev": true
+    },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -4942,7 +4948,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.1"
+            "ansi-regex": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
     "acorn": "^8.5.0",
+    "acorn-import-assertions": "^1.8.0",
     "acorn-jsx": "^5.3.2",
     "acorn-walk": "^8.2.0",
     "buble": "^0.20.0",

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -1,4 +1,5 @@
 import * as acorn from 'acorn';
+import { importAssertions } from 'acorn-import-assertions';
 import ExternalModule from './ExternalModule';
 import Module from './Module';
 import { ModuleLoader, UnresolvedModule } from './ModuleLoader';
@@ -89,7 +90,10 @@ export default class Graph {
 			});
 		}
 		this.pluginDriver = new PluginDriver(this, options, options.plugins, this.pluginCache);
-		this.acornParser = acorn.Parser.extend(...(options.acornInjectPlugins as any));
+		this.acornParser = acorn.Parser.extend(
+			importAssertions,
+			...(options.acornInjectPlugins as any)
+		);
 		this.moduleLoader = new ModuleLoader(this, this.modulesById, this.options, this.pluginDriver);
 	}
 

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -9,6 +9,10 @@ declare module 'rollup-plugin-string' {
 	export const string: import('rollup').PluginImpl;
 }
 
+declare module 'acorn-import-assertions' {
+	export const importAssertions: (BaseParser: typeof acorn.Parser) => typeof acorn.Parser;
+}
+
 declare module 'acorn-walk' {
 	type WalkerCallback<TState> = (node: acorn.Node, state: TState) => void;
 	type RecursiveWalkerFn<TState> = (


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
https://github.com/rollup/rollup/issues/3799

node.js support: json modules import assertions was recently merged into master ~(not yet released)~ released with v17.1.0: https://github.com/nodejs/node/pull/40250

webpack support: https://github.com/webpack/webpack/pull/12278  (parsing only)

typescript support: https://github.com/microsoft/TypeScript/pull/40698  (parsing only)

babel support: https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-import-assertions  (parsing only)

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

there's a couple questions we need to figure out about the differences on what is currently supported, and what and how support should look like going forward:

### current json support:
- needs a plugin
- plugin `always` exports a `default` export, and named exports if it's a plain object with properties
- all other types are being exported as default export only
- ~node.js support behind a flag `--experimental-json-modules`~, support behind the flag has been removed in v17.1.0.  `import assertions` are now required, including the same flag. only supports default exports
- not supported by browsers (and likely never will be)

- this should be not possible, but currently is supported:
```js
import foo from "./foo.json";

console.log(foo);
```

// foo.json
```json
{
  "__proto__": null,
  "foo": 2
}
```

bundled to:
```js
var __proto__ = null;
var foo = 2;
const foo$1 = {
	__proto__: __proto__,
	foo: foo
};

console.log(foo$1); // this is entirely different than going thru JSON.parse()
```

- another problem JSON.parse() would avoid. since this example is already using the json plugin, we could properly throw that this is not valid "json":

```json
<html />
```

```shell
(!) Plugin json: Could not parse JSON file
foo.json
[!] Error: Unexpected token (Note that you need @rollup/plugin-json to import JSON files)
foo.json (1:0)
1: <html />
   ^
Error: Unexpected token (Note that you need @rollup/plugin-json to import JSON files)
```

### import assertions/json modules
- should? need a plugin?
- spec indicates json is always a default export, named exports are no supported
- it should also be parsed with JSON.parse(), otherwise throw (hence assertion syntax)
- supported by node.js (behind `--experimental-json-modules`)
- supported by browsers

I think the most straight forward and spec compliant way would be to export as default and use JSON.parse() at user runtime on the file content. if not json, throw. in addition retire named exports - in a major version - otherwise it would just add more confusion in an ecosystem with a lot of weirdness, fragmentation and inconsistencies. (javascript in general, but also the cjs, esm, amd, umd, systemjs module nightmare [and transition] we are currently in.)

another possible spec compliant alternative could also be to read the file contents and run JSON.parse(...) at rollup runtime. I think I prefer the former, as it aligns with the non-bundled runtime. on the end of the day it might not matter, other than performance https://github.com/rollup/rollup/issues/3799#issuecomment-705130084 and the fact that one would throws at user runtime, and the other would throw at rollup runtime (if we don't have valid json). throwing at user runtime should not be considered much of a problem, since javascript (or any scripting language) is doing the same.

_edit:_

forgot to mention a scenario where import assertions are being used, but declared as external. the import assertion should remain in the code as it otherwise would fail loading unbundled. (currently it is being removed)

```js
import foo from "./foo.json" assert { type: 'json' }
console.log(foo)
```

```js
// rollup.config.js
export default {
  external: ["./foo.json"],
  // ...
}
```

becomes:
```js
import foo from "./foo.json"
console.log(foo)
```