### PR TITLE
Refactor side effect handling for property interactions

### DIFF
--- a/src/ast/CallOptions.ts
+++ b/src/ast/CallOptions.ts
@@ -1,8 +1,0 @@
-import type SpreadElement from './nodes/SpreadElement';
-import type { ExpressionEntity } from './nodes/shared/Expression';
-
-export interface CallOptions {
-	args: (ExpressionEntity | SpreadElement)[];
-	thisArg: ExpressionEntity | null;
-	withNew: boolean;
-}

--- a/src/ast/CallOptions.ts
+++ b/src/ast/CallOptions.ts
@@ -1,10 +1,8 @@
 import type SpreadElement from './nodes/SpreadElement';
 import type { ExpressionEntity } from './nodes/shared/Expression';
 
-export const NO_ARGS = [];
-
 export interface CallOptions {
 	args: (ExpressionEntity | SpreadElement)[];
-	thisParam: ExpressionEntity | null;
+	thisArg: ExpressionEntity | null;
 	withNew: boolean;
 }

--- a/src/ast/Entity.ts
+++ b/src/ast/Entity.ts
@@ -1,4 +1,5 @@
 import type { HasEffectsContext } from './ExecutionContext';
+import { NodeInteractionAssigned } from './NodeInteractions';
 import type { ObjectPath } from './utils/PathTracker';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -13,5 +14,9 @@ export interface WritableEntity extends Entity {
 	 */
 	deoptimizePath(path: ObjectPath): void;
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean;
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteractionAssigned,
+		context: HasEffectsContext
+	): boolean;
 }

--- a/src/ast/NodeEvents.ts
+++ b/src/ast/NodeEvents.ts
@@ -1,5 +1,0 @@
-export const EVENT_ACCESSED = 0;
-export const EVENT_ASSIGNED = 1;
-export const EVENT_CALLED = 2;
-
-export type NodeEvent = typeof EVENT_ACCESSED | typeof EVENT_ASSIGNED | typeof EVENT_CALLED;

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -1,8 +1,24 @@
+import { CallOptions } from './CallOptions';
+
 export const INTERACTION_ACCESSED = 0;
 export const INTERACTION_ASSIGNED = 1;
 export const INTERACTION_CALLED = 2;
 
+export interface NodeInteractionAccessed {
+	type: typeof INTERACTION_ACCESSED;
+}
+
+interface NodeInteractionAssigned {
+	type: typeof INTERACTION_ASSIGNED;
+}
+
+// TODO Lukas call options should be flattened into this one
+interface NodeInteractionCalled {
+	callOptions: CallOptions;
+	type: typeof INTERACTION_CALLED;
+}
+
 export type NodeInteraction =
-	| typeof INTERACTION_ACCESSED
-	| typeof INTERACTION_ASSIGNED
-	| typeof INTERACTION_CALLED;
+	| NodeInteractionAccessed
+	| NodeInteractionAssigned
+	| NodeInteractionCalled;

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -1,0 +1,8 @@
+export const INTERACTION_ACCESSED = 0;
+export const INTERACTION_ASSIGNED = 1;
+export const INTERACTION_CALLED = 2;
+
+export type NodeInteraction =
+	| typeof INTERACTION_ACCESSED
+	| typeof INTERACTION_ASSIGNED
+	| typeof INTERACTION_CALLED;

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -16,7 +16,7 @@ interface NodeInteractionAssigned {
 	value: ExpressionEntity;
 }
 
-interface NodeInteractionCalled {
+export interface NodeInteractionCalled {
 	args: (ExpressionEntity | SpreadElement)[];
 	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_CALLED;

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -1,22 +1,29 @@
-import { CallOptions } from './CallOptions';
+import SpreadElement from './nodes/SpreadElement';
+import { ExpressionEntity } from './nodes/shared/Expression';
 
 export const INTERACTION_ACCESSED = 0;
 export const INTERACTION_ASSIGNED = 1;
 export const INTERACTION_CALLED = 2;
 
 export interface NodeInteractionAccessed {
+	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_ACCESSED;
 }
 
 interface NodeInteractionAssigned {
+	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_ASSIGNED;
+	value: ExpressionEntity;
 }
 
-// TODO Lukas call options should be flattened into this one
 interface NodeInteractionCalled {
-	callOptions: CallOptions;
+	args: (ExpressionEntity | SpreadElement)[];
+	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_CALLED;
+	withNew: boolean;
 }
+
+export const NO_ARGS = [];
 
 export type NodeInteraction =
 	| NodeInteractionAccessed

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -29,3 +29,5 @@ export type NodeInteraction =
 	| NodeInteractionAccessed
 	| NodeInteractionAssigned
 	| NodeInteractionCalled;
+
+export type NodeInteractionWithThisArg = NodeInteraction & { thisArg: ExpressionEntity };

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -1,5 +1,5 @@
 import SpreadElement from './nodes/SpreadElement';
-import { ExpressionEntity } from './nodes/shared/Expression';
+import { ExpressionEntity, UNKNOWN_EXPRESSION } from './nodes/shared/Expression';
 
 // TODO Lukas for usages and see if caching makes sense
 export const INTERACTION_ACCESSED = 0;
@@ -7,13 +7,26 @@ export const INTERACTION_ASSIGNED = 1;
 export const INTERACTION_CALLED = 2;
 
 export interface NodeInteractionAccessed {
+	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_ACCESSED;
 }
 
+export const NODE_INTERACTION_ACCESS: NodeInteractionAccessed = {
+	thisArg: null,
+	type: INTERACTION_ACCESSED
+};
+
 export interface NodeInteractionAssigned {
+	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_ASSIGNED;
 	value: ExpressionEntity;
 }
+
+export const NODE_INTERACTION_UNKNOWN_ASSIGNMENT: NodeInteractionAssigned = {
+	thisArg: null,
+	type: INTERACTION_ASSIGNED,
+	value: UNKNOWN_EXPRESSION
+};
 
 export interface NodeInteractionCalled {
 	args: (ExpressionEntity | SpreadElement)[];
@@ -24,11 +37,9 @@ export interface NodeInteractionCalled {
 
 export const NO_ARGS = [];
 
-// TODO Lukas destructure interactions where they are not forwarded
 export type NodeInteraction =
 	| NodeInteractionAccessed
 	| NodeInteractionAssigned
 	| NodeInteractionCalled;
 
-// TODO Lukas getters and setters can only every have their actual parent as thisArg -> do not add them to the interaction but get them statically
 export type NodeInteractionWithThisArg = NodeInteraction & { thisArg: ExpressionEntity };

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -17,19 +17,21 @@ export const NODE_INTERACTION_ACCESS: NodeInteractionAccessed = {
 };
 
 export interface NodeInteractionAssigned {
+	args: readonly [ExpressionEntity];
 	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_ASSIGNED;
-	value: ExpressionEntity;
 }
 
+export const UNKNOWN_ARG = [UNKNOWN_EXPRESSION] as const;
+
 export const NODE_INTERACTION_UNKNOWN_ASSIGNMENT: NodeInteractionAssigned = {
+	args: UNKNOWN_ARG,
 	thisArg: null,
-	type: INTERACTION_ASSIGNED,
-	value: UNKNOWN_EXPRESSION
+	type: INTERACTION_ASSIGNED
 };
 
 export interface NodeInteractionCalled {
-	args: (ExpressionEntity | SpreadElement)[];
+	args: readonly (ExpressionEntity | SpreadElement)[];
 	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_CALLED;
 	withNew: boolean;

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -1,7 +1,6 @@
 import SpreadElement from './nodes/SpreadElement';
 import { ExpressionEntity, UNKNOWN_EXPRESSION } from './nodes/shared/Expression';
 
-// TODO Lukas for usages and see if caching makes sense
 export const INTERACTION_ACCESSED = 0;
 export const INTERACTION_ASSIGNED = 1;
 export const INTERACTION_CALLED = 2;
@@ -11,7 +10,7 @@ export interface NodeInteractionAccessed {
 	type: typeof INTERACTION_ACCESSED;
 }
 
-export const NODE_INTERACTION_ACCESS: NodeInteractionAccessed = {
+export const NODE_INTERACTION_UNKNOWN_ACCESS: NodeInteractionAccessed = {
 	thisArg: null,
 	type: INTERACTION_ACCESSED
 };
@@ -38,6 +37,16 @@ export interface NodeInteractionCalled {
 }
 
 export const NO_ARGS = [];
+
+// While this is technically a call without arguments, we can compare against
+// this reference in places where precise values or thisArg would make a
+// difference
+export const NODE_INTERACTION_UNKNOWN_CALL: NodeInteractionCalled = {
+	args: NO_ARGS,
+	thisArg: null,
+	type: INTERACTION_CALLED,
+	withNew: false
+};
 
 export type NodeInteraction =
 	| NodeInteractionAccessed

--- a/src/ast/NodeInteractions.ts
+++ b/src/ast/NodeInteractions.ts
@@ -1,17 +1,16 @@
 import SpreadElement from './nodes/SpreadElement';
 import { ExpressionEntity } from './nodes/shared/Expression';
 
+// TODO Lukas for usages and see if caching makes sense
 export const INTERACTION_ACCESSED = 0;
 export const INTERACTION_ASSIGNED = 1;
 export const INTERACTION_CALLED = 2;
 
 export interface NodeInteractionAccessed {
-	thisArg: ExpressionEntity | null;
 	type: typeof INTERACTION_ACCESSED;
 }
 
-interface NodeInteractionAssigned {
-	thisArg: ExpressionEntity | null;
+export interface NodeInteractionAssigned {
 	type: typeof INTERACTION_ASSIGNED;
 	value: ExpressionEntity;
 }
@@ -25,9 +24,11 @@ export interface NodeInteractionCalled {
 
 export const NO_ARGS = [];
 
+// TODO Lukas destructure interactions where they are not forwarded
 export type NodeInteraction =
 	| NodeInteractionAccessed
 	| NodeInteractionAssigned
 	| NodeInteractionCalled;
 
+// TODO Lukas getters and setters can only every have their actual parent as thisArg -> do not add them to the interaction but get them statically
 export type NodeInteractionWithThisArg = NodeInteraction & { thisArg: ExpressionEntity };

--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import {
 	type ObjectPath,
 	type PathTracker,
@@ -26,17 +26,11 @@ export default class ArrayExpression extends NodeBase {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import {
 	type ObjectPath,
 	type PathTracker,
@@ -25,14 +25,14 @@ export default class ArrayExpression extends NodeBase {
 		this.getObjectEntity().deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.getObjectEntity().deoptimizeThisOnEventAtPath(
-			event,
+		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
+			interaction,
 			path,
 			thisParameter,
 			recursionTracker

--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import type { NodeInteractionCalled, NodeInteractionWithThisArg } from '../NodeInteractions';
 import {
 	type ObjectPath,
 	type PathTracker,
@@ -43,13 +43,13 @@ export default class ArrayExpression extends NodeBase {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		return this.getObjectEntity().getReturnExpressionWhenCalledAtPath(
 			path,
-			callOptions,
+			interaction,
 			recursionTracker,
 			origin
 		);

--- a/src/ast/nodes/ArrayExpression.ts
+++ b/src/ast/nodes/ArrayExpression.ts
@@ -1,7 +1,7 @@
-import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionCalled, NodeInteractionWithThisArg } from '../NodeInteractions';
+import { NodeInteraction } from '../NodeInteractions';
 import {
 	type ObjectPath,
 	type PathTracker,
@@ -55,20 +55,12 @@ export default class ArrayExpression extends NodeBase {
 		);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAccessedAtPath(path, context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		return this.getObjectEntity().hasEffectsWhenCalledAtPath(path, callOptions, context);
+		return this.getObjectEntity().hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 
 	protected applyDeoptimizations(): void {

--- a/src/ast/nodes/ArrayPattern.ts
+++ b/src/ast/nodes/ArrayPattern.ts
@@ -1,4 +1,5 @@
 import type { HasEffectsContext } from '../ExecutionContext';
+import { NodeInteractionAssigned } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath } from '../utils/PathTracker';
 import type LocalVariable from '../variables/LocalVariable';
 import type Variable from '../variables/Variable';
@@ -38,9 +39,13 @@ export default class ArrayPattern extends NodeBase implements PatternNode {
 	}
 
 	// Patterns are only checked at the emtpy path at the moment
-	hasEffectsWhenAssignedAtPath(_path: ObjectPath, context: HasEffectsContext): boolean {
+	hasEffectsOnInteractionAtPath(
+		_path: ObjectPath,
+		interaction: NodeInteractionAssigned,
+		context: HasEffectsContext
+	): boolean {
 		for (const element of this.elements) {
-			if (element?.hasEffectsWhenAssignedAtPath(EMPTY_PATH, context)) return true;
+			if (element?.hasEffectsOnInteractionAtPath(EMPTY_PATH, interaction, context)) return true;
 		}
 		return false;
 	}

--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -1,5 +1,5 @@
-import { type CallOptions } from '../CallOptions';
 import { type HasEffectsContext, InclusionContext } from '../ExecutionContext';
+import { INTERACTION_CALLED, NodeInteraction } from '../NodeInteractions';
 import ReturnValueScope from '../scopes/ReturnValueScope';
 import type Scope from '../scopes/Scope';
 import { type ObjectPath } from '../utils/PathTracker';
@@ -30,22 +30,24 @@ export default class ArrowFunctionExpression extends FunctionBase {
 		return false;
 	}
 
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (super.hasEffectsWhenCalledAtPath(path, callOptions, context)) return true;
-		const { ignore, brokenFlow } = context;
-		context.ignore = {
-			breaks: false,
-			continues: false,
-			labels: new Set(),
-			returnYield: true
-		};
-		if (this.body.hasEffects(context)) return true;
-		context.ignore = ignore;
-		context.brokenFlow = brokenFlow;
+		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) return true;
+		if (interaction.type === INTERACTION_CALLED) {
+			const { ignore, brokenFlow } = context;
+			context.ignore = {
+				breaks: false,
+				continues: false,
+				labels: new Set(),
+				returnYield: true
+			};
+			if (this.body.hasEffects(context)) return true;
+			context.ignore = ignore;
+			context.brokenFlow = brokenFlow;
+		}
 		return false;
 	}
 

--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -17,7 +17,7 @@ import {
 	type HasEffectsContext,
 	type InclusionContext
 } from '../ExecutionContext';
-import { INTERACTION_ACCESSED, INTERACTION_ASSIGNED, NodeInteraction } from '../NodeInteractions';
+import { NodeInteraction } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_PATH } from '../utils/PathTracker';
 import type Variable from '../variables/Variable';
 import Identifier from './Identifier';
@@ -60,14 +60,6 @@ export default class AssignmentExpression extends NodeBase {
 		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (path.length === 0) {
-			if (interaction.type === INTERACTION_ACCESSED) {
-				return false;
-			}
-			if (interaction.type === INTERACTION_ASSIGNED) {
-				return true;
-			}
-		}
 		return this.right.hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 

--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -53,7 +53,7 @@ export default class AssignmentExpression extends NodeBase {
 		return (
 			right.hasEffects(context) ||
 			(left instanceof MemberExpression
-				? left.hasEffectsAsAssignmentTarget(context, this.operator !== '=')
+				? left.hasEffectsAsAssignmentTarget(context, this.operator !== '=', right)
 				: left.hasEffects(context) || left.hasEffectsWhenAssignedAtPath(EMPTY_PATH, context))
 		);
 	}
@@ -74,12 +74,17 @@ export default class AssignmentExpression extends NodeBase {
 			left.included ||
 			((hasEffectsContext = createHasEffectsContext()),
 			isMemberExpression
-				? left.hasEffectsAsAssignmentTarget(hasEffectsContext, false)
+				? left.hasEffectsAsAssignmentTarget(hasEffectsContext, false, right)
 				: left.hasEffects(hasEffectsContext) ||
 				  left.hasEffectsWhenAssignedAtPath(EMPTY_PATH, hasEffectsContext))
 		) {
 			if (isMemberExpression) {
-				left.includeAsAssignmentTarget(context, includeChildrenRecursively, operator !== '=');
+				left.includeAsAssignmentTarget(
+					context,
+					includeChildrenRecursively,
+					operator !== '=',
+					right
+				);
 			} else {
 				left.include(context, includeChildrenRecursively);
 			}

--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -17,22 +17,15 @@ import {
 	type HasEffectsContext,
 	type InclusionContext
 } from '../ExecutionContext';
-import {
-	INTERACTION_ACCESSED,
-	INTERACTION_ASSIGNED,
-	NodeInteraction,
-	NodeInteractionAssigned
-} from '../NodeInteractions';
+import { INTERACTION_ACCESSED, INTERACTION_ASSIGNED, NodeInteraction } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_PATH } from '../utils/PathTracker';
 import type Variable from '../variables/Variable';
 import Identifier from './Identifier';
-import MemberExpression from './MemberExpression';
 import * as NodeType from './NodeType';
 import ObjectPattern from './ObjectPattern';
 import { type ExpressionNode, type IncludeChildren, NodeBase } from './shared/Node';
 import type { PatternNode } from './shared/Pattern';
 
-// TODO during initialise, call a method on the ME target to set the assignment value
 export default class AssignmentExpression extends NodeBase {
 	declare left: ExpressionNode | PatternNode;
 	declare operator:
@@ -51,19 +44,14 @@ export default class AssignmentExpression extends NodeBase {
 		| '**=';
 	declare right: ExpressionNode;
 	declare type: NodeType.tAssignmentExpression;
-	private declare interaction: NodeInteractionAssigned;
 
 	hasEffects(context: HasEffectsContext): boolean {
 		const { deoptimized, left, right } = this;
 		if (!deoptimized) this.applyDeoptimizations();
 		// MemberExpressions do not access the property before assignments if the
-		// operator is '='. Moreover, they imply a "this" value for setters.
+		// operator is '='.
 		return (
-			right.hasEffects(context) ||
-			(left instanceof MemberExpression
-				? left.hasEffectsAsAssignmentTarget(context, this.operator !== '=')
-				: left.hasEffects(context) ||
-				  left.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context))
+			right.hasEffects(context) || left.hasEffectsAsAssignmentTarget(context, this.operator !== '=')
 		);
 	}
 
@@ -87,33 +75,19 @@ export default class AssignmentExpression extends NodeBase {
 		const { deoptimized, left, right, operator } = this;
 		if (!deoptimized) this.applyDeoptimizations();
 		this.included = true;
-		let hasEffectsContext;
-		const isMemberExpression = left instanceof MemberExpression;
 		if (
 			includeChildrenRecursively ||
 			operator !== '=' ||
 			left.included ||
-			((hasEffectsContext = createHasEffectsContext()),
-			isMemberExpression
-				? left.hasEffectsAsAssignmentTarget(hasEffectsContext, false)
-				: left.hasEffects(hasEffectsContext) ||
-				  left.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, hasEffectsContext))
+			left.hasEffectsAsAssignmentTarget(createHasEffectsContext(), false)
 		) {
-			if (isMemberExpression) {
-				left.includeAsAssignmentTarget(context, includeChildrenRecursively, operator !== '=');
-			} else {
-				left.include(context, includeChildrenRecursively);
-			}
+			left.includeAsAssignmentTarget(context, includeChildrenRecursively, operator !== '=');
 		}
 		right.include(context, includeChildrenRecursively);
 	}
 
 	initialise(): void {
-		const { left, right } = this;
-		this.interaction = { thisArg: null, type: INTERACTION_ASSIGNED, value: right };
-		if (left instanceof MemberExpression) {
-			left.setAssignedValue(right);
-		}
+		this.left.setAssignedValue(this.right);
 	}
 
 	render(

--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -3,6 +3,7 @@ import { BLANK } from '../../utils/blank';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import type { HasEffectsContext } from '../ExecutionContext';
 import { InclusionContext } from '../ExecutionContext';
+import { NodeInteractionAssigned } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_PATH } from '../utils/PathTracker';
 import type LocalVariable from '../variables/LocalVariable';
 import type Variable from '../variables/Variable';
@@ -31,8 +32,14 @@ export default class AssignmentPattern extends NodeBase implements PatternNode {
 		path.length === 0 && this.left.deoptimizePath(path);
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return path.length > 0 || this.left.hasEffectsWhenAssignedAtPath(EMPTY_PATH, context);
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteractionAssigned,
+		context: HasEffectsContext
+	): boolean {
+		return (
+			path.length > 0 || this.left.hasEffectsOnInteractionAtPath(EMPTY_PATH, interaction, context)
+		);
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -2,14 +2,13 @@ import type MagicString from 'magic-string';
 import { BLANK } from '../../utils/blank';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import type { HasEffectsContext } from '../ExecutionContext';
-import { InclusionContext } from '../ExecutionContext';
 import { NodeInteractionAssigned } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_PATH } from '../utils/PathTracker';
 import type LocalVariable from '../variables/LocalVariable';
 import type Variable from '../variables/Variable';
 import type * as NodeType from './NodeType';
 import type { ExpressionEntity } from './shared/Expression';
-import { type ExpressionNode, IncludeChildren, NodeBase } from './shared/Node';
+import { type ExpressionNode, NodeBase } from './shared/Node';
 import type { PatternNode } from './shared/Pattern';
 
 export default class AssignmentPattern extends NodeBase implements PatternNode {
@@ -42,13 +41,6 @@ export default class AssignmentPattern extends NodeBase implements PatternNode {
 		);
 	}
 
-	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {
-		if (!this.deoptimized) this.applyDeoptimizations();
-		this.included = true;
-		this.left.include(context, includeChildrenRecursively);
-		this.right.include(context, includeChildrenRecursively);
-	}
-
 	markDeclarationReached(): void {
 		this.left.markDeclarationReached();
 	}
@@ -59,11 +51,7 @@ export default class AssignmentPattern extends NodeBase implements PatternNode {
 		{ isShorthandProperty }: NodeRenderOptions = BLANK
 	): void {
 		this.left.render(code, options, { isShorthandProperty });
-		if (this.right.included) {
-			this.right.render(code, options);
-		} else {
-			code.remove(this.left.end, this.end);
-		}
+		this.right.render(code, options);
 	}
 
 	protected applyDeoptimizations(): void {

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -3,6 +3,7 @@ import { BLANK } from '../../utils/blank';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
+import { INTERACTION_ACCESSED, NodeInteraction } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -83,8 +84,8 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 		return super.hasEffects(context);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-		return path.length > 1;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
+		return interaction.type !== INTERACTION_ACCESSED || path.length > 1;
 	}
 
 	render(

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -84,8 +84,8 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 		return super.hasEffects(context);
 	}
 
-	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
-		return interaction.type !== INTERACTION_ACCESSED || path.length > 1;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
+		return type !== INTERACTION_ACCESSED || path.length > 1;
 	}
 
 	render(

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -120,8 +120,9 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 		this.deoptimized = true;
 		const { thisParam } = this.callOptions;
 		if (thisParam) {
+			// TODO Lukas cache interaction
 			this.callee.deoptimizeThisOnInteractionAtPath(
-				INTERACTION_CALLED,
+				{ callOptions: this.callOptions, type: INTERACTION_CALLED },
 				EMPTY_PATH,
 				thisParam,
 				SHARED_RECURSION_TRACKER

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -55,7 +55,7 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 		}
 		this.callOptions = {
 			args: this.arguments,
-			thisParam:
+			thisArg:
 				this.callee instanceof MemberExpression && !this.callee.variable
 					? this.callee.object
 					: null,
@@ -118,13 +118,13 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 
 	protected applyDeoptimizations(): void {
 		this.deoptimized = true;
-		const { thisParam } = this.callOptions;
-		if (thisParam) {
+		const { args, thisArg, withNew } = this.callOptions;
+		if (thisArg) {
 			// TODO Lukas cache interaction
 			this.callee.deoptimizeThisOnInteractionAtPath(
-				{ callOptions: this.callOptions, type: INTERACTION_CALLED },
+				{ args, thisArg, type: INTERACTION_CALLED, withNew },
 				EMPTY_PATH,
-				thisParam,
+				thisArg,
 				SHARED_RECURSION_TRACKER
 			);
 		}

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -124,7 +124,6 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 			this.callee.deoptimizeThisOnInteractionAtPath(
 				{ args, thisArg, type: INTERACTION_CALLED, withNew },
 				EMPTY_PATH,
-				thisArg,
 				SHARED_RECURSION_TRACKER
 			);
 		}

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -5,7 +5,7 @@ import { renderCallArguments } from '../../utils/renderCallArguments';
 import { type NodeRenderOptions, type RenderOptions } from '../../utils/renderHelpers';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import { EVENT_CALLED } from '../NodeEvents';
+import { INTERACTION_CALLED } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type PathTracker,
@@ -120,8 +120,8 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 		this.deoptimized = true;
 		const { thisParam } = this.callOptions;
 		if (thisParam) {
-			this.callee.deoptimizeThisOnEventAtPath(
-				EVENT_CALLED,
+			this.callee.deoptimizeThisOnInteractionAtPath(
+				INTERACTION_CALLED,
 				EMPTY_PATH,
 				thisParam,
 				SHARED_RECURSION_TRACKER

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -76,7 +76,7 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 				return false;
 			return (
 				this.callee.hasEffects(context) ||
-				this.callee.hasEffectsWhenCalledAtPath(EMPTY_PATH, this.interaction, context)
+				this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
 			);
 		} finally {
 			if (!this.deoptimized) this.applyDeoptimizations();

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -11,7 +11,7 @@ import { removeAnnotations } from '../../utils/treeshakeNode';
 import { CallOptions } from '../CallOptions';
 import { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import { NodeInteractionWithThisArg } from '../NodeInteractions';
+import { NodeInteractionCalled, NodeInteractionWithThisArg } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	ObjectPath,
@@ -78,7 +78,7 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
@@ -87,13 +87,13 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 			return new MultiExpression([
 				this.consequent.getReturnExpressionWhenCalledAtPath(
 					path,
-					callOptions,
+					interaction,
 					recursionTracker,
 					origin
 				),
 				this.alternate.getReturnExpressionWhenCalledAtPath(
 					path,
-					callOptions,
+					interaction,
 					recursionTracker,
 					origin
 				)
@@ -101,7 +101,7 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 		this.expressionsToBeDeoptimized.push(origin);
 		return usedBranch.getReturnExpressionWhenCalledAtPath(
 			path,
-			callOptions,
+			interaction,
 			recursionTracker,
 			origin
 		);

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -8,10 +8,13 @@ import {
 	RenderOptions
 } from '../../utils/renderHelpers';
 import { removeAnnotations } from '../../utils/treeshakeNode';
-import { CallOptions } from '../CallOptions';
 import { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import { NodeInteractionCalled, NodeInteractionWithThisArg } from '../NodeInteractions';
+import {
+	NodeInteraction,
+	NodeInteractionCalled,
+	NodeInteractionWithThisArg
+} from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	ObjectPath,
@@ -116,41 +119,19 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 		return usedBranch.hasEffects(context);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		const usedBranch = this.getUsedBranch();
-		if (!usedBranch) {
-			return (
-				this.consequent.hasEffectsWhenAccessedAtPath(path, context) ||
-				this.alternate.hasEffectsWhenAccessedAtPath(path, context)
-			);
-		}
-		return usedBranch.hasEffectsWhenAccessedAtPath(path, context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		const usedBranch = this.getUsedBranch();
-		if (!usedBranch) {
-			return (
-				this.consequent.hasEffectsWhenAssignedAtPath(path, context) ||
-				this.alternate.hasEffectsWhenAssignedAtPath(path, context)
-			);
-		}
-		return usedBranch.hasEffectsWhenAssignedAtPath(path, context);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
 		const usedBranch = this.getUsedBranch();
 		if (!usedBranch) {
 			return (
-				this.consequent.hasEffectsWhenCalledAtPath(path, callOptions, context) ||
-				this.alternate.hasEffectsWhenCalledAtPath(path, callOptions, context)
+				this.consequent.hasEffectsOnInteractionAtPath(path, interaction, context) ||
+				this.alternate.hasEffectsOnInteractionAtPath(path, interaction, context)
 			);
 		}
-		return usedBranch.hasEffectsWhenCalledAtPath(path, callOptions, context);
+		return usedBranch.hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -11,7 +11,7 @@ import { removeAnnotations } from '../../utils/treeshakeNode';
 import { CallOptions } from '../CallOptions';
 import { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import { NodeInteraction } from '../NodeInteractions';
+import { NodeInteractionWithThisArg } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	ObjectPath,
@@ -57,23 +57,12 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.consequent.deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
-		this.alternate.deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.consequent.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
+		this.alternate.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -11,7 +11,7 @@ import { removeAnnotations } from '../../utils/treeshakeNode';
 import { CallOptions } from '../CallOptions';
 import { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import { NodeEvent } from '../NodeEvents';
+import { NodeInteraction } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	ObjectPath,
@@ -56,14 +56,24 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 		}
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.consequent.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
-		this.alternate.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
+		this.consequent.deoptimizeThisOnInteractionAtPath(
+			interaction,
+			path,
+			thisParameter,
+			recursionTracker
+		);
+		this.alternate.deoptimizeThisOnInteractionAtPath(
+			interaction,
+			path,
+			thisParameter,
+			recursionTracker
+		);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/ForInStatement.ts
+++ b/src/ast/nodes/ForInStatement.ts
@@ -1,11 +1,13 @@
 import type MagicString from 'magic-string';
 import { NO_SEMICOLON, type RenderOptions } from '../../utils/renderHelpers';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
+import { INTERACTION_ASSIGNED } from '../NodeInteractions';
 import BlockScope from '../scopes/BlockScope';
 import type Scope from '../scopes/Scope';
 import { EMPTY_PATH } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import type VariableDeclaration from './VariableDeclaration';
+import { UNKNOWN_EXPRESSION } from './shared/Expression';
 import {
 	type ExpressionNode,
 	type IncludeChildren,
@@ -29,7 +31,11 @@ export default class ForInStatement extends StatementBase {
 		if (
 			(this.left &&
 				(this.left.hasEffects(context) ||
-					this.left.hasEffectsWhenAssignedAtPath(EMPTY_PATH, context))) ||
+					this.left.hasEffectsOnInteractionAtPath(
+						EMPTY_PATH,
+						{ type: INTERACTION_ASSIGNED, value: UNKNOWN_EXPRESSION },
+						context
+					))) ||
 			(this.right && this.right.hasEffects(context))
 		)
 			return true;

--- a/src/ast/nodes/ForInStatement.ts
+++ b/src/ast/nodes/ForInStatement.ts
@@ -29,8 +29,7 @@ export default class ForInStatement extends StatementBase {
 	hasEffects(context: HasEffectsContext): boolean {
 		const { deoptimized, left, right } = this;
 		if (!deoptimized) this.applyDeoptimizations();
-		if (left?.hasEffectsAsAssignmentTarget(context, false) || right?.hasEffects(context))
-			return true;
+		if (left.hasEffectsAsAssignmentTarget(context, false) || right.hasEffects(context)) return true;
 		const {
 			brokenFlow,
 			ignore: { breaks, continues }

--- a/src/ast/nodes/ForOfStatement.ts
+++ b/src/ast/nodes/ForOfStatement.ts
@@ -37,12 +37,7 @@ export default class ForOfStatement extends StatementBase {
 		const { body, deoptimized, left, right } = this;
 		if (!deoptimized) this.applyDeoptimizations();
 		this.included = true;
-		const includeLeftChildren = includeChildrenRecursively || true;
-		if (left instanceof MemberExpression) {
-			left.includeAsAssignmentTarget(context, includeLeftChildren, false);
-		} else {
-			left.include(context, includeLeftChildren);
-		}
+		left.includeAsAssignmentTarget(context, includeChildrenRecursively || true, false);
 		right.include(context, includeChildrenRecursively);
 		const { brokenFlow } = context;
 		body.include(context, includeChildrenRecursively, { asSingleStatement: true });
@@ -50,10 +45,7 @@ export default class ForOfStatement extends StatementBase {
 	}
 
 	initialise() {
-		const { left } = this;
-		if (left instanceof MemberExpression) {
-			left.setAssignedValue(UNKNOWN_EXPRESSION);
-		}
+		this.left.setAssignedValue(UNKNOWN_EXPRESSION);
 	}
 
 	render(code: MagicString, options: RenderOptions): void {

--- a/src/ast/nodes/ForOfStatement.ts
+++ b/src/ast/nodes/ForOfStatement.ts
@@ -4,8 +4,10 @@ import type { InclusionContext } from '../ExecutionContext';
 import BlockScope from '../scopes/BlockScope';
 import type Scope from '../scopes/Scope';
 import { EMPTY_PATH } from '../utils/PathTracker';
+import MemberExpression from './MemberExpression';
 import type * as NodeType from './NodeType';
 import type VariableDeclaration from './VariableDeclaration';
+import { UNKNOWN_EXPRESSION } from './shared/Expression';
 import {
 	type ExpressionNode,
 	type IncludeChildren,
@@ -17,7 +19,7 @@ import type { PatternNode } from './shared/Pattern';
 export default class ForOfStatement extends StatementBase {
 	declare await: boolean;
 	declare body: StatementNode;
-	declare left: VariableDeclaration | PatternNode;
+	declare left: VariableDeclaration | PatternNode | MemberExpression;
 	declare right: ExpressionNode;
 	declare type: NodeType.tForOfStatement;
 
@@ -32,13 +34,26 @@ export default class ForOfStatement extends StatementBase {
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {
-		if (!this.deoptimized) this.applyDeoptimizations();
+		const { body, deoptimized, left, right } = this;
+		if (!deoptimized) this.applyDeoptimizations();
 		this.included = true;
-		this.left.include(context, includeChildrenRecursively || true);
-		this.right.include(context, includeChildrenRecursively);
+		const includeLeftChildren = includeChildrenRecursively || true;
+		if (left instanceof MemberExpression) {
+			left.includeAsAssignmentTarget(context, includeLeftChildren, false);
+		} else {
+			left.include(context, includeLeftChildren);
+		}
+		right.include(context, includeChildrenRecursively);
 		const { brokenFlow } = context;
-		this.body.include(context, includeChildrenRecursively, { asSingleStatement: true });
+		body.include(context, includeChildrenRecursively, { asSingleStatement: true });
 		context.brokenFlow = brokenFlow;
+	}
+
+	initialise() {
+		const { left } = this;
+		if (left instanceof MemberExpression) {
+			left.setAssignedValue(UNKNOWN_EXPRESSION);
+		}
 	}
 
 	render(code: MagicString, options: RenderOptions): void {

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -10,7 +10,7 @@ import {
 	INTERACTION_ACCESSED,
 	INTERACTION_ASSIGNED,
 	INTERACTION_CALLED,
-	NODE_INTERACTION_ACCESS,
+	NODE_INTERACTION_UNKNOWN_ACCESS,
 	NodeInteraction,
 	NodeInteractionCalled
 } from '../NodeInteractions';
@@ -140,7 +140,11 @@ export default class Identifier extends NodeBase implements PatternNode {
 		return (
 			(this.context.options.treeshake as NormalizedTreeshakingOptions).unknownGlobalSideEffects &&
 			this.variable instanceof GlobalVariable &&
-			this.variable.hasEffectsOnInteractionAtPath(EMPTY_PATH, NODE_INTERACTION_ACCESS, context)
+			this.variable.hasEffectsOnInteractionAtPath(
+				EMPTY_PATH,
+				NODE_INTERACTION_UNKNOWN_ACCESS,
+				context
+			)
 		);
 	}
 

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -7,6 +7,7 @@ import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import { NodeInteractionCalled } from '../NodeInteractions';
 import type FunctionScope from '../scopes/FunctionScope';
 import { EMPTY_PATH, type ObjectPath, type PathTracker } from '../utils/PathTracker';
 import GlobalVariable from '../variables/GlobalVariable';
@@ -113,13 +114,13 @@ export default class Identifier extends NodeBase implements PatternNode {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		return this.getVariableRespectingTDZ()!.getReturnExpressionWhenCalledAtPath(
 			path,
-			callOptions,
+			interaction,
 			recursionTracker,
 			origin
 		);

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -10,6 +10,7 @@ import {
 	INTERACTION_ACCESSED,
 	INTERACTION_ASSIGNED,
 	INTERACTION_CALLED,
+	NODE_INTERACTION_ACCESS,
 	NodeInteraction,
 	NodeInteractionCalled
 } from '../NodeInteractions';
@@ -139,11 +140,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 		return (
 			(this.context.options.treeshake as NormalizedTreeshakingOptions).unknownGlobalSideEffects &&
 			this.variable instanceof GlobalVariable &&
-			this.variable.hasEffectsOnInteractionAtPath(
-				EMPTY_PATH,
-				{ type: INTERACTION_ACCESSED },
-				context
-			)
+			this.variable.hasEffectsOnInteractionAtPath(EMPTY_PATH, NODE_INTERACTION_ACCESS, context)
 		);
 	}
 

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -6,7 +6,7 @@ import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import type FunctionScope from '../scopes/FunctionScope';
 import { EMPTY_PATH, type ObjectPath, type PathTracker } from '../utils/PathTracker';
 import GlobalVariable from '../variables/GlobalVariable';
@@ -96,17 +96,11 @@ export default class Identifier extends NodeBase implements PatternNode {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.variable!.deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.variable!.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -6,7 +6,7 @@ import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import type FunctionScope from '../scopes/FunctionScope';
 import { EMPTY_PATH, type ObjectPath, type PathTracker } from '../utils/PathTracker';
 import GlobalVariable from '../variables/GlobalVariable';
@@ -95,13 +95,18 @@ export default class Identifier extends NodeBase implements PatternNode {
 		this.variable?.deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.variable!.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
+		this.variable!.deoptimizeThisOnInteractionAtPath(
+			interaction,
+			path,
+			thisParameter,
+			recursionTracker
+		);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -1,6 +1,11 @@
 import type MagicString from 'magic-string';
-import type { CallOptions } from '../CallOptions';
 import type { HasEffectsContext } from '../ExecutionContext';
+import {
+	INTERACTION_ACCESSED,
+	INTERACTION_ASSIGNED,
+	INTERACTION_CALLED,
+	NodeInteraction
+} from '../NodeInteractions';
 import type { ObjectPath } from '../utils/PathTracker';
 import {
 	getLiteralMembersForValue,
@@ -50,22 +55,22 @@ export default class Literal<T extends LiteralValue = LiteralValue> extends Node
 		return getMemberReturnExpressionWhenCalled(this.members, path[0]);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-		if (this.value === null) {
-			return path.length > 0;
-		}
-		return path.length > 1;
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (path.length === 1) {
-			return hasMemberEffectWhenCalled(this.members, path[0], callOptions, context);
+		switch (interaction.type) {
+			case INTERACTION_ACCESSED:
+				return path.length > (this.value === null ? 0 : 1);
+			case INTERACTION_ASSIGNED:
+				return true;
+			case INTERACTION_CALLED:
+				return (
+					path.length !== 1 ||
+					hasMemberEffectWhenCalled(this.members, path[0], interaction, context)
+				);
 		}
-		return true;
 	}
 
 	initialise(): void {

--- a/src/ast/nodes/Literal.ts
+++ b/src/ast/nodes/Literal.ts
@@ -29,7 +29,7 @@ export default class Literal<T extends LiteralValue = LiteralValue> extends Node
 
 	private declare members: { [key: string]: MemberDescription };
 
-	deoptimizeThisOnEventAtPath(): void {}
+	deoptimizeThisOnInteractionAtPath(): void {}
 
 	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
 		if (

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -8,11 +8,10 @@ import {
 	type RenderOptions
 } from '../../utils/renderHelpers';
 import { removeAnnotations } from '../../utils/treeshakeNode';
-import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
-import { NodeInteractionCalled } from '../NodeInteractions';
+import { NodeInteraction, NodeInteractionCalled } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -117,41 +116,19 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 		return false;
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		const usedBranch = this.getUsedBranch();
-		if (!usedBranch) {
-			return (
-				this.left.hasEffectsWhenAccessedAtPath(path, context) ||
-				this.right.hasEffectsWhenAccessedAtPath(path, context)
-			);
-		}
-		return usedBranch.hasEffectsWhenAccessedAtPath(path, context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		const usedBranch = this.getUsedBranch();
-		if (!usedBranch) {
-			return (
-				this.left.hasEffectsWhenAssignedAtPath(path, context) ||
-				this.right.hasEffectsWhenAssignedAtPath(path, context)
-			);
-		}
-		return usedBranch.hasEffectsWhenAssignedAtPath(path, context);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
 		const usedBranch = this.getUsedBranch();
 		if (!usedBranch) {
 			return (
-				this.left.hasEffectsWhenCalledAtPath(path, callOptions, context) ||
-				this.right.hasEffectsWhenCalledAtPath(path, callOptions, context)
+				this.left.hasEffectsOnInteractionAtPath(path, interaction, context) ||
+				this.right.hasEffectsOnInteractionAtPath(path, interaction, context)
 			);
 		}
-		return usedBranch.hasEffectsWhenCalledAtPath(path, callOptions, context);
+		return usedBranch.hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -12,6 +12,7 @@ import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import { NodeInteractionCalled } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -87,20 +88,20 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		const usedBranch = this.getUsedBranch();
 		if (!usedBranch)
 			return new MultiExpression([
-				this.left.getReturnExpressionWhenCalledAtPath(path, callOptions, recursionTracker, origin),
-				this.right.getReturnExpressionWhenCalledAtPath(path, callOptions, recursionTracker, origin)
+				this.left.getReturnExpressionWhenCalledAtPath(path, interaction, recursionTracker, origin),
+				this.right.getReturnExpressionWhenCalledAtPath(path, interaction, recursionTracker, origin)
 			]);
 		this.expressionsToBeDeoptimized.push(origin);
 		return usedBranch.getReturnExpressionWhenCalledAtPath(
 			path,
-			callOptions,
+			interaction,
 			recursionTracker,
 			origin
 		);

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -11,7 +11,7 @@ import { removeAnnotations } from '../../utils/treeshakeNode';
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -66,18 +66,12 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.left.deoptimizeThisOnInteractionAtPath(interaction, path, thisParameter, recursionTracker);
-		this.right.deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.left.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
+		this.right.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -11,7 +11,7 @@ import { removeAnnotations } from '../../utils/treeshakeNode';
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -65,14 +65,19 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 		}
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.left.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
-		this.right.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
+		this.left.deoptimizeThisOnInteractionAtPath(interaction, path, thisParameter, recursionTracker);
+		this.right.deoptimizeThisOnInteractionAtPath(
+			interaction,
+			path,
+			thisParameter,
+			recursionTracker
+		);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -362,8 +362,9 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			!(this.variable || this.replacement)
 		) {
 			const propertyKey = this.getPropertyKey();
+			// TODO Lukas cache interaction
 			this.object.deoptimizeThisOnInteractionAtPath(
-				INTERACTION_ACCESSED,
+				{ type: INTERACTION_ACCESSED },
 				[propertyKey],
 				this.object,
 				SHARED_RECURSION_TRACKER
@@ -382,8 +383,9 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			propertyReadSideEffects &&
 			!(this.variable || this.replacement)
 		) {
+			// TODO Lukas cache interaction
 			this.object.deoptimizeThisOnInteractionAtPath(
-				INTERACTION_ASSIGNED,
+				{ type: INTERACTION_ASSIGNED },
 				[this.getPropertyKey()],
 				this.object,
 				SHARED_RECURSION_TRACKER

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -6,7 +6,11 @@ import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import { EVENT_ACCESSED, EVENT_ASSIGNED, type NodeEvent } from '../NodeEvents';
+import {
+	INTERACTION_ACCESSED,
+	INTERACTION_ASSIGNED,
+	type NodeInteraction
+} from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -137,18 +141,23 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		}
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		if (this.variable) {
-			this.variable.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
+			this.variable.deoptimizeThisOnInteractionAtPath(
+				interaction,
+				path,
+				thisParameter,
+				recursionTracker
+			);
 		} else if (!this.replacement) {
 			if (path.length < MAX_PATH_DEPTH) {
-				this.object.deoptimizeThisOnEventAtPath(
-					event,
+				this.object.deoptimizeThisOnInteractionAtPath(
+					interaction,
 					[this.getPropertyKey(), ...path],
 					thisParameter,
 					recursionTracker
@@ -343,16 +352,16 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		) {
 			// Regular Assignments do not access the property before assigning
 			if (!(this.parent instanceof AssignmentExpression && this.parent.operator === '=')) {
-				this.object.deoptimizeThisOnEventAtPath(
-					EVENT_ACCESSED,
+				this.object.deoptimizeThisOnInteractionAtPath(
+					INTERACTION_ACCESSED,
 					[this.propertyKey!],
 					this.object,
 					SHARED_RECURSION_TRACKER
 				);
 			}
 			if (this.parent instanceof AssignmentExpression) {
-				this.object.deoptimizeThisOnEventAtPath(
-					EVENT_ASSIGNED,
+				this.object.deoptimizeThisOnInteractionAtPath(
+					INTERACTION_ASSIGNED,
 					[this.propertyKey!],
 					this.object,
 					SHARED_RECURSION_TRACKER

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -97,9 +97,9 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 	declare propertyKey: ObjectPathKey | null;
 	declare type: NodeType.tMemberExpression;
 	variable: Variable | null = null;
+	protected declare assignmentInteraction: NodeInteractionAssigned & { thisArg: ExpressionEntity };
 	private declare accessInteraction: NodeInteractionAccessed & { thisArg: ExpressionEntity };
 	private assignmentDeoptimized = false;
-	private declare assignmentInteraction: NodeInteractionAssigned & { thisArg: ExpressionEntity };
 	private bound = false;
 	private expressionsToBeDeoptimized: DeoptimizableEntity[] = [];
 	private replacement: string | null = null;
@@ -233,6 +233,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 	}
 
 	hasEffectsAsAssignmentTarget(context: HasEffectsContext, checkAccess: boolean): boolean {
+		if (checkAccess && !this.deoptimized) this.applyDeoptimizations();
 		if (!this.assignmentDeoptimized) this.applyAssignmentDeoptimization();
 		return (
 			this.property.hasEffects(context) ||

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -88,7 +88,6 @@ function getStringFromPath(path: PathWithPositions): string {
 	return pathString;
 }
 
-// TODO Lukas if we check each access separately, we do not need to check getters when accessing a nested property in MethodBase, verify
 export default class MemberExpression extends NodeBase implements DeoptimizableEntity {
 	declare computed: boolean;
 	declare object: ExpressionNode | Super;

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -327,7 +327,11 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 	}
 
 	setAssignedValue(value: ExpressionEntity) {
-		this.assignmentInteraction = { thisArg: this.object, type: INTERACTION_ASSIGNED, value };
+		this.assignmentInteraction = {
+			args: [value],
+			thisArg: this.object,
+			type: INTERACTION_ASSIGNED
+		};
 	}
 
 	protected applyDeoptimizations(): void {

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -10,7 +10,7 @@ import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import {
 	INTERACTION_ACCESSED,
 	INTERACTION_ASSIGNED,
-	type NodeInteraction
+	NodeInteractionWithThisArg
 } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
@@ -147,28 +147,21 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		if (this.variable) {
-			this.variable.deoptimizeThisOnInteractionAtPath(
-				interaction,
-				path,
-				thisParameter,
-				recursionTracker
-			);
+			this.variable.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 		} else if (!this.replacement) {
 			if (path.length < MAX_PATH_DEPTH) {
 				this.object.deoptimizeThisOnInteractionAtPath(
 					interaction,
 					[this.getPropertyKey(), ...path],
-					thisParameter,
 					recursionTracker
 				);
 			} else {
-				thisParameter.deoptimizePath(UNKNOWN_PATH);
+				interaction.thisArg.deoptimizePath(UNKNOWN_PATH);
 			}
 		}
 	}
@@ -371,7 +364,6 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			this.object.deoptimizeThisOnInteractionAtPath(
 				{ thisArg: this.object, type: INTERACTION_ACCESSED },
 				[propertyKey],
-				this.object,
 				SHARED_RECURSION_TRACKER
 			);
 			this.context.requestTreeshakingPass();
@@ -392,7 +384,6 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 			this.object.deoptimizeThisOnInteractionAtPath(
 				{ thisArg: this.object, type: INTERACTION_ASSIGNED, value },
 				[this.getPropertyKey()],
-				this.object,
 				SHARED_RECURSION_TRACKER
 			);
 			this.context.requestTreeshakingPass();

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -10,6 +10,7 @@ import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import {
 	INTERACTION_ACCESSED,
 	INTERACTION_ASSIGNED,
+	NodeInteractionCalled,
 	NodeInteractionWithThisArg
 } from '../NodeInteractions';
 import {
@@ -190,14 +191,14 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		if (this.variable) {
 			return this.variable.getReturnExpressionWhenCalledAtPath(
 				path,
-				callOptions,
+				interaction,
 				recursionTracker,
 				origin
 			);
@@ -209,7 +210,7 @@ export default class MemberExpression extends NodeBase implements DeoptimizableE
 		if (path.length < MAX_PATH_DEPTH) {
 			return this.object.getReturnExpressionWhenCalledAtPath(
 				[this.getPropertyKey(), ...path],
-				callOptions,
+				interaction,
 				recursionTracker,
 				origin
 			);

--- a/src/ast/nodes/MetaProperty.ts
+++ b/src/ast/nodes/MetaProperty.ts
@@ -53,8 +53,8 @@ export default class MetaProperty extends NodeBase {
 		return false;
 	}
 
-	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
-		return path.length > 1 || interaction.type !== INTERACTION_ACCESSED;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
+		return path.length > 1 || type !== INTERACTION_ACCESSED;
 	}
 
 	include(): void {

--- a/src/ast/nodes/MetaProperty.ts
+++ b/src/ast/nodes/MetaProperty.ts
@@ -4,8 +4,9 @@ import type { PluginDriver } from '../../utils/PluginDriver';
 import { warnDeprecation } from '../../utils/error';
 import type { GenerateCodeSnippets } from '../../utils/generateCodeSnippets';
 import { dirname, normalize, relative } from '../../utils/path';
+import { INTERACTION_ACCESSED, NodeInteraction } from '../NodeInteractions';
 import type ChildScope from '../scopes/ChildScope';
-import type { ObjectPathKey } from '../utils/PathTracker';
+import type { ObjectPath } from '../utils/PathTracker';
 import type Identifier from './Identifier';
 import MemberExpression from './MemberExpression';
 import type * as NodeType from './NodeType';
@@ -52,8 +53,8 @@ export default class MetaProperty extends NodeBase {
 		return false;
 	}
 
-	hasEffectsWhenAccessedAtPath(path: readonly ObjectPathKey[]): boolean {
-		return path.length > 1;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
+		return path.length > 1 || interaction.type !== INTERACTION_ACCESSED;
 	}
 
 	include(): void {

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -52,7 +52,7 @@ export default class NewExpression extends NodeBase {
 	initialise(): void {
 		this.callOptions = {
 			args: this.arguments,
-			thisParam: null,
+			thisArg: null,
 			withNew: true
 		};
 	}

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -2,9 +2,14 @@ import MagicString from 'magic-string';
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import { renderCallArguments } from '../../utils/renderCallArguments';
 import { RenderOptions } from '../../utils/renderHelpers';
-import type { CallOptions } from '../CallOptions';
 import type { HasEffectsContext } from '../ExecutionContext';
 import { InclusionContext } from '../ExecutionContext';
+import {
+	INTERACTION_ACCESSED,
+	INTERACTION_CALLED,
+	NodeInteraction,
+	NodeInteractionCalled
+} from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_PATH } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import { type ExpressionNode, IncludeChildren, NodeBase } from './shared/Node';
@@ -13,7 +18,7 @@ export default class NewExpression extends NodeBase {
 	declare arguments: ExpressionNode[];
 	declare callee: ExpressionNode;
 	declare type: NodeType.tNewExpression;
-	private declare callOptions: CallOptions;
+	private declare interaction: NodeInteractionCalled;
 
 	hasEffects(context: HasEffectsContext): boolean {
 		try {
@@ -27,15 +32,15 @@ export default class NewExpression extends NodeBase {
 				return false;
 			return (
 				this.callee.hasEffects(context) ||
-				this.callee.hasEffectsWhenCalledAtPath(EMPTY_PATH, this.callOptions, context)
+				this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
 			);
 		} finally {
 			if (!this.deoptimized) this.applyDeoptimizations();
 		}
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-		return path.length > 0;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
+		return path.length > 0 || interaction.type !== INTERACTION_ACCESSED;
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {
@@ -50,9 +55,10 @@ export default class NewExpression extends NodeBase {
 	}
 
 	initialise(): void {
-		this.callOptions = {
+		this.interaction = {
 			args: this.arguments,
 			thisArg: null,
+			type: INTERACTION_CALLED,
 			withNew: true
 		};
 	}

--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -39,8 +39,8 @@ export default class NewExpression extends NodeBase {
 		}
 	}
 
-	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
-		return path.length > 0 || interaction.type !== INTERACTION_ACCESSED;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
+		return path.length > 0 || type !== INTERACTION_ACCESSED;
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -5,6 +5,7 @@ import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import { NodeInteractionCalled } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -53,13 +54,13 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		return this.getObjectEntity().getReturnExpressionWhenCalledAtPath(
 			path,
-			callOptions,
+			interaction,
 			recursionTracker,
 			origin
 		);

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -1,11 +1,10 @@
 import type MagicString from 'magic-string';
 import { BLANK } from '../../utils/blank';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
-import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
-import { NodeInteractionCalled } from '../NodeInteractions';
+import { NodeInteraction, NodeInteractionCalled } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -66,20 +65,12 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 		);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAccessedAtPath(path, context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		return this.getObjectEntity().hasEffectsWhenCalledAtPath(path, callOptions, context);
+		return this.getObjectEntity().hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 
 	render(

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -4,7 +4,7 @@ import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -36,17 +36,11 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/ObjectExpression.ts
+++ b/src/ast/nodes/ObjectExpression.ts
@@ -4,7 +4,7 @@ import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -35,14 +35,14 @@ export default class ObjectExpression extends NodeBase implements DeoptimizableE
 		this.getObjectEntity().deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.getObjectEntity().deoptimizeThisOnEventAtPath(
-			event,
+		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
+			interaction,
 			path,
 			thisParameter,
 			recursionTracker

--- a/src/ast/nodes/ObjectPattern.ts
+++ b/src/ast/nodes/ObjectPattern.ts
@@ -47,11 +47,12 @@ export default class ObjectPattern extends NodeBase implements PatternNode {
 	}
 
 	hasEffectsOnInteractionAtPath(
-		path: ObjectPath,
+		// At the moment, this is only triggered for assignment left-hand sides,
+		// where the path is empty
+		_path: ObjectPath,
 		interaction: NodeInteractionAssigned,
 		context: HasEffectsContext
 	): boolean {
-		if (path.length > 0) return true;
 		for (const property of this.properties) {
 			if (property.hasEffectsOnInteractionAtPath(EMPTY_PATH, interaction, context)) return true;
 		}

--- a/src/ast/nodes/ObjectPattern.ts
+++ b/src/ast/nodes/ObjectPattern.ts
@@ -1,4 +1,5 @@
 import type { HasEffectsContext } from '../ExecutionContext';
+import { NodeInteractionAssigned } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath } from '../utils/PathTracker';
 import type LocalVariable from '../variables/LocalVariable';
 import type Variable from '../variables/Variable';
@@ -45,10 +46,14 @@ export default class ObjectPattern extends NodeBase implements PatternNode {
 		}
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteractionAssigned,
+		context: HasEffectsContext
+	): boolean {
 		if (path.length > 0) return true;
 		for (const property of this.properties) {
-			if (property.hasEffectsWhenAssignedAtPath(EMPTY_PATH, context)) return true;
+			if (property.hasEffectsOnInteractionAtPath(EMPTY_PATH, interaction, context)) return true;
 		}
 		return false;
 	}

--- a/src/ast/nodes/PropertyDefinition.ts
+++ b/src/ast/nodes/PropertyDefinition.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import type PrivateIdentifier from './PrivateIdentifier';
@@ -24,13 +24,18 @@ export default class PropertyDefinition extends NodeBase {
 		this.value?.deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.value?.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
+		this.value?.deoptimizeThisOnInteractionAtPath(
+			interaction,
+			path,
+			thisParameter,
+			recursionTracker
+		);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/PropertyDefinition.ts
+++ b/src/ast/nodes/PropertyDefinition.ts
@@ -1,8 +1,7 @@
-import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
-import { NodeInteractionCalled } from '../NodeInteractions';
+import { NodeInteraction, NodeInteractionCalled } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import type PrivateIdentifier from './PrivateIdentifier';
@@ -58,20 +57,12 @@ export default class PropertyDefinition extends NodeBase {
 		return this.key.hasEffects(context) || (this.static && !!this.value?.hasEffects(context));
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return !this.value || this.value.hasEffectsWhenAccessedAtPath(path, context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return !this.value || this.value.hasEffectsWhenAssignedAtPath(path, context);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		return !this.value || this.value.hasEffectsWhenCalledAtPath(path, callOptions, context);
+		return !this.value || this.value.hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 
 	protected applyDeoptimizations() {}

--- a/src/ast/nodes/PropertyDefinition.ts
+++ b/src/ast/nodes/PropertyDefinition.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import type PrivateIdentifier from './PrivateIdentifier';
@@ -25,17 +25,11 @@ export default class PropertyDefinition extends NodeBase {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.value?.deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.value?.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/PropertyDefinition.ts
+++ b/src/ast/nodes/PropertyDefinition.ts
@@ -2,6 +2,7 @@ import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import { NodeInteractionCalled } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import type PrivateIdentifier from './PrivateIdentifier';
@@ -44,12 +45,12 @@ export default class PropertyDefinition extends NodeBase {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		return this.value
-			? this.value.getReturnExpressionWhenCalledAtPath(path, callOptions, recursionTracker, origin)
+			? this.value.getReturnExpressionWhenCalledAtPath(path, interaction, recursionTracker, origin)
 			: UNKNOWN_EXPRESSION;
 	}
 

--- a/src/ast/nodes/RestElement.ts
+++ b/src/ast/nodes/RestElement.ts
@@ -1,4 +1,5 @@
 import type { HasEffectsContext } from '../ExecutionContext';
+import { NodeInteractionAssigned } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UnknownKey } from '../utils/PathTracker';
 import type LocalVariable from '../variables/LocalVariable';
 import type Variable from '../variables/Variable';
@@ -28,8 +29,15 @@ export default class RestElement extends NodeBase implements PatternNode {
 		path.length === 0 && this.argument.deoptimizePath(EMPTY_PATH);
 	}
 
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return path.length > 0 || this.argument.hasEffectsWhenAssignedAtPath(EMPTY_PATH, context);
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteractionAssigned,
+		context: HasEffectsContext
+	): boolean {
+		return (
+			path.length > 0 ||
+			this.argument.hasEffectsOnInteractionAtPath(EMPTY_PATH, interaction, context)
+		);
 	}
 
 	markDeclarationReached(): void {

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -10,11 +10,11 @@ import { treeshakeNode } from '../../utils/treeshakeNode';
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import ExpressionStatement from './ExpressionStatement';
 import type * as NodeType from './NodeType';
-import type { ExpressionEntity, LiteralValueOrUnknown } from './shared/Expression';
+import type { LiteralValueOrUnknown } from './shared/Expression';
 import { type ExpressionNode, type IncludeChildren, NodeBase } from './shared/Node';
 
 export default class SequenceExpression extends NodeBase {
@@ -26,15 +26,13 @@ export default class SequenceExpression extends NodeBase {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		this.expressions[this.expressions.length - 1].deoptimizeThisOnInteractionAtPath(
 			interaction,
 			path,
-			thisParameter,
 			recursionTracker
 		);
 	}

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -10,7 +10,7 @@ import { treeshakeNode } from '../../utils/treeshakeNode';
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import ExpressionStatement from './ExpressionStatement';
 import type * as NodeType from './NodeType';
@@ -25,14 +25,14 @@ export default class SequenceExpression extends NodeBase {
 		this.expressions[this.expressions.length - 1].deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.expressions[this.expressions.length - 1].deoptimizeThisOnEventAtPath(
-			event,
+		this.expressions[this.expressions.length - 1].deoptimizeThisOnInteractionAtPath(
+			interaction,
 			path,
 			thisParameter,
 			recursionTracker

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -7,10 +7,10 @@ import {
 	type RenderOptions
 } from '../../utils/renderHelpers';
 import { treeshakeNode } from '../../utils/treeshakeNode';
-import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import { INTERACTION_ACCESSED, NodeInteraction } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import ExpressionStatement from './ExpressionStatement';
 import type * as NodeType from './NodeType';
@@ -56,28 +56,17 @@ export default class SequenceExpression extends NodeBase {
 		return false;
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return (
-			path.length > 0 &&
-			this.expressions[this.expressions.length - 1].hasEffectsWhenAccessedAtPath(path, context)
-		);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.expressions[this.expressions.length - 1].hasEffectsWhenAssignedAtPath(
-			path,
-			context
-		);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		return this.expressions[this.expressions.length - 1].hasEffectsWhenCalledAtPath(
+		if (path.length === 0 && interaction.type === INTERACTION_ACCESSED) {
+			return false;
+		}
+		return this.expressions[this.expressions.length - 1].hasEffectsOnInteractionAtPath(
 			path,
-			callOptions,
+			interaction,
 			context
 		);
 	}

--- a/src/ast/nodes/SequenceExpression.ts
+++ b/src/ast/nodes/SequenceExpression.ts
@@ -10,7 +10,7 @@ import { treeshakeNode } from '../../utils/treeshakeNode';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
-import { INTERACTION_ACCESSED, NodeInteraction } from '../NodeInteractions';
+import { NodeInteraction } from '../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import ExpressionStatement from './ExpressionStatement';
 import type * as NodeType from './NodeType';
@@ -61,9 +61,6 @@ export default class SequenceExpression extends NodeBase {
 		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (path.length === 0 && interaction.type === INTERACTION_ACCESSED) {
-			return false;
-		}
 		return this.expressions[this.expressions.length - 1].hasEffectsOnInteractionAtPath(
 			path,
 			interaction,

--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,6 +1,7 @@
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import { INTERACTION_ACCESSED } from '../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import { type ExpressionNode, NodeBase } from './shared/Node';
@@ -31,7 +32,11 @@ export default class SpreadElement extends NodeBase {
 			this.argument.hasEffects(context) ||
 			(propertyReadSideEffects &&
 				(propertyReadSideEffects === 'always' ||
-					this.argument.hasEffectsWhenAccessedAtPath(UNKNOWN_PATH, context)))
+					this.argument.hasEffectsOnInteractionAtPath(
+						UNKNOWN_PATH,
+						{ type: INTERACTION_ACCESSED },
+						context
+					)))
 		);
 	}
 

--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,7 +1,7 @@
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
-import { NODE_INTERACTION_ACCESS } from '../NodeInteractions';
+import { NODE_INTERACTION_UNKNOWN_ACCESS } from '../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import { type ExpressionNode, NodeBase } from './shared/Node';
@@ -34,7 +34,7 @@ export default class SpreadElement extends NodeBase {
 				(propertyReadSideEffects === 'always' ||
 					this.argument.hasEffectsOnInteractionAtPath(
 						UNKNOWN_PATH,
-						NODE_INTERACTION_ACCESS,
+						NODE_INTERACTION_UNKNOWN_ACCESS,
 						context
 					)))
 		);

--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,9 +1,8 @@
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
-import type { ExpressionEntity } from './shared/Expression';
 import { type ExpressionNode, NodeBase } from './shared/Node';
 
 export default class SpreadElement extends NodeBase {
@@ -11,16 +10,14 @@ export default class SpreadElement extends NodeBase {
 	declare type: NodeType.tSpreadElement;
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		if (path.length > 0) {
 			this.argument.deoptimizeThisOnInteractionAtPath(
 				interaction,
 				[UnknownKey, ...path],
-				thisParameter,
 				recursionTracker
 			);
 		}

--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,6 +1,6 @@
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import type { ExpressionEntity } from './shared/Expression';
@@ -10,15 +10,15 @@ export default class SpreadElement extends NodeBase {
 	declare argument: ExpressionNode;
 	declare type: NodeType.tSpreadElement;
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		if (path.length > 0) {
-			this.argument.deoptimizeThisOnEventAtPath(
-				event,
+			this.argument.deoptimizeThisOnInteractionAtPath(
+				interaction,
 				[UnknownKey, ...path],
 				thisParameter,
 				recursionTracker

--- a/src/ast/nodes/SpreadElement.ts
+++ b/src/ast/nodes/SpreadElement.ts
@@ -1,7 +1,7 @@
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../NodeInteractions';
-import { INTERACTION_ACCESSED } from '../NodeInteractions';
+import { NODE_INTERACTION_ACCESS } from '../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH, UnknownKey } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
 import { type ExpressionNode, NodeBase } from './shared/Node';
@@ -34,7 +34,7 @@ export default class SpreadElement extends NodeBase {
 				(propertyReadSideEffects === 'always' ||
 					this.argument.hasEffectsOnInteractionAtPath(
 						UNKNOWN_PATH,
-						{ type: INTERACTION_ACCESSED },
+						NODE_INTERACTION_ACCESS,
 						context
 					)))
 		);

--- a/src/ast/nodes/Super.ts
+++ b/src/ast/nodes/Super.ts
@@ -1,4 +1,4 @@
-import { NodeEvent } from '../NodeEvents';
+import { NodeInteraction } from '../NodeInteractions';
 import type { ObjectPath } from '../utils/PathTracker';
 import { PathTracker } from '../utils/PathTracker';
 import Variable from '../variables/Variable';
@@ -18,13 +18,18 @@ export default class Super extends NodeBase {
 		this.variable.deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	) {
-		this.variable.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
+		this.variable.deoptimizeThisOnInteractionAtPath(
+			interaction,
+			path,
+			thisParameter,
+			recursionTracker
+		);
 	}
 
 	include(): void {

--- a/src/ast/nodes/Super.ts
+++ b/src/ast/nodes/Super.ts
@@ -1,9 +1,8 @@
-import { NodeInteraction } from '../NodeInteractions';
+import { NodeInteractionWithThisArg } from '../NodeInteractions';
 import type { ObjectPath } from '../utils/PathTracker';
 import { PathTracker } from '../utils/PathTracker';
 import Variable from '../variables/Variable';
 import type * as NodeType from './NodeType';
-import { ExpressionEntity } from './shared/Expression';
 import { NodeBase } from './shared/Node';
 
 export default class Super extends NodeBase {
@@ -19,17 +18,11 @@ export default class Super extends NodeBase {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	) {
-		this.variable.deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.variable.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	include(): void {

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -2,7 +2,7 @@ import type MagicString from 'magic-string';
 import { type RenderOptions } from '../../utils/renderHelpers';
 import type { HasEffectsContext } from '../ExecutionContext';
 import { InclusionContext } from '../ExecutionContext';
-import { EVENT_CALLED } from '../NodeEvents';
+import { INTERACTION_CALLED } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	PathTracker,
@@ -88,8 +88,8 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 		this.deoptimized = true;
 		const { thisParam } = this.callOptions;
 		if (thisParam) {
-			this.tag.deoptimizeThisOnEventAtPath(
-				EVENT_CALLED,
+			this.tag.deoptimizeThisOnInteractionAtPath(
+				INTERACTION_CALLED,
 				EMPTY_PATH,
 				thisParam,
 				SHARED_RECURSION_TRACKER

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -88,8 +88,9 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 		this.deoptimized = true;
 		const { thisParam } = this.callOptions;
 		if (thisParam) {
+			// TODO Lukas cache interaction
 			this.tag.deoptimizeThisOnInteractionAtPath(
-				INTERACTION_CALLED,
+				{ callOptions: this.callOptions, type: INTERACTION_CALLED },
 				EMPTY_PATH,
 				thisParam,
 				SHARED_RECURSION_TRACKER

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -91,7 +91,6 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 			this.tag.deoptimizeThisOnInteractionAtPath(
 				{ args, thisArg, type: INTERACTION_CALLED, withNew },
 				EMPTY_PATH,
-				thisArg,
 				SHARED_RECURSION_TRACKER
 			);
 		}

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -47,7 +47,7 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 			}
 			return (
 				this.tag.hasEffects(context) ||
-				this.tag.hasEffectsWhenCalledAtPath(EMPTY_PATH, this.interaction, context)
+				this.tag.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
 			);
 		} finally {
 			if (!this.deoptimized) this.applyDeoptimizations();

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -2,7 +2,7 @@ import type MagicString from 'magic-string';
 import { type RenderOptions } from '../../utils/renderHelpers';
 import type { HasEffectsContext } from '../ExecutionContext';
 import { InclusionContext } from '../ExecutionContext';
-import { INTERACTION_CALLED } from '../NodeInteractions';
+import { INTERACTION_CALLED, NodeInteractionWithThisArg } from '../NodeInteractions';
 import {
 	EMPTY_PATH,
 	PathTracker,
@@ -47,7 +47,7 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 			}
 			return (
 				this.tag.hasEffects(context) ||
-				this.tag.hasEffectsWhenCalledAtPath(EMPTY_PATH, this.callOptions, context)
+				this.tag.hasEffectsWhenCalledAtPath(EMPTY_PATH, this.interaction, context)
 			);
 		} finally {
 			if (!this.deoptimized) this.applyDeoptimizations();
@@ -63,7 +63,7 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 			this.tag.include(context, includeChildrenRecursively);
 			this.quasi.include(context, includeChildrenRecursively);
 		}
-		this.tag.includeCallArguments(context, this.callOptions.args);
+		this.tag.includeCallArguments(context, this.interaction.args);
 		const returnExpression = this.getReturnExpression();
 		if (!returnExpression.included) {
 			returnExpression.include(context, false);
@@ -71,9 +71,10 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 	}
 
 	initialise(): void {
-		this.callOptions = {
+		this.interaction = {
 			args: [UNKNOWN_EXPRESSION, ...this.quasi.expressions],
 			thisArg: this.tag instanceof MemberExpression && !this.tag.variable ? this.tag.object : null,
+			type: INTERACTION_CALLED,
 			withNew: false
 		};
 	}
@@ -85,11 +86,9 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 
 	protected applyDeoptimizations(): void {
 		this.deoptimized = true;
-		const { args, thisArg, withNew } = this.callOptions;
-		if (thisArg) {
-			// TODO Lukas cache interaction
+		if (this.interaction.thisArg) {
 			this.tag.deoptimizeThisOnInteractionAtPath(
-				{ args, thisArg, type: INTERACTION_CALLED, withNew },
+				this.interaction as NodeInteractionWithThisArg,
 				EMPTY_PATH,
 				SHARED_RECURSION_TRACKER
 			);
@@ -108,7 +107,7 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 			this.returnExpression = UNKNOWN_EXPRESSION;
 			return (this.returnExpression = this.tag.getReturnExpressionWhenCalledAtPath(
 				EMPTY_PATH,
-				this.callOptions,
+				this.interaction,
 				recursionTracker,
 				this
 			));

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -73,8 +73,7 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 	initialise(): void {
 		this.callOptions = {
 			args: [UNKNOWN_EXPRESSION, ...this.quasi.expressions],
-			thisParam:
-				this.tag instanceof MemberExpression && !this.tag.variable ? this.tag.object : null,
+			thisArg: this.tag instanceof MemberExpression && !this.tag.variable ? this.tag.object : null,
 			withNew: false
 		};
 	}
@@ -86,13 +85,13 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 
 	protected applyDeoptimizations(): void {
 		this.deoptimized = true;
-		const { thisParam } = this.callOptions;
-		if (thisParam) {
+		const { args, thisArg, withNew } = this.callOptions;
+		if (thisArg) {
 			// TODO Lukas cache interaction
 			this.tag.deoptimizeThisOnInteractionAtPath(
-				{ callOptions: this.callOptions, type: INTERACTION_CALLED },
+				{ args, thisArg, type: INTERACTION_CALLED, withNew },
 				EMPTY_PATH,
-				thisParam,
+				thisArg,
 				SHARED_RECURSION_TRACKER
 			);
 		}

--- a/src/ast/nodes/TemplateLiteral.ts
+++ b/src/ast/nodes/TemplateLiteral.ts
@@ -1,7 +1,7 @@
 import type MagicString from 'magic-string';
 import type { RenderOptions } from '../../utils/renderHelpers';
-import { CallOptions } from '../CallOptions';
 import { HasEffectsContext } from '../ExecutionContext';
+import { INTERACTION_ACCESSED, INTERACTION_CALLED, NodeInteraction } from '../NodeInteractions';
 import type { ObjectPath } from '../utils/PathTracker';
 import {
 	getMemberReturnExpressionWhenCalled,
@@ -39,17 +39,16 @@ export default class TemplateLiteral extends NodeBase {
 		return getMemberReturnExpressionWhenCalled(literalStringMembers, path[0]);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-		return path.length > 1;
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (path.length === 1) {
-			return hasMemberEffectWhenCalled(literalStringMembers, path[0], callOptions, context);
+		if (interaction.type === INTERACTION_ACCESSED) {
+			return path.length > 1;
+		}
+		if (interaction.type === INTERACTION_CALLED && path.length === 1) {
+			return hasMemberEffectWhenCalled(literalStringMembers, path[0], interaction, context);
 		}
 		return true;
 	}

--- a/src/ast/nodes/TemplateLiteral.ts
+++ b/src/ast/nodes/TemplateLiteral.ts
@@ -23,7 +23,7 @@ export default class TemplateLiteral extends NodeBase {
 	declare quasis: TemplateElement[];
 	declare type: NodeType.tTemplateLiteral;
 
-	deoptimizeThisOnEventAtPath(): void {}
+	deoptimizeThisOnInteractionAtPath(): void {}
 
 	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
 		if (path.length > 0 || this.quasis.length !== 1) {

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -1,6 +1,6 @@
 import type MagicString from 'magic-string';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import ModuleScope from '../scopes/ModuleScope';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type Variable from '../variables/Variable';
@@ -21,14 +21,14 @@ export default class ThisExpression extends NodeBase {
 		this.variable.deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.variable.deoptimizeThisOnEventAtPath(
-			event,
+		this.variable.deoptimizeThisOnInteractionAtPath(
+			interaction,
 			path,
 			// We rewrite the parameter so that a ThisVariable can detect self-mutations
 			thisParameter === this ? this.variable : thisParameter,

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -1,6 +1,7 @@
 import type MagicString from 'magic-string';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import type { NodeInteraction, NodeInteractionWithThisArg } from '../NodeInteractions';
+import { INTERACTION_ACCESSED } from '../NodeInteractions';
 import ModuleScope from '../scopes/ModuleScope';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type Variable from '../variables/Variable';
@@ -33,12 +34,15 @@ export default class ThisExpression extends NodeBase {
 		);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return path.length > 0 && this.variable.hasEffectsWhenAccessedAtPath(path, context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.variable.hasEffectsWhenAssignedAtPath(path, context);
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteraction,
+		context: HasEffectsContext
+	): boolean {
+		if (path.length === 0) {
+			return interaction.type !== INTERACTION_ACCESSED;
+		}
+		return this.variable.hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 
 	include(): void {

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -1,11 +1,10 @@
 import type MagicString from 'magic-string';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import ModuleScope from '../scopes/ModuleScope';
 import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type Variable from '../variables/Variable';
 import type * as NodeType from './NodeType';
-import type { ExpressionEntity } from './shared/Expression';
 import { NodeBase } from './shared/Node';
 
 export default class ThisExpression extends NodeBase {
@@ -22,16 +21,14 @@ export default class ThisExpression extends NodeBase {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
+		// We rewrite the parameter so that a ThisVariable can detect self-mutations
 		this.variable.deoptimizeThisOnInteractionAtPath(
-			interaction,
+			interaction.thisArg === this ? { ...interaction, thisArg: this.variable } : interaction,
 			path,
-			// We rewrite the parameter so that a ThisVariable can detect self-mutations
-			thisParameter === this ? this.variable : thisParameter,
 			recursionTracker
 		);
 	}

--- a/src/ast/nodes/UnaryExpression.ts
+++ b/src/ast/nodes/UnaryExpression.ts
@@ -1,11 +1,15 @@
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import { INTERACTION_ACCESSED, INTERACTION_ASSIGNED, NodeInteraction } from '../NodeInteractions';
+import {
+	INTERACTION_ACCESSED,
+	NODE_INTERACTION_UNKNOWN_ASSIGNMENT,
+	NodeInteraction
+} from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, type PathTracker } from '../utils/PathTracker';
 import Identifier from './Identifier';
 import type { LiteralValue } from './Literal';
 import type * as NodeType from './NodeType';
-import { type LiteralValueOrUnknown, UNKNOWN_EXPRESSION, UnknownValue } from './shared/Expression';
+import { type LiteralValueOrUnknown, UnknownValue } from './shared/Expression';
 import { type ExpressionNode, NodeBase } from './shared/Node';
 
 const unaryOperators: {
@@ -46,16 +50,14 @@ export default class UnaryExpression extends NodeBase {
 			(this.operator === 'delete' &&
 				this.argument.hasEffectsOnInteractionAtPath(
 					EMPTY_PATH,
-					{ type: INTERACTION_ASSIGNED, value: UNKNOWN_EXPRESSION },
+					NODE_INTERACTION_UNKNOWN_ASSIGNMENT,
 					context
 				))
 		);
 	}
 
-	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
-		return (
-			interaction.type !== INTERACTION_ACCESSED || path.length > (this.operator === 'void' ? 0 : 1)
-		);
+	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
+		return type !== INTERACTION_ACCESSED || path.length > (this.operator === 'void' ? 0 : 1);
 	}
 
 	protected applyDeoptimizations(): void {

--- a/src/ast/nodes/UpdateExpression.ts
+++ b/src/ast/nodes/UpdateExpression.ts
@@ -6,9 +6,11 @@ import {
 	renderSystemExportSequenceBeforeExpression
 } from '../../utils/systemJsRendering';
 import type { HasEffectsContext } from '../ExecutionContext';
+import { INTERACTION_ACCESSED, INTERACTION_ASSIGNED, NodeInteraction } from '../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath } from '../utils/PathTracker';
 import Identifier from './Identifier';
 import * as NodeType from './NodeType';
+import { UNKNOWN_EXPRESSION } from './shared/Expression';
 import { type ExpressionNode, NodeBase } from './shared/Node';
 
 export default class UpdateExpression extends NodeBase {
@@ -21,12 +23,16 @@ export default class UpdateExpression extends NodeBase {
 		if (!this.deoptimized) this.applyDeoptimizations();
 		return (
 			this.argument.hasEffects(context) ||
-			this.argument.hasEffectsWhenAssignedAtPath(EMPTY_PATH, context)
+			this.argument.hasEffectsOnInteractionAtPath(
+				EMPTY_PATH,
+				{ type: INTERACTION_ASSIGNED, value: UNKNOWN_EXPRESSION },
+				context
+			)
 		);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-		return path.length > 1;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
+		return path.length > 1 || interaction.type !== INTERACTION_ACCESSED;
 	}
 
 	render(code: MagicString, options: RenderOptions): void {

--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -49,7 +49,7 @@ export default class VariableDeclaration extends NodeBase {
 		}
 	}
 
-	hasEffectsWhenAssignedAtPath(): boolean {
+	hasEffectsOnInteractionAtPath(): boolean {
 		return false;
 	}
 

--- a/src/ast/nodes/shared/CallExpressionBase.ts
+++ b/src/ast/nodes/shared/CallExpressionBase.ts
@@ -125,7 +125,7 @@ export default abstract class CallExpressionBase extends NodeBase implements Deo
 				(interaction.withNew
 					? context.instantiated
 					: context.called
-				).trackEntityAtPathAndGetIfTracked(path, interaction, this)
+				).trackEntityAtPathAndGetIfTracked(path, interaction.args, this)
 			) {
 				return false;
 			}

--- a/src/ast/nodes/shared/CallExpressionBase.ts
+++ b/src/ast/nodes/shared/CallExpressionBase.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { type NodeEvent } from '../../NodeEvents';
+import { type NodeInteraction } from '../../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import {
 	type ExpressionEntity,
@@ -42,8 +42,8 @@ export default abstract class CallExpressionBase extends NodeBase implements Deo
 		}
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
@@ -57,8 +57,8 @@ export default abstract class CallExpressionBase extends NodeBase implements Deo
 				returnExpression,
 				() => {
 					this.expressionsToBeDeoptimized.add(thisParameter);
-					returnExpression.deoptimizeThisOnEventAtPath(
-						event,
+					returnExpression.deoptimizeThisOnInteractionAtPath(
+						interaction,
 						path,
 						thisParameter,
 						recursionTracker

--- a/src/ast/nodes/shared/CallExpressionBase.ts
+++ b/src/ast/nodes/shared/CallExpressionBase.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { type NodeInteraction } from '../../NodeInteractions';
+import { NodeInteractionWithThisArg } from '../../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import {
 	type ExpressionEntity,
@@ -43,26 +43,20 @@ export default abstract class CallExpressionBase extends NodeBase implements Deo
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		const returnExpression = this.getReturnExpression(recursionTracker);
 		if (returnExpression === UNKNOWN_EXPRESSION) {
-			thisParameter.deoptimizePath(UNKNOWN_PATH);
+			interaction.thisArg.deoptimizePath(UNKNOWN_PATH);
 		} else {
 			recursionTracker.withTrackedEntityAtPath(
 				path,
 				returnExpression,
 				() => {
-					this.expressionsToBeDeoptimized.add(thisParameter);
-					returnExpression.deoptimizeThisOnInteractionAtPath(
-						interaction,
-						path,
-						thisParameter,
-						recursionTracker
-					);
+					this.expressionsToBeDeoptimized.add(interaction.thisArg);
+					returnExpression.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 				},
 				undefined
 			);

--- a/src/ast/nodes/shared/CallExpressionBase.ts
+++ b/src/ast/nodes/shared/CallExpressionBase.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { NodeInteractionWithThisArg } from '../../NodeInteractions';
+import { NodeInteractionCalled, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import {
 	type ExpressionEntity,
@@ -12,7 +12,7 @@ import {
 import { NodeBase } from './Node';
 
 export default abstract class CallExpressionBase extends NodeBase implements DeoptimizableEntity {
-	protected declare callOptions: CallOptions;
+	protected declare interaction: NodeInteractionCalled;
 	protected returnExpression: ExpressionEntity | null = null;
 	private readonly deoptimizableDependentExpressions: DeoptimizableEntity[] = [];
 	private readonly expressionsToBeDeoptimized = new Set<ExpressionEntity>();
@@ -85,7 +85,7 @@ export default abstract class CallExpressionBase extends NodeBase implements Deo
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
@@ -100,7 +100,7 @@ export default abstract class CallExpressionBase extends NodeBase implements Deo
 				this.deoptimizableDependentExpressions.push(origin);
 				return returnExpression.getReturnExpressionWhenCalledAtPath(
 					path,
-					callOptions,
+					interaction,
 					recursionTracker,
 					origin
 				);

--- a/src/ast/nodes/shared/CallExpressionBase.ts
+++ b/src/ast/nodes/shared/CallExpressionBase.ts
@@ -1,7 +1,12 @@
-import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { NodeInteractionCalled, NodeInteractionWithThisArg } from '../../NodeInteractions';
+import {
+	INTERACTION_ASSIGNED,
+	INTERACTION_CALLED,
+	NodeInteraction,
+	NodeInteractionCalled,
+	NodeInteractionWithThisArg
+} from '../../NodeInteractions';
 import { type ObjectPath, type PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import {
 	type ExpressionEntity,
@@ -109,31 +114,30 @@ export default abstract class CallExpressionBase extends NodeBase implements Deo
 		);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return (
-			!context.accessed.trackEntityAtPathAndGetIfTracked(path, this) &&
-			this.getReturnExpression().hasEffectsWhenAccessedAtPath(path, context)
-		);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return (
-			!context.assigned.trackEntityAtPathAndGetIfTracked(path, this) &&
-			this.getReturnExpression().hasEffectsWhenAssignedAtPath(path, context)
-		);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		return (
-			!(
-				callOptions.withNew ? context.instantiated : context.called
-			).trackEntityAtPathAndGetIfTracked(path, callOptions, this) &&
-			this.getReturnExpression().hasEffectsWhenCalledAtPath(path, callOptions, context)
-		);
+		const { type } = interaction;
+		if (type === INTERACTION_CALLED) {
+			if (
+				(interaction.withNew
+					? context.instantiated
+					: context.called
+				).trackEntityAtPathAndGetIfTracked(path, interaction, this)
+			) {
+				return false;
+			}
+		} else if (
+			(type === INTERACTION_ASSIGNED
+				? context.assigned
+				: context.accessed
+			).trackEntityAtPathAndGetIfTracked(path, this)
+		) {
+			return false;
+		}
+		return this.getReturnExpression().hasEffectsOnInteractionAtPath(path, interaction, context);
 	}
 
 	protected abstract getReturnExpression(recursionTracker?: PathTracker): ExpressionEntity;

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -47,10 +47,10 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 
 	deoptimizeThisOnInteractionAtPath(
 		interaction: NodeInteractionWithThisArg,
-		_path: ObjectPath,
-		_recursionTracker: PathTracker
+		path: ObjectPath,
+		recursionTracker: PathTracker
 	): void {
-		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(interaction, _path, _recursionTracker);
+		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -1,7 +1,11 @@
-import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import type { NodeInteractionCalled, NodeInteractionWithThisArg } from '../../NodeInteractions';
+import {
+	INTERACTION_CALLED,
+	NodeInteraction,
+	NodeInteractionCalled,
+	NodeInteractionWithThisArg
+} from '../../NodeInteractions';
 import ChildScope from '../../scopes/ChildScope';
 import type Scope from '../../scopes/Scope';
 import {
@@ -78,29 +82,21 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 		return initEffect || super.hasEffects(context);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAccessedAtPath(path, context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.getObjectEntity().hasEffectsWhenAssignedAtPath(path, context);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (path.length === 0) {
+		if (interaction.type === INTERACTION_CALLED && path.length === 0) {
 			return (
-				!callOptions.withNew ||
+				!interaction.withNew ||
 				(this.classConstructor !== null
-					? this.classConstructor.hasEffectsWhenCalledAtPath(EMPTY_PATH, callOptions, context)
-					: this.superClass?.hasEffectsWhenCalledAtPath(path, callOptions, context)) ||
+					? this.classConstructor.hasEffectsOnInteractionAtPath(path, interaction, context)
+					: this.superClass?.hasEffectsOnInteractionAtPath(path, interaction, context)) ||
 				false
 			);
 		} else {
-			return this.getObjectEntity().hasEffectsWhenCalledAtPath(path, callOptions, context);
+			return this.getObjectEntity().hasEffectsOnInteractionAtPath(path, interaction, context);
 		}
 	}
 

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import type { NodeInteraction } from '../../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../../NodeInteractions';
 import ChildScope from '../../scopes/ChildScope';
 import type Scope from '../../scopes/Scope';
 import {
@@ -42,17 +42,11 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
-		path: ObjectPath,
-		thisParameter: ExpressionEntity,
-		recursionTracker: PathTracker
+		interaction: NodeInteractionWithThisArg,
+		_path: ObjectPath,
+		_recursionTracker: PathTracker
 	): void {
-		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(interaction, _path, _recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import type { NodeEvent } from '../../NodeEvents';
+import type { NodeInteraction } from '../../NodeInteractions';
 import ChildScope from '../../scopes/ChildScope';
 import type Scope from '../../scopes/Scope';
 import {
@@ -41,14 +41,14 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 		this.getObjectEntity().deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.getObjectEntity().deoptimizeThisOnEventAtPath(
-			event,
+		this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
+			interaction,
 			path,
 			thisParameter,
 			recursionTracker

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import type { NodeInteractionWithThisArg } from '../../NodeInteractions';
+import type { NodeInteractionCalled, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import ChildScope from '../../scopes/ChildScope';
 import type Scope from '../../scopes/Scope';
 import {
@@ -59,13 +59,13 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		return this.getObjectEntity().getReturnExpressionWhenCalledAtPath(
 			path,
-			callOptions,
+			interaction,
 			recursionTracker,
 			origin
 		);

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -1,8 +1,11 @@
-import { CallOptions } from '../../CallOptions';
 import { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import { WritableEntity } from '../../Entity';
 import { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import { NodeInteractionCalled, NodeInteractionWithThisArg } from '../../NodeInteractions';
+import {
+	NodeInteraction,
+	NodeInteractionCalled,
+	NodeInteractionWithThisArg
+} from '../../NodeInteractions';
 import { ObjectPath, PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import { LiteralValue } from '../Literal';
 import SpreadElement from '../SpreadElement';
@@ -55,17 +58,9 @@ export class ExpressionEntity implements WritableEntity {
 		return UNKNOWN_EXPRESSION;
 	}
 
-	hasEffectsWhenAccessedAtPath(_path: ObjectPath, _context: HasEffectsContext): boolean {
-		return true;
-	}
-
-	hasEffectsWhenAssignedAtPath(_path: ObjectPath, _context: HasEffectsContext): boolean {
-		return true;
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		_path: ObjectPath,
-		_callOptions: CallOptions,
+		_interaction: NodeInteraction,
 		_context: HasEffectsContext
 	): boolean {
 		return true;

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -2,7 +2,7 @@ import { CallOptions } from '../../CallOptions';
 import { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import { WritableEntity } from '../../Entity';
 import { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import { NodeInteraction } from '../../NodeInteractions';
+import { NodeInteractionWithThisArg } from '../../NodeInteractions';
 import { ObjectPath, PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import { LiteralValue } from '../Literal';
 import SpreadElement from '../SpreadElement';
@@ -26,13 +26,11 @@ export class ExpressionEntity implements WritableEntity {
 	deoptimizePath(_path: ObjectPath): void {}
 
 	deoptimizeThisOnInteractionAtPath(
-		_interaction: NodeInteraction,
+		{ thisArg }: NodeInteractionWithThisArg,
 		_path: ObjectPath,
-		// TODO Lukas remove
-		thisParameter: ExpressionEntity,
 		_recursionTracker: PathTracker
 	): void {
-		thisParameter.deoptimizePath(UNKNOWN_PATH);
+		thisArg!.deoptimizePath(UNKNOWN_PATH);
 	}
 
 	/**

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -2,7 +2,7 @@ import { CallOptions } from '../../CallOptions';
 import { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import { WritableEntity } from '../../Entity';
 import { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import { NodeEvent } from '../../NodeEvents';
+import { NodeInteraction } from '../../NodeInteractions';
 import { ObjectPath, PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import { LiteralValue } from '../Literal';
 import SpreadElement from '../SpreadElement';
@@ -25,8 +25,8 @@ export class ExpressionEntity implements WritableEntity {
 
 	deoptimizePath(_path: ObjectPath): void {}
 
-	deoptimizeThisOnEventAtPath(
-		_event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		_interaction: NodeInteraction,
 		_path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		_recursionTracker: PathTracker

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -28,6 +28,7 @@ export class ExpressionEntity implements WritableEntity {
 	deoptimizeThisOnInteractionAtPath(
 		_interaction: NodeInteraction,
 		_path: ObjectPath,
+		// TODO Lukas remove
 		thisParameter: ExpressionEntity,
 		_recursionTracker: PathTracker
 	): void {

--- a/src/ast/nodes/shared/Expression.ts
+++ b/src/ast/nodes/shared/Expression.ts
@@ -2,7 +2,7 @@ import { CallOptions } from '../../CallOptions';
 import { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import { WritableEntity } from '../../Entity';
 import { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import { NodeInteractionWithThisArg } from '../../NodeInteractions';
+import { NodeInteractionCalled, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import { ObjectPath, PathTracker, UNKNOWN_PATH } from '../../utils/PathTracker';
 import { LiteralValue } from '../Literal';
 import SpreadElement from '../SpreadElement';
@@ -48,7 +48,7 @@ export class ExpressionEntity implements WritableEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		_path: ObjectPath,
-		_callOptions: CallOptions,
+		_interaction: NodeInteractionCalled,
 		_recursionTracker: PathTracker,
 		_origin: DeoptimizableEntity
 	): ExpressionEntity {

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -105,14 +105,14 @@ export default abstract class FunctionBase extends NodeBase {
 			if (
 				returnExpression.hasEffectsOnInteractionAtPath(
 					['then'],
-					{ args: NO_ARGS, thisArg: null, type: INTERACTION_CALLED, withNew: false },
+					{ args: NO_ARGS, thisArg: returnExpression, type: INTERACTION_CALLED, withNew: false },
 					context
 				) ||
 				(propertyReadSideEffects &&
 					(propertyReadSideEffects === 'always' ||
 						returnExpression.hasEffectsOnInteractionAtPath(
 							['then'],
-							{ type: INTERACTION_ACCESSED },
+							{ thisArg: returnExpression, type: INTERACTION_ACCESSED },
 							context
 						)))
 			) {

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -6,9 +6,9 @@ import {
 	type InclusionContext
 } from '../../ExecutionContext';
 import {
-	INTERACTION_ACCESSED,
 	INTERACTION_CALLED,
-	NO_ARGS,
+	NODE_INTERACTION_UNKNOWN_ACCESS,
+	NODE_INTERACTION_UNKNOWN_CALL,
 	NodeInteraction,
 	NodeInteractionCalled,
 	NodeInteractionWithThisArg
@@ -105,14 +105,14 @@ export default abstract class FunctionBase extends NodeBase {
 			if (
 				returnExpression.hasEffectsOnInteractionAtPath(
 					['then'],
-					{ args: NO_ARGS, thisArg: returnExpression, type: INTERACTION_CALLED, withNew: false },
+					NODE_INTERACTION_UNKNOWN_CALL,
 					context
 				) ||
 				(propertyReadSideEffects &&
 					(propertyReadSideEffects === 'always' ||
 						returnExpression.hasEffectsOnInteractionAtPath(
 							['then'],
-							{ thisArg: returnExpression, type: INTERACTION_ACCESSED },
+							NODE_INTERACTION_UNKNOWN_ACCESS,
 							context
 						)))
 			) {

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -1,12 +1,12 @@
 import type { NormalizedTreeshakingOptions } from '../../../rollup/types';
-import { type CallOptions, NO_ARGS } from '../../CallOptions';
+import { type CallOptions } from '../../CallOptions';
 import { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import {
 	BROKEN_FLOW_NONE,
 	type HasEffectsContext,
 	type InclusionContext
 } from '../../ExecutionContext';
-import { NodeInteraction } from '../../NodeInteractions';
+import { NO_ARGS, NodeInteraction } from '../../NodeInteractions';
 import ReturnValueScope from '../../scopes/ReturnValueScope';
 import { type ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../../utils/PathTracker';
 import BlockStatement from '../BlockStatement';
@@ -113,7 +113,7 @@ export default abstract class FunctionBase extends NodeBase {
 			if (
 				returnExpression.hasEffectsWhenCalledAtPath(
 					['then'],
-					{ args: NO_ARGS, thisParam: null, withNew: false },
+					{ args: NO_ARGS, thisArg: null, withNew: false },
 					context
 				) ||
 				(propertyReadSideEffects &&

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -6,7 +6,7 @@ import {
 	type HasEffectsContext,
 	type InclusionContext
 } from '../../ExecutionContext';
-import { NO_ARGS, NodeInteractionWithThisArg } from '../../NodeInteractions';
+import { NO_ARGS, NodeInteractionCalled, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import ReturnValueScope from '../../scopes/ReturnValueScope';
 import { type ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../../utils/PathTracker';
 import BlockStatement from '../BlockStatement';
@@ -61,14 +61,14 @@ export default abstract class FunctionBase extends NodeBase {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		if (path.length > 0) {
 			return this.getObjectEntity().getReturnExpressionWhenCalledAtPath(
 				path,
-				callOptions,
+				interaction,
 				recursionTracker,
 				origin
 			);

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -6,7 +6,7 @@ import {
 	type HasEffectsContext,
 	type InclusionContext
 } from '../../ExecutionContext';
-import { NO_ARGS, NodeInteraction } from '../../NodeInteractions';
+import { NO_ARGS, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import ReturnValueScope from '../../scopes/ReturnValueScope';
 import { type ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../../utils/PathTracker';
 import BlockStatement from '../BlockStatement';
@@ -42,18 +42,12 @@ export default abstract class FunctionBase extends NodeBase {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		if (path.length > 0) {
-			this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
-				interaction,
-				path,
-				thisParameter,
-				recursionTracker
-			);
+			this.getObjectEntity().deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 		}
 	}
 

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -6,7 +6,7 @@ import {
 	type HasEffectsContext,
 	type InclusionContext
 } from '../../ExecutionContext';
-import { NodeEvent } from '../../NodeEvents';
+import { NodeInteraction } from '../../NodeInteractions';
 import ReturnValueScope from '../../scopes/ReturnValueScope';
 import { type ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../../utils/PathTracker';
 import BlockStatement from '../BlockStatement';
@@ -41,15 +41,15 @@ export default abstract class FunctionBase extends NodeBase {
 		}
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		if (path.length > 0) {
-			this.getObjectEntity().deoptimizeThisOnEventAtPath(
-				event,
+			this.getObjectEntity().deoptimizeThisOnInteractionAtPath(
+				interaction,
 				path,
 				thisParameter,
 				recursionTracker

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -32,7 +32,7 @@ export default class FunctionNode extends FunctionBase {
 		recursionTracker: PathTracker
 	): void {
 		super.deoptimizeThisOnInteractionAtPath(interaction, path, thisParameter, recursionTracker);
-		if (interaction === INTERACTION_CALLED && path.length === 0) {
+		if (interaction.type === INTERACTION_CALLED && path.length === 0) {
 			this.scope.thisVariable.addEntityToBeDeoptimized(thisParameter);
 		}
 	}

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -1,11 +1,11 @@
 import { type CallOptions } from '../../CallOptions';
 import { type HasEffectsContext, type InclusionContext } from '../../ExecutionContext';
-import { INTERACTION_CALLED, type NodeInteraction } from '../../NodeInteractions';
+import { INTERACTION_CALLED, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import FunctionScope from '../../scopes/FunctionScope';
 import { type ObjectPath, PathTracker } from '../../utils/PathTracker';
 import BlockStatement from '../BlockStatement';
 import Identifier, { type IdentifierWithVariable } from '../Identifier';
-import { type ExpressionEntity, UNKNOWN_EXPRESSION } from './Expression';
+import { UNKNOWN_EXPRESSION } from './Expression';
 import FunctionBase from './FunctionBase';
 import { type IncludeChildren } from './Node';
 import { ObjectEntity } from './ObjectEntity';
@@ -26,14 +26,13 @@ export default class FunctionNode extends FunctionBase {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		super.deoptimizeThisOnInteractionAtPath(interaction, path, thisParameter, recursionTracker);
+		super.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 		if (interaction.type === INTERACTION_CALLED && path.length === 0) {
-			this.scope.thisVariable.addEntityToBeDeoptimized(thisParameter);
+			this.scope.thisVariable.addEntityToBeDeoptimized(interaction.thisArg);
 		}
 	}
 

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -1,6 +1,6 @@
 import { type CallOptions } from '../../CallOptions';
 import { type HasEffectsContext, type InclusionContext } from '../../ExecutionContext';
-import { EVENT_CALLED, type NodeEvent } from '../../NodeEvents';
+import { INTERACTION_CALLED, type NodeInteraction } from '../../NodeInteractions';
 import FunctionScope from '../../scopes/FunctionScope';
 import { type ObjectPath, PathTracker } from '../../utils/PathTracker';
 import BlockStatement from '../BlockStatement';
@@ -25,14 +25,14 @@ export default class FunctionNode extends FunctionBase {
 		this.scope = new FunctionScope(parentScope, this.context);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		super.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker);
-		if (event === EVENT_CALLED && path.length === 0) {
+		super.deoptimizeThisOnInteractionAtPath(interaction, path, thisParameter, recursionTracker);
+		if (interaction === INTERACTION_CALLED && path.length === 0) {
 			this.scope.thisVariable.addEntityToBeDeoptimized(thisParameter);
 		}
 	}

--- a/src/ast/nodes/shared/MethodBase.ts
+++ b/src/ast/nodes/shared/MethodBase.ts
@@ -5,6 +5,7 @@ import {
 	INTERACTION_ASSIGNED,
 	INTERACTION_CALLED,
 	NO_ARGS,
+	NODE_INTERACTION_UNKNOWN_CALL,
 	NodeInteraction,
 	NodeInteractionCalled,
 	NodeInteractionWithThisArg
@@ -139,7 +140,7 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 				this.accessedValue = UNKNOWN_EXPRESSION;
 				return (this.accessedValue = this.value.getReturnExpressionWhenCalledAtPath(
 					EMPTY_PATH,
-					{ args: NO_ARGS, thisArg: null, type: INTERACTION_CALLED, withNew: false },
+					NODE_INTERACTION_UNKNOWN_CALL,
 					SHARED_RECURSION_TRACKER,
 					this
 				));

--- a/src/ast/nodes/shared/MethodBase.ts
+++ b/src/ast/nodes/shared/MethodBase.ts
@@ -1,7 +1,12 @@
 import { type CallOptions, NO_ARGS } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { EVENT_ACCESSED, EVENT_ASSIGNED, EVENT_CALLED, type NodeEvent } from '../../NodeEvents';
+import {
+	INTERACTION_ACCESSED,
+	INTERACTION_ASSIGNED,
+	INTERACTION_CALLED,
+	type NodeInteraction
+} from '../../NodeInteractions';
 import {
 	EMPTY_PATH,
 	type ObjectPath,
@@ -38,30 +43,30 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 		this.getAccessedValue().deoptimizePath(path);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		if (event === EVENT_ACCESSED && this.kind === 'get' && path.length === 0) {
-			return this.value.deoptimizeThisOnEventAtPath(
-				EVENT_CALLED,
+		if (interaction === INTERACTION_ACCESSED && this.kind === 'get' && path.length === 0) {
+			return this.value.deoptimizeThisOnInteractionAtPath(
+				INTERACTION_CALLED,
 				EMPTY_PATH,
 				thisParameter,
 				recursionTracker
 			);
 		}
-		if (event === EVENT_ASSIGNED && this.kind === 'set' && path.length === 0) {
-			return this.value.deoptimizeThisOnEventAtPath(
-				EVENT_CALLED,
+		if (interaction === INTERACTION_ASSIGNED && this.kind === 'set' && path.length === 0) {
+			return this.value.deoptimizeThisOnInteractionAtPath(
+				INTERACTION_CALLED,
 				EMPTY_PATH,
 				thisParameter,
 				recursionTracker
 			);
 		}
-		this.getAccessedValue().deoptimizeThisOnEventAtPath(
-			event,
+		this.getAccessedValue().deoptimizeThisOnInteractionAtPath(
+			interaction,
 			path,
 			thisParameter,
 			recursionTracker

--- a/src/ast/nodes/shared/MethodBase.ts
+++ b/src/ast/nodes/shared/MethodBase.ts
@@ -6,7 +6,7 @@ import {
 	INTERACTION_ASSIGNED,
 	INTERACTION_CALLED,
 	NO_ARGS,
-	type NodeInteraction
+	NodeInteractionWithThisArg
 } from '../../NodeInteractions';
 import {
 	EMPTY_PATH,
@@ -45,9 +45,8 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		// TODO Lukas cache and share interaction with hasEffects
@@ -55,7 +54,6 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 			return this.value.deoptimizeThisOnInteractionAtPath(
 				{ args: NO_ARGS, thisArg: interaction.thisArg, type: INTERACTION_CALLED, withNew: false },
 				EMPTY_PATH,
-				thisParameter,
 				recursionTracker
 			);
 		}
@@ -69,16 +67,10 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 					withNew: false
 				},
 				EMPTY_PATH,
-				thisParameter,
 				recursionTracker
 			);
 		}
-		this.getAccessedValue().deoptimizeThisOnInteractionAtPath(
-			interaction,
-			path,
-			thisParameter,
-			recursionTracker
-		);
+		this.getAccessedValue().deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker);
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/shared/MethodBase.ts
+++ b/src/ast/nodes/shared/MethodBase.ts
@@ -47,7 +47,12 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 	): void {
 		if (interaction.type === INTERACTION_ACCESSED && this.kind === 'get' && path.length === 0) {
 			return this.value.deoptimizeThisOnInteractionAtPath(
-				{ args: NO_ARGS, thisArg: interaction.thisArg, type: INTERACTION_CALLED, withNew: false },
+				{
+					args: NO_ARGS,
+					thisArg: interaction.thisArg,
+					type: INTERACTION_CALLED,
+					withNew: false
+				},
 				EMPTY_PATH,
 				recursionTracker
 			);
@@ -55,7 +60,7 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 		if (interaction.type === INTERACTION_ASSIGNED && this.kind === 'set' && path.length === 0) {
 			return this.value.deoptimizeThisOnInteractionAtPath(
 				{
-					args: [interaction.value],
+					args: interaction.args,
 					thisArg: interaction.thisArg,
 					type: INTERACTION_CALLED,
 					withNew: false
@@ -99,21 +104,24 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 		context: HasEffectsContext
 	): boolean {
 		if (this.kind === 'get' && interaction.type === INTERACTION_ACCESSED && path.length === 0) {
-			// TODO Lukas thisArg should be determined by parent alone
 			return this.value.hasEffectsOnInteractionAtPath(
 				EMPTY_PATH,
-				{ args: NO_ARGS, thisArg: null, type: INTERACTION_CALLED, withNew: false },
+				{
+					args: NO_ARGS,
+					thisArg: interaction.thisArg,
+					type: INTERACTION_CALLED,
+					withNew: false
+				},
 				context
 			);
 		}
 		// setters are only called for empty paths
 		if (this.kind === 'set' && interaction.type === INTERACTION_ASSIGNED) {
-			// TODO Lukas thisArg should be determined by parent alone
 			return this.value.hasEffectsOnInteractionAtPath(
 				EMPTY_PATH,
 				{
-					args: [interaction.value],
-					thisArg: null,
+					args: interaction.args,
+					thisArg: interaction.thisArg,
 					type: INTERACTION_CALLED,
 					withNew: false
 				},

--- a/src/ast/nodes/shared/MethodBase.ts
+++ b/src/ast/nodes/shared/MethodBase.ts
@@ -1,10 +1,11 @@
-import { type CallOptions, NO_ARGS } from '../../CallOptions';
+import { type CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
 import {
 	INTERACTION_ACCESSED,
 	INTERACTION_ASSIGNED,
 	INTERACTION_CALLED,
+	NO_ARGS,
 	type NodeInteraction
 } from '../../NodeInteractions';
 import {
@@ -31,7 +32,7 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 	private accessedValue: ExpressionEntity | null = null;
 	private accessorCallOptions: CallOptions = {
 		args: NO_ARGS,
-		thisParam: null,
+		thisArg: null,
 		withNew: false
 	};
 
@@ -52,7 +53,7 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 		// TODO Lukas cache and share interaction with hasEffects
 		if (interaction.type === INTERACTION_ACCESSED && this.kind === 'get' && path.length === 0) {
 			return this.value.deoptimizeThisOnInteractionAtPath(
-				{ callOptions: this.accessorCallOptions, type: INTERACTION_CALLED },
+				{ args: NO_ARGS, thisArg: interaction.thisArg, type: INTERACTION_CALLED, withNew: false },
 				EMPTY_PATH,
 				thisParameter,
 				recursionTracker
@@ -61,7 +62,12 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 		// TODO Lukas cache and share interaction with hasEffects
 		if (interaction.type === INTERACTION_ASSIGNED && this.kind === 'set' && path.length === 0) {
 			return this.value.deoptimizeThisOnInteractionAtPath(
-				{ callOptions: this.accessorCallOptions, type: INTERACTION_CALLED },
+				{
+					args: [interaction.value],
+					thisArg: interaction.thisArg,
+					type: INTERACTION_CALLED,
+					withNew: false
+				},
 				EMPTY_PATH,
 				thisParameter,
 				recursionTracker

--- a/src/ast/nodes/shared/MethodBase.ts
+++ b/src/ast/nodes/shared/MethodBase.ts
@@ -49,17 +49,19 @@ export default class MethodBase extends NodeBase implements DeoptimizableEntity 
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		if (interaction === INTERACTION_ACCESSED && this.kind === 'get' && path.length === 0) {
+		// TODO Lukas cache and share interaction with hasEffects
+		if (interaction.type === INTERACTION_ACCESSED && this.kind === 'get' && path.length === 0) {
 			return this.value.deoptimizeThisOnInteractionAtPath(
-				INTERACTION_CALLED,
+				{ callOptions: this.accessorCallOptions, type: INTERACTION_CALLED },
 				EMPTY_PATH,
 				thisParameter,
 				recursionTracker
 			);
 		}
-		if (interaction === INTERACTION_ASSIGNED && this.kind === 'set' && path.length === 0) {
+		// TODO Lukas cache and share interaction with hasEffects
+		if (interaction.type === INTERACTION_ASSIGNED && this.kind === 'set' && path.length === 0) {
 			return this.value.deoptimizeThisOnInteractionAtPath(
-				INTERACTION_CALLED,
+				{ callOptions: this.accessorCallOptions, type: INTERACTION_CALLED },
 				EMPTY_PATH,
 				thisParameter,
 				recursionTracker

--- a/src/ast/nodes/shared/MethodTypes.ts
+++ b/src/ast/nodes/shared/MethodTypes.ts
@@ -1,9 +1,9 @@
 import type { HasEffectsContext } from '../../ExecutionContext';
 import {
 	INTERACTION_ACCESSED,
-	INTERACTION_ASSIGNED,
 	INTERACTION_CALLED,
 	NO_ARGS,
+	NODE_INTERACTION_UNKNOWN_ASSIGNMENT,
 	NodeInteraction,
 	NodeInteractionCalled,
 	NodeInteractionWithThisArg
@@ -46,7 +46,7 @@ export class Method extends ExpressionEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		interaction: NodeInteractionCalled
+		{ thisArg }: NodeInteractionCalled
 	): ExpressionEntity {
 		if (path.length > 0) {
 			return UNKNOWN_EXPRESSION;
@@ -54,7 +54,7 @@ export class Method extends ExpressionEntity {
 		return (
 			this.description.returnsPrimitive ||
 			(this.description.returns === 'self'
-				? interaction.thisArg || UNKNOWN_EXPRESSION
+				? thisArg || UNKNOWN_EXPRESSION
 				: this.description.returns())
 		);
 	}
@@ -73,7 +73,7 @@ export class Method extends ExpressionEntity {
 				this.description.mutatesSelfAsArray === true &&
 				interaction.thisArg?.hasEffectsOnInteractionAtPath(
 					UNKNOWN_INTEGER_PATH,
-					{ type: INTERACTION_ASSIGNED, value: UNKNOWN_EXPRESSION },
+					NODE_INTERACTION_UNKNOWN_ASSIGNMENT,
 					context
 				)
 			) {

--- a/src/ast/nodes/shared/MethodTypes.ts
+++ b/src/ast/nodes/shared/MethodTypes.ts
@@ -1,6 +1,6 @@
-import { type CallOptions, NO_ARGS } from '../../CallOptions';
+import { type CallOptions } from '../../CallOptions';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { INTERACTION_CALLED, type NodeInteraction } from '../../NodeInteractions';
+import { INTERACTION_CALLED, NO_ARGS, type NodeInteraction } from '../../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_INTEGER_PATH } from '../../utils/PathTracker';
 import {
 	UNKNOWN_LITERAL_BOOLEAN,
@@ -52,7 +52,7 @@ export class Method extends ExpressionEntity {
 		return (
 			this.description.returnsPrimitive ||
 			(this.description.returns === 'self'
-				? callOptions.thisParam || UNKNOWN_EXPRESSION
+				? callOptions.thisArg || UNKNOWN_EXPRESSION
 				: this.description.returns())
 		);
 	}
@@ -73,7 +73,7 @@ export class Method extends ExpressionEntity {
 		if (
 			path.length > 0 ||
 			(this.description.mutatesSelfAsArray === true &&
-				callOptions.thisParam?.hasEffectsWhenAssignedAtPath(UNKNOWN_INTEGER_PATH, context))
+				callOptions.thisArg?.hasEffectsWhenAssignedAtPath(UNKNOWN_INTEGER_PATH, context))
 		) {
 			return true;
 		}
@@ -86,7 +86,7 @@ export class Method extends ExpressionEntity {
 					EMPTY_PATH,
 					{
 						args: NO_ARGS,
-						thisParam: null,
+						thisArg: null,
 						withNew: false
 					},
 					context

--- a/src/ast/nodes/shared/MethodTypes.ts
+++ b/src/ast/nodes/shared/MethodTypes.ts
@@ -34,7 +34,7 @@ export class Method extends ExpressionEntity {
 		thisParameter: ExpressionEntity
 	): void {
 		if (
-			interaction === INTERACTION_CALLED &&
+			interaction.type === INTERACTION_CALLED &&
 			path.length === 0 &&
 			this.description.mutatesSelfAsArray
 		) {

--- a/src/ast/nodes/shared/MethodTypes.ts
+++ b/src/ast/nodes/shared/MethodTypes.ts
@@ -1,6 +1,11 @@
 import { type CallOptions } from '../../CallOptions';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { INTERACTION_CALLED, NO_ARGS, NodeInteractionWithThisArg } from '../../NodeInteractions';
+import {
+	INTERACTION_CALLED,
+	NO_ARGS,
+	NodeInteraction,
+	NodeInteractionWithThisArg
+} from '../../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_INTEGER_PATH } from '../../utils/PathTracker';
 import {
 	UNKNOWN_LITERAL_BOOLEAN,
@@ -39,7 +44,7 @@ export class Method extends ExpressionEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions
+		interaction: NodeInteraction
 	): ExpressionEntity {
 		if (path.length > 0) {
 			return UNKNOWN_EXPRESSION;
@@ -47,7 +52,7 @@ export class Method extends ExpressionEntity {
 		return (
 			this.description.returnsPrimitive ||
 			(this.description.returns === 'self'
-				? callOptions.thisArg || UNKNOWN_EXPRESSION
+				? interaction.thisArg || UNKNOWN_EXPRESSION
 				: this.description.returns())
 		);
 	}

--- a/src/ast/nodes/shared/MethodTypes.ts
+++ b/src/ast/nodes/shared/MethodTypes.ts
@@ -1,6 +1,6 @@
 import { type CallOptions, NO_ARGS } from '../../CallOptions';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { EVENT_CALLED, type NodeEvent } from '../../NodeEvents';
+import { INTERACTION_CALLED, type NodeInteraction } from '../../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_INTEGER_PATH } from '../../utils/PathTracker';
 import {
 	UNKNOWN_LITERAL_BOOLEAN,
@@ -28,12 +28,16 @@ export class Method extends ExpressionEntity {
 		super();
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity
 	): void {
-		if (event === EVENT_CALLED && path.length === 0 && this.description.mutatesSelfAsArray) {
+		if (
+			interaction === INTERACTION_CALLED &&
+			path.length === 0 &&
+			this.description.mutatesSelfAsArray
+		) {
 			thisParameter.deoptimizePath(UNKNOWN_INTEGER_PATH);
 		}
 	}

--- a/src/ast/nodes/shared/MethodTypes.ts
+++ b/src/ast/nodes/shared/MethodTypes.ts
@@ -1,6 +1,6 @@
 import { type CallOptions } from '../../CallOptions';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import { INTERACTION_CALLED, NO_ARGS, type NodeInteraction } from '../../NodeInteractions';
+import { INTERACTION_CALLED, NO_ARGS, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_INTEGER_PATH } from '../../utils/PathTracker';
 import {
 	UNKNOWN_LITERAL_BOOLEAN,
@@ -29,16 +29,11 @@ export class Method extends ExpressionEntity {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
-		path: ObjectPath,
-		thisParameter: ExpressionEntity
+		{ type, thisArg }: NodeInteractionWithThisArg,
+		path: ObjectPath
 	): void {
-		if (
-			interaction.type === INTERACTION_CALLED &&
-			path.length === 0 &&
-			this.description.mutatesSelfAsArray
-		) {
-			thisParameter.deoptimizePath(UNKNOWN_INTEGER_PATH);
+		if (type === INTERACTION_CALLED && path.length === 0 && this.description.mutatesSelfAsArray) {
+			thisArg.deoptimizePath(UNKNOWN_INTEGER_PATH);
 		}
 	}
 

--- a/src/ast/nodes/shared/MethodTypes.ts
+++ b/src/ast/nodes/shared/MethodTypes.ts
@@ -2,8 +2,8 @@ import type { HasEffectsContext } from '../../ExecutionContext';
 import {
 	INTERACTION_ACCESSED,
 	INTERACTION_CALLED,
-	NO_ARGS,
 	NODE_INTERACTION_UNKNOWN_ASSIGNMENT,
+	NODE_INTERACTION_UNKNOWN_CALL,
 	NodeInteraction,
 	NodeInteractionCalled,
 	NodeInteractionWithThisArg
@@ -84,12 +84,7 @@ export class Method extends ExpressionEntity {
 					if (
 						interaction.args[argIndex]?.hasEffectsOnInteractionAtPath(
 							EMPTY_PATH,
-							{
-								args: NO_ARGS,
-								thisArg: null,
-								type: INTERACTION_CALLED,
-								withNew: false
-							},
+							NODE_INTERACTION_UNKNOWN_CALL,
 							context
 						)
 					) {

--- a/src/ast/nodes/shared/MultiExpression.ts
+++ b/src/ast/nodes/shared/MultiExpression.ts
@@ -1,7 +1,6 @@
-import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
-import { NodeInteractionCalled } from '../../NodeInteractions';
+import { NodeInteraction, NodeInteractionCalled } from '../../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import { ExpressionEntity } from './Expression';
 import type { IncludeChildren } from './Node';
@@ -32,27 +31,13 @@ export class MultiExpression extends ExpressionEntity {
 		);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		for (const expression of this.expressions) {
-			if (expression.hasEffectsWhenAccessedAtPath(path, context)) return true;
-		}
-		return false;
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		for (const expression of this.expressions) {
-			if (expression.hasEffectsWhenAssignedAtPath(path, context)) return true;
-		}
-		return false;
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
 		for (const expression of this.expressions) {
-			if (expression.hasEffectsWhenCalledAtPath(path, callOptions, context)) return true;
+			if (expression.hasEffectsOnInteractionAtPath(path, interaction, context)) return true;
 		}
 		return false;
 	}

--- a/src/ast/nodes/shared/MultiExpression.ts
+++ b/src/ast/nodes/shared/MultiExpression.ts
@@ -1,6 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../../ExecutionContext';
+import { NodeInteractionCalled } from '../../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import { ExpressionEntity } from './Expression';
 import type { IncludeChildren } from './Node';
@@ -20,13 +21,13 @@ export class MultiExpression extends ExpressionEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		return new MultiExpression(
 			this.expressions.map(expression =>
-				expression.getReturnExpressionWhenCalledAtPath(path, callOptions, recursionTracker, origin)
+				expression.getReturnExpressionWhenCalledAtPath(path, interaction, recursionTracker, origin)
 			)
 		);
 	}

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -289,7 +289,7 @@ export class NodeBase extends ExpressionEntity implements ExpressionNode {
 	}
 
 	setAssignedValue(value: ExpressionEntity): void {
-		this.assignmentInteraction = { thisArg: null, type: INTERACTION_ASSIGNED, value };
+		this.assignmentInteraction = { args: [value], thisArg: null, type: INTERACTION_ASSIGNED };
 	}
 
 	shouldBeIncluded(context: InclusionContext): boolean {

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -10,9 +10,10 @@ import {
 	type HasEffectsContext,
 	type InclusionContext
 } from '../../ExecutionContext';
+import { INTERACTION_ASSIGNED, NodeInteractionAssigned } from '../../NodeInteractions';
 import { getAndCreateKeys, keys } from '../../keys';
 import type ChildScope from '../../scopes/ChildScope';
-import { UNKNOWN_PATH } from '../../utils/PathTracker';
+import { EMPTY_PATH, UNKNOWN_PATH } from '../../utils/PathTracker';
 import type Variable from '../../variables/Variable';
 import * as NodeType from '../NodeType';
 import { ExpressionEntity, InclusionOptions } from './Expression';
@@ -44,22 +45,32 @@ export interface Node extends Entity {
 	): void;
 
 	/**
-	 * Called once all nodes have been initialised and the scopes have been populated.
+	 * Called once all nodes have been initialised and the scopes have been
+	 * populated.
 	 */
 	bind(): void;
 
 	/**
-	 * Determine if this Node would have an effect on the bundle.
-	 * This is usually true for already included nodes. Exceptions are e.g. break statements
-	 * which only have an effect if their surrounding loop or switch statement is included.
+	 * Determine if this Node would have an effect on the bundle. This is usually
+	 * true for already included nodes. Exceptions are e.g. break statements which
+	 * only have an effect if their surrounding loop or switch statement is
+	 * included.
 	 * The options pass on information like this about the current execution path.
 	 */
 	hasEffects(context: HasEffectsContext): boolean;
 
 	/**
-	 * Includes the node in the bundle. If the flag is not set, children are usually included
-	 * if they are necessary for this node (e.g. a function body) or if they have effects.
-	 * Necessary variables need to be included as well.
+	 * Special version of hasEffects for assignment left-hand sides which ensures
+	 * that accessor effects are checked as well. This is necessary to do from the
+	 * child so that member expressions can use the correct thisArg value.
+	 * setAssignedValue needs to be called during initialise to use this.
+	 */
+	hasEffectsAsAssignmentTarget(context: HasEffectsContext, checkAccess: boolean): boolean;
+
+	/**
+	 * Includes the node in the bundle. If the flag is not set, children are
+	 * usually included if they are necessary for this node (e.g. a function body)
+	 * or if they have effects. Necessary variables need to be included as well.
 	 */
 	include(
 		context: InclusionContext,
@@ -67,13 +78,33 @@ export interface Node extends Entity {
 		options?: InclusionOptions
 	): void;
 
+	/**
+	 * Special version of include for assignment left-hand sides which ensures
+	 * that accessors are handled correctly. This is necessary to do from the
+	 * child so that member expressions can use the correct thisArg value.
+	 * setAssignedValue needs to be called during initialise to use this.
+	 */
+	includeAsAssignmentTarget(
+		context: InclusionContext,
+		includeChildrenRecursively: IncludeChildren,
+		deoptimizeAccess: boolean
+	): void;
+
 	render(code: MagicString, options: RenderOptions, nodeRenderOptions?: NodeRenderOptions): void;
 
 	/**
-	 * Start a new execution path to determine if this node has an effect on the bundle and
-	 * should therefore be included. Included nodes should always be included again in subsequent
-	 * visits as the inclusion of additional variables may require the inclusion of more child
-	 * nodes in e.g. block statements.
+	 * Sets the assigned value e.g. for assignment expression left. This must be
+	 * called during initialise in case hasEffects/includeAsAssignmentTarget are
+	 * used.
+	 */
+	setAssignedValue(value: ExpressionEntity): void;
+
+	/**
+	 * Start a new execution path to determine if this node has an effect on the
+	 * bundle and should therefore be included. Included nodes should always be
+	 * included again in subsequent visits as the inclusion of additional
+	 * variables may require the inclusion of more child nodes in e.g. block
+	 * statements.
 	 */
 	shouldBeIncluded(context: InclusionContext): boolean;
 }
@@ -92,10 +123,16 @@ export class NodeBase extends ExpressionEntity implements ExpressionNode {
 	declare scope: ChildScope;
 	declare start: number;
 	declare type: keyof typeof NodeType;
-	// Nodes can apply custom deoptimizations once they become part of the
-	// executed code. To do this, they must initialize this as false, implement
-	// applyDeoptimizations and call this from include and hasEffects if they
-	// have custom handlers
+	/**
+	 * This will be populated during initialise if setAssignedValue is called.
+	 */
+	protected declare assignmentInteraction: NodeInteractionAssigned;
+	/**
+	 * Nodes can apply custom deoptimizations once they become part of the
+	 * executed code. To do this, they must initialize this as false, implement
+	 * applyDeoptimizations and call this from include and hasEffects if they have
+	 * custom handlers
+	 */
 	protected deoptimized = false;
 
 	constructor(
@@ -159,6 +196,13 @@ export class NodeBase extends ExpressionEntity implements ExpressionNode {
 		return false;
 	}
 
+	hasEffectsAsAssignmentTarget(context: HasEffectsContext, _checkAccess: boolean): boolean {
+		return (
+			this.hasEffects(context) ||
+			this.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.assignmentInteraction, context)
+		);
+	}
+
 	include(
 		context: InclusionContext,
 		includeChildrenRecursively: IncludeChildren,
@@ -177,6 +221,14 @@ export class NodeBase extends ExpressionEntity implements ExpressionNode {
 				value.include(context, includeChildrenRecursively);
 			}
 		}
+	}
+
+	includeAsAssignmentTarget(
+		context: InclusionContext,
+		includeChildrenRecursively: IncludeChildren,
+		_deoptimizeAccess: boolean
+	) {
+		this.include(context, includeChildrenRecursively);
 	}
 
 	/**
@@ -234,6 +286,10 @@ export class NodeBase extends ExpressionEntity implements ExpressionNode {
 				value.render(code, options);
 			}
 		}
+	}
+
+	setAssignedValue(value: ExpressionEntity): void {
+		this.assignmentInteraction = { thisArg: null, type: INTERACTION_ASSIGNED, value };
 	}
 
 	shouldBeIncluded(context: InclusionContext): boolean {

--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -4,6 +4,7 @@ import { HasEffectsContext } from '../../ExecutionContext';
 import {
 	INTERACTION_ACCESSED,
 	INTERACTION_CALLED,
+	NodeInteractionCalled,
 	NodeInteractionWithThisArg
 } from '../../NodeInteractions';
 import {
@@ -246,7 +247,7 @@ export class ObjectEntity extends ExpressionEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
@@ -258,7 +259,7 @@ export class ObjectEntity extends ExpressionEntity {
 		if (expressionAtPath) {
 			return expressionAtPath.getReturnExpressionWhenCalledAtPath(
 				path.slice(1),
-				callOptions,
+				interaction,
 				recursionTracker,
 				origin
 			);
@@ -266,7 +267,7 @@ export class ObjectEntity extends ExpressionEntity {
 		if (this.prototypeExpression) {
 			return this.prototypeExpression.getReturnExpressionWhenCalledAtPath(
 				path,
-				callOptions,
+				interaction,
 				recursionTracker,
 				origin
 			);

--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -157,7 +157,7 @@ export class ObjectEntity extends ExpressionEntity {
 		if (
 			this.hasLostTrack ||
 			// single paths that are deoptimized will not become getters or setters
-			((interaction === INTERACTION_CALLED || path.length > 1) &&
+			((interaction.type === INTERACTION_CALLED || path.length > 1) &&
 				(this.hasUnknownDeoptimizedProperty ||
 					(typeof key === 'string' && this.deoptimizedPaths[key])))
 		) {
@@ -166,13 +166,13 @@ export class ObjectEntity extends ExpressionEntity {
 		}
 
 		const [propertiesForExactMatchByKey, relevantPropertiesByKey, relevantUnmatchableProperties] =
-			interaction === INTERACTION_CALLED || path.length > 1
+			interaction.type === INTERACTION_CALLED || path.length > 1
 				? [
 						this.propertiesAndGettersByKey,
 						this.propertiesAndGettersByKey,
 						this.unmatchablePropertiesAndGetters
 				  ]
-				: interaction === INTERACTION_ACCESSED
+				: interaction.type === INTERACTION_ACCESSED
 				? [this.propertiesAndGettersByKey, this.gettersByKey, this.unmatchableGetters]
 				: [this.propertiesAndSettersByKey, this.settersByKey, this.unmatchableSetters];
 

--- a/src/ast/nodes/shared/ObjectMember.ts
+++ b/src/ast/nodes/shared/ObjectMember.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import type { NodeInteraction } from '../../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import { ExpressionEntity, type LiteralValueOrUnknown } from './Expression';
 
@@ -15,15 +15,13 @@ export class ObjectMember extends ExpressionEntity {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		this.object.deoptimizeThisOnInteractionAtPath(
 			interaction,
 			[this.key, ...path],
-			thisParameter,
 			recursionTracker
 		);
 	}

--- a/src/ast/nodes/shared/ObjectMember.ts
+++ b/src/ast/nodes/shared/ObjectMember.ts
@@ -2,6 +2,7 @@ import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../../NodeInteractions';
+import { NodeInteractionCalled } from '../../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import { ExpressionEntity, type LiteralValueOrUnknown } from './Expression';
 
@@ -36,13 +37,13 @@ export class ObjectMember extends ExpressionEntity {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
 		return this.object.getReturnExpressionWhenCalledAtPath(
 			[this.key, ...path],
-			callOptions,
+			interaction,
 			recursionTracker,
 			origin
 		);

--- a/src/ast/nodes/shared/ObjectMember.ts
+++ b/src/ast/nodes/shared/ObjectMember.ts
@@ -1,7 +1,7 @@
 import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
-import type { NodeEvent } from '../../NodeEvents';
+import type { NodeInteraction } from '../../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import { ExpressionEntity, type LiteralValueOrUnknown } from './Expression';
 
@@ -14,14 +14,14 @@ export class ObjectMember extends ExpressionEntity {
 		this.object.deoptimizePath([this.key, ...path]);
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
-		this.object.deoptimizeThisOnEventAtPath(
-			event,
+		this.object.deoptimizeThisOnInteractionAtPath(
+			interaction,
 			[this.key, ...path],
 			thisParameter,
 			recursionTracker

--- a/src/ast/nodes/shared/ObjectMember.ts
+++ b/src/ast/nodes/shared/ObjectMember.ts
@@ -1,8 +1,7 @@
-import type { CallOptions } from '../../CallOptions';
 import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { HasEffectsContext } from '../../ExecutionContext';
 import type { NodeInteractionWithThisArg } from '../../NodeInteractions';
-import { NodeInteractionCalled } from '../../NodeInteractions';
+import { NodeInteraction, NodeInteractionCalled } from '../../NodeInteractions';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import { ExpressionEntity, type LiteralValueOrUnknown } from './Expression';
 
@@ -49,19 +48,11 @@ export class ObjectMember extends ExpressionEntity {
 		);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.object.hasEffectsWhenAccessedAtPath([this.key, ...path], context);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return this.object.hasEffectsWhenAssignedAtPath([this.key, ...path], context);
-	}
-
-	hasEffectsWhenCalledAtPath(
+	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		return this.object.hasEffectsWhenCalledAtPath([this.key, ...path], callOptions, context);
+		return this.object.hasEffectsOnInteractionAtPath([this.key, ...path], interaction, context);
 	}
 }

--- a/src/ast/nodes/shared/ObjectPrototype.ts
+++ b/src/ast/nodes/shared/ObjectPrototype.ts
@@ -1,4 +1,4 @@
-import { EVENT_CALLED, NodeEvent } from '../../NodeEvents';
+import { INTERACTION_CALLED, NodeInteraction } from '../../NodeInteractions';
 import { ObjectPath, ObjectPathKey, UNKNOWN_PATH } from '../../utils/PathTracker';
 import { ExpressionEntity, LiteralValueOrUnknown, UnknownValue } from './Expression';
 import {
@@ -16,12 +16,12 @@ const isInteger = (prop: ObjectPathKey): boolean => typeof prop === 'string' && 
 // will improve tree-shaking for out-of-bounds array properties
 const OBJECT_PROTOTYPE_FALLBACK: ExpressionEntity =
 	new (class ObjectPrototypeFallbackExpression extends ExpressionEntity {
-		deoptimizeThisOnEventAtPath(
-			event: NodeEvent,
+		deoptimizeThisOnInteractionAtPath(
+			interaction: NodeInteraction,
 			path: ObjectPath,
 			thisParameter: ExpressionEntity
 		): void {
-			if (event === EVENT_CALLED && path.length === 1 && !isInteger(path[0])) {
+			if (interaction === INTERACTION_CALLED && path.length === 1 && !isInteger(path[0])) {
 				thisParameter.deoptimizePath(UNKNOWN_PATH);
 			}
 		}

--- a/src/ast/nodes/shared/ObjectPrototype.ts
+++ b/src/ast/nodes/shared/ObjectPrototype.ts
@@ -36,8 +36,8 @@ const OBJECT_PROTOTYPE_FALLBACK: ExpressionEntity =
 			return path.length === 1 && isInteger(path[0]) ? undefined : UnknownValue;
 		}
 
-		hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
-			return path.length > 1 || interaction.type === INTERACTION_CALLED;
+		hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
+			return path.length > 1 || type === INTERACTION_CALLED;
 		}
 	})();
 

--- a/src/ast/nodes/shared/ObjectPrototype.ts
+++ b/src/ast/nodes/shared/ObjectPrototype.ts
@@ -1,4 +1,8 @@
-import { INTERACTION_CALLED, NodeInteractionWithThisArg } from '../../NodeInteractions';
+import {
+	INTERACTION_CALLED,
+	NodeInteraction,
+	NodeInteractionWithThisArg
+} from '../../NodeInteractions';
 import { ObjectPath, ObjectPathKey, UNKNOWN_PATH } from '../../utils/PathTracker';
 import { ExpressionEntity, LiteralValueOrUnknown, UnknownValue } from './Expression';
 import {
@@ -32,12 +36,8 @@ const OBJECT_PROTOTYPE_FALLBACK: ExpressionEntity =
 			return path.length === 1 && isInteger(path[0]) ? undefined : UnknownValue;
 		}
 
-		hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-			return path.length > 1;
-		}
-
-		hasEffectsWhenAssignedAtPath(path: ObjectPath): boolean {
-			return path.length > 1;
+		hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
+			return path.length > 1 || interaction.type === INTERACTION_CALLED;
 		}
 	})();
 

--- a/src/ast/nodes/shared/ObjectPrototype.ts
+++ b/src/ast/nodes/shared/ObjectPrototype.ts
@@ -21,7 +21,7 @@ const OBJECT_PROTOTYPE_FALLBACK: ExpressionEntity =
 			path: ObjectPath,
 			thisParameter: ExpressionEntity
 		): void {
-			if (interaction === INTERACTION_CALLED && path.length === 1 && !isInteger(path[0])) {
+			if (interaction.type === INTERACTION_CALLED && path.length === 1 && !isInteger(path[0])) {
 				thisParameter.deoptimizePath(UNKNOWN_PATH);
 			}
 		}

--- a/src/ast/nodes/shared/ObjectPrototype.ts
+++ b/src/ast/nodes/shared/ObjectPrototype.ts
@@ -1,4 +1,4 @@
-import { INTERACTION_CALLED, NodeInteraction } from '../../NodeInteractions';
+import { INTERACTION_CALLED, NodeInteractionWithThisArg } from '../../NodeInteractions';
 import { ObjectPath, ObjectPathKey, UNKNOWN_PATH } from '../../utils/PathTracker';
 import { ExpressionEntity, LiteralValueOrUnknown, UnknownValue } from './Expression';
 import {
@@ -17,12 +17,11 @@ const isInteger = (prop: ObjectPathKey): boolean => typeof prop === 'string' && 
 const OBJECT_PROTOTYPE_FALLBACK: ExpressionEntity =
 	new (class ObjectPrototypeFallbackExpression extends ExpressionEntity {
 		deoptimizeThisOnInteractionAtPath(
-			interaction: NodeInteraction,
-			path: ObjectPath,
-			thisParameter: ExpressionEntity
+			{ type, thisArg }: NodeInteractionWithThisArg,
+			path: ObjectPath
 		): void {
-			if (interaction.type === INTERACTION_CALLED && path.length === 1 && !isInteger(path[0])) {
-				thisParameter.deoptimizePath(UNKNOWN_PATH);
+			if (type === INTERACTION_CALLED && path.length === 1 && !isInteger(path[0])) {
+				thisArg.deoptimizePath(UNKNOWN_PATH);
 			}
 		}
 

--- a/src/ast/nodes/shared/knownGlobals.ts
+++ b/src/ast/nodes/shared/knownGlobals.ts
@@ -1,10 +1,9 @@
 /* eslint sort-keys: "off" */
 
 import { HasEffectsContext } from '../../ExecutionContext';
-import { INTERACTION_ASSIGNED, NodeInteractionCalled } from '../../NodeInteractions';
+import { NODE_INTERACTION_UNKNOWN_ASSIGNMENT, NodeInteractionCalled } from '../../NodeInteractions';
 import type { ObjectPath } from '../../utils/PathTracker';
 import { UNKNOWN_NON_ACCESSOR_PATH } from '../../utils/PathTracker';
-import { UNKNOWN_EXPRESSION } from './Expression';
 
 const ValueProperties = Symbol('Value Properties');
 
@@ -52,7 +51,7 @@ const MUTATES_ARG_WITHOUT_ACCESSOR: GlobalDescription = {
 				!args.length ||
 				args[0].hasEffectsOnInteractionAtPath(
 					UNKNOWN_NON_ACCESSOR_PATH,
-					{ type: INTERACTION_ASSIGNED, value: UNKNOWN_EXPRESSION },
+					NODE_INTERACTION_UNKNOWN_ASSIGNMENT,
 					context
 				)
 			);

--- a/src/ast/nodes/shared/knownGlobals.ts
+++ b/src/ast/nodes/shared/knownGlobals.ts
@@ -1,14 +1,15 @@
 /* eslint sort-keys: "off" */
 
-import { CallOptions } from '../../CallOptions';
 import { HasEffectsContext } from '../../ExecutionContext';
-import { UNKNOWN_NON_ACCESSOR_PATH } from '../../utils/PathTracker';
+import { INTERACTION_ASSIGNED, NodeInteractionCalled } from '../../NodeInteractions';
 import type { ObjectPath } from '../../utils/PathTracker';
+import { UNKNOWN_NON_ACCESSOR_PATH } from '../../utils/PathTracker';
+import { UNKNOWN_EXPRESSION } from './Expression';
 
 const ValueProperties = Symbol('Value Properties');
 
 interface ValueDescription {
-	hasEffectsWhenCalled(callOptions: CallOptions, context: HasEffectsContext): boolean;
+	hasEffectsWhenCalled(interaction: NodeInteractionCalled, context: HasEffectsContext): boolean;
 }
 
 interface GlobalDescription {
@@ -46,10 +47,14 @@ const PF: GlobalDescription = {
 const MUTATES_ARG_WITHOUT_ACCESSOR: GlobalDescription = {
 	__proto__: null,
 	[ValueProperties]: {
-		hasEffectsWhenCalled(callOptions, context) {
+		hasEffectsWhenCalled({ args }, context) {
 			return (
-				!callOptions.args.length ||
-				callOptions.args[0].hasEffectsWhenAssignedAtPath(UNKNOWN_NON_ACCESSOR_PATH, context)
+				!args.length ||
+				args[0].hasEffectsOnInteractionAtPath(
+					UNKNOWN_NON_ACCESSOR_PATH,
+					{ type: INTERACTION_ASSIGNED, value: UNKNOWN_EXPRESSION },
+					context
+				)
 			);
 		}
 	}

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -2,7 +2,7 @@ import type { HasEffectsContext } from './ExecutionContext';
 import {
 	INTERACTION_ACCESSED,
 	INTERACTION_CALLED,
-	NO_ARGS,
+	NODE_INTERACTION_UNKNOWN_CALL,
 	NodeInteraction,
 	NodeInteractionCalled
 } from './NodeInteractions';
@@ -153,16 +153,7 @@ const stringReplace: RawMemberDescription = {
 				(typeof arg1.getLiteralValueAtPath(EMPTY_PATH, SHARED_RECURSION_TRACKER, {
 					deoptimizeCache() {}
 				}) === 'symbol' &&
-					arg1.hasEffectsOnInteractionAtPath(
-						EMPTY_PATH,
-						{
-							args: NO_ARGS,
-							thisArg: null,
-							type: INTERACTION_CALLED,
-							withNew: false
-						},
-						context
-					))
+					arg1.hasEffectsOnInteractionAtPath(EMPTY_PATH, NODE_INTERACTION_UNKNOWN_CALL, context))
 			);
 		},
 		returns: UNKNOWN_LITERAL_STRING

--- a/src/ast/values.ts
+++ b/src/ast/values.ts
@@ -1,5 +1,6 @@
-import { type CallOptions, NO_ARGS } from './CallOptions';
+import { type CallOptions } from './CallOptions';
 import type { HasEffectsContext } from './ExecutionContext';
+import { NO_ARGS } from './NodeInteractions';
 import type { LiteralValue } from './nodes/Literal';
 import { ExpressionEntity, UNKNOWN_EXPRESSION } from './nodes/shared/Expression';
 import {
@@ -152,7 +153,7 @@ const stringReplace: RawMemberDescription = {
 						EMPTY_PATH,
 						{
 							args: NO_ARGS,
-							thisParam: null,
+							thisArg: null,
 							withNew: false
 						},
 						context

--- a/src/ast/variables/ArgumentsVariable.ts
+++ b/src/ast/variables/ArgumentsVariable.ts
@@ -1,6 +1,7 @@
 import type { AstContext } from '../../Module';
+import { INTERACTION_ACCESSED, NodeInteraction } from '../NodeInteractions';
 import { UNKNOWN_EXPRESSION } from '../nodes/shared/Expression';
-import type { ObjectPath } from '../utils/PathTracker';
+import { ObjectPath } from '../utils/PathTracker';
 import LocalVariable from './LocalVariable';
 
 export default class ArgumentsVariable extends LocalVariable {
@@ -8,15 +9,7 @@ export default class ArgumentsVariable extends LocalVariable {
 		super('arguments', null, UNKNOWN_EXPRESSION, context);
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-		return path.length > 1;
-	}
-
-	hasEffectsWhenAssignedAtPath(): boolean {
-		return true;
-	}
-
-	hasEffectsWhenCalledAtPath(): boolean {
-		return true;
+	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
+		return type !== INTERACTION_ACCESSED || path.length > 1;
 	}
 }

--- a/src/ast/variables/ExternalVariable.ts
+++ b/src/ast/variables/ExternalVariable.ts
@@ -1,4 +1,5 @@
 import type ExternalModule from '../../ExternalModule';
+import { INTERACTION_ACCESSED, NodeInteraction } from '../NodeInteractions';
 import type Identifier from '../nodes/Identifier';
 import type { ObjectPath } from '../utils/PathTracker';
 import Variable from './Variable';
@@ -21,8 +22,8 @@ export default class ExternalVariable extends Variable {
 		}
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath): boolean {
-		return path.length > (this.isNamespace ? 1 : 0);
+	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
+		return interaction.type !== INTERACTION_ACCESSED || path.length > (this.isNamespace ? 1 : 0);
 	}
 
 	include(): void {

--- a/src/ast/variables/ExternalVariable.ts
+++ b/src/ast/variables/ExternalVariable.ts
@@ -22,8 +22,8 @@ export default class ExternalVariable extends Variable {
 		}
 	}
 
-	hasEffectsOnInteractionAtPath(path: ObjectPath, interaction: NodeInteraction): boolean {
-		return interaction.type !== INTERACTION_ACCESSED || path.length > (this.isNamespace ? 1 : 0);
+	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
+		return type !== INTERACTION_ACCESSED || path.length > (this.isNamespace ? 1 : 0);
 	}
 
 	include(): void {

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -2,7 +2,7 @@ import Module, { AstContext } from '../../Module';
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { createInclusionContext, HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteractionWithThisArg } from '../NodeInteractions';
 import type ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import type Identifier from '../nodes/Identifier';
 import * as NodeType from '../nodes/NodeType';
@@ -82,24 +82,17 @@ export default class LocalVariable extends Variable {
 	}
 
 	deoptimizeThisOnInteractionAtPath(
-		interaction: NodeInteraction,
+		interaction: NodeInteractionWithThisArg,
 		path: ObjectPath,
-		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
 	): void {
 		if (this.isReassigned || !this.init) {
-			return thisParameter.deoptimizePath(UNKNOWN_PATH);
+			return interaction.thisArg.deoptimizePath(UNKNOWN_PATH);
 		}
 		recursionTracker.withTrackedEntityAtPath(
 			path,
 			this.init,
-			() =>
-				this.init!.deoptimizeThisOnInteractionAtPath(
-					interaction,
-					path,
-					thisParameter,
-					recursionTracker
-				),
+			() => this.init!.deoptimizeThisOnInteractionAtPath(interaction, path, recursionTracker),
 			undefined
 		);
 	}

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -2,7 +2,7 @@ import Module, { AstContext } from '../../Module';
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { createInclusionContext, HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import type { NodeInteractionCalled, NodeInteractionWithThisArg } from '../NodeInteractions';
 import type ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import type Identifier from '../nodes/Identifier';
 import * as NodeType from '../nodes/NodeType';
@@ -118,7 +118,7 @@ export default class LocalVariable extends Variable {
 
 	getReturnExpressionWhenCalledAtPath(
 		path: ObjectPath,
-		callOptions: CallOptions,
+		interaction: NodeInteractionCalled,
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): ExpressionEntity {
@@ -132,7 +132,7 @@ export default class LocalVariable extends Variable {
 				this.expressionsToBeDeoptimized.push(origin);
 				return this.init!.getReturnExpressionWhenCalledAtPath(
 					path,
-					callOptions,
+					interaction,
 					recursionTracker,
 					origin
 				);

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -2,7 +2,7 @@ import Module, { AstContext } from '../../Module';
 import type { CallOptions } from '../CallOptions';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import { createInclusionContext, HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import type { NodeEvent } from '../NodeEvents';
+import type { NodeInteraction } from '../NodeInteractions';
 import type ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import type Identifier from '../nodes/Identifier';
 import * as NodeType from '../nodes/NodeType';
@@ -81,8 +81,8 @@ export default class LocalVariable extends Variable {
 		}
 	}
 
-	deoptimizeThisOnEventAtPath(
-		event: NodeEvent,
+	deoptimizeThisOnInteractionAtPath(
+		interaction: NodeInteraction,
 		path: ObjectPath,
 		thisParameter: ExpressionEntity,
 		recursionTracker: PathTracker
@@ -93,7 +93,13 @@ export default class LocalVariable extends Variable {
 		recursionTracker.withTrackedEntityAtPath(
 			path,
 			this.init,
-			() => this.init!.deoptimizeThisOnEventAtPath(event, path, thisParameter, recursionTracker),
+			() =>
+				this.init!.deoptimizeThisOnInteractionAtPath(
+					interaction,
+					path,
+					thisParameter,
+					recursionTracker
+				),
 			undefined
 		);
 	}

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -169,7 +169,7 @@ export default class LocalVariable extends Variable {
 				return (this.init &&
 					!(
 						interaction.withNew ? context.instantiated : context.called
-					).trackEntityAtPathAndGetIfTracked(path, interaction, this) &&
+					).trackEntityAtPathAndGetIfTracked(path, interaction.args, this) &&
 					this.init.hasEffectsOnInteractionAtPath(path, interaction, context))!;
 		}
 	}

--- a/src/ast/variables/ThisVariable.ts
+++ b/src/ast/variables/ThisVariable.ts
@@ -1,6 +1,6 @@
 import type { AstContext } from '../../Module';
 import type { HasEffectsContext } from '../ExecutionContext';
-import type { NodeInteractionWithThisArg } from '../NodeInteractions';
+import type { NodeInteraction, NodeInteractionWithThisArg } from '../NodeInteractions';
 import { type ExpressionEntity, UNKNOWN_EXPRESSION } from '../nodes/shared/Expression';
 import {
 	DiscriminatedPathTracker,
@@ -69,17 +69,14 @@ export default class ThisVariable extends LocalVariable {
 		}
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteraction,
+		context: HasEffectsContext
+	): boolean {
 		return (
-			this.getInit(context).hasEffectsWhenAccessedAtPath(path, context) ||
-			super.hasEffectsWhenAccessedAtPath(path, context)
-		);
-	}
-
-	hasEffectsWhenAssignedAtPath(path: ObjectPath, context: HasEffectsContext): boolean {
-		return (
-			this.getInit(context).hasEffectsWhenAssignedAtPath(path, context) ||
-			super.hasEffectsWhenAssignedAtPath(path, context)
+			this.getInit(context).hasEffectsOnInteractionAtPath(path, interaction, context) ||
+			super.hasEffectsOnInteractionAtPath(path, interaction, context)
 		);
 	}
 

--- a/src/ast/variables/ThisVariable.ts
+++ b/src/ast/variables/ThisVariable.ts
@@ -58,7 +58,7 @@ export default class ThisVariable extends LocalVariable {
 		if (
 			!this.thisDeoptimizations.trackEntityAtPathAndGetIfTracked(
 				path,
-				interaction,
+				interaction.type,
 				interaction.thisArg
 			)
 		) {

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -39,13 +39,10 @@ export default class Variable extends ExpressionEntity {
 
 	hasEffectsOnInteractionAtPath(
 		path: ObjectPath,
-		interaction: NodeInteraction,
+		{ type }: NodeInteraction,
 		_context: HasEffectsContext
 	): boolean {
-		if (interaction.type === INTERACTION_ACCESSED) {
-			return path.length > 0;
-		}
-		return true;
+		return type !== INTERACTION_ACCESSED || path.length > 0;
 	}
 
 	/**

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -1,6 +1,7 @@
 import type ExternalModule from '../../ExternalModule';
 import type Module from '../../Module';
 import type { HasEffectsContext } from '../ExecutionContext';
+import { INTERACTION_ACCESSED, NodeInteraction } from '../NodeInteractions';
 import type Identifier from '../nodes/Identifier';
 import { ExpressionEntity } from '../nodes/shared/Expression';
 import type { ObjectPath } from '../utils/PathTracker';
@@ -36,8 +37,15 @@ export default class Variable extends ExpressionEntity {
 		return this.renderBaseName ? `${this.renderBaseName}${getPropertyAccess(name)}` : name;
 	}
 
-	hasEffectsWhenAccessedAtPath(path: ObjectPath, _context: HasEffectsContext): boolean {
-		return path.length > 0;
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteraction,
+		_context: HasEffectsContext
+	): boolean {
+		if (interaction.type === INTERACTION_ACCESSED) {
+			return path.length > 0;
+		}
+		return true;
 	}
 
 	/**

--- a/test/function/samples/for-in-accessors/_config.js
+++ b/test/function/samples/for-in-accessors/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimizes "this" for accessors triggered by for-in loops'
+};

--- a/test/function/samples/for-in-accessors/main.js
+++ b/test/function/samples/for-in-accessors/main.js
@@ -1,0 +1,10 @@
+const obj = {
+	setter: false,
+	set foo(value) {
+		this.setter = true;
+	}
+};
+
+for (obj.foo in {x:1});
+
+assert.ok(obj.setter ? true : false);

--- a/test/function/samples/for-of-accessors/_config.js
+++ b/test/function/samples/for-of-accessors/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimizes "this" for accessors triggered by for-of loops'
+};

--- a/test/function/samples/for-of-accessors/main.js
+++ b/test/function/samples/for-of-accessors/main.js
@@ -1,0 +1,10 @@
+const obj = {
+	setter: false,
+	set foo(value) {
+		this.setter = true;
+	}
+};
+
+for (obj.foo of [1]);
+
+assert.ok(obj.setter ? true : false);

--- a/test/function/samples/update-expression-accessors/_config.js
+++ b/test/function/samples/update-expression-accessors/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimizes "this" for accessors triggered by update expressions'
+};

--- a/test/function/samples/update-expression-accessors/main.js
+++ b/test/function/samples/update-expression-accessors/main.js
@@ -1,0 +1,16 @@
+const obj = {
+	getter: false,
+	setter: false,
+	get foo() {
+		this.getter = true;
+		return 0;
+	},
+	set foo(value) {
+		this.setter = true;
+	}
+};
+
+obj.foo++;
+
+assert.ok(obj.getter ? true : false);
+assert.ok(obj.setter ? true : false);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This will refactor and simplify the mechanism for checking property side effects (read, write, call) to use a single function `hasEffectsOnInteractionAtPath` that uses "interaction" objects as parameters that are also used by `deoptimizeThisOnInteractionAtPath` (formerly "eventAtPath).
These interaction objects have a type to determine if it is a read, write or call. They also have a `thisArg` that is used for deoptimizations but may also be used for other purposes in the future. Besides depending on the interaction type, they may also specify `args`. For writes, `args` is an array with a single element to make it easy for setters to convert writes to calls.
While this is mostly a refactoring, it will hopefully make the algorithm slightly more approachable, but it will more importantly lay the ground work for some future improvements.

Also, some subtle bugs were fixed as setters did not properly deoptimize their `this` value when called in updated expressions or for-in/of loops [Previous version REPL](https://rollupjs.org/repl/?version=2.75.5&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmNvbnN0JTIwb2JqMSUyMCUzRCUyMCU3QiU1Q24lNUN0bXV0YXRlZCUzQSUyMGZhbHNlJTJDJTVDbiU1Q3RnZXQlMjBmb28oKSUyMCU3QiU1Q24lNUN0JTVDdHJldHVybiUyMDAlM0IlNUNuJTVDdCU3RCUyQyU1Q24lNUN0c2V0JTIwZm9vKHZhbHVlKSUyMCU3QiU1Q24lNUN0JTVDdHRoaXMubXV0YXRlZCUyMCUzRCUyMHRydWUlM0IlNUNuJTVDdCU3RCU1Q24lN0QlM0IlNUNuJTVDbm9iajEuZm9vJTJCJTJCJTNCJTVDbiU1Q25jb25zb2xlLmxvZyhvYmoxLm11dGF0ZWQlMjAlM0YlMjAnT0snJTIwJTNBJTIwJ0ZBSUwnKSUzQiU1Q24lNUNuY29uc3QlMjBvYmoyJTIwJTNEJTIwJTdCJTVDbiU1Q3RtdXRhdGVkJTNBJTIwZmFsc2UlMkMlNUNuJTVDdHNldCUyMGZvbyh2YWx1ZSklMjAlN0IlNUNuJTVDdCU1Q3R0aGlzLm11dGF0ZWQlMjAlM0QlMjB0cnVlJTNCJTVDbiU1Q3QlN0QlNUNuJTdEJTNCJTVDbiU1Q25mb3IlMjAob2JqMi5mb28lMjBvZiUyMCU1QjAlNUQpJTNCJTVDbiU1Q25jb25zb2xlLmxvZyhvYmoyLm11dGF0ZWQlMjAlM0YlMjAnT0snJTIwJTNBJTIwJ0ZBSUwnKSUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmVzJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlMkMlMjJnbG9iYWxzJTIyJTNBJTdCJTdEJTdEJTJDJTIyZXhhbXBsZSUyMiUzQW51bGwlN0Q=) → [FIxed REPL](https://rollupjs.org/repl/?pr=4522&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmNvbnN0JTIwb2JqMSUyMCUzRCUyMCU3QiU1Q24lNUN0bXV0YXRlZCUzQSUyMGZhbHNlJTJDJTVDbiU1Q3RnZXQlMjBmb28oKSUyMCU3QiU1Q24lNUN0JTVDdHJldHVybiUyMDAlM0IlNUNuJTVDdCU3RCUyQyU1Q24lNUN0c2V0JTIwZm9vKHZhbHVlKSUyMCU3QiU1Q24lNUN0JTVDdHRoaXMubXV0YXRlZCUyMCUzRCUyMHRydWUlM0IlNUNuJTVDdCU3RCU1Q24lN0QlM0IlNUNuJTVDbm9iajEuZm9vJTJCJTJCJTNCJTVDbiU1Q25jb25zb2xlLmxvZyhvYmoxLm11dGF0ZWQlMjAlM0YlMjAnT0snJTIwJTNBJTIwJ0ZBSUwnKSUzQiU1Q24lNUNuY29uc3QlMjBvYmoyJTIwJTNEJTIwJTdCJTVDbiU1Q3RtdXRhdGVkJTNBJTIwZmFsc2UlMkMlNUNuJTVDdHNldCUyMGZvbyh2YWx1ZSklMjAlN0IlNUNuJTVDdCU1Q3R0aGlzLm11dGF0ZWQlMjAlM0QlMjB0cnVlJTNCJTVDbiU1Q3QlN0QlNUNuJTdEJTNCJTVDbiU1Q25mb3IlMjAob2JqMi5mb28lMjBvZiUyMCU1QjAlNUQpJTNCJTVDbiU1Q25jb25zb2xlLmxvZyhvYmoyLm11dGF0ZWQlMjAlM0YlMjAnT0snJTIwJTNBJTIwJ0ZBSUwnKSUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmVzJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlMkMlMjJnbG9iYWxzJTIyJTNBJTdCJTdEJTdEJTJDJTIyZXhhbXBsZSUyMiUzQW51bGwlN0Q=)