### PR TITLE
[v3.0] Fully deprecate maxParallelFileReads

### DIFF
--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -185,7 +185,7 @@ const getmaxParallelFileOps = (
 	if (typeof maxParallelFileReads === 'number') {
 		warnDeprecationWithOptions(
 			'The "maxParallelFileReads" option is deprecated. Use the "maxParallelFileOps" option instead.',
-			false,
+			true,
 			warn,
 			strictDeprecations
 		);

--- a/test/function/samples/deprecated/max-parallel-file-reads/infinity/_config.js
+++ b/test/function/samples/deprecated/max-parallel-file-reads/infinity/_config.js
@@ -25,5 +25,12 @@ module.exports = {
 	after() {
 		fs.readFile = fsReadFile;
 		assert.strictEqual(maxReads, 5, 'Wrong number of parallel file reads: ' + maxReads);
-	}
+	},
+	warnings: [
+		{
+			code: 'DEPRECATED_FEATURE',
+			message:
+				'The "maxParallelFileReads" option is deprecated. Use the "maxParallelFileOps" option instead.'
+		}
+	]
 };

--- a/test/function/samples/deprecated/max-parallel-file-reads/set/_config.js
+++ b/test/function/samples/deprecated/max-parallel-file-reads/set/_config.js
@@ -25,5 +25,12 @@ module.exports = {
 	after() {
 		fs.readFile = fsReadFile;
 		assert.strictEqual(maxReads, 3, 'Wrong number of parallel file reads: ' + maxReads);
-	}
+	},
+	warnings: [
+		{
+			code: 'DEPRECATED_FEATURE',
+			message:
+				'The "maxParallelFileReads" option is deprecated. Use the "maxParallelFileOps" option instead.'
+		}
+	]
 };

--- a/test/function/samples/deprecated/max-parallel-file-reads/with-plugin/_config.js
+++ b/test/function/samples/deprecated/max-parallel-file-reads/with-plugin/_config.js
@@ -32,5 +32,12 @@ module.exports = {
 	after() {
 		fs.readFile = fsReadFile;
 		assert.strictEqual(maxReads, 3, 'Wrong number of parallel file reads: ' + maxReads);
-	}
+	},
+	warnings: [
+		{
+			code: 'DEPRECATED_FEATURE',
+			message:
+				'The "maxParallelFileReads" option is deprecated. Use the "maxParallelFileOps" option instead.'
+		}
+	]
 };

--- a/test/misc/sanity-checks.js
+++ b/test/misc/sanity-checks.js
@@ -197,10 +197,13 @@ describe('sanity checks', () => {
 	it('does not throw when using dynamic imports with the "file" option and "inlineDynamicImports"', async () => {
 		const bundle = await rollup.rollup({
 			input: 'x',
-			inlineDynamicImports: true,
 			plugins: [loader({ x: 'console.log( "x" );import("y");', y: 'console.log( "y" );' })]
 		});
-		await bundle.generate({ file: 'x', format: 'es' });
+		await bundle.generate({
+			file: 'x',
+			format: 'es',
+			inlineDynamicImports: true
+		});
 	});
 
 	it('throws when using the object form of "input" together with the "file" option', async () => {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Actually show a deprecation warning when `maxParallelFileReads` is used (that prompts the user to use `maxParallelFileOps`).