### PR TITLE
Update docs for --configPlugin using typescript

### DIFF
--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -444,6 +444,7 @@ rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript
 ```
 
 Note for Typescript: make sure you have the Rollup config file in your `tsconfig.json`'s `include` paths. For example:
+
 ```
 "include": ["src/**/*", "rollup.config.ts"],
 ```

--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -443,7 +443,12 @@ Allows specifying Rollup plugins to transpile or otherwise control the parsing o
 rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript
 ```
 
-It supports the same syntax as the [`--plugin`](guide/en/#-p-plugin---plugin-plugin) option i.e., you can specify the option multiple times, you can omit the `@rollup/plugin-` prefix and just write `typescript` and you can specify plugin options via `={...}`.
+Note for Typescript: make sure you have the Rollup config file in your `tsconfig.json`'s `include` paths. For example:
+```
+"include": ["src/**/*", "rollup.config.ts"],
+```
+
+This option supports the same syntax as the [`--plugin`](guide/en/#-p-plugin---plugin-plugin) option i.e., you can specify the option multiple times, you can omit the `@rollup/plugin-` prefix and just write `typescript` and you can specify plugin options via `={...}`.
 
 #### `-v`/`--version`
 


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

The documentation gives examples for using `@rollup/plugin-typescript` to parse the Rollup configuration file, with a CLI code example. However, that example will fail to build with a somewhat misleading error if the Rollup config is not declared in the `tsconfig.json`'s `include` property, so a note about needing to do so has been added with this commit.

For an example of the error I'm referring to, here is what happened to me:
```
[!] Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
rollup.config.ts (5:13)
3: import del from "rollup-plugin-delete";
4:
5: const options: RollupOptions = {
                ^
6:   input: "src/index.ts",
7:   output: [
Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
```

This is pretty obvious when you know the answer, but when you first get this error after following the docs, it is a bit confusing because it seems like something is wrong with your CLI flags or the config itself due to the error giving the same output as if the `@rollup/plugin-typescript` was not setup at all.

I'm happy to reword this, or move it somewhere else if anyone has suggestions.