### PR TITLE
chor(package.json): allow to import modules from dist without extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,6 @@
       },
       "default": "./dist/es/rollup.browser.js"
     },
-    "./dist/*": "./dist/*"
+    "./dist/*": "./dist/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     },
     "./dist/*": "./dist/*.js",
     "./dist/*.js": "./dist/*.js",
-    "./dist/**/*.js": "./dist/**/*.js",
     "./dist/es/*.json": "./dist/es/*.json",
     "./dist/*.d.ts": "./dist/*.d.ts"
   }

--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
       },
       "default": "./dist/es/rollup.browser.js"
     },
-    "./dist/*": "./dist/*.js"
+    "./dist/*": "./dist/*.js",
+    "./dist/es/*.json": "./dist/es/*.json",
+    "./dist/*.d.ts": "./dist/*.d.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -137,6 +137,8 @@
       "default": "./dist/es/rollup.browser.js"
     },
     "./dist/*": "./dist/*.js",
+    "./dist/*.js": "./dist/*.js",
+    "./dist/**/*.js": "./dist/**/*.js",
     "./dist/es/*.json": "./dist/es/*.json",
     "./dist/*.d.ts": "./dist/*.d.ts"
   }


### PR DESCRIPTION
Allow to import modules without extension from dist see: https://github.com/rollup/rollup/pull/4436#issuecomment-1066403067

This should address your concerns in the comment and should fix your api problem.

when there are export or import issues with that patterns simply ping me i am really deep into all this resolve stuff. 

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
