### PR TITLE
Try to make logical expression deoptimization more robust

### DIFF
--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -1,11 +1,8 @@
 import type MagicString from 'magic-string';
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import { BLANK } from '../../utils/blank';
-import {
-	findFirstOccurrenceOutsideComment,
-	type NodeRenderOptions,
-	type RenderOptions
-} from '../../utils/renderHelpers';
+import { renderCallArguments } from '../../utils/renderCallArguments';
+import { type NodeRenderOptions, type RenderOptions } from '../../utils/renderHelpers';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import { EVENT_CALLED } from '../NodeEvents';
@@ -116,36 +113,7 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 			isCalleeOfRenderedParent: true,
 			renderedSurroundingElement
 		});
-		if (this.arguments.length > 0) {
-			if (this.arguments[this.arguments.length - 1].included) {
-				for (const arg of this.arguments) {
-					arg.render(code, options);
-				}
-			} else {
-				let lastIncludedIndex = this.arguments.length - 2;
-				while (lastIncludedIndex >= 0 && !this.arguments[lastIncludedIndex].included) {
-					lastIncludedIndex--;
-				}
-				if (lastIncludedIndex >= 0) {
-					for (let index = 0; index <= lastIncludedIndex; index++) {
-						this.arguments[index].render(code, options);
-					}
-					code.remove(
-						findFirstOccurrenceOutsideComment(
-							code.original,
-							',',
-							this.arguments[lastIncludedIndex].end
-						),
-						this.end - 1
-					);
-				} else {
-					code.remove(
-						findFirstOccurrenceOutsideComment(code.original, '(', this.callee.end) + 1,
-						this.end - 1
-					);
-				}
-			}
-		}
+		renderCallArguments(code, options, this);
 	}
 
 	protected applyDeoptimizations(): void {

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -42,13 +42,16 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 	private usedBranch: ExpressionNode | null = null;
 
 	deoptimizeCache(): void {
-		if (this.usedBranch !== null) {
+		if (this.usedBranch) {
 			const unusedBranch = this.usedBranch === this.left ? this.right : this.left;
 			this.usedBranch = null;
 			unusedBranch.deoptimizePath(UNKNOWN_PATH);
 			for (const expression of this.expressionsToBeDeoptimized) {
 				expression.deoptimizeCache();
 			}
+			// Request another pass because we need to ensure "include" runs again if
+			// it is rendered
+			this.context.requestTreeshakingPass();
 		}
 	}
 

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -1,4 +1,7 @@
+import MagicString from 'magic-string';
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
+import { renderCallArguments } from '../../utils/renderCallArguments';
+import { RenderOptions } from '../../utils/renderHelpers';
 import type { CallOptions } from '../CallOptions';
 import type { HasEffectsContext } from '../ExecutionContext';
 import { InclusionContext } from '../ExecutionContext';
@@ -52,6 +55,11 @@ export default class NewExpression extends NodeBase {
 			thisParam: null,
 			withNew: true
 		};
+	}
+
+	render(code: MagicString, options: RenderOptions) {
+		this.callee.render(code, options);
+		renderCallArguments(code, options, this);
 	}
 
 	protected applyDeoptimizations(): void {

--- a/src/utils/renderCallArguments.ts
+++ b/src/utils/renderCallArguments.ts
@@ -1,0 +1,41 @@
+import MagicString from 'magic-string';
+import CallExpression from '../ast/nodes/CallExpression';
+import NewExpression from '../ast/nodes/NewExpression';
+import { findFirstOccurrenceOutsideComment, RenderOptions } from './renderHelpers';
+
+export function renderCallArguments(
+	code: MagicString,
+	options: RenderOptions,
+	node: CallExpression | NewExpression
+): void {
+	if (node.arguments.length > 0) {
+		if (node.arguments[node.arguments.length - 1].included) {
+			for (const arg of node.arguments) {
+				arg.render(code, options);
+			}
+		} else {
+			let lastIncludedIndex = node.arguments.length - 2;
+			while (lastIncludedIndex >= 0 && !node.arguments[lastIncludedIndex].included) {
+				lastIncludedIndex--;
+			}
+			if (lastIncludedIndex >= 0) {
+				for (let index = 0; index <= lastIncludedIndex; index++) {
+					node.arguments[index].render(code, options);
+				}
+				code.remove(
+					findFirstOccurrenceOutsideComment(
+						code.original,
+						',',
+						node.arguments[lastIncludedIndex].end
+					),
+					node.end - 1
+				);
+			} else {
+				code.remove(
+					findFirstOccurrenceOutsideComment(code.original, '(', node.callee.end) + 1,
+					node.end - 1
+				);
+			}
+		}
+	}
+}

--- a/test/form/samples/side-effect-es5-classes/_expected.js
+++ b/test/form/samples/side-effect-es5-classes/_expected.js
@@ -22,7 +22,7 @@ var Arrow = ( x ) => {
 console.log( 'before' );
 new Bar(5);
 new Baz(5);
-new Qux(5);
+new Qux();
 Corge(5);
 new Arrow(5);
 

--- a/test/function/samples/unused-constructor-argument-fallback/_config.js
+++ b/test/function/samples/unused-constructor-argument-fallback/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'handles unused logical expressions as constructor arguments (#4517)',
+	exports({ create }) {
+		assert.strictEqual(create().foo, 'foo');
+	}
+};

--- a/test/function/samples/unused-constructor-argument-fallback/main.js
+++ b/test/function/samples/unused-constructor-argument-fallback/main.js
@@ -1,0 +1,7 @@
+function Note() {
+	this.foo = 'foo';
+}
+
+export function create(data) {
+	return new Note(data || {});
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #4517

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Turns out that while unused arguments of new expressions were not included, they were still rendered, which was causing issues for certain types of arguments like logical expressions. This is fixed here. As a result, unused arguments of new expressions at the end of the call are now removed, just like unused arguments of call expressions.