### PR TITLE
Track unfinished hook actions as regular errors

### DIFF
--- a/browser/hookActions.ts
+++ b/browser/hookActions.ts
@@ -1,3 +1,8 @@
-export function addUnresolvedAction(_actionTuple: [string, string, Parameters<any>]): void {}
+import { PluginDriver } from '../src/utils/PluginDriver';
 
-export function resolveAction(_actionTuple: [string, string, Parameters<any>]): void {}
+export function catchUnfinishedHookActions<T>(
+	_pluginDriver: PluginDriver,
+	callback: () => Promise<T>
+): Promise<T> {
+	return callback();
+}

--- a/test/cli/samples/unfulfilled-hook-actions-error/_config.js
+++ b/test/cli/samples/unfulfilled-hook-actions-error/_config.js
@@ -1,21 +1,16 @@
 const assert = require('assert');
-const { assertIncludes } = require('../../../utils.js');
+const { assertIncludes, assertDoesNotInclude } = require('../../../utils.js');
 
 module.exports = {
-	description: 'does not swallow errors on unfulfilled hooks actions',
+	description: 'does not show unfulfilled hook actions if there are errors',
 	minNodeVersion: 13,
 	command: 'node build.mjs',
 	after(err) {
 		// exit code check has to be here as error(err) is only called upon failure
-		assert.strictEqual(err && err.code, 1);
-	},
-	error() {
-		// do not abort test upon error
-		return true;
+		assert.strictEqual(err, null);
 	},
 	stderr(stderr) {
-		assertIncludes(stderr, '[!] Error: unfinished hook action(s) on exit');
-		assertIncludes(stderr, '(test) transform');
 		assertIncludes(stderr, 'Error: Error must be displayed.');
+		assertDoesNotInclude(stderr, 'Unfinished');
 	}
 };

--- a/test/cli/samples/unfulfilled-hook-actions-error/build.mjs
+++ b/test/cli/samples/unfulfilled-hook-actions-error/build.mjs
@@ -3,21 +3,25 @@ import { rollup } from 'rollup';
 let resolveA;
 const waitForA = new Promise(resolve => (resolveA = resolve));
 
-// The error must not be swallowed when using top-level-await
-await rollup({
-	input: './index.js',
-	plugins: [
-		{
-			name: 'test',
-			transform(code, id) {
-				if (id.endsWith('a.js')) {
-					resolveA();
-					return new Promise(() => {});
-				}
-				if (id.endsWith('b.js')) {
-					return waitForA.then(() => Promise.reject(new Error('Error must be displayed.')))
+try {
+	// The error must not be swallowed when using top-level-await
+	await rollup({
+		input: './index.js',
+		plugins: [
+			{
+				name: 'test',
+				transform(code, id) {
+					if (id.endsWith('a.js')) {
+						resolveA();
+						return new Promise(() => {});
+					}
+					if (id.endsWith('b.js')) {
+						return waitForA.then(() => Promise.reject(new Error('Error must be displayed.')));
+					}
 				}
 			}
-		}
-	]
-});
+		]
+	});
+} catch (err) {
+	console.error(err);
+}

--- a/test/cli/samples/unfulfilled-hook-actions-manual-exit/_config.js
+++ b/test/cli/samples/unfulfilled-hook-actions-manual-exit/_config.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { assertDoesNotInclude } = require('../../../utils');
+const { assertIncludes } = require('../../../utils.js');
+
+module.exports = {
+	description:
+		'does not show unfulfilled hook actions when exiting manually with a non-zero exit code',
+	command: 'rollup -c --silent',
+	after(err) {
+		assert.strictEqual(err && err.code, 1);
+	},
+	error() {
+		// do not abort test upon error
+		return true;
+	},
+	stderr(stderr) {
+		assertDoesNotInclude(stderr, 'Unfinished');
+		assertIncludes(stderr, 'Manual exit');
+	}
+};

--- a/test/cli/samples/unfulfilled-hook-actions-manual-exit/a.js
+++ b/test/cli/samples/unfulfilled-hook-actions-manual-exit/a.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/test/cli/samples/unfulfilled-hook-actions-manual-exit/b.js
+++ b/test/cli/samples/unfulfilled-hook-actions-manual-exit/b.js
@@ -1,0 +1,1 @@
+console.log('b');

--- a/test/cli/samples/unfulfilled-hook-actions-manual-exit/c.js
+++ b/test/cli/samples/unfulfilled-hook-actions-manual-exit/c.js
@@ -1,0 +1,1 @@
+console.log('c');

--- a/test/cli/samples/unfulfilled-hook-actions-manual-exit/index.js
+++ b/test/cli/samples/unfulfilled-hook-actions-manual-exit/index.js
@@ -1,0 +1,3 @@
+import './a.js';
+import './b.js';
+import './c.js';

--- a/test/cli/samples/unfulfilled-hook-actions-manual-exit/rollup.config.js
+++ b/test/cli/samples/unfulfilled-hook-actions-manual-exit/rollup.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+let resolveA;
+const waitForA = new Promise(resolve => (resolveA = resolve));
+
+module.exports = {
+	input: './index.js',
+	plugins: [
+		{
+			name: 'test',
+			transform(code, id) {
+				if (id.endsWith('a.js')) {
+					resolveA();
+					return new Promise(() => {});
+				}
+				if (id.endsWith('b.js')) {
+					return waitForA.then(() => {
+						console.error('Manual exit');
+						process.exit(1);
+						return new Promise(() => {});
+					});
+				}
+			}
+		}
+	],
+	output: {
+		format: 'es'
+	}
+};

--- a/test/cli/samples/unfulfilled-hook-actions/_config.js
+++ b/test/cli/samples/unfulfilled-hook-actions/_config.js
@@ -13,7 +13,11 @@ module.exports = {
 		return true;
 	},
 	stderr(stderr) {
-		assertIncludes(stderr, '[!] Error: unfinished hook action(s) on exit');
+		console.error(stderr);
+		assertIncludes(
+			stderr,
+			'Error: Unexpected early exit. This happens when Promises returned by plugins cannot resolve. Unfinished hook action(s) on exit:'
+		);
 
 		// these unfulfilled async hook actions may occur in random order
 		assertIncludes(stderr, '(buggy-plugin) resolveId "./c.js" "main.js"');

--- a/test/utils.js
+++ b/test/utils.js
@@ -228,7 +228,20 @@ exports.assertIncludes = function assertIncludes(actual, expected) {
 	try {
 		assert.ok(
 			actual.includes(expected),
-			`${JSON.stringify(actual)}\nincludes\n${JSON.stringify(expected)}`
+			`${JSON.stringify(actual)}\nshould include\n${JSON.stringify(expected)}`
+		);
+	} catch (err) {
+		err.actual = actual;
+		err.expected = expected;
+		throw err;
+	}
+};
+
+exports.assertDoesNotInclude = function assertDoesNotInclude(actual, expected) {
+	try {
+		assert.ok(
+			!actual.includes(expected),
+			`${JSON.stringify(actual)}\nshould not include\n${JSON.stringify(expected)}`
 		);
 	} catch (err) {
 		err.actual = actual;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #4432

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
By using the `beforeExit` event, this PR solves a key issue with the previous implementation to track unfinished hook actions: They are now reported as regular errors. That means that
* There are no unexpected prints to the console if used from a script
* Regular error formatting logic kicks in, especially when used from custom scripts
* There is no longer any global state, but unfinished actions are tracked per build
* There is no unexpected output when the build is manually aborted via `process.exit()`