### PR TITLE
fix: config path problem on windows

### DIFF
--- a/cli/run/loadConfigFile.ts
+++ b/cli/run/loadConfigFile.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from 'fs';
 import { extname, isAbsolute } from 'path';
 import { version } from 'process';
 import { pathToFileURL } from 'url';
@@ -103,8 +102,8 @@ async function getDefaultFromTranspiledConfigFile(
 	return loadConfigFromBundledFile(fileName, code);
 }
 
-async function loadConfigFromBundledFile(fileName: string, bundledCode: string): Promise<unknown> {
-	const resolvedFileName = await fs.realpath(fileName);
+function loadConfigFromBundledFile(fileName: string, bundledCode: string): unknown {
+	const resolvedFileName = require.resolve(fileName);
 	const extension = extname(resolvedFileName);
 	const defaultLoader = require.extensions[extension];
 	require.extensions[extension] = (module: NodeModule, requiredFileName: string) => {

--- a/test/cli/samples/config-cwd-case-insensitive-es6/_config.js
+++ b/test/cli/samples/config-cwd-case-insensitive-es6/_config.js
@@ -1,0 +1,11 @@
+function toggleCase(s) {
+	return s == s.toLowerCase() ? s.toUpperCase() : s.toLowerCase();
+}
+
+module.exports = {
+	onlyWindows: true,
+	description: "can load ES6 config with cwd that doesn't match realpath",
+	command: 'rollup -c',
+	cwd: __dirname.replace(/^[A-Z]:\\/i, toggleCase),
+	execute: true
+};

--- a/test/cli/samples/config-cwd-case-insensitive-es6/main.js
+++ b/test/cli/samples/config-cwd-case-insensitive-es6/main.js
@@ -1,0 +1,1 @@
+assert.equal( ANSWER, 42 );

--- a/test/cli/samples/config-cwd-case-insensitive-es6/rollup.config.js
+++ b/test/cli/samples/config-cwd-case-insensitive-es6/rollup.config.js
@@ -1,0 +1,9 @@
+import replace from '@rollup/plugin-replace';
+
+export default {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+	plugins: [replace({ preventAssignment: true, ANSWER: 42 })]
+};


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

resolves #3949
#4260
#4439
#4440
#4446
resolves #4465

### Description

The `loadConfigFromBundledFile` function patches the default `require` algorithm for the `fileName` file. It replaces the [require.extensions](https://nodejs.org/api/modules.html#requireextensions) handler for it. In certain scenarios the file name parameter value in the `require.extensions` handler differs from the required file name (for example for symlinked files). The #3783 fix processed this by preparing the input file name before comparation. It uses the [fsPromises.realpath](https://nodejs.org/api/fs.html#fspromisesrealpathpath-options) function for it. The problem is that the `fsPromises.realpath` result and the file name in the `require.extensions` handler are not the same in certain scenarios (refer to the relevant issue list above). I suggest use the [require.resolve](https://nodejs.org/api/modules.html#requireresolverequest-options) function instead of the `fsPromises.realpath` because the `require` and the `require.resolve` functions use the same [algorithm](https://nodejs.org/api/modules.html#modules_all_together).