### PR TITLE
[v3.0] Restructure perf timings

### DIFF
--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -45,23 +45,25 @@ export default class Bundle {
 		this.pluginDriver.setOutputBundle(outputBundle, this.outputOptions);
 
 		try {
+			timeStart('initialize render', 2);
+
 			await this.pluginDriver.hookParallel('renderStart', [this.outputOptions, this.inputOptions]);
 
+			timeEnd('initialize render', 2);
 			timeStart('generate chunks', 2);
+
 			const getHashPlaceholder = getHashPlaceholderGenerator();
 			const chunks = await this.generateChunks(outputBundle, getHashPlaceholder);
 			if (chunks.length > 1) {
 				validateOptionsForMultiChunkOutput(this.outputOptions, this.inputOptions.onwarn);
 			}
 			this.pluginDriver.setChunkInformation(this.facadeChunkByModule);
-
-			timeEnd('generate chunks', 2);
-
-			timeStart('render chunks', 2);
-
 			for (const chunk of chunks) {
 				chunk.generateExports();
 			}
+
+			timeEnd('generate chunks', 2);
+
 			await renderChunks(
 				chunks,
 				outputBundle,
@@ -69,12 +71,13 @@ export default class Bundle {
 				this.outputOptions,
 				this.inputOptions.onwarn
 			);
-
-			timeEnd('render chunks', 2);
 		} catch (err: any) {
 			await this.pluginDriver.hookParallel('renderError', [err]);
 			throw err;
 		}
+
+		timeStart('generate bundle', 2);
+
 		await this.pluginDriver.hookSeq('generateBundle', [
 			this.outputOptions,
 			outputBundle as OutputBundle,
@@ -82,6 +85,7 @@ export default class Bundle {
 		]);
 		this.finaliseAssets(outputBundle);
 
+		timeEnd('generate bundle', 2);
 		timeEnd('GENERATE', 1);
 		return outputBundle as OutputBundle;
 	}

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -55,7 +55,6 @@ import { basename, extname, isAbsolute } from './utils/path';
 import relativeId, { getAliasName, getImportPath } from './utils/relativeId';
 import type { RenderOptions } from './utils/renderHelpers';
 import { makeUnique, renderNamePattern } from './utils/renderNamePattern';
-import { timeEnd, timeStart } from './utils/timers';
 import { MISSING_EXPORT_SHIM_VARIABLE } from './utils/variableNames';
 
 export interface ModuleDeclarations {
@@ -600,7 +599,6 @@ export default class Chunk {
 		const { accessedGlobals, indent, magicString, renderedSource, usedModules, usesTopLevelAwait } =
 			this.renderModules(preliminaryFileName.fileName);
 
-		timeStart('render format', 2);
 		const renderedDependencies = [...this.getRenderedDependencies().values()];
 		const renderedExports = exportMode === 'none' ? [] : this.getChunkExportDeclarations(format);
 		const hasExports =
@@ -634,7 +632,6 @@ export default class Chunk {
 		);
 		if (banner) magicString.prepend(banner);
 		if (footer) magicString.append(footer);
-		timeEnd('render format', 2);
 
 		return {
 			chunk: this,

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -97,10 +97,10 @@ export default class Graph {
 		await this.generateModuleGraph();
 		timeEnd('generate module graph', 2);
 
-		timeStart('sort modules', 2);
+		timeStart('sort and bind modules', 2);
 		this.phase = BuildPhase.ANALYSE;
 		this.sortModules();
-		timeEnd('sort modules', 2);
+		timeEnd('sort and bind modules', 2);
 
 		timeStart('mark included statements', 2);
 		this.includeStatements();

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -712,6 +712,8 @@ export default class Module {
 		resolvedIds?: ResolvedIdMap;
 		transformFiles?: EmittedFile[] | undefined;
 	}): void {
+		timeStart('generate ast', 3);
+
 		this.info.code = code;
 		this.originalCode = originalCode;
 		this.originalSourcemap = originalSourcemap;
@@ -723,13 +725,12 @@ export default class Module {
 		this.customTransformCache = customTransformCache;
 		this.updateOptions(moduleOptions);
 
-		timeStart('generate ast', 3);
-
 		if (!ast) {
 			ast = this.tryParse();
 		}
 
 		timeEnd('generate ast', 3);
+		timeStart('analyze ast', 3);
 
 		this.resolvedIds = resolvedIds || Object.create(null);
 
@@ -741,8 +742,6 @@ export default class Module {
 			filename: (this.excludeFromSourcemap ? null : fileName)!, // don't include plugin helpers in sourcemap
 			indentExclusionRanges: []
 		});
-
-		timeStart('analyse ast', 3);
 
 		this.astContext = {
 			addDynamicImport: this.addDynamicImport.bind(this),
@@ -778,7 +777,7 @@ export default class Module {
 		this.ast = new Program(ast, { context: this.astContext, type: 'Module' }, this.scope);
 		this.info.ast = ast;
 
-		timeEnd('analyse ast', 3);
+		timeEnd('analyze ast', 3);
 	}
 
 	toJSON(): ModuleJSON {

--- a/src/ModuleLoader.ts
+++ b/src/ModuleLoader.ts
@@ -33,7 +33,6 @@ import { promises as fs } from './utils/fs';
 import { isAbsolute, isRelative, resolve } from './utils/path';
 import relativeId from './utils/relativeId';
 import { resolveId } from './utils/resolveId';
-import { timeEnd, timeStart } from './utils/timers';
 import transform from './utils/transform';
 
 export interface UnresolvedModule {
@@ -245,7 +244,6 @@ export class ModuleLoader {
 		importer: string | undefined,
 		module: Module
 	): Promise<void> {
-		timeStart('load modules', 3);
 		let source: LoadResult;
 		try {
 			source = await this.graph.fileOperationQueue.run(
@@ -253,14 +251,12 @@ export class ModuleLoader {
 					(await this.pluginDriver.hookFirst('load', [id])) ?? (await fs.readFile(id, 'utf8'))
 			);
 		} catch (err: any) {
-			timeEnd('load modules', 3);
 			let msg = `Could not load ${id}`;
 			if (importer) msg += ` (imported by ${relativeId(importer)})`;
 			msg += `: ${err.message}`;
 			err.message = msg;
 			throw err;
 		}
-		timeEnd('load modules', 3);
 		const sourceDescription =
 			typeof source === 'string'
 				? { code: source }

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -51,7 +51,9 @@ export async function rollupInternal(
 
 	await catchUnfinishedHookActions(graph.pluginDriver, async () => {
 		try {
+			timeStart('initialize', 2);
 			await graph.pluginDriver.hookParallel('buildStart', [inputOptions]);
+			timeEnd('initialize', 2);
 			await graph.build();
 		} catch (err: any) {
 			const watchFiles = Object.keys(graph.watchFiles);
@@ -167,6 +169,7 @@ function handleGenerateWrite(
 		const bundle = new Bundle(outputOptions, unsetOptions, inputOptions, outputPluginDriver, graph);
 		const generated = await bundle.generate(isWrite);
 		if (isWrite) {
+			timeStart('WRITE', 1);
 			if (!outputOptions.dir && !outputOptions.file) {
 				return error({
 					code: 'MISSING_OPTION',
@@ -179,6 +182,7 @@ function handleGenerateWrite(
 				)
 			);
 			await outputPluginDriver.hookParallel('writeBundle', [outputOptions, generated]);
+			timeEnd('WRITE', 1);
 		}
 		return createOutput(generated);
 	});

--- a/src/utils/renderChunks.ts
+++ b/src/utils/renderChunks.ts
@@ -41,8 +41,14 @@ export async function renderChunks(
 	outputOptions: NormalizedOutputOptions,
 	onwarn: WarningHandler
 ) {
+	timeStart('render chunks', 2);
+
 	reserveEntryChunksInBundle(chunks);
 	const renderedChunks = await Promise.all(chunks.map(chunk => chunk.render()));
+
+	timeEnd('render chunks', 2);
+	timeStart('transform chunks', 2);
+
 	const chunkGraph = getChunkGraph(chunks);
 	const {
 		nonHashedChunksWithPlaceholders,
@@ -66,6 +72,8 @@ export async function renderChunks(
 		outputBundle,
 		nonHashedChunksWithPlaceholders
 	);
+
+	timeEnd('transform chunks', 2);
 }
 
 function reserveEntryChunksInBundle(chunks: Chunk[]) {
@@ -122,7 +130,7 @@ async function transformChunk(
 	if (!compact && code[code.length - 1] !== '\n') code += '\n';
 
 	if (sourcemap) {
-		timeStart('sourcemap', 2);
+		timeStart('sourcemaps', 3);
 
 		let file: string;
 		if (options.file) file = resolve(options.sourcemapFile || options.file);
@@ -154,7 +162,7 @@ async function transformChunk(
 			})
 			.map(normalize);
 
-		timeEnd('sourcemap', 2);
+		timeEnd('sourcemaps', 3);
 	}
 	return {
 		code,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This restructures some aspects of the timings displayed when running `rollup --perf`.

* The measuring points now better reflect the new algorithm
* async plugin hook time is no longer measured as those numbers were always completely misleading anyway
* ALL plugin hooks are measured, not just a small selection