### PR TITLE
refactor: remove acorn-walk ambient type definitions

### DIFF
--- a/src/utils/pureComments.ts
+++ b/src/utils/pureComments.ts
@@ -1,5 +1,5 @@
 import * as acorn from 'acorn';
-import { type BaseWalker, base as basicWalker } from 'acorn-walk';
+import { base as basicWalker } from 'acorn-walk';
 import {
 	BinaryExpression,
 	CallExpression,
@@ -29,7 +29,7 @@ interface NodeWithComments extends acorn.Node {
 function handlePureAnnotationsOfNode(
 	node: acorn.Node,
 	state: CommentState,
-	type: string = node.type
+	type = node.type
 ): void {
 	const { annotations } = state;
 	let comment = annotations[state.annotationIndex];
@@ -38,7 +38,7 @@ function handlePureAnnotationsOfNode(
 		comment = annotations[++state.annotationIndex];
 	}
 	if (comment && comment.end <= node.end) {
-		(basicWalker as BaseWalker<CommentState>)[type](node, state, handlePureAnnotationsOfNode);
+		basicWalker[type](node, state, handlePureAnnotationsOfNode);
 		while ((comment = annotations[state.annotationIndex]) && comment.end <= node.end) {
 			++state.annotationIndex;
 			annotateNode(node, comment, false);

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -9,17 +9,6 @@ declare module 'rollup-plugin-string' {
 	export const string: import('rollup').PluginImpl;
 }
 
-declare module 'acorn-walk' {
-	type WalkerCallback<TState> = (node: acorn.Node, state: TState) => void;
-	type RecursiveWalkerFn<TState> = (
-		node: acorn.Node,
-		state: TState,
-		callback: WalkerCallback<TState>
-	) => void;
-	export type BaseWalker<TState> = Record<string, RecursiveWalkerFn<TState>>;
-	export const base: BaseWalker<unknown>;
-}
-
 declare module 'is-reference' {
 	export default function is_reference(
 		node: NodeWithFieldDefinition,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

`base` is defined in `acorn-walk` module