### PR TITLE
docs: update deprecated option in tools.md

### DIFF
--- a/docs/07-tools.md
+++ b/docs/07-tools.md
@@ -100,9 +100,7 @@ export default {
   plugins: [
     resolve({
       // pass custom options to the resolve plugin
-      customResolveOptions: {
-        moduleDirectory: 'node_modules'
-      }
+      moduleDirectories: ['node_modules']
     })
   ],
   // indicate which modules should be treated as external


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
according to the documentation. I use the `customResolveOptions.moduleDirectory` option, but I get the following warning:

`(!) Plugin node-resolve: node-resolve: The 'customResolveOptions.moduleDirectory' option has been deprecated. Use 'moduleDirectories', which must be an array.`

I think this will also need to update the document.