### PR TITLE
Ensure parameter defaults are deoptimized

### DIFF
--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -25,6 +25,7 @@ export default class ArrowFunctionExpression extends FunctionBase {
 	}
 
 	hasEffects(): boolean {
+		if (!this.deoptimized) this.applyDeoptimizations();
 		return false;
 	}
 

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -175,6 +175,7 @@ export default abstract class FunctionBase extends NodeBase implements Deoptimiz
 		includeChildrenRecursively: IncludeChildren,
 		{ includeWithoutParameterDefaults }: InclusionOptions = BLANK
 	): void {
+		if (!this.deoptimized) this.applyDeoptimizations();
 		this.included = true;
 		const { brokenFlow } = context;
 		context.brokenFlow = BROKEN_FLOW_NONE;
@@ -242,6 +243,16 @@ export default abstract class FunctionBase extends NodeBase implements Deoptimiz
 			this.body = new BlockStatement(esTreeNode.body, this, this.scope.hoistedBodyVarScope);
 		}
 		super.parseNode(esTreeNode);
+	}
+
+	protected applyDeoptimizations() {
+		// We currently do not track deoptimizations of default values, deoptimize them
+		// just as we deoptimize call arguments
+		for (const param of this.params) {
+			if (param instanceof AssignmentPattern) {
+				param.right.deoptimizePath(UNKNOWN_PATH);
+			}
+		}
 	}
 
 	protected abstract getObjectEntity(): ObjectEntity;

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -39,6 +39,7 @@ export default class FunctionNode extends FunctionBase {
 	}
 
 	hasEffects(): boolean {
+		if (!this.deoptimized) this.applyDeoptimizations();
 		return !!this.id?.hasEffects();
 	}
 

--- a/test/function/samples/parameter-defaults/function-as-default/_config.js
+++ b/test/function/samples/parameter-defaults/function-as-default/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimizes functions supplied as default values'
+};

--- a/test/function/samples/parameter-defaults/function-as-default/main.js
+++ b/test/function/samples/parameter-defaults/function-as-default/main.js
@@ -1,0 +1,4 @@
+const foo = (a = 'fallback') => a;
+const bar = (a = foo) => a;
+
+assert.strictEqual(bar()(), 'fallback');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #4514

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Currently, we do not deoptimize parameter default values, which means we do not track deoptimizations or calls. This fixes it. See the linked issue for an example.