### PR TITLE
Fix reassignment tracking

### DIFF
--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -155,7 +155,7 @@ export default class LocalVariable extends Variable {
 		if (path.length === 0) return false;
 		if (this.isReassigned) return true;
 		return (this.init &&
-			!context.accessed.trackEntityAtPathAndGetIfTracked(path, this) &&
+			!context.assigned.trackEntityAtPathAndGetIfTracked(path, this) &&
 			this.init.hasEffectsWhenAssignedAtPath(path, context))!;
 	}
 

--- a/test/function/samples/track-reassignments/_config.js
+++ b/test/function/samples/track-reassignments/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'properly track reassignments (#4468)'
+};

--- a/test/function/samples/track-reassignments/main.js
+++ b/test/function/samples/track-reassignments/main.js
@@ -1,0 +1,15 @@
+import { patchEventTarget } from './patchEventTarget.js';
+
+class EventTarget {
+	addEventListener(callback) {
+		callback();
+	}
+}
+global.window = { EventTarget };
+
+let patchCalled = false;
+patchEventTarget(() => (patchCalled = true));
+const target = new EventTarget();
+target.addEventListener()
+
+assert.ok(patchCalled, 'patch');

--- a/test/function/samples/track-reassignments/patchEventTarget.js
+++ b/test/function/samples/track-reassignments/patchEventTarget.js
@@ -1,0 +1,10 @@
+export function patchEventTarget(callback) {
+	var proto = window.EventTarget.prototype;
+	var nativeAddEventListener = proto.addEventListener;
+
+	proto.addEventListener = function () {
+		return nativeAddEventListener(callback);
+	};
+
+	return proto;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #4468

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This one seemed quite the mystery bug. It seemed code was removed when you arranged things "just the right way". Turns out, the logic to prevent infinite recursions for assignment tracking was accidentally sharing an object with the same logic for property accesses, with the effect that an earlier property access could tell the system that an assignment had no effect even though it had.