### PR TITLE
refactor: convert utils.transform to async function

### DIFF
--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -37,7 +37,7 @@ export default async function transform(
 	const emittedFiles: EmittedFile[] = [];
 	let customTransformCache = false;
 	const useCustomTransformCache = () => (customTransformCache = true);
-	let curPlugin: Plugin | undefined;
+	let pluginName = '';
 	const curSource: string = source.code;
 
 	function transformReducer(
@@ -85,7 +85,7 @@ export default async function transform(
 			[curSource, id],
 			transformReducer,
 			(pluginContext, plugin): TransformPluginContext => {
-				curPlugin = plugin;
+				pluginName = plugin.name;
 				return {
 					...pluginContext,
 					addWatchFile(id: string) {
@@ -153,7 +153,7 @@ export default async function transform(
 			}
 		);
 	} catch (err: any) {
-		throwPluginError(err, curPlugin?.name ?? 'Unknown plugin', { hook: 'transform', id });
+		throwPluginError(err, pluginName, { hook: 'transform', id });
 	}
 
 	if (!customTransformCache) {

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -21,7 +21,7 @@ import { decodedSourcemap } from './decodedSourcemap';
 import { augmentCodeLocation, errNoTransformMapOrAstWithoutCode } from './error';
 import { throwPluginError } from './pluginUtils';
 
-export default function transform(
+export default async function transform(
 	source: SourceDescription,
 	module: Module,
 	pluginDriver: PluginDriver,
@@ -37,7 +37,7 @@ export default function transform(
 	const emittedFiles: EmittedFile[] = [];
 	let customTransformCache = false;
 	const useCustomTransformCache = () => (customTransformCache = true);
-	let curPlugin: Plugin;
+	let curPlugin: Plugin | undefined;
 	const curSource: string = source.code;
 
 	function transformReducer(
@@ -77,8 +77,10 @@ export default function transform(
 		return code;
 	}
 
-	return pluginDriver
-		.hookReduceArg0(
+	let code: string;
+
+	try {
+		code = await pluginDriver.hookReduceArg0(
 			'transform',
 			[curSource, id],
 			transformReducer,
@@ -149,23 +151,24 @@ export default function transform(
 					}
 				};
 			}
-		)
-		.catch(err => throwPluginError(err, curPlugin.name, { hook: 'transform', id }))
-		.then(code => {
-			if (!customTransformCache) {
-				// files emitted by a transform hook need to be emitted again if the hook is skipped
-				if (emittedFiles.length) module.transformFiles = emittedFiles;
-			}
+		);
+	} catch (err: any) {
+		throwPluginError(err, curPlugin?.name ?? 'Unknown plugin', { hook: 'transform', id });
+	}
 
-			return {
-				ast,
-				code,
-				customTransformCache,
-				meta: module.info.meta,
-				originalCode,
-				originalSourcemap,
-				sourcemapChain,
-				transformDependencies
-			};
-		});
+	if (!customTransformCache) {
+		// files emitted by a transform hook need to be emitted again if the hook is skipped
+		if (emittedFiles.length) module.transformFiles = emittedFiles;
+	}
+
+	return {
+		ast,
+		code,
+		customTransformCache,
+		meta: module.info.meta,
+		originalCode,
+		originalSourcemap,
+		sourcemapChain,
+		transformDependencies
+	};
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Typescript found another potential bug during the conversion:

```
[!] (plugin typescript) Error: @rollup/plugin-typescript TS2454: Variable 'curPlugin' is used before being assigned.
src/utils/transform.ts (156:25)

156   throwPluginError(err, curPlugin.name, { hook: 'transform', id });
```

which makes sense, since the assignment is not guaranteed in the `try` block, if the code throws anywhere prior.