### PR TITLE
Add exports exception for loadConfigFile

### DIFF
--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -260,7 +260,7 @@ See above for details on `inputOptions` and `outputOptions`, or consult the [big
 In order to aid in generating such a config, rollup exposes the helper it uses to load config files in its command line interface via a separate entry-point. This helper receives a resolved `fileName` and optionally an object containing command line parameters:
 
 ```js
-const loadConfigFile = require('rollup/dist/loadConfigFile');
+const loadConfigFile = require('rollup/loadConfigFile');
 const path = require('path');
 const rollup = require('rollup');
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
       },
       "default": "./dist/es/rollup.browser.js"
     },
+    "./dist/loadConfigFile": "./dist/loadConfigFile.js",
     "./dist/*": "./dist/*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
       },
       "default": "./dist/es/rollup.browser.js"
     },
+    "./loadConfigFile": "./dist/loadConfigFile.js",
     "./dist/loadConfigFile": "./dist/loadConfigFile.js",
     "./dist/*": "./dist/*"
   }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #4460

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
As we explicitly state that you can require `loadConfigFile` without extension in the docs, this will add an explicit exports route for this.

In preparation for the next major release where I would like to remove that hack again, `loadConfigFile` can now directly be imported as `rollup/loadConfigFile` as well.