### PR TITLE
Treeshake instanceof

### DIFF
--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -28,8 +28,9 @@ export default class NewExpression extends NodeBase {
 			if (
 				(this.context.options.treeshake as NormalizedTreeshakingOptions).annotations &&
 				this.annotations
-			)
+			) {
 				return false;
+			}
 			return (
 				this.callee.hasEffects(context) ||
 				this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -13,6 +13,7 @@ import {
 	type ObjectPath,
 	type PathTracker,
 	SHARED_RECURSION_TRACKER,
+	TestInstanceof,
 	UNKNOWN_PATH,
 	UnknownKey
 } from '../../utils/PathTracker';
@@ -95,6 +96,8 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 					: this.superClass?.hasEffectsOnInteractionAtPath(path, interaction, context)) ||
 				false
 			);
+		} else if (path[0] === TestInstanceof) {
+			return false;
 		} else {
 			return this.getObjectEntity().hasEffectsOnInteractionAtPath(path, interaction, context);
 		}

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -14,7 +14,13 @@ import {
 	NodeInteractionWithThisArg
 } from '../../NodeInteractions';
 import ReturnValueScope from '../../scopes/ReturnValueScope';
-import { type ObjectPath, PathTracker, UNKNOWN_PATH, UnknownKey } from '../../utils/PathTracker';
+import {
+	type ObjectPath,
+	PathTracker,
+	TestInstanceof,
+	UNKNOWN_PATH,
+	UnknownKey
+} from '../../utils/PathTracker';
 import BlockStatement from '../BlockStatement';
 import * as NodeType from '../NodeType';
 import RestElement from '../RestElement';
@@ -95,6 +101,9 @@ export default abstract class FunctionBase extends NodeBase {
 		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
+		if (path[0] === TestInstanceof) {
+			return false;
+		}
 		if (path.length > 0 || interaction.type !== INTERACTION_CALLED) {
 			return this.getObjectEntity().hasEffectsOnInteractionAtPath(path, interaction, context);
 		}

--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -11,6 +11,7 @@ import {
 	ObjectPath,
 	ObjectPathKey,
 	PathTracker,
+	TestInclusionKey,
 	UNKNOWN_INTEGER_PATH,
 	UNKNOWN_PATH,
 	UnknownInteger,
@@ -281,6 +282,7 @@ export class ObjectEntity extends ExpressionEntity {
 		context: HasEffectsContext
 	): boolean {
 		const [key, ...subPath] = path;
+		if (key === TestInclusionKey) return false;
 		if (subPath.length || interaction.type === INTERACTION_CALLED) {
 			const expressionAtPath = this.getMemberExpression(key);
 			if (expressionAtPath) {

--- a/src/ast/nodes/shared/ObjectEntity.ts
+++ b/src/ast/nodes/shared/ObjectEntity.ts
@@ -11,7 +11,7 @@ import {
 	ObjectPath,
 	ObjectPathKey,
 	PathTracker,
-	TestInclusionKey,
+	TestInstanceof,
 	UNKNOWN_INTEGER_PATH,
 	UNKNOWN_PATH,
 	UnknownInteger,
@@ -282,7 +282,7 @@ export class ObjectEntity extends ExpressionEntity {
 		context: HasEffectsContext
 	): boolean {
 		const [key, ...subPath] = path;
-		if (key === TestInclusionKey) return false;
+		if (key === TestInstanceof) return true;
 		if (subPath.length || interaction.type === INTERACTION_CALLED) {
 			const expressionAtPath = this.getMemberExpression(key);
 			if (expressionAtPath) {

--- a/src/ast/utils/PathTracker.ts
+++ b/src/ast/utils/PathTracker.ts
@@ -6,21 +6,22 @@ export const UnknownNonAccessorKey = Symbol('Unknown Non-Accessor Key');
 export const UnknownInteger = Symbol('Unknown Integer');
 /**
  * A special key that does not actually reference a property but can be used to
- * test if a variable is included via
- * .hasEffectsOnInteractionAtPath([TestInclusionKey], {type: INTERACTION_ASSIGNED,...}, ...)
+ * test if the right hand side of "instanceof" is either included or not a class
+ * or function via
+ * .hasEffectsOnInteractionAtPath([TestInstanceof], {type: INTERACTION_ASSIGNED,...}, ...)
  */
-export const TestInclusionKey = Symbol('Test Inclusion Key');
+export const TestInstanceof = Symbol('Test instanceof');
 export type ObjectPathKey =
 	| string
 	| typeof UnknownKey
 	| typeof UnknownNonAccessorKey
 	| typeof UnknownInteger
-	| typeof TestInclusionKey;
+	| typeof TestInstanceof;
 
 export type ObjectPath = ObjectPathKey[];
 export const EMPTY_PATH: ObjectPath = [];
 export const UNKNOWN_PATH: ObjectPath = [UnknownKey];
-export const TEST_INCLUSION_PATH: ObjectPath = [TestInclusionKey];
+export const TEST_INSTANCEOF_PATH: ObjectPath = [TestInstanceof];
 // For deoptimizations, this means we are modifying an unknown property but did
 // not lose track of the object or are creating a setter/getter;
 // For assignment effects it means we do not check for setter/getter effects
@@ -33,7 +34,7 @@ const EntitiesKey = Symbol('Entities');
 interface EntityPaths {
 	[pathSegment: string]: EntityPaths;
 	[EntitiesKey]: Set<Entity>;
-	[TestInclusionKey]?: EntityPaths;
+	[TestInstanceof]?: EntityPaths;
 	[UnknownInteger]?: EntityPaths;
 	[UnknownKey]?: EntityPaths;
 	[UnknownNonAccessorKey]?: EntityPaths;
@@ -81,7 +82,7 @@ export const SHARED_RECURSION_TRACKER = new PathTracker();
 interface DiscriminatedEntityPaths {
 	[pathSegment: string]: DiscriminatedEntityPaths;
 	[EntitiesKey]: Map<unknown, Set<Entity>>;
-	[TestInclusionKey]?: DiscriminatedEntityPaths;
+	[TestInstanceof]?: DiscriminatedEntityPaths;
 	[UnknownInteger]?: DiscriminatedEntityPaths;
 	[UnknownKey]?: DiscriminatedEntityPaths;
 	[UnknownNonAccessorKey]?: DiscriminatedEntityPaths;

--- a/src/ast/utils/PathTracker.ts
+++ b/src/ast/utils/PathTracker.ts
@@ -4,15 +4,23 @@ import type { Entity } from '../Entity';
 export const UnknownKey = Symbol('Unknown Key');
 export const UnknownNonAccessorKey = Symbol('Unknown Non-Accessor Key');
 export const UnknownInteger = Symbol('Unknown Integer');
+/**
+ * A special key that does not actually reference a property but can be used to
+ * test if a variable is included via
+ * .hasEffectsOnInteractionAtPath([TestInclusionKey], {type: INTERACTION_ASSIGNED,...}, ...)
+ */
+export const TestInclusionKey = Symbol('Test Inclusion Key');
 export type ObjectPathKey =
 	| string
 	| typeof UnknownKey
 	| typeof UnknownNonAccessorKey
-	| typeof UnknownInteger;
+	| typeof UnknownInteger
+	| typeof TestInclusionKey;
 
 export type ObjectPath = ObjectPathKey[];
 export const EMPTY_PATH: ObjectPath = [];
 export const UNKNOWN_PATH: ObjectPath = [UnknownKey];
+export const TEST_INCLUSION_PATH: ObjectPath = [TestInclusionKey];
 // For deoptimizations, this means we are modifying an unknown property but did
 // not lose track of the object or are creating a setter/getter;
 // For assignment effects it means we do not check for setter/getter effects
@@ -25,6 +33,7 @@ const EntitiesKey = Symbol('Entities');
 interface EntityPaths {
 	[pathSegment: string]: EntityPaths;
 	[EntitiesKey]: Set<Entity>;
+	[TestInclusionKey]?: EntityPaths;
 	[UnknownInteger]?: EntityPaths;
 	[UnknownKey]?: EntityPaths;
 	[UnknownNonAccessorKey]?: EntityPaths;
@@ -72,6 +81,7 @@ export const SHARED_RECURSION_TRACKER = new PathTracker();
 interface DiscriminatedEntityPaths {
 	[pathSegment: string]: DiscriminatedEntityPaths;
 	[EntitiesKey]: Map<unknown, Set<Entity>>;
+	[TestInclusionKey]?: DiscriminatedEntityPaths;
 	[UnknownInteger]?: DiscriminatedEntityPaths;
 	[UnknownKey]?: DiscriminatedEntityPaths;
 	[UnknownNonAccessorKey]?: DiscriminatedEntityPaths;

--- a/test/form/samples/instanceof/_config.js
+++ b/test/form/samples/instanceof/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'removes instanceof checks if the right side is not included'
+};

--- a/test/form/samples/instanceof/_expected.js
+++ b/test/form/samples/instanceof/_expected.js
@@ -1,0 +1,3 @@
+console.log('retained');
+
+console.log('retained');

--- a/test/form/samples/instanceof/_expected.js
+++ b/test/form/samples/instanceof/_expected.js
@@ -1,3 +1,15 @@
 console.log('retained');
 
 console.log('retained');
+
+class Used1 {}
+const Intermediate = Used1;
+const used1 = new Used1();
+
+if (used1 instanceof Intermediate) console.log('retained');
+else console.log('does not matter');
+
+class Used2 {}
+
+if (new Used2() instanceof Intermediate) console.log('retained');
+else console.log('does not matter');

--- a/test/form/samples/instanceof/main.js
+++ b/test/form/samples/instanceof/main.js
@@ -1,0 +1,17 @@
+class Unused1 {}
+class Used1 {}
+const Intermediate = Used1;
+
+if (new Intermediate() instanceof Unused1) console.log('removed');
+else console.log('retained');
+
+class Unused2 {}
+class WithEffect {
+	constructor() {
+		console.log('effect');
+	}
+}
+
+if (new WithEffect() instanceof Unused2)
+	console.log('does not matter, but effect should be retained');
+else console.log('retained');

--- a/test/form/samples/instanceof/main.js
+++ b/test/form/samples/instanceof/main.js
@@ -1,17 +1,21 @@
 class Unused1 {}
+
+if ({} instanceof Unused1) console.log('removed');
+else console.log('retained');
+
+function Unused2() {}
+
+if ({} instanceof Unused2) console.log('removed');
+else console.log('retained');
+
 class Used1 {}
 const Intermediate = Used1;
+const used1 = new Used1();
 
-if (new Intermediate() instanceof Unused1) console.log('removed');
-else console.log('retained');
+if (used1 instanceof Intermediate) console.log('retained');
+else console.log('does not matter');
 
-class Unused2 {}
-class WithEffect {
-	constructor() {
-		console.log('effect');
-	}
-}
+class Used2 {}
 
-if (new WithEffect() instanceof Unused2)
-	console.log('does not matter, but effect should be retained');
-else console.log('retained');
+if (new Used2() instanceof Intermediate) console.log('retained');
+else console.log('does not matter');

--- a/test/form/samples/invalid-binary-expressions/_expected.js
+++ b/test/form/samples/invalid-binary-expressions/_expected.js
@@ -37,3 +37,7 @@ if (null instanceof true) {
 if (null instanceof 'y') {
 	console.log('retained');
 }
+
+if (null instanceof {}) {
+	console.log('retained');
+}

--- a/test/form/samples/invalid-binary-expressions/_expected.js
+++ b/test/form/samples/invalid-binary-expressions/_expected.js
@@ -37,7 +37,3 @@ if (null instanceof true) {
 if (null instanceof 'y') {
 	console.log('retained');
 }
-
-if (null instanceof {}) {
-	console.log('retained');
-}

--- a/test/function/samples/instanceof/left-hand-effect/_config.js
+++ b/test/function/samples/instanceof/left-hand-effect/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'retains side effects in the left hand side of instanceof'
+};

--- a/test/function/samples/instanceof/left-hand-effect/main.js
+++ b/test/function/samples/instanceof/left-hand-effect/main.js
@@ -1,0 +1,14 @@
+let effect = false;
+
+class Bar {}
+class Foo {
+	constructor() {
+		effect = true;
+	}
+}
+
+if (new Foo() instanceof Bar) {
+	assert.fail('Wrong instance relation');
+}
+
+assert.ok(effect);

--- a/test/function/samples/instanceof/right-hand-effect/_config.js
+++ b/test/function/samples/instanceof/right-hand-effect/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'retains side effects in the right hand side of instanceof'
+};

--- a/test/function/samples/instanceof/right-hand-effect/main.js
+++ b/test/function/samples/instanceof/right-hand-effect/main.js
@@ -1,0 +1,14 @@
+let effect = false;
+
+class Foo {}
+
+if (
+	new Foo() instanceof
+	class {
+		[(effect = true)]() {}
+	}
+) {
+	assert.fail('Wrong instance relation');
+}
+
+assert.ok(effect);

--- a/test/function/samples/instanceof/used/_config.js
+++ b/test/function/samples/instanceof/used/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'retains instanceof if it is true'
+};

--- a/test/function/samples/instanceof/used/main.js
+++ b/test/function/samples/instanceof/used/main.js
@@ -1,0 +1,5 @@
+class Foo {}
+
+if (!(new Foo() instanceof Foo)) {
+	assert.fail('instanceof not resolved correctly');
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This is an approach to evaluate "instanceof" as "false" if the right hand side is not included, see here: https://rollupjs.org/repl/?pr=4524&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmNsYXNzJTIwVW51c2VkJTIwJTdCJTdEJTVDbmNsYXNzJTIwVXNlZCUyMCU3QiU3RCU1Q24lNUNuaWYlMjAobmV3JTIwVXNlZCgpJTIwaW5zdGFuY2VvZiUyMFVudXNlZCklMjBjb25zb2xlLmxvZygncmVtb3ZlZCcpJTNCJTVDbmVsc2UlMjBjb25zb2xlLmxvZygncmV0YWluZWQnKSUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmZvcm1hdCUyMiUzQSUyMmVzJTIyJTJDJTIybmFtZSUyMiUzQSUyMm15QnVuZGxlJTIyJTJDJTIyYW1kJTIyJTNBJTdCJTIyaWQlMjIlM0ElMjIlMjIlN0QlMkMlMjJnbG9iYWxzJTIyJTNBJTdCJTdEJTdEJTJDJTIyZXhhbXBsZSUyMiUzQW51bGwlN0Q=