### PR TITLE
Add support for absolute plugin paths

### DIFF
--- a/cli/run/commandPlugins.ts
+++ b/cli/run/commandPlugins.ts
@@ -48,7 +48,7 @@ async function loadAndRegisterPlugin(
 		// -p "{transform(c,i){...}}"
 		plugin = new Function('return ' + pluginText);
 	} else {
-		const match = pluginText.match(/^([@./\\\w|^{}-]+)(=(.*))?$/);
+		const match = pluginText.match(/^([@.:/\\\w|^{}-]+)(=(.*))?$/);
 		if (match) {
 			// -p plugin
 			// -p plugin=arg
@@ -72,6 +72,8 @@ async function loadAndRegisterPlugin(
 		if (!plugin) {
 			try {
 				if (pluginText[0] == '.') pluginText = resolve(pluginText);
+				// Windows absolute paths must be specified as file:// protocol URL
+				else if (pluginText.match(/^[A-Za-z]:\\/)) pluginText = "file://" + require$$0.resolve(pluginText);
 				plugin = await requireOrImport(pluginText);
 			} catch (err: any) {
 				throw new Error(`Cannot load plugin "${pluginText}": ${err.message}.`);

--- a/cli/run/commandPlugins.ts
+++ b/cli/run/commandPlugins.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'path';
+import { pathToFileURL } from 'url';
 import type { InputOptions } from '../../src/rollup/types';
 import { stdinPlugin } from './stdin';
 import { waitForInputPlugin } from './waitForInput';
@@ -73,7 +74,10 @@ async function loadAndRegisterPlugin(
 			try {
 				if (pluginText[0] == '.') pluginText = resolve(pluginText);
 				// Windows absolute paths must be specified as file:// protocol URL
-				else if (pluginText.match(/^[A-Za-z]:\\/)) pluginText = "file://" + require$$0.resolve(pluginText);
+				// Note that we do not have coverage for Windows-only code paths
+				else if (pluginText.match(/^[A-Za-z]:\\/)) {
+					pluginText = pathToFileURL(resolve(pluginText)).href;
+				}
 				plugin = await requireOrImport(pluginText);
 			} catch (err: any) {
 				throw new Error(`Cannot load plugin "${pluginText}": ${err.message}.`);

--- a/test/cli/samples/plugin/absolute-esm/_config.js
+++ b/test/cli/samples/plugin/absolute-esm/_config.js
@@ -1,6 +1,7 @@
+const { sep } = require('path');
+
 module.exports = {
 	description: 'ESM CLI --plugin /absolute/path',
 	minNodeVersion: 12,
-	skipIfWindows: true,
-	command: `echo 'console.log(1 ? 2 : 3);' | rollup -p "\`pwd\`/my-esm-plugin.mjs={comment: 'Absolute ESM'}"`
+	command: `rollup main.js -p "${__dirname}${sep}my-esm-plugin.mjs={comment: 'Absolute ESM'}"`
 };

--- a/test/cli/samples/plugin/absolute-esm/main.js
+++ b/test/cli/samples/plugin/absolute-esm/main.js
@@ -1,0 +1,1 @@
+console.log(1 ? 2 : 3);

--- a/test/cli/samples/plugin/absolute/_config.js
+++ b/test/cli/samples/plugin/absolute/_config.js
@@ -1,5 +1,7 @@
+const { sep } = require('path');
+
 module.exports = {
 	description: 'CLI --plugin /absolute/path',
-	skipIfWindows: true,
-	command: `echo 'console.log(VALUE);' | rollup -p "\`pwd\`/my-plugin={VALUE: 'absolute', ZZZ: 1}"`
+	minNodeVersion: 12,
+	command: `rollup main.js -p "${__dirname}${sep}my-plugin.js={VALUE: 'absolute', ZZZ: 1}"`
 };

--- a/test/cli/samples/plugin/absolute/main.js
+++ b/test/cli/samples/plugin/absolute/main.js
@@ -1,0 +1,1 @@
+console.log(VALUE);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Plugins can only be specified as package names or relative paths on the command line. This doesn't meet my requirements. When using rollup packaged in my tool application, I need to specify the absolute installation path of a plugin. No other solution will work for me.

I have verified that this change satisfies this requirement in my local installed copy of the code. I don't have any environment for TypeScript or rollup development, so I can only provide the backport of my patched JavaScript source code. I'm unable to provide anything more than this. It's a trivial change though and should be easy to review.

If necessary, I can try to locate the relevant documentation in this repository and update it, too.