### PR TITLE
Initial exploration of startService API

### DIFF
--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -139,14 +139,11 @@ export default class Graph {
 		// Make sure that the same module / external module can only be added to the
 		// graph once since it may be requested multiple times over the life of a
 		// service.
-		if (module instanceof Module) {
-			if (this.modules.indexOf(module) === -1) {
-				this.modules.push(module);
-			}
-		} else {
-			if (this.externalModules.indexOf(module) === -1) {
-				this.externalModules.push(module);
-			}
+		const modules: Array<Module | ExternalModule> =
+			module instanceof Module ? this.modules : this.externalModules;
+
+		if (!modules.includes(module)) {
+			modules.push(module);
 		}
 	}
 

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -135,6 +135,21 @@ export default class Graph {
 		return ast;
 	}
 
+	ensureModule(module: Module | ExternalModule) {
+		// Make sure that the same module / external module can only be added to the
+		// graph once since it may be requested multiple times over the life of a
+		// service.
+		if (module instanceof Module) {
+			if (this.modules.indexOf(module) === -1) {
+				this.modules.push(module);
+			}
+		} else {
+			if (this.externalModules.indexOf(module) === -1) {
+				this.externalModules.push(module);
+			}
+		}
+	}
+
 	getCache(): RollupCache {
 		// handle plugin cache eviction
 		for (const name in this.pluginCache) {
@@ -167,21 +182,6 @@ export default class Graph {
 		}
 		for (const module of this.modulesById.values()) {
 			this.ensureModule(module);
-		}
-	}
-
-	ensureModule(module: Module | ExternalModule) {
-		// Make sure that the same module / external module can only be added to the
-		// graph once since it may be requested multiple times over the life of a
-		// service.
-		if (module instanceof Module) {
-			if (this.modules.indexOf(module) === -1) {
-				this.modules.push(module);
-			}
-		} else {
-			if (this.externalModules.indexOf(module) === -1) {
-				this.externalModules.push(module);
-			}
 		}
 	}
 

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -166,9 +166,20 @@ export default class Graph {
 			throw new Error('You must supply options.input to rollup');
 		}
 		for (const module of this.modulesById.values()) {
-			if (module instanceof Module) {
+			this.ensureModule(module);
+		}
+	}
+
+	ensureModule(module: Module | ExternalModule) {
+		// Make sure that the same module / external module can only be added to the
+		// graph once since it may be requested multiple times over the life of a
+		// service.
+		if (module instanceof Module) {
+			if (this.modules.indexOf(module) === -1) {
 				this.modules.push(module);
-			} else {
+			}
+		} else {
+			if (this.externalModules.indexOf(module) === -1) {
 				this.externalModules.push(module);
 			}
 		}

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -676,12 +676,16 @@ export default class Module {
 		this.addModulesToImportDescriptions(this.reexportDescriptions);
 		const externalExportAllModules: ExternalModule[] = [];
 		for (const source of this.exportAllSources) {
-			const module = this.graph.modulesById.get(this.resolvedIds[source].id)!;
+			const module = this.graph.modulesById.get(this.resolvedIds[source].id);
 			if (module instanceof ExternalModule) {
 				externalExportAllModules.push(module);
-				continue;
+			} else if (module instanceof Module) {
+				this.exportAllModules.push(module);
+			} else {
+				this.exportAllModules.push(
+					new ExternalModule(this.options, this.resolvedIds[source].id, true, {}, true)
+				);
 			}
-			this.exportAllModules.push(module);
 		}
 		this.exportAllModules.push(...externalExportAllModules);
 	}
@@ -1019,7 +1023,8 @@ export default class Module {
 	): void {
 		for (const specifier of importDescription.values()) {
 			const { id } = this.resolvedIds[specifier.source];
-			specifier.module = this.graph.modulesById.get(id)!;
+			specifier.module =
+				this.graph.modulesById.get(id) ?? new ExternalModule(this.options, id, true, {}, true);
 		}
 	}
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -682,7 +682,7 @@ export default class Module {
 			} else if (module instanceof Module) {
 				this.exportAllModules.push(module);
 			} else {
-				this.exportAllModules.push(
+				externalExportAllModules.push(
 					new ExternalModule(this.options, this.resolvedIds[source].id, true, {}, true)
 				);
 			}

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -177,12 +177,15 @@ export class ModuleLoader {
 	}
 
 	public async preloadModule(
-		resolvedId: { id: string; resolveDependencies?: boolean } & Partial<PartialNull<ModuleOptions>>
+		resolvedId: { id: string; isEntry?: boolean; resolveDependencies?: boolean } & Partial<
+			PartialNull<ModuleOptions>
+		>
 	): Promise<ModuleInfo> {
+		const isEntry = resolvedId.isEntry !== false;
 		const module = await this.fetchModule(
 			this.getResolvedIdWithDefaults(resolvedId)!,
 			undefined,
-			false,
+			isEntry,
 			resolvedId.resolveDependencies ? RESOLVE_DEPENDENCIES : true
 		);
 		return module.info;

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -40,6 +40,7 @@ import transform from './utils/transform';
 export interface UnresolvedModule {
 	fileName: string | null;
 	id: string;
+	implicitlyLoadedAfter?: string[];
 	importer: string | undefined;
 	name: string | null;
 }

--- a/src/browser-entry.ts
+++ b/src/browser-entry.ts
@@ -1,2 +1,2 @@
-export { default as rollup, defineConfig } from './rollup/rollup';
+export { default as rollup, defineConfig, startService } from './rollup/rollup';
 export { version as VERSION } from 'package.json';

--- a/src/node-entry.ts
+++ b/src/node-entry.ts
@@ -1,3 +1,3 @@
-export { default as rollup, defineConfig } from './rollup/rollup';
+export { default as rollup, defineConfig, startService } from './rollup/rollup';
 export { default as watch } from './watch/watch-proxy';
 export { version as VERSION } from 'package.json';

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -129,9 +129,11 @@ export async function startService(
 				graph.ensureModule(module);
 			}
 
-			// for (const module of modulesById.values()) {
-			// 	module.bindReferences();
-			// }
+			for (const module of modulesById.values()) {
+				module.linkImports();
+				module.bindReferences();
+				module.includeAllInBundle();
+			}
 
 			const {
 				options: outputOptions,

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -54,11 +54,12 @@ export async function startService(
 			await graph.pluginDriver.hookParallel('closeBundle', []);
 		},
 		closed: false,
-		resolve(source: string, importer?: string | undefined) {
-			return graph.moduleLoader.resolveId(source, importer, undefined, false);
+		getModuleInfo: graph.getModuleInfo,
+		load(id, options) {
+			return graph.moduleLoader.preloadModule({ ...options, id });
 		},
-		load(id: string) {
-			return graph.moduleLoader.preloadModule({ id, resolveDependencies: true });
+		resolve(source, importer, options) {
+			return graph.moduleLoader.resolveId(source, importer, options, false);
 		}
 	};
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -830,7 +830,15 @@ export interface RollupBuild {
 	write: (options: OutputOptions) => Promise<RollupOutput>;
 }
 
+export interface BuildOptions {
+	signal?: {
+		aborted: boolean;
+	};
+	shouldIncludeInBundle?: (resolvedId: ResolvedId, source: string, fromId: string) => boolean;
+}
+
 export interface RollupService {
+	build: (input: InputOption, options: BuildOptions) => Promise<RollupBuild>;
 	close: (err?: any) => Promise<void>;
 	closed: boolean;
 	load: (
@@ -838,11 +846,11 @@ export interface RollupService {
 		options?: { resolveDependencies?: boolean } & Partial<PartialNull<ModuleOptions>>
 	) => Promise<ModuleInfo>;
 	getModuleInfo: GetModuleInfo;
-	resolve(
+	resolve: (
 		source: string,
 		importer?: string,
 		options?: { custom?: CustomPluginOptions; isEntry?: boolean }
-	): Promise<ResolvedId | null>;
+	) => Promise<ResolvedId | null>;
 }
 
 export interface RollupOptions extends InputOptions {

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -833,7 +833,11 @@ export interface RollupBuild {
 export interface RollupService {
 	close: (err?: any) => Promise<void>;
 	closed: boolean;
-	load(id: string): Promise<ModuleInfo>;
+	load: (
+		source: string,
+		options?: { resolveDependencies?: boolean } & Partial<PartialNull<ModuleOptions>>
+	) => Promise<ModuleInfo>;
+	getModuleInfo: GetModuleInfo;
 	resolve(
 		source: string,
 		importer?: string,

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -830,7 +830,7 @@ export interface RollupBuild {
 	write: (options: OutputOptions) => Promise<RollupOutput>;
 }
 
-export interface BuildOptions {
+export interface BuildOptions extends OutputOptions {
 	signal?: {
 		aborted: boolean;
 	};
@@ -838,7 +838,7 @@ export interface BuildOptions {
 }
 
 export interface RollupService {
-	build: (input: InputOption, options: BuildOptions) => Promise<RollupBuild>;
+	build: (input: InputOption, options: BuildOptions) => Promise<RollupOutput>;
 	close: (err?: any) => Promise<void>;
 	closed: boolean;
 	load: (

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -830,6 +830,17 @@ export interface RollupBuild {
 	write: (options: OutputOptions) => Promise<RollupOutput>;
 }
 
+export interface RollupService {
+	close: (err?: any) => Promise<void>;
+	closed: boolean;
+	load(id: string): Promise<ModuleInfo>;
+	resolve(
+		source: string,
+		importer?: string,
+		options?: { custom?: CustomPluginOptions; isEntry?: boolean }
+	): Promise<ResolvedId | null>;
+}
+
 export interface RollupOptions extends InputOptions {
 	// This is included for compatibility with config files but ignored by rollup.rollup
 	output?: OutputOptions | OutputOptions[];
@@ -840,6 +851,8 @@ export interface MergedRollupOptions extends InputOptions {
 }
 
 export function rollup(options: RollupOptions): Promise<RollupBuild>;
+
+export function startService(options: RollupOptions): Promise<RollupService>;
 
 export interface ChokidarOptions {
 	alwaysStat?: boolean;


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

*Not yet*

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

N/A - Experimental feature exploration

### Description

This PR is designed to add a new operating paradigm ('service mode') to Rollup to allow it to fulfill the requirements of tools like Vite and WMR's dev mode such that those tools can use Rollup directly instead of re-implementing parts of it that are specific to the dev workflow.

To be useful to tools like Vite, I extrapolate the following top-level requirements (but would love it if others can fine-tune this):

1. **An application can request the bundling a specific source file on-demand and obtain a result that could be generated in a target module format.** That result would be functionally equivalent to how the module would have behaved in the context of a `Bundle` with `preserveModules` and `preserveEntrySignatures` set to `strict` or `allow-extension`. For example, this might be used to translate an http request for a source file into code suitable for serving to the browser. It might also be used to create a dynamic Node module usable in the same way [`ViteDevServer::ssrLoadModule`](https://vitejs.dev/guide/api-javascript.html#vitedevserver) is used in Vite.
1. **An application can obtain assets that have been produced as a side-effect of bundling other source files.** In the situation where a `Plugin` has used `emitFile` to produce a new asset (or module), the application must be able to determine if the requested asset exists and obtain a reference to it. For example, a dev server would want to distinguish between urls it controls and `404`s. If the Rollup Service has an asset at the requested path, then that is a 'controlled' url and the app would want to serve the asset owned by Rollup.
1. **Changes to the host environment will correctly invalidate outdated internal state.** The addition of new files to directories might invalidate module resolutions. Changes to config files might invalidate transformed modules. Changes to the source code will invalidate the corresponding Modules and perhaps any emitted Assets. Invalidation should happen immediately (ideally synchronously) but no work would need to be done to re-create invalidated state until it is re-requested.
1. **An application can observe invalidations.** When modules and assets are invalidated, the application can subscribe to these events. For this to be useful, the **application must be able to query the dependency Graph**. For example, if a source file is modified, the application could use information about changes in exported symbols and their linkage to perform very nuanced hot-module replacement (HMR). More coarse-grained HMR would also be possible by querying the module-level dependency graph.
1. **An application can determine the granularity of output production.** An application could indicate to the Rollup Service how much of the graph it wants to include in a given bundling request. This would be conceptually similar to `manualChunks` where the app could indicate that it wants to treat `react` as a black-box. The app would ask Rollup to traverse the graph and include everything within the app-defined boundary (in this case `./node_modules/react`) in a single output unit. The app might say that a user's source files should be `1:1` with output artifacts but a users's dependencies would be `n:1`.

I suspect that Rollup has almost all of the essential bits to satisfy these requirements but that it would take some refactoring. I expect that the change of paradigm from run-to-completion to also supporting a long-lived, incremental service would be tricky. Assumptions about internal state at different phases of the pipeline might be broken. To attack this problem will mean finding those and coming up with strategies to support re-entrancy.

The hardest parts that I anticipate are related to invalidation tracking. Specifically, invalidation of module resolution. To support this sort of invalidation would require the cooperation of module-resolution plugins and perhaps new APIs in Rollup's Plugin Context to support tracking changes to the contents (or existence of) directories. Invalidating internal state will also expose a lot of assumptions about statefulness.

Having talked through a lot of this with @lukastaegert at a high level on Discord, we think that tree-shaking (as a concept) would be counter-productive to the effort. Perhaps this Service mode would force disable tree-shaking.

We also talked about how to deal with some conventions that would affect performance in real-world use-cases, such as those for which Vite is designed. Notably, libraries like `react` use the `process.env.NODE_ENV` convention to package both dev and production builds in the same module. A tool using the Service mode of Rollup would want to be able to build plugins that could prune branches of the AST based on this convention and have graph building reflect this.

Thoughts?