### PR TITLE
Improve the error prompt and output the error file name

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -709,10 +709,12 @@ export default class Chunk {
 			);
 
 		let usesTopLevelAwait = false;
+		let usesTopLevelAwaitId: string;
 		const accessedGlobals = new Set<string>();
 		for (const module of this.orderedModules) {
 			if (module.usesTopLevelAwait) {
 				usesTopLevelAwait = true;
+				usesTopLevelAwaitId = module.id;
 			}
 			const accessedGlobalVariables = this.accessedGlobalsByScope.get(module.scope);
 			if (accessedGlobalVariables) {
@@ -725,7 +727,8 @@ export default class Chunk {
 		if (usesTopLevelAwait && format !== 'es' && format !== 'system') {
 			return error({
 				code: 'INVALID_TLA_FORMAT',
-				message: `Module format ${format} does not support top-level await. Use the "es" or "system" output formats rather.`
+				message: `Module format ${format} does not support top-level await. Use the "es" or "system" output formats rather.`,
+				id: usesTopLevelAwaitId!
 			});
 		}
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

It prompts me when I use rollup.
```log
Module format cjs does not support top-level await. Use the "es" or "system" output formats rather.
```
But I don't know which file this error comes from.
I want it to prompt me for specific file.
```log
Module format cjs does not support top-level await. Use the "es" or "system" output formats rather.
file: /Users/atom/Desktop/github/electron-vue-vite/packages/main/samples/execa.ts
```

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
