### PR TITLE
Do not make Object.defineProperty/ies a side effect by default

### DIFF
--- a/src/ast/Entity.ts
+++ b/src/ast/Entity.ts
@@ -12,5 +12,10 @@ export interface WritableEntity extends Entity {
 	 * expression of this node is reassigned as well.
 	 */
 	deoptimizePath(path: ObjectPath): void;
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean;
+
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors?: boolean
+	): boolean;
 }

--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -60,8 +60,12 @@ export default class ArrayExpression extends NodeBase {
 		return this.getObjectEntity().hasEffectsWhenAccessedAtPath(path, context);
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context);
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors: boolean
+	): boolean {
+		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context, ignoreAccessors);
 	}
 
 	hasEffectsWhenCalledAtPath(

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -144,13 +144,17 @@ export default class Identifier extends NodeBase implements PatternNode {
 		);
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors: boolean
+	): boolean {
 		return (
 			!this.variable ||
 			(path.length > 0
 				? this.getVariableRespectingTDZ()
 				: this.variable
-			).hasEffectsWhenAssignedAtPath(path, context)
+			).hasEffectsWhenAssignedAtPath(path, context, ignoreAccessors)
 		);
 	}
 

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -79,8 +79,12 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 		return this.getObjectEntity().hasEffectsWhenAccessedAtPath(path, context);
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context);
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors: boolean
+	): boolean {
+		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context, ignoreAccessors);
 	}
 
 	hasEffectsWhenCalledAtPath(

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -86,8 +86,12 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 		return this.getObjectEntity().hasEffectsWhenAccessedAtPath(path, context);
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context);
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors: boolean
+	): boolean {
+		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context, ignoreAccessors);
 	}
 
 	hasEffectsWhenCalledAtPath(

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -52,7 +52,11 @@ export class ExpressionEntity implements WritableEntity {
 		return true;
 	}
 
-	hasEffectsWhenAssignedAtPath(_path: ObjectPath, _context: HasEffectsContext): boolean {
+	hasEffectsWhenAssignedAtPath(
+		_path: ObjectPath,
+		_context: HasEffectsContext,
+		_ignoreAccessors?: boolean
+	): boolean {
 		return true;
 	}
 

--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -302,7 +302,11 @@ export class ObjectEntity extends ExpressionEntity {
 		return false;
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors: boolean
+	): boolean {
 		const [key, ...subPath] = path;
 		if (path.length > 1) {
 			if (typeof key !== 'string') {
@@ -310,14 +314,19 @@ export class ObjectEntity extends ExpressionEntity {
 			}
 			const expressionAtPath = this.getMemberExpression(key);
 			if (expressionAtPath) {
-				return expressionAtPath.hasEffectsWhenAssignedAtPath(subPath, context);
+				return expressionAtPath.hasEffectsWhenAssignedAtPath(subPath, context, ignoreAccessors);
 			}
 			if (this.prototypeExpression) {
-				return this.prototypeExpression.hasEffectsWhenAssignedAtPath(path, context);
+				return this.prototypeExpression.hasEffectsWhenAssignedAtPath(
+					path,
+					context,
+					ignoreAccessors
+				);
 			}
 			return true;
 		}
 
+		if (ignoreAccessors) return false;
 		if (this.hasUnknownDeoptimizedProperty) return true;
 		// We do not need to test for unknown properties as in that case, hasUnknownDeoptimizedProperty is true
 		if (typeof key === 'string') {

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -150,13 +150,17 @@ export default class LocalVariable extends Variable {
 			this.init.hasEffectsWhenAccessedAtPath(path, context))!;
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors: boolean
+	): boolean {
 		if (this.included) return true;
 		if (path.length === 0) return false;
 		if (this.isReassigned) return true;
 		return (this.init &&
 			!context.assigned.trackEntityAtPathAndGetIfTracked(path, this) &&
-			this.init.hasEffectsWhenAssignedAtPath(path, context))!;
+			this.init.hasEffectsWhenAssignedAtPath(path, context, ignoreAccessors))!;
 	}
 
 	hasEffectsWhenCalledAtPath(

--- a/src/ast/variables/ThisVariable.ts
+++ b/src/ast/variables/ThisVariable.ts
@@ -73,10 +73,14 @@ export default class ThisVariable extends LocalVariable {
 		);
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
+	hasEffectsWhenAssignedAtPath(
+		path: ObjectPath,
+		context: HasEffectsContext,
+		ignoreAccessors: boolean
+	): boolean {
 		return (
 			this.getInit(context).hasEffectsWhenAssignedAtPath(path, context) ||
-			super.hasEffectsWhenAssignedAtPath(path, context)
+			super.hasEffectsWhenAssignedAtPath(path, context, ignoreAccessors)
 		);
 	}
 

--- a/test/form/samples/object-define-property/_config.js
+++ b/test/form/samples/object-define-property/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'allows globals to have parameter mutation side effects'
+};

--- a/test/form/samples/object-define-property/_expected.js
+++ b/test/form/samples/object-define-property/_expected.js
@@ -1,0 +1,7 @@
+const retained1 = {};
+Object.defineProperty(retained1, 'foo', { value: true });
+console.log(retained1);
+
+const retained2 = {};
+Object.defineProperties(retained2, { bar: { value: true } });
+console.log(retained2);

--- a/test/form/samples/object-define-property/main.js
+++ b/test/form/samples/object-define-property/main.js
@@ -1,0 +1,20 @@
+const removed = {};
+Object.defineProperty(removed, 'foo', { value: true });
+Object.defineProperties(removed, { bar: { value: true } });
+
+const retained1 = {};
+Object.defineProperty(retained1, 'foo', { value: true });
+console.log(retained1);
+
+const retained2 = {};
+Object.defineProperties(retained2, { bar: { value: true } });
+console.log(retained2);
+
+const removed2 = [];
+Object.defineProperty(removed2, 'foo', { value: true });
+
+class removed3 {}
+Object.defineProperty(removed3, 'foo', { value: true });
+
+function removed4() {}
+Object.defineProperty(removed4, 'foo', { value: true });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This was spawned from the same discussion https://twitter.com/pschroen/status/1522269915864256512?s=20&t=8igcqT2KuKkLKgGP3hjvVA as #4489 and will improve tree-shaking by only considering `Object.defineProperty` and `Object.defineProperties` side effects if the target object is used. Their presence will still deoptimize the object in question, though.
This is not entirely correct in so far as those two functions can throw e.g. when incorrect parameters are used ore when try to redefine a non-configurable property. I think this is acceptable as when this is actually critical, it will likely be wrapped in a try-catch, in which case Rollup will deoptimize and include the statement anyway.

https://rollupjs.org/repl/?pr=4492&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGNvbnN0JTIwZm9vJTIwJTNEJTIwJTdCJTdEJTNCJTVDbiUyRiUyRiUyMFRoaXMlMjB3aWxsJTIwYmUlMjBpbmNsdWRlZCUyMGJlY2F1c2UlMjBmb28lMjBpcyUyMGV4cG9zZWQlNUNuT2JqZWN0LmRlZmluZVByb3BlcnR5KGZvbyUyQyUyMCdmb28nJTJDJTIwJTdCdmFsdWUlM0ElMjB0cnVlJTdEKSUzQiU1Q25PYmplY3QuZGVmaW5lUHJvcGVydGllcyhmb28lMkMlMjAlN0IlMjBiYXIlM0ElMjAlN0J2YWx1ZSUzQSUyMHRydWUlN0QlN0QpJTNCJTVDbiU1Q24lMkYlMkYlMjBUaGlzJTIwd2lsbCUyMGJlJTIwbm90JTIwYmUlMjBpbmNsdWRlZCU1Q25jb25zdCUyMGJhciUyMCUzRCUyMCU3QiU3RCUzQiU1Q25PYmplY3QuZGVmaW5lUHJvcGVydHkoYmFyJTJDJTIwJ2ZvbyclMkMlMjAlN0J2YWx1ZSUzQSUyMHRydWUlN0QpJTNCJTVDbk9iamVjdC5kZWZpbmVQcm9wZXJ0aWVzKGJhciUyQyUyMCU3QiUyMGJhciUzQSUyMCU3QnZhbHVlJTNBJTIwdHJ1ZSU3RCU3RCklM0IlMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlMjJmb3JtYXQlMjIlM0ElMjJlcyUyMiUyQyUyMm5hbWUlMjIlM0ElMjJteUJ1bmRsZSUyMiUyQyUyMmFtZCUyMiUzQSU3QiUyMmlkJTIyJTNBJTIyJTIyJTdEJTJDJTIyZ2xvYmFscyUyMiUzQSU3QiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE