### PR TITLE
Directly restart Rollup when config file change is detected

### DIFF
--- a/cli/logging.ts
+++ b/cli/logging.ts
@@ -3,7 +3,7 @@ import { bold, cyan, dim, red } from '../src/utils/colors';
 import relativeId from '../src/utils/relativeId';
 
 // log to stderr to keep `rollup main.js > bundle.js` from breaking
-export const stderr = console.error.bind(console);
+export const stderr = (...args: unknown[]) => process.stderr.write(`${args.join('')}\n`);
 
 export function handleError(err: RollupError, recover = false): void {
 	let description = err.message || err;

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -35,113 +35,116 @@ function runTest(dir, config, pass) {
 			if (pass > 0) {
 				getFileNamesAndRemoveOutput(dir);
 			}
-			if (config.before) config.before();
-
 			const command = config.command.replace(
 				/(^| )rollup($| )/g,
 				`node ${path.resolve(__dirname, '../../dist/bin')}${path.sep}rollup `
 			);
 
-			const childProcess = exec(
-				command,
-				{
-					timeout: 40000,
-					env: { ...process.env, FORCE_COLOR: '0', ...config.env }
-				},
-				(err, code, stderr) => {
-					if (config.after) config.after(err, code, stderr);
-					if (err && !err.killed) {
-						if (config.error) {
-							const shouldContinue = config.error(err);
-							if (!shouldContinue) return done();
-						} else {
-							throw err;
-						}
-					}
-
-					if ('stderr' in config) {
-						const shouldContinue = config.stderr(stderr);
-						if (!shouldContinue) return done();
-					} else if (stderr) {
-						console.error(stderr);
-					}
-
-					let unintendedError;
-
-					if (config.execute) {
-						try {
-							const fn = new Function('require', 'module', 'exports', 'assert', code);
-							const module = {
-								exports: {}
-							};
-							fn(require, module, module.exports, assert);
-
+			Promise.resolve(config.before && config.before()).then(() => {
+				const childProcess = exec(
+					command,
+					{
+						timeout: 40000,
+						env: { ...process.env, FORCE_COLOR: '0', ...config.env }
+					},
+					(err, code, stderr) => {
+						if (config.after) config.after(err, code, stderr);
+						if (err && !err.killed) {
 							if (config.error) {
-								unintendedError = new Error('Expected an error while executing output');
-							}
-
-							if (config.exports) {
-								config.exports(module.exports);
-							}
-						} catch (err) {
-							if (config.error) {
-								config.error(err);
+								const shouldContinue = config.error(err);
+								if (!shouldContinue) return done();
 							} else {
-								unintendedError = err;
+								throw err;
 							}
 						}
 
-						if (config.show || unintendedError) {
-							console.log(code + '\n\n\n');
+						if ('stderr' in config) {
+							const shouldContinue = config.stderr(stderr);
+							if (!shouldContinue) return done();
+						} else if (stderr) {
+							console.error(stderr);
 						}
 
-						if (config.solo) console.groupEnd();
+						let unintendedError;
 
-						unintendedError ? done(unintendedError) : done();
-					} else if (config.result) {
-						try {
-							config.result(code);
-							done();
-						} catch (err) {
-							done(err);
-						}
-					} else if (config.test) {
-						try {
-							config.test();
-							done();
-						} catch (err) {
-							done(err);
-						}
-					} else if (sander.existsSync('_expected') && sander.statSync('_expected').isDirectory()) {
-						try {
-							assertDirectoriesAreEqual('_actual', '_expected');
-							done();
-						} catch (err) {
-							done(err);
-						}
-					} else {
-						const expected = sander.readFileSync('_expected.js').toString();
-						try {
-							assert.equal(normaliseOutput(code), normaliseOutput(expected));
-							done();
-						} catch (err) {
-							done(err);
+						if (config.execute) {
+							try {
+								const fn = new Function('require', 'module', 'exports', 'assert', code);
+								const module = {
+									exports: {}
+								};
+								fn(require, module, module.exports, assert);
+
+								if (config.error) {
+									unintendedError = new Error('Expected an error while executing output');
+								}
+
+								if (config.exports) {
+									config.exports(module.exports);
+								}
+							} catch (err) {
+								if (config.error) {
+									config.error(err);
+								} else {
+									unintendedError = err;
+								}
+							}
+
+							if (config.show || unintendedError) {
+								console.log(code + '\n\n\n');
+							}
+
+							if (config.solo) console.groupEnd();
+
+							unintendedError ? done(unintendedError) : done();
+						} else if (config.result) {
+							try {
+								config.result(code);
+								done();
+							} catch (err) {
+								done(err);
+							}
+						} else if (config.test) {
+							try {
+								config.test();
+								done();
+							} catch (err) {
+								done(err);
+							}
+						} else if (
+							sander.existsSync('_expected') &&
+							sander.statSync('_expected').isDirectory()
+						) {
+							try {
+								assertDirectoriesAreEqual('_actual', '_expected');
+								done();
+							} catch (err) {
+								done(err);
+							}
+						} else {
+							const expected = sander.readFileSync('_expected.js').toString();
+							try {
+								assert.equal(normaliseOutput(code), normaliseOutput(expected));
+								done();
+							} catch (err) {
+								done(err);
+							}
 						}
 					}
-				}
-			);
+				);
 
-			childProcess.stderr.on('data', async data => {
-				if (config.abortOnStderr) {
-					try {
-						if (await config.abortOnStderr(data)) {
+				childProcess.stderr.on('data', async data => {
+					if (config.abortOnStderr) {
+						try {
+							if (await config.abortOnStderr(data)) {
+								childProcess.kill('SIGTERM');
+							}
+						} catch (err) {
 							childProcess.kill('SIGTERM');
+							done(err);
 						}
-					} catch (err) {
-						childProcess.kill('SIGTERM');
-						done(err);
 					}
-				}
+				});
 			});
 		}
 	).timeout(50000);

--- a/test/cli/samples/wait-for-bundle-input/_config.js
+++ b/test/cli/samples/wait-for-bundle-input/_config.js
@@ -18,5 +18,7 @@ module.exports = {
 			// wait longer than one polling interval
 			setTimeout(() => atomicWriteFileSync(mainFile, 'export default 42;'), 600);
 		}
+		// We wait for a regular abort as we do not watch
+		return false;
 	}
 };

--- a/test/cli/samples/watch/no-config-file/_config.js
+++ b/test/cli/samples/watch/no-config-file/_config.js
@@ -1,8 +1,10 @@
+const path = require('path');
+
 module.exports = {
 	description: 'watches without a config file',
 	command: 'rollup main.js --watch --format es --file _actual/main.js',
 	abortOnStderr(data) {
-		if (data.includes('created _actual/main.js')) {
+		if (data.includes(`created _actual${path.sep}main.js`)) {
 			return true;
 		}
 	}

--- a/test/cli/samples/watch/node-config-file/_config.js
+++ b/test/cli/samples/watch/node-config-file/_config.js
@@ -1,8 +1,10 @@
+const path = require('path');
+
 module.exports = {
 	description: 'watches using a node_modules config files',
 	command: 'rollup --watch --config node:custom',
 	abortOnStderr(data) {
-		if (data.includes('created _actual/main.js')) {
+		if (data.includes(`created _actual${path.sep}main.js`)) {
 			return true;
 		}
 	}

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -5,6 +5,7 @@ const { writeAndSync } = require('../../../../utils');
 let configFile;
 
 module.exports = {
+	repeat: 10,
 	description: 'immediately reloads the config file if a change happens while it is parsed',
 	command: 'rollup -cw',
 	before() {

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -16,11 +16,11 @@ module.exports = {
 		fs.writeFileSync(
 			configFile,
 			`
-		  import { watch } from 'fs';
+		  import { watchFile, unwatchFile } from 'fs';
       export default new Promise(resolve => {
-				const watcher = watch(${JSON.stringify(configFile)}, () => {
+        const listener = () => {
 				  console.error('config update detected');
-				  watcher.close();
+				  unwatchFile(${JSON.stringify(configFile)}, listener);
 				  setTimeout(() => {
 				    console.error('resolve original config');
 				    resolve({
@@ -32,7 +32,8 @@ module.exports = {
             })
           // wait a moment to make sure we do not trigger before Rollup's watcher
           }, 600)
-				});
+				};
+				watchFile(${JSON.stringify(configFile)}, { interval: 100 }, listener);
 				console.error('initial');
       });
   		`

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -6,7 +6,6 @@ const configFile = path.join(__dirname, 'rollup.config.js');
 let stopUpdate;
 
 module.exports = {
-	repeat: 100,
 	description: 'immediately reloads the config file if a change happens while it is parsed',
 	command: 'rollup -cw',
 	before() {

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -5,7 +5,6 @@ const { writeAndSync } = require('../../../../utils');
 let configFile;
 
 module.exports = {
-	repeat: 10,
 	description: 'immediately reloads the config file if a change happens while it is parsed',
 	command: 'rollup -cw',
 	before() {
@@ -27,7 +26,7 @@ module.exports = {
                 format: 'es'
               }
             }),
-          2000
+          4000
         );
       });`
 		);

--- a/test/cli/samples/watch/watch-config-error/_config.js
+++ b/test/cli/samples/watch/watch-config-error/_config.js
@@ -48,7 +48,7 @@ module.exports = {
 			return false;
 		}
 		if (data.includes(`created _actual${path.sep}main2.js`)) {
-			return new Promise(resolve => setTimeout(() => resolve(true), 600));
+			return true;
 		}
 	}
 };

--- a/test/cli/samples/watch/watch-config-no-update/_config.js
+++ b/test/cli/samples/watch/watch-config-no-update/_config.js
@@ -23,9 +23,10 @@ module.exports = {
 		fs.unlinkSync(configFile);
 	},
 	abortOnStderr(data) {
-		if (data.includes('created _actual/main.js')) {
+		if (data.includes(`created _actual${path.sep}main.js`)) {
 			atomicWriteFileSync(configFile, configContent);
-			return new Promise(resolve => setTimeout(() => resolve(true), 500));
+			// wait some time for the watcher to trigger
+			return new Promise(resolve => setTimeout(() => resolve(true), 600));
 		}
 	},
 	stderr(stderr) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
As there was another test failure on a branch, this one picks up a suggestion by @kzc to use `fs.fsync` to make sure an updated file is flushed to disk earlier.
