### PR TITLE
fix: escape dynamic import paths

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -921,13 +921,15 @@ export default class Chunk {
 				}
 				const renderedResolution =
 					resolution instanceof Module
-						? `'${this.getRelativePath((facadeChunk || chunk!).id!, stripKnownJsExtensions)}'`
+						? `'${escapeId(
+								this.getRelativePath((facadeChunk || chunk!).id!, stripKnownJsExtensions)
+						  )}'`
 						: resolution instanceof ExternalModule
-						? `'${
+						? `'${escapeId(
 								resolution.renormalizeRenderPath
 									? this.getRelativePath(resolution.renderPath, stripKnownJsExtensions)
 									: resolution.renderPath
-						  }'`
+						  )}'`
 						: resolution;
 				node.renderFinalResolution(
 					code,

--- a/test/chunking-form/samples/emit-file/emit-chunk/_config.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk/_config.js
@@ -9,6 +9,14 @@ module.exports = {
 			buildStart() {
 				referenceId = this.emitFile({ type: 'chunk', id: 'buildStart' });
 			},
+			resolveId(id) {
+				if (id === 'external') {
+					return {
+						id: "./ext'ernal",
+						external: true
+					};
+				}
+			},
 			renderChunk() {
 				assert.strictEqual(this.getFileName(referenceId), 'generated-buildStart.js');
 			}

--- a/test/chunking-form/samples/emit-file/emit-chunk/_expected/amd/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk/_expected/amd/main.js
@@ -1,4 +1,24 @@
-define(['./generated-dep'], (function (dep) { 'use strict';
+define(['require', './generated-dep'], (function (require, dep) { 'use strict';
+
+	function _interopNamespace(e) {
+		if (e && e.__esModule) return e;
+		var n = Object.create(null);
+		if (e) {
+			Object.keys(e).forEach(function (k) {
+				if (k !== 'default') {
+					var d = Object.getOwnPropertyDescriptor(e, k);
+					Object.defineProperty(n, k, d.get ? d : {
+						enumerable: true,
+						get: function () { return e[k]; }
+					});
+				}
+			});
+		}
+		n["default"] = e;
+		return Object.freeze(n);
+	}
+
+	new Promise(function (resolve, reject) { require(['./ext\'ernal'], function (m) { resolve(/*#__PURE__*/_interopNamespace(m)); }, reject); });
 
 	console.log('main', dep.value);
 

--- a/test/chunking-form/samples/emit-file/emit-chunk/_expected/cjs/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk/_expected/cjs/main.js
@@ -2,4 +2,24 @@
 
 var dep = require('./generated-dep.js');
 
+function _interopNamespace(e) {
+	if (e && e.__esModule) return e;
+	var n = Object.create(null);
+	if (e) {
+		Object.keys(e).forEach(function (k) {
+			if (k !== 'default') {
+				var d = Object.getOwnPropertyDescriptor(e, k);
+				Object.defineProperty(n, k, d.get ? d : {
+					enumerable: true,
+					get: function () { return e[k]; }
+				});
+			}
+		});
+	}
+	n["default"] = e;
+	return Object.freeze(n);
+}
+
+Promise.resolve().then(function () { return /*#__PURE__*/_interopNamespace(require('./ext\'ernal')); });
+
 console.log('main', dep.value);

--- a/test/chunking-form/samples/emit-file/emit-chunk/_expected/es/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk/_expected/es/main.js
@@ -1,3 +1,5 @@
 import { v as value } from './generated-dep.js';
 
+import('./ext\'ernal');
+
 console.log('main', value);

--- a/test/chunking-form/samples/emit-file/emit-chunk/_expected/system/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk/_expected/system/main.js
@@ -1,4 +1,4 @@
-System.register(['./generated-dep.js'], (function () {
+System.register(['./generated-dep.js'], (function (exports, module) {
 	'use strict';
 	var value;
 	return {
@@ -6,6 +6,8 @@ System.register(['./generated-dep.js'], (function () {
 			value = module.v;
 		}],
 		execute: (function () {
+
+			module.import('./ext\'ernal');
 
 			console.log('main', value);
 

--- a/test/chunking-form/samples/emit-file/emit-chunk/main.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk/main.js
@@ -1,3 +1,4 @@
 import value from './dep.js';
+import('external');
 
 console.log('main', value);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR addresses issues when using rollup for a project with `'` in the path, for example `/Users/Daniel's Projects/project/`. Although normal imports are escaped correctly, it seems that dynamic imports are treated differently and we need to escape them as well.

Context: https://github.com/nuxt/framework/issues/2192.