### PR TITLE
Document how resolveId is cached

### DIFF
--- a/docs/build-hooks.mmd
+++ b/docs/build-hooks.mmd
@@ -3,6 +3,7 @@ flowchart TB
     classDef hook-sequential fill:#ffd2b3,stroke:#000;
     classDef hook-first fill:#fff2b3,stroke:#000;
     classDef hook-sequential-sync fill:#ffd2b3,stroke:#f00;
+    classDef hook-first-sync fill:#fff2b3,stroke:#f00;
 
 	buildend("buildEnd"):::hook-parallel
 	click buildend "/guide/en/#buildend" _parent
@@ -60,7 +61,10 @@ flowchart TB
     --> |non-external|load
 
     moduleparsed
-    --> |each import|resolveid
+    --> |"each import\n(cached)"|load
+
+    moduleparsed
+    --> |"each import\n(not cached)"|resolveid
 
     resolvedynamicimport
     .-> |external|buildend


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When working on caching the commonjs plugin, I found that it is not documented that caching will not only skip the `load` hook but also the `resolveId` hook of dependencies (which does indeed save a lot).