### PR TITLE
Create a shallow copy when returning meta from resolveId

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -293,7 +293,7 @@ export default class Module {
 				}
 				return module.isIncluded();
 			},
-			meta,
+			meta: { ...meta },
 			syntheticNamedExports
 		};
 	}

--- a/test/function/samples/reuse-resolve-meta/_config.js
+++ b/test/function/samples/reuse-resolve-meta/_config.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const path = require('path');
+const meta = { plugin: { initial: true } };
+
+const ID_MAIN = path.join(__dirname, 'main.js');
+
+module.exports = {
+	description: 'does not modify meta objects passed in resolveId',
+	options: {
+		plugins: [
+			{
+				async resolveId(source, importer) {
+					const { id } = await this.resolve(source, importer, { skipSelf: true });
+					return { id, meta };
+				},
+				transform(code) {
+					return { code, meta: { otherPlugin: { ignored: true }, plugin: { replaced: true } } };
+				},
+				buildEnd() {
+					assert.deepStrictEqual(meta, { plugin: { initial: true } });
+					assert.deepStrictEqual(this.getModuleInfo(ID_MAIN).meta, {
+						otherPlugin: { ignored: true },
+						plugin: { replaced: true }
+					});
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/reuse-resolve-meta/main.js
+++ b/test/function/samples/reuse-resolve-meta/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When returning a meta object from a resolveId hook, Rollup would use this object as the meta property of a module. As it turned out, this is not only inconsistent with the `load` and `transform` hooks (where the object is merged shallowly) but also causes unexpected behaviour. E.g., the meta object returned from a `resolveId` hook can not be safely reused for other modules. But more importantly, it is unsafe to cache the return value of `this.resolve` as the associated `meta` property can change later on. This is fixed here.

The issue turned up in rollup/plugins#1038