### PR TITLE
chore(repo): replace `git.io` in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -41,7 +41,7 @@ body:
         Issues without minimal reproductions will be closed! Please provide a link to one by:
         1. Using the REPL at https://rollupjs.org/repl/, or
         2. Using the REPL.it reproduction template at https://repl.it/@rollup/rollup-repro (allows full use of all rollup options and plugins), or
-        3. Provide a minimal repository link (Read https://git.io/fNzHA for instructions). These may take more time to triage than the other options.
+        3. Provide a minimal repository link (Read https://gist.github.com/Rich-Harris/88c5fc2ac6dc941b22e7996af05d70ff for instructions). These may take more time to triage than the other options.
           
         For some bugs it this may seem like overkill but believe us, very often what seems like a "clear issue" is actually specific to some details of your setup. Having a runnable reproduction not only "proves" your bug to us but also allows us to spend all our effort fixing the bug instead of struggling to understand your issue.
     validations:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

https://github.com/rollup/plugins/pull/1171

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace the `git.io` link with its actual URL.