### PR TITLE
Adapt Node versions on CI to prepare for v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node: ['10', '14', '18']
+        node: ['14', '18']
     name: Node ${{ matrix.node }} (macOS)
     steps:
       - name: Checkout Commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,9 @@ permissions:
   contents: read
 
 jobs:
-  linux16:
+  linux18:
     runs-on: ubuntu-latest
-    name: Node 16 + Coverage (Linux)
+    name: Node 18 + Coverage (Linux)
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Run tests with coverage
@@ -33,16 +33,16 @@ jobs:
         with:
           commit_parent: ${{ github.event.pull_request.head.sha }}
 
-  linux14:
+  linux16:
     runs-on: ubuntu-latest
-    name: Node 14 + Extra Tests (Linux)
+    name: Node 16 + Extra Tests (Linux)
     steps:
       - name: Checkout Commit
         uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Lint
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['10', '12', '18']
+        node: ['10', '12', '14']
     name: Node ${{ matrix.node }} (Linux)
     steps:
       - name: Checkout Commit
@@ -78,7 +78,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node: ['12', '16']
+        node: ['10', '14', '18']
     name: Node ${{ matrix.node }} (macOS)
     steps:
       - name: Checkout Commit
@@ -98,7 +98,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        node: ['10', '16']
+        node: ['10', '14', '18']
     name: Node ${{ matrix.node }} (Windows)
     steps:
       - name: Checkout Commit

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  require_ci_to_pass: no
+  notify:
+    wait_for_ci: no


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
To make the deprecation of Node 10 and Node 12 easier, this changes the Node CI versions so that each platform includes Node 14 and Node 18