### PR TITLE
Fix: tsc did not build

### DIFF
--- a/cli/run/loadConfigFile.ts
+++ b/cli/run/loadConfigFile.ts
@@ -111,7 +111,9 @@ async function loadConfigFromBundledFile(fileName: string, bundledCode: string):
 		if (requiredFileName === resolvedFileName) {
 			(module as NodeModuleWithCompile)._compile(bundledCode, requiredFileName);
 		} else {
-			defaultLoader(module, requiredFileName);
+			if (defaultLoader) {
+				defaultLoader(module, requiredFileName);
+			}
 		}
 	};
 	delete require.cache[resolvedFileName];


### PR DESCRIPTION
tsc Version 4.7.0-dev.20220305
```
cli/run/loadConfigFile.ts:114:4 - error TS2722: Cannot invoke an object which is possibly 'undefined'.

114    defaultLoader(module, requiredFileName);
       ~~~~~~~~~~~~~
```
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Newer Typescript versions will error on build i marked that this includes tests as running typescript nightly already is the test.



<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
