### PR TITLE
[v3.0] Better esm config file support

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -240,6 +240,35 @@ Repository: jonschlinkert/fill-range
 
 ---------------------------------------
 
+## get-package-type
+License: MIT
+By: Corey Farrell
+Repository: git+https://github.com/cfware/get-package-type.git
+
+> MIT License
+> 
+> Copyright (c) 2020 CFWare, LLC
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+---------------------------------------
+
 ## glob-parent
 License: ISC
 By: Gulp Team, Elan Shanker, Blaine Bublitz

--- a/cli/run/loadConfigFile.ts
+++ b/cli/run/loadConfigFile.ts
@@ -13,7 +13,11 @@ import batchWarnings, { type BatchWarnings } from './batchWarnings';
 import { addCommandPluginsToInputOptions, addPluginsFromCommandOption } from './commandPlugins';
 
 function supportsNativeESM(): boolean {
-	return Number(/^v(\d+)/.exec(version)![1]) >= 13;
+	const versionMatch = version.match(/^v(\d+)\.(\d+)\.\d+$/);
+	const major = parseInt(versionMatch[1], 10);
+	const minor = parseInt(versionMatch[2], 10);
+
+	return major >= 14 || (major === 13 && minor >= 2) || (major === 12 && minor >= 17);
 }
 
 interface NodeModuleWithCompile extends NodeModule {

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -15,13 +15,13 @@ Either a function that takes an `id` and returns `true` (external) or `false` (n
 
 ```js
 // rollup.config.js
-import path from 'path';
+import { fileURLToPath } from 'url'
 
 export default {
   ...,
   external: [
     'some-externally-required-library',
-    path.resolve( __dirname, 'src/some-local-file-that-should-not-be-bundled.js' ),
+    fileURLToPath(new URL('src/some-local-file-that-should-not-be-bundled.js', import.meta.url)),
     /node_modules/
   ]
 };
@@ -183,8 +183,8 @@ To tell Rollup that a local file should be replaced by a global variable, use an
 
 ```js
 // rollup.config.js
-import path from 'path';
-const externalId = path.resolve( __dirname, 'src/some-local-file-that-should-not-be-bundled.js' );
+import { fileURLToPath } from 'url'
+const externalId = fileURLToPath(new URL('src/some-local-file-that-should-not-be-bundled.js', import.meta.url))
 
 export default {
   ...,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "execa": "^6.1.0",
         "fixturify": "^2.1.1",
         "fs-extra": "^10.1.0",
+        "get-package-type": "^0.1.0",
         "hash.js": "^1.1.7",
         "husky": "^8.0.1",
         "is-reference": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "execa": "^6.1.0",
     "fixturify": "^2.1.1",
     "fs-extra": "^10.1.0",
+    "get-package-type": "^0.1.0",
     "hash.js": "^1.1.7",
     "husky": "^8.0.1",
     "is-reference": "^3.0.0",

--- a/scripts/perf-init.js
+++ b/scripts/perf-init.js
@@ -1,12 +1,11 @@
 /* eslint-disable no-console */
 
-import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execa } from 'execa';
 import fs from 'fs-extra';
 import { findConfigFileName } from './find-config.js';
 
-const TARGET_DIR = path.resolve(dirname(fileURLToPath(import.meta.url)), '..', 'perf');
+const TARGET_DIR = fileURLToPath(new URL('../perf', import.meta.url).href);
 const VALID_REPO = /^([^/\s#]+\/[^/\s#]+)(#([^/\s#]+))?$/;
 const repoWithBranch = process.argv[2];
 

--- a/scripts/perf.js
+++ b/scripts/perf.js
@@ -2,7 +2,6 @@
 /* global gc */
 
 import { readFileSync, writeFileSync } from 'fs';
-import path, { dirname } from 'path';
 import { cwd } from 'process';
 import { fileURLToPath } from 'url';
 import { createColors } from 'colorette';
@@ -12,8 +11,8 @@ import { rollup } from '../dist/rollup.js';
 import { findConfigFileName } from './find-config.js';
 
 const initialDir = cwd();
-const targetDir = path.resolve(dirname(fileURLToPath(import.meta.url)), '..', 'perf');
-const perfFile = path.resolve(targetDir, 'rollup.perf.json');
+const targetDir = fileURLToPath(new URL('../perf', import.meta.url).href);
+const perfFile = fileURLToPath(new URL('../perf/rollup.perf.json', import.meta.url).href);
 const { bold, underline, cyan, red, green } = createColors();
 const MIN_ABSOLUTE_TIME_DEVIATION = 10;
 const RELATIVE_DEVIATION_FOR_COLORING = 5;

--- a/test/cli/samples/config-no-module/_config.js
+++ b/test/cli/samples/config-no-module/_config.js
@@ -3,7 +3,7 @@ const { assertIncludes } = require('../../../utils.js');
 module.exports = {
 	description: 'provides a helpful error message if a transpiled config is interpreted as "module"',
 	minNodeVersion: 13,
-	command: 'cd sub && rollup -c',
+	command: 'rollup -c',
 	error: () => true,
 	stderr: stderr =>
 		assertIncludes(

--- a/test/cli/samples/config-no-module/rollup.config.js
+++ b/test/cli/samples/config-no-module/rollup.config.js
@@ -1,7 +1,7 @@
 import { shebang } from 'rollup-plugin-thatworks';
 
 export default {
-  input: './sub/main.js',
+	input: './sub/main.js',
 	output: { format: 'cjs' },
 	plugins: [shebang()]
 };

--- a/test/cli/samples/config-no-module/rollup.config.js
+++ b/test/cli/samples/config-no-module/rollup.config.js
@@ -1,7 +1,7 @@
 import { shebang } from 'rollup-plugin-thatworks';
 
 export default {
-	input: 'main.js',
+  input: './sub/main.js',
 	output: { format: 'cjs' },
 	plugins: [shebang()]
 };

--- a/test/cli/samples/config-type-module/_config.js
+++ b/test/cli/samples/config-type-module/_config.js
@@ -1,0 +1,16 @@
+const { assertIncludes } = require('../../../utils.js');
+
+module.exports = {
+	description: 'tries to load .js config file if package type is "module"',
+	minNodeVersion: 13,
+	command: 'cd sub && rollup -c rollup.config.js',
+	error: () => true,
+	stderr: stderr =>
+		assertIncludes(
+			stderr,
+			'[!] ReferenceError: module is not defined in ES module scope\n' +
+				"This file is being treated as an ES module because it has a '.js' file extension and " +
+				'\'/home/lohfu/dev/rollup/test/cli/samples/config-type-module/sub/package.json\' contains "type": "module". ' +
+				"To treat it as a CommonJS script, rename it to use the '.cjs' file extension."
+		)
+};

--- a/test/cli/samples/config-type-module/_config.js
+++ b/test/cli/samples/config-type-module/_config.js
@@ -2,15 +2,17 @@ const { assertIncludes } = require('../../../utils.js');
 
 module.exports = {
 	description: 'tries to load .js config file if package type is "module"',
-	minNodeVersion: 13,
 	command: 'cd sub && rollup -c rollup.config.js',
 	error: () => true,
-	stderr: stderr =>
+	stderr: stderr => {
 		assertIncludes(
 			stderr,
 			'[!] ReferenceError: module is not defined in ES module scope\n' +
-				"This file is being treated as an ES module because it has a '.js' file extension and " +
-				'\'/home/lohfu/dev/rollup/test/cli/samples/config-type-module/sub/package.json\' contains "type": "module". ' +
-				"To treat it as a CommonJS script, rename it to use the '.cjs' file extension."
-		)
+				"This file is being treated as an ES module because it has a '.js' file extension and"
+		);
+		assertIncludes(
+			stderr,
+			'contains "type": "module". To treat it as a CommonJS script, rename it to use the \'.cjs\' file extension.'
+		);
+	}
 };

--- a/test/cli/samples/config-type-module/sub/main.js
+++ b/test/cli/samples/config-type-module/sub/main.js
@@ -1,0 +1,1 @@
+console.log(42);

--- a/test/cli/samples/config-type-module/sub/package.json
+++ b/test/cli/samples/config-type-module/sub/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "module"
+}

--- a/test/cli/samples/config-type-module/sub/rollup.config.js
+++ b/test/cli/samples/config-type-module/sub/rollup.config.js
@@ -2,5 +2,5 @@ module.exports = {
 	input: 'main.js',
 	output: {
 		format: 'cjs'
-	},
+	}
 };

--- a/test/cli/samples/config-type-module/sub/rollup.config.js
+++ b/test/cli/samples/config-type-module/sub/rollup.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+};

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -99,3 +99,11 @@ declare module 'is-reference' {
 				value: Node;
 		  };
 }
+
+declare module 'get-package-type' {
+	interface GetPackageType {
+		sync(fileName: string): 'module' | 'commonjs';
+	}
+	const getPackageType: GetPackageType;
+	export default getPackageType;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:
- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?
- [x] yes (*bugfixes and features will not be merged without tests*)
- [ ] no

Breaking Changes?
- [x] yes (*breaking changes will not be merged unless absolutely necessary*)
- [ ] no

List any relevant issue numbers:

- #4055 
- closes #4123 

### Description

This PR supersedes #4123 as unfortunately the original author removed their branch before the PR was merged.

It changes the logic in the following way:
* I reduced the cases to "transpile or use import()" where the logic is
  * We transpile (to CommonJS) if config plugins are used (because then we MUST transpile) or if the extension is .js and the type is not explicitly "module". The reason we transpile the latter is because there is a huge number of "legacy" code bases that use an ES module for Rollup's config file without setting "type": "module", and I would want to avoid the churn. We could consider warning in that case, though, but I am undecided. Thoughts?
  * Otherwise we use import (even for the .cjs case for simplicity), checking is there is an __esModule flag on the default export (I feel that check should not cause too many issues for ESM files)