### PR TITLE
Improve test stability by getting independent of module id ordering in more places

### DIFF
--- a/test/function/samples/custom-module-options/_config.js
+++ b/test/function/samples/custom-module-options/_config.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { getObject } = require('../../../utils');
 
 function getTestPlugin(index) {
 	const pluginName = `test-${index}`;
@@ -40,28 +41,26 @@ module.exports = {
 				name: 'wrap-up',
 				buildEnd() {
 					assert.deepStrictEqual(
-						[...this.getModuleIds()]
-							.filter(id => id.includes('resolve'))
-							.sort()
-							.map(id => ({ id, meta: this.getModuleInfo(id).meta })),
-						[
-							{
-								id: 'resolve1-load2-transform3',
-								meta: {
-									'test-1': { resolved: 1 },
-									'test-2': { loaded: 2 },
-									'test-3': { transformed: 3 }
-								}
+						getObject(
+							[...this.getModuleIds()]
+								.filter(id => id.includes('resolve'))
+								.map(id => [id, this.getModuleInfo(id).meta])
+						),
+						{
+							'resolve1-load2-transform3': {
+								'test-1': { resolved: 1 },
+								'test-2': { loaded: 2 },
+								'test-3': { transformed: 3 }
 							},
-							{
-								id: 'resolve2-load2-transform3',
-								meta: { 'test-2': { loaded: 2 }, 'test-3': { transformed: 3 } }
+							'resolve2-load2-transform3': {
+								'test-2': { loaded: 2 },
+								'test-3': { transformed: 3 }
 							},
-							{
-								id: 'resolve3-load3-transform1-transform3',
-								meta: { 'test-3': { transformed: 3 }, 'test-1': { transformed: 1 } }
+							'resolve3-load3-transform1-transform3': {
+								'test-3': { transformed: 3 },
+								'test-1': { transformed: 1 }
 							}
-						]
+						}
 					);
 				}
 			}

--- a/test/function/samples/deprecated/manual-chunks-info/_config.js
+++ b/test/function/samples/deprecated/manual-chunks-info/_config.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const path = require('path');
+const { getObject } = require('../../../../utils');
 
 function getId(name) {
 	return path.join(__dirname, `${name}.js`);
@@ -13,9 +14,11 @@ module.exports = {
 		output: {
 			manualChunks(id, { getModuleIds, getModuleInfo }) {
 				assert.deepStrictEqual(
-					JSON.parse(JSON.stringify([...getModuleIds()].sort().map(id => getModuleInfo(id)))),
-					[
-						{
+					getObject(
+						[...getModuleIds()].map(id => [id, JSON.parse(JSON.stringify(getModuleInfo(id)))])
+					),
+					{
+						[getId('dynamic')]: {
 							id: getId('dynamic'),
 							ast: {
 								type: 'Program',
@@ -107,7 +110,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						},
-						{
+						[getId('lib')]: {
 							id: getId('lib'),
 							ast: {
 								type: 'Program',
@@ -140,7 +143,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						},
-						{
+						[getId('main')]: {
 							id: getId('main'),
 							ast: {
 								type: 'Program',
@@ -261,7 +264,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						},
-						{
+						external: {
 							id: 'external',
 							ast: null,
 							code: null,
@@ -281,7 +284,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						}
-					]
+					}
 				);
 			}
 		}

--- a/test/function/samples/deprecated/resolve-id-external/_config.js
+++ b/test/function/samples/deprecated/resolve-id-external/_config.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const path = require('path');
 const sideEffects = [];
+const { getObject } = require('../../../../utils');
 
 module.exports = {
 	description: 'does not include modules without used exports if moduleSideEffect is false',
@@ -47,33 +48,31 @@ module.exports = {
 			},
 			buildEnd() {
 				assert.deepStrictEqual(
-					Array.from(this.getModuleIds())
-						.filter(id => !path.isAbsolute(id))
-						.sort()
-						.map(id => ({ id, hasModuleSideEffects: this.getModuleInfo(id).hasModuleSideEffects })),
-					[
-						{ id: 'sideeffects-false-usereffects-false', hasModuleSideEffects: false },
-						{
-							id: 'sideeffects-false-usereffects-false-unused-import',
-							hasModuleSideEffects: false
-						},
-						{ id: 'sideeffects-false-usereffects-false-used-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true', hasModuleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-unused-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-used-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-unused-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-used-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-true', hasModuleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-unused-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-used-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-unused-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-used-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-unused-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-used-import', hasModuleSideEffects: true }
-					]
+					getObject(
+						[...this.getModuleIds()]
+							.filter(id => !path.isAbsolute(id))
+							.map(id => [id, this.getModuleInfo(id).hasModuleSideEffects])
+					),
+					{
+						'sideeffects-false-usereffects-false': false,
+						'sideeffects-false-usereffects-false-unused-import': false,
+						'sideeffects-false-usereffects-false-used-import': false,
+						'sideeffects-false-usereffects-true': false,
+						'sideeffects-false-usereffects-true-unused-import': false,
+						'sideeffects-false-usereffects-true-used-import': false,
+						'sideeffects-null-usereffects-false': false,
+						'sideeffects-null-usereffects-false-unused-import': false,
+						'sideeffects-null-usereffects-false-used-import': false,
+						'sideeffects-null-usereffects-true': true,
+						'sideeffects-null-usereffects-true-unused-import': true,
+						'sideeffects-null-usereffects-true-used-import': true,
+						'sideeffects-true-usereffects-false': true,
+						'sideeffects-true-usereffects-false-unused-import': true,
+						'sideeffects-true-usereffects-false-used-import': true,
+						'sideeffects-true-usereffects-true': true,
+						'sideeffects-true-usereffects-true-unused-import': true,
+						'sideeffects-true-usereffects-true-used-import': true
+					}
 				);
 			}
 		}

--- a/test/function/samples/deprecated/resolve-id/_config.js
+++ b/test/function/samples/deprecated/resolve-id/_config.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const path = require('path');
+const { getObject } = require('../../../../utils');
+
 const sideEffects = [];
 
 module.exports = {
@@ -55,33 +57,31 @@ module.exports = {
 			},
 			buildEnd() {
 				assert.deepStrictEqual(
-					Array.from(this.getModuleIds())
-						.filter(id => !path.isAbsolute(id))
-						.sort()
-						.map(id => ({ id, hasModuleSideEffects: this.getModuleInfo(id).hasModuleSideEffects })),
-					[
-						{ id: 'sideeffects-false-usereffects-false', hasModuleSideEffects: false },
-						{
-							id: 'sideeffects-false-usereffects-false-unused-import',
-							hasModuleSideEffects: false
-						},
-						{ id: 'sideeffects-false-usereffects-false-used-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true', hasModuleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-unused-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-used-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-unused-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-used-import', hasModuleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-true', hasModuleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-unused-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-used-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-unused-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-used-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-unused-import', hasModuleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-used-import', hasModuleSideEffects: true }
-					]
+					getObject(
+						[...this.getModuleIds()]
+							.filter(id => !path.isAbsolute(id))
+							.map(id => [id, this.getModuleInfo(id).hasModuleSideEffects])
+					),
+					{
+						'sideeffects-false-usereffects-false': false,
+						'sideeffects-false-usereffects-false-unused-import': false,
+						'sideeffects-false-usereffects-false-used-import': false,
+						'sideeffects-false-usereffects-true': false,
+						'sideeffects-false-usereffects-true-unused-import': false,
+						'sideeffects-false-usereffects-true-used-import': false,
+						'sideeffects-null-usereffects-false': false,
+						'sideeffects-null-usereffects-false-unused-import': false,
+						'sideeffects-null-usereffects-false-used-import': false,
+						'sideeffects-null-usereffects-true': true,
+						'sideeffects-null-usereffects-true-unused-import': true,
+						'sideeffects-null-usereffects-true-used-import': true,
+						'sideeffects-true-usereffects-false': true,
+						'sideeffects-true-usereffects-false-unused-import': true,
+						'sideeffects-true-usereffects-false-used-import': true,
+						'sideeffects-true-usereffects-true': true,
+						'sideeffects-true-usereffects-true-unused-import': true,
+						'sideeffects-true-usereffects-true-used-import': true
+					}
 				);
 			}
 		}

--- a/test/function/samples/manual-chunks-info/_config.js
+++ b/test/function/samples/manual-chunks-info/_config.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const path = require('path');
+const { getObject } = require('../../../utils');
 
 function getId(name) {
 	return path.join(__dirname, `${name}.js`);
@@ -12,13 +13,139 @@ module.exports = {
 		output: {
 			manualChunks(id, { getModuleIds, getModuleInfo }) {
 				assert.deepStrictEqual(
-					[...getModuleIds()],
-					[getId('main'), 'external', getId('lib'), getId('dynamic')]
-				);
-				assert.deepStrictEqual(
-					JSON.parse(JSON.stringify([...getModuleIds()].map(id => getModuleInfo(id)))),
-					[
-						{
+					getObject(
+						[...getModuleIds()]
+							.sort()
+							.map(id => [id, JSON.parse(JSON.stringify(getModuleInfo(id)))])
+					),
+					{
+						[getId('dynamic')]: {
+							id: getId('dynamic'),
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 88,
+								body: [
+									{
+										type: 'ExportNamedDeclaration',
+										start: 0,
+										end: 42,
+										declaration: {
+											type: 'VariableDeclaration',
+											start: 7,
+											end: 42,
+											declarations: [
+												{
+													type: 'VariableDeclarator',
+													start: 13,
+													end: 41,
+													id: { type: 'Identifier', start: 13, end: 20, name: 'promise' },
+													init: {
+														type: 'ImportExpression',
+														start: 23,
+														end: 41,
+														source: {
+															type: 'Literal',
+															start: 30,
+															end: 40,
+															value: 'external',
+															raw: "'external'"
+														}
+													}
+												}
+											],
+											kind: 'const'
+										},
+										specifiers: [],
+										source: null
+									},
+									{
+										type: 'ExportNamedDeclaration',
+										start: 43,
+										end: 87,
+										declaration: null,
+										specifiers: [
+											{
+												type: 'ExportSpecifier',
+												start: 52,
+												end: 71,
+												local: { type: 'Identifier', start: 52, end: 59, name: 'default' },
+												exported: { type: 'Identifier', start: 63, end: 71, name: 'internal' }
+											}
+										],
+										source: { type: 'Literal', start: 79, end: 86, value: './lib', raw: "'./lib'" }
+									}
+								],
+								sourceType: 'module'
+							},
+							code: "export const promise = import('external');\nexport { default as internal } from './lib';\n",
+							dynamicallyImportedIdResolutions: [
+								{
+									external: true,
+									id: 'external',
+									meta: {},
+									moduleSideEffects: true,
+									syntheticNamedExports: false
+								}
+							],
+							dynamicallyImportedIds: ['external'],
+							dynamicImporters: [getId('main')],
+							hasDefaultExport: false,
+							moduleSideEffects: true,
+							implicitlyLoadedAfterOneOf: [],
+							implicitlyLoadedBefore: [],
+							importedIdResolutions: [
+								{
+									external: false,
+									id: getId('lib'),
+									meta: {},
+									moduleSideEffects: true,
+									syntheticNamedExports: false
+								}
+							],
+							importedIds: [getId('lib')],
+							importers: [],
+							isEntry: false,
+							isExternal: false,
+							isIncluded: true,
+							meta: {},
+							syntheticNamedExports: false
+						},
+						[getId('lib')]: {
+							id: getId('lib'),
+							ast: {
+								type: 'Program',
+								start: 0,
+								end: 19,
+								body: [
+									{
+										type: 'ExportDefaultDeclaration',
+										start: 0,
+										end: 18,
+										declaration: { type: 'Literal', start: 15, end: 17, value: 42, raw: '42' }
+									}
+								],
+								sourceType: 'module'
+							},
+							code: 'export default 42;\n',
+							dynamicallyImportedIdResolutions: [],
+							dynamicallyImportedIds: [],
+							dynamicImporters: [],
+							hasDefaultExport: true,
+							moduleSideEffects: true,
+							implicitlyLoadedAfterOneOf: [],
+							implicitlyLoadedBefore: [],
+							importedIdResolutions: [],
+							importedIds: [],
+							importers: [getId('dynamic'), getId('main')],
+							isEntry: false,
+							isExternal: false,
+							isIncluded: true,
+							meta: {},
+							syntheticNamedExports: false
+						},
+						[getId('main')]: {
+							id: getId('main'),
 							ast: {
 								type: 'Program',
 								start: 0,
@@ -112,7 +239,6 @@ module.exports = {
 							dynamicImporters: [],
 							hasDefaultExport: false,
 							moduleSideEffects: true,
-							id: getId('main'),
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
 							importedIdResolutions: [
@@ -139,7 +265,8 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						},
-						{
+						external: {
+							id: 'external',
 							ast: null,
 							code: null,
 							dynamicallyImportedIdResolutions: [],
@@ -147,7 +274,6 @@ module.exports = {
 							dynamicImporters: [getId('dynamic')],
 							hasDefaultExport: null,
 							moduleSideEffects: true,
-							id: 'external',
 							implicitlyLoadedAfterOneOf: [],
 							implicitlyLoadedBefore: [],
 							importedIdResolutions: [],
@@ -158,133 +284,8 @@ module.exports = {
 							isIncluded: null,
 							meta: {},
 							syntheticNamedExports: false
-						},
-						{
-							ast: {
-								type: 'Program',
-								start: 0,
-								end: 19,
-								body: [
-									{
-										type: 'ExportDefaultDeclaration',
-										start: 0,
-										end: 18,
-										declaration: { type: 'Literal', start: 15, end: 17, value: 42, raw: '42' }
-									}
-								],
-								sourceType: 'module'
-							},
-							code: 'export default 42;\n',
-							dynamicallyImportedIdResolutions: [],
-							dynamicallyImportedIds: [],
-							dynamicImporters: [],
-							hasDefaultExport: true,
-							moduleSideEffects: true,
-							id: getId('lib'),
-							implicitlyLoadedAfterOneOf: [],
-							implicitlyLoadedBefore: [],
-							importedIdResolutions: [],
-							importedIds: [],
-							importers: [getId('dynamic'), getId('main')],
-							isEntry: false,
-							isExternal: false,
-							isIncluded: true,
-							meta: {},
-							syntheticNamedExports: false
-						},
-						{
-							ast: {
-								type: 'Program',
-								start: 0,
-								end: 88,
-								body: [
-									{
-										type: 'ExportNamedDeclaration',
-										start: 0,
-										end: 42,
-										declaration: {
-											type: 'VariableDeclaration',
-											start: 7,
-											end: 42,
-											declarations: [
-												{
-													type: 'VariableDeclarator',
-													start: 13,
-													end: 41,
-													id: { type: 'Identifier', start: 13, end: 20, name: 'promise' },
-													init: {
-														type: 'ImportExpression',
-														start: 23,
-														end: 41,
-														source: {
-															type: 'Literal',
-															start: 30,
-															end: 40,
-															value: 'external',
-															raw: "'external'"
-														}
-													}
-												}
-											],
-											kind: 'const'
-										},
-										specifiers: [],
-										source: null
-									},
-									{
-										type: 'ExportNamedDeclaration',
-										start: 43,
-										end: 87,
-										declaration: null,
-										specifiers: [
-											{
-												type: 'ExportSpecifier',
-												start: 52,
-												end: 71,
-												local: { type: 'Identifier', start: 52, end: 59, name: 'default' },
-												exported: { type: 'Identifier', start: 63, end: 71, name: 'internal' }
-											}
-										],
-										source: { type: 'Literal', start: 79, end: 86, value: './lib', raw: "'./lib'" }
-									}
-								],
-								sourceType: 'module'
-							},
-							code: "export const promise = import('external');\nexport { default as internal } from './lib';\n",
-							dynamicallyImportedIdResolutions: [
-								{
-									external: true,
-									id: 'external',
-									meta: {},
-									moduleSideEffects: true,
-									syntheticNamedExports: false
-								}
-							],
-							dynamicallyImportedIds: ['external'],
-							dynamicImporters: [getId('main')],
-							hasDefaultExport: false,
-							moduleSideEffects: true,
-							id: getId('dynamic'),
-							implicitlyLoadedAfterOneOf: [],
-							implicitlyLoadedBefore: [],
-							importedIdResolutions: [
-								{
-									external: false,
-									id: getId('lib'),
-									meta: {},
-									moduleSideEffects: true,
-									syntheticNamedExports: false
-								}
-							],
-							importedIds: [getId('lib')],
-							importers: [],
-							isEntry: false,
-							isExternal: false,
-							isIncluded: true,
-							meta: {},
-							syntheticNamedExports: false
 						}
-					]
+					}
 				);
 			}
 		}

--- a/test/function/samples/max-parallel-file-reads-default/_config.js
+++ b/test/function/samples/max-parallel-file-reads-default/_config.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { promises: fs } = require('fs');
+const { wait } = require('../../../utils');
 
 const fsReadFile = fs.readFile;
 let currentReads = 0;
@@ -12,6 +13,7 @@ module.exports = {
 			currentReads++;
 			maxReads = Math.max(maxReads, currentReads);
 			const content = await fsReadFile(path, options);
+			await wait(50);
 			currentReads--;
 			return content;
 		};

--- a/test/function/samples/max-parallel-file-reads-infinity/_config.js
+++ b/test/function/samples/max-parallel-file-reads-infinity/_config.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { promises: fs } = require('fs');
+const { wait } = require('../../../utils');
 
 const fsReadFile = fs.readFile;
 let currentReads = 0;
@@ -15,6 +16,7 @@ module.exports = {
 			currentReads++;
 			maxReads = Math.max(maxReads, currentReads);
 			const content = await fsReadFile(path, options);
+			await wait(50);
 			currentReads--;
 			return content;
 		};

--- a/test/function/samples/max-parallel-file-reads-set/_config.js
+++ b/test/function/samples/max-parallel-file-reads-set/_config.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { promises: fs } = require('fs');
+const { wait } = require('../../../utils');
 
 const fsReadFile = fs.readFile;
 let currentReads = 0;
@@ -15,6 +16,7 @@ module.exports = {
 			currentReads++;
 			maxReads = Math.max(maxReads, currentReads);
 			const content = await fsReadFile(path, options);
+			await wait(50);
 			currentReads--;
 			return content;
 		};

--- a/test/function/samples/max-parallel-file-reads-with-plugin/_config.js
+++ b/test/function/samples/max-parallel-file-reads-with-plugin/_config.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { promises: fs } = require('fs');
+const { wait } = require('../../../utils');
 
 const fsReadFile = fs.readFile;
 let currentReads = 0;
@@ -22,6 +23,7 @@ module.exports = {
 			currentReads++;
 			maxReads = Math.max(maxReads, currentReads);
 			const content = await fsReadFile(path, options);
+			await wait(50);
 			currentReads--;
 			return content;
 		};

--- a/test/function/samples/module-side-effects/resolve-id-external/_config.js
+++ b/test/function/samples/module-side-effects/resolve-id-external/_config.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const path = require('path');
 const sideEffects = [];
+const { getObject } = require('../../../../utils');
 
 module.exports = {
 	description: 'does not include modules without used exports if moduleSideEffect is false',
@@ -46,30 +47,32 @@ module.exports = {
 			},
 			buildEnd() {
 				assert.deepStrictEqual(
-					Array.from(this.getModuleIds())
-						.filter(id => !path.isAbsolute(id))
-						.sort()
-						.map(id => ({ id, moduleSideEffects: this.getModuleInfo(id).moduleSideEffects })),
-					[
-						{ id: 'sideeffects-false-usereffects-false', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-false-unused-import', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-false-used-import', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-unused-import', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-used-import', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-unused-import', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-used-import', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-true', moduleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-unused-import', moduleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-used-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-unused-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-used-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-unused-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-used-import', moduleSideEffects: true }
-					]
+					getObject(
+						[...this.getModuleIds()]
+							.filter(id => !path.isAbsolute(id))
+							.sort()
+							.map(id => [id, this.getModuleInfo(id).moduleSideEffects])
+					),
+					{
+						'sideeffects-false-usereffects-false': false,
+						'sideeffects-false-usereffects-false-unused-import': false,
+						'sideeffects-false-usereffects-false-used-import': false,
+						'sideeffects-false-usereffects-true': false,
+						'sideeffects-false-usereffects-true-unused-import': false,
+						'sideeffects-false-usereffects-true-used-import': false,
+						'sideeffects-null-usereffects-false': false,
+						'sideeffects-null-usereffects-false-unused-import': false,
+						'sideeffects-null-usereffects-false-used-import': false,
+						'sideeffects-null-usereffects-true': true,
+						'sideeffects-null-usereffects-true-unused-import': true,
+						'sideeffects-null-usereffects-true-used-import': true,
+						'sideeffects-true-usereffects-false': true,
+						'sideeffects-true-usereffects-false-unused-import': true,
+						'sideeffects-true-usereffects-false-used-import': true,
+						'sideeffects-true-usereffects-true': true,
+						'sideeffects-true-usereffects-true-unused-import': true,
+						'sideeffects-true-usereffects-true-used-import': true
+					}
 				);
 			}
 		}

--- a/test/function/samples/module-side-effects/resolve-id/_config.js
+++ b/test/function/samples/module-side-effects/resolve-id/_config.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const path = require('path');
+const { getObject } = require('../../../../utils');
+
 const sideEffects = [];
 
 module.exports = {
@@ -54,30 +56,32 @@ module.exports = {
 			},
 			buildEnd() {
 				assert.deepStrictEqual(
-					Array.from(this.getModuleIds())
-						.filter(id => !path.isAbsolute(id))
-						.sort()
-						.map(id => ({ id, moduleSideEffects: this.getModuleInfo(id).moduleSideEffects })),
-					[
-						{ id: 'sideeffects-false-usereffects-false', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-false-unused-import', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-false-used-import', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-unused-import', moduleSideEffects: false },
-						{ id: 'sideeffects-false-usereffects-true-used-import', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-unused-import', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-false-used-import', moduleSideEffects: false },
-						{ id: 'sideeffects-null-usereffects-true', moduleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-unused-import', moduleSideEffects: true },
-						{ id: 'sideeffects-null-usereffects-true-used-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-unused-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-false-used-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-unused-import', moduleSideEffects: true },
-						{ id: 'sideeffects-true-usereffects-true-used-import', moduleSideEffects: true }
-					]
+					getObject(
+						[...this.getModuleIds()]
+							.filter(id => !path.isAbsolute(id))
+							.sort()
+							.map(id => [id, this.getModuleInfo(id).moduleSideEffects])
+					),
+					{
+						'sideeffects-false-usereffects-false': false,
+						'sideeffects-false-usereffects-false-unused-import': false,
+						'sideeffects-false-usereffects-false-used-import': false,
+						'sideeffects-false-usereffects-true': false,
+						'sideeffects-false-usereffects-true-unused-import': false,
+						'sideeffects-false-usereffects-true-used-import': false,
+						'sideeffects-null-usereffects-false': false,
+						'sideeffects-null-usereffects-false-unused-import': false,
+						'sideeffects-null-usereffects-false-used-import': false,
+						'sideeffects-null-usereffects-true': true,
+						'sideeffects-null-usereffects-true-unused-import': true,
+						'sideeffects-null-usereffects-true-used-import': true,
+						'sideeffects-true-usereffects-false': true,
+						'sideeffects-true-usereffects-false-unused-import': true,
+						'sideeffects-true-usereffects-false-used-import': true,
+						'sideeffects-true-usereffects-true': true,
+						'sideeffects-true-usereffects-true-unused-import': true,
+						'sideeffects-true-usereffects-true-used-import': true
+					}
 				);
 			}
 		}

--- a/test/function/samples/plugin-module-information/_config.js
+++ b/test/function/samples/plugin-module-information/_config.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const path = require('path');
+const { getObject } = require('../../../utils');
 
 const ID_MAIN = path.join(__dirname, 'main.js');
 const ID_FOO = path.join(__dirname, 'foo.js');
@@ -14,7 +15,7 @@ module.exports = {
 		external: ['path'],
 		plugins: {
 			load(id) {
-				assert.deepStrictEqual(this.getModuleInfo(id), {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(id))), {
 					ast: null,
 					code: null,
 					dynamicImporters: [],
@@ -38,11 +39,14 @@ module.exports = {
 			renderStart() {
 				rendered = true;
 				assert.deepStrictEqual(
-					JSON.parse(
-						JSON.stringify([...this.getModuleIds()].sort().map(id => this.getModuleInfo(id)))
+					getObject(
+						[...this.getModuleIds()].map(id => [
+							id,
+							JSON.parse(JSON.stringify(this.getModuleInfo(id)))
+						])
 					),
-					[
-						{
+					{
+						[ID_FOO]: {
 							ast: {
 								type: 'Program',
 								start: 0,
@@ -130,7 +134,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						},
-						{
+						[ID_MAIN]: {
 							ast: {
 								type: 'Program',
 								start: 0,
@@ -295,7 +299,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						},
-						{
+						[ID_NESTED]: {
 							ast: {
 								type: 'Program',
 								start: 0,
@@ -386,7 +390,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						},
-						{
+						[ID_PATH]: {
 							ast: null,
 							code: null,
 							dynamicallyImportedIdResolutions: [],
@@ -406,7 +410,7 @@ module.exports = {
 							meta: {},
 							syntheticNamedExports: false
 						}
-					]
+					}
 				);
 			}
 		}

--- a/test/function/samples/preload-module/_config.js
+++ b/test/function/samples/preload-module/_config.js
@@ -58,7 +58,7 @@ module.exports = {
 						// No dependencies have been loaded yet
 						assert.deepStrictEqual([...this.getModuleIds()], [ID_MAIN]);
 						await this.load({ id: ID_OTHER });
-						assert.deepStrictEqual([...this.getModuleIds()], [ID_MAIN, ID_OTHER]);
+						assert.deepStrictEqual([...this.getModuleIds()].sort(), [ID_MAIN, ID_OTHER]);
 						return resolvedId;
 					}
 				},
@@ -96,7 +96,7 @@ module.exports = {
 						1
 					);
 					assert.strictEqual(parsedModules.filter(id => id === ID_DEP, 'parsed').length, 1);
-					assert.deepStrictEqual([...this.getModuleIds()], [ID_MAIN, ID_OTHER, ID_DEP]);
+					assert.deepStrictEqual([...this.getModuleIds()].sort(), [ID_DEP, ID_MAIN, ID_OTHER]);
 				}
 			}
 		]

--- a/test/incremental/index.js
+++ b/test/incremental/index.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const acorn = require('acorn');
 const rollup = require('../../dist/rollup');
-const { executeBundle } = require('../utils.js');
+const { executeBundle, getObject } = require('../utils.js');
 
 describe('incremental', () => {
 	let resolveIdCalls;
@@ -309,11 +309,11 @@ describe('incremental', () => {
 
 			buildEnd() {
 				assert.deepStrictEqual(
-					[...this.getModuleIds()].map(id => ({ id, meta: this.getModuleInfo(id).meta })),
-					[
-						{ id: 'entry', meta: { test: { transformed: 'entry' } } },
-						{ id: 'foo', meta: { test: { transformed: 'foo' } } }
-					],
+					getObject([...this.getModuleIds()].map(id => [id, this.getModuleInfo(id).meta])),
+					{
+						entry: { test: { transformed: 'entry' } },
+						foo: { test: { transformed: 'foo' } }
+					},
 					'buildEnd'
 				);
 			}


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There were still some cases where module ids in tests were not properly ordered. This fixes this by using objects instead of arrays in some places, which also improves readability.