### PR TITLE
chor: feature: bugfix: Add Typescript 4.5 nodenext node12 module resolution support

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/rollup.d.ts",
       "node": {
         "require": "./dist/rollup.js",
         "import": "./dist/es/rollup.js"


### PR DESCRIPTION
Added Typescript 4.5+ Support for nodenext and node12 resolve it will not lookup typings

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

If we do not apply this changes users of Typescript 4.5 with moduleResolution nodenext and node12 will not be able to get typings