### PR TITLE
Do not deoptimize entire super class when adding a property

### DIFF
--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -128,7 +128,7 @@ export class ObjectEntity extends ExpressionEntity {
 			: this.allProperties) {
 			property.deoptimizePath(subPath);
 		}
-		this.prototypeExpression?.deoptimizePath(path.length === 1 ? [UnknownKey, UnknownKey] : path);
+		this.prototypeExpression?.deoptimizePath(path.length === 1 ? [...path, UnknownKey] : path);
 	}
 
 	deoptimizeThisOnEventAtPath(

--- a/test/form/samples/deoptimize-superclass/_config.js
+++ b/test/form/samples/deoptimize-superclass/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not deoptimize the entire superclass when reassigning a property'
+};

--- a/test/form/samples/deoptimize-superclass/_expected.js
+++ b/test/form/samples/deoptimize-superclass/_expected.js
@@ -1,0 +1,2 @@
+// Everything else should be removed
+console.log('retained');

--- a/test/form/samples/deoptimize-superclass/main.js
+++ b/test/form/samples/deoptimize-superclass/main.js
@@ -1,0 +1,10 @@
+class Foo {}
+
+Foo.prototype.bar = {};
+
+class Bar extends Foo {}
+
+Bar.baz = {};
+
+// Everything else should be removed
+console.log('retained');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
We do not want to deoptimize the entire super class when adding a property, it is enough to deoptimize just properties of the given path (actually in a manner of speaking we may not need to deoptimize at all but deoptimization is a more general concept than reassignment and there may be some edge cases we need to cover).

Following a discussion in Twitter https://twitter.com/pschroen/status/1522269915864256512?s=20&t=8igcqT2KuKkLKgGP3hjvVA, see https://rollupjs.org/repl/?version=2.71.1&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmNsYXNzJTIwRm9vJTIwJTdCJTdEJTVDbiU1Q24lMkYlMkYlMjB0cnklMjByZW1vdmluZyUyMHRoaXMlMjBwcm90b3R5cGUlMjBwcm9wZXJ0eSU1Q25Gb28ucHJvdG90eXBlLmJhciUyMCUzRCUyMCU3QiU3RCUzQiU1Q24lNUNuY2xhc3MlMjBCYXIlMjBleHRlbmRzJTIwRm9vJTIwJTdCJTdEJTVDbiU1Q24lMkYlMkYlMjB0cnklMjByZW1vdmluZyUyMHRoaXMlMjBzdGF0aWMlMjBwcm9wZXJ0eSU1Q25CYXIuYmF6JTIwJTNEJTIwJTdCJTdEJTNCJTVDbiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmVzJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlMkMlMjJnbG9iYWxzJTIyJTNBJTdCJTdEJTdEJTJDJTIyZXhhbXBsZSUyMiUzQW51bGwlN0Q=
