### PR TITLE
Ensure reexports are available for namespaces

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -206,8 +206,8 @@ export default class Module {
 	readonly importMetas: MetaProperty[] = [];
 	importedFromNotTreeshaken = false;
 	readonly importers: string[] = [];
-	readonly imports = new Set<Variable>();
 	readonly includedDynamicImporters: Module[] = [];
+	readonly includedImports = new Set<Variable>();
 	readonly info: ModuleInfo;
 	isExecuted = false;
 	isUserDefinedEntryPoint = false;
@@ -383,7 +383,7 @@ export default class Module {
 		this.relevantDependencies = new Set<Module | ExternalModule>();
 		const necessaryDependencies = new Set<Module | ExternalModule>();
 		const alwaysCheckedDependencies = new Set<Module>();
-		const dependencyVariables = new Set(this.imports);
+		const dependencyVariables = new Set(this.includedImports);
 
 		if (
 			this.info.isEntry ||
@@ -1134,12 +1134,12 @@ export default class Module {
 			if (module instanceof ExternalModule) {
 				const [externalVariable] = module.getVariableForExportName('*');
 				externalVariable.include();
-				this.imports.add(externalVariable);
+				this.includedImports.add(externalVariable);
 				externalNamespaces.add(externalVariable);
 			} else if (module.info.syntheticNamedExports) {
 				const syntheticNamespace = module.getSyntheticNamespace();
 				syntheticNamespace.include();
-				this.imports.add(syntheticNamespace);
+				this.includedImports.add(syntheticNamespace);
 				syntheticNamespaces.add(syntheticNamespace);
 			}
 		}
@@ -1183,7 +1183,7 @@ export default class Module {
 		this.includeVariable(variable);
 		const variableModule = variable.module;
 		if (variableModule && variableModule !== this) {
-			this.imports.add(variable);
+			this.includedImports.add(variable);
 		}
 	}
 

--- a/test/function/samples/dynamic-imports-shared-exports/_config.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	description: 'allows sharing imports between dynamic chunks',
+	options: {
+		preserveEntrySignatures: 'allow-extension'
+	},
+	exports(exports) {
+		return exports.promise;
+	}
+};

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/amd/generated-dynamic1.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/amd/generated-dynamic1.js
@@ -1,0 +1,16 @@
+define(['require', 'exports', './main'], (function (require, exports, main) { 'use strict';
+
+	const sharedDynamic = true;
+
+	new Promise(function (resolve, reject) { require(['./generated-dynamic2'], resolve, reject); });
+	console.log(sharedDynamic);
+
+	var dynamic1 = /*#__PURE__*/Object.freeze({
+		__proto__: null,
+		shared: main.shared
+	});
+
+	exports.dynamic1 = dynamic1;
+	exports.sharedDynamic = sharedDynamic;
+
+}));

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/amd/generated-dynamic2.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/amd/generated-dynamic2.js
@@ -1,0 +1,5 @@
+define(['./generated-dynamic1', './main'], (function (dynamic1, main) { 'use strict';
+
+	console.log(dynamic1.sharedDynamic);
+
+}));

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/amd/main.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/amd/main.js
@@ -1,0 +1,12 @@
+define(['require', 'exports'], (function (require, exports) { 'use strict';
+
+	const shared = true;
+
+	new Promise(function (resolve, reject) { require(['./generated-dynamic1'], resolve, reject); }).then(function (n) { return n.dynamic1; });
+	console.log(shared);
+
+	exports.shared = shared;
+
+	Object.defineProperty(exports, '__esModule', { value: true });
+
+}));

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/cjs/generated-dynamic1.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/cjs/generated-dynamic1.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var main = require('./main.js');
+
+const sharedDynamic = true;
+
+Promise.resolve().then(function () { return require('./generated-dynamic2.js'); });
+console.log(sharedDynamic);
+
+var dynamic1 = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	shared: main.shared
+});
+
+exports.dynamic1 = dynamic1;
+exports.sharedDynamic = sharedDynamic;

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/cjs/generated-dynamic2.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/cjs/generated-dynamic2.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dynamic1 = require('./generated-dynamic1.js');
+require('./main.js');
+
+console.log(dynamic1.sharedDynamic);

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/cjs/main.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/cjs/main.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const shared = true;
+
+Promise.resolve().then(function () { return require('./generated-dynamic1.js'); }).then(function (n) { return n.dynamic1; });
+console.log(shared);
+
+exports.shared = shared;

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/es/generated-dynamic1.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/es/generated-dynamic1.js
@@ -1,0 +1,13 @@
+import { s as shared } from './main.js';
+
+const sharedDynamic = true;
+
+import('./generated-dynamic2.js');
+console.log(sharedDynamic);
+
+var dynamic1 = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	shared: shared
+});
+
+export { dynamic1 as d, sharedDynamic as s };

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/es/generated-dynamic2.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/es/generated-dynamic2.js
@@ -1,0 +1,4 @@
+import { s as sharedDynamic } from './generated-dynamic1.js';
+import './main.js';
+
+console.log(sharedDynamic);

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/es/main.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/es/main.js
@@ -1,0 +1,6 @@
+const shared = true;
+
+import('./generated-dynamic1.js').then(function (n) { return n.d; });
+console.log(shared);
+
+export { shared as s };

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/system/generated-dynamic1.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/system/generated-dynamic1.js
@@ -1,0 +1,23 @@
+System.register(['./main.js'], (function (exports, module) {
+	'use strict';
+	var shared;
+	return {
+		setters: [function (module) {
+			shared = module.s;
+		}],
+		execute: (function () {
+
+			const sharedDynamic = exports('s', true);
+
+			module.import('./generated-dynamic2.js');
+			console.log(sharedDynamic);
+
+			var dynamic1 = /*#__PURE__*/Object.freeze({
+				__proto__: null,
+				shared: shared
+			});
+			exports('d', dynamic1);
+
+		})
+	};
+}));

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/system/generated-dynamic2.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/system/generated-dynamic2.js
@@ -1,0 +1,14 @@
+System.register(['./generated-dynamic1.js', './main.js'], (function () {
+	'use strict';
+	var sharedDynamic;
+	return {
+		setters: [function (module) {
+			sharedDynamic = module.s;
+		}, function () {}],
+		execute: (function () {
+
+			console.log(sharedDynamic);
+
+		})
+	};
+}));

--- a/test/function/samples/dynamic-imports-shared-exports/_expected/system/main.js
+++ b/test/function/samples/dynamic-imports-shared-exports/_expected/system/main.js
@@ -1,0 +1,13 @@
+System.register([], (function (exports, module) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const shared = exports('s', true);
+
+			module.import('./generated-dynamic1.js').then(function (n) { return n.d; });
+			console.log(shared);
+
+		})
+	};
+}));

--- a/test/function/samples/dynamic-imports-shared-exports/dynamic1.js
+++ b/test/function/samples/dynamic-imports-shared-exports/dynamic1.js
@@ -1,0 +1,8 @@
+import { sharedDynamic } from './sharedDynamic.js';
+
+assert.ok(sharedDynamic);
+export const promise = import('./dynamic2.js').then(ns =>
+	assert.deepStrictEqual(ns, { sharedDynamic: true })
+);
+
+export { shared } from './shared.js';

--- a/test/function/samples/dynamic-imports-shared-exports/dynamic2.js
+++ b/test/function/samples/dynamic-imports-shared-exports/dynamic2.js
@@ -1,0 +1,1 @@
+export { sharedDynamic } from './sharedDynamic.js';

--- a/test/function/samples/dynamic-imports-shared-exports/main.js
+++ b/test/function/samples/dynamic-imports-shared-exports/main.js
@@ -1,0 +1,7 @@
+import { shared } from './shared.js';
+
+assert.ok(shared);
+export const promise = import('./dynamic1.js').then(({ promise, ...ns }) => {
+	assert.deepStrictEqual(ns, { shared: true });
+	return ns.promise;
+});

--- a/test/function/samples/dynamic-imports-shared-exports/shared.js
+++ b/test/function/samples/dynamic-imports-shared-exports/shared.js
@@ -1,0 +1,1 @@
+export const shared = true;

--- a/test/function/samples/dynamic-imports-shared-exports/sharedDynamic.js
+++ b/test/function/samples/dynamic-imports-shared-exports/sharedDynamic.js
@@ -1,0 +1,1 @@
+export const sharedDynamic = true;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #4490

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This fixes an issue where namespaces in dynamic chunks were not referencing reexports correctly because imports were missing. See #4490 for the issue.

The problem was that the logic to make reexported variables available was run before facades were generated, and facade generation could add additional namespaces to the module.