### PR TITLE
[v3.0] Refine errors and warnings

### DIFF
--- a/browser/error.ts
+++ b/browser/error.ts
@@ -1,9 +1,4 @@
-import { error } from '../src/utils/error';
+import { errNoFileSystemInBrowser, error } from '../src/utils/error';
 
-export const throwNoFileSystem = (method: string) => (): never => {
-	error({
-		code: 'NO_FS_IN_BROWSER',
-		message: `Cannot access the file system (via "${method}") when using the browser build of Rollup. Make sure you supply a plugin with custom resolveId and load hooks to Rollup.`,
-		url: 'https://rollupjs.org/guide/en/#a-simple-example'
-	});
-};
+export const throwNoFileSystem = (method: string) => (): never =>
+	error(errNoFileSystemInBrowser(method));

--- a/cli/logging.ts
+++ b/cli/logging.ts
@@ -7,9 +7,10 @@ import relativeId from '../src/utils/relativeId';
 export const stderr = (...args: readonly unknown[]) => process.stderr.write(`${args.join('')}\n`);
 
 export function handleError(err: RollupError, recover = false): void {
-	let description = err.message || err;
-	if (err.name || err.cause?.name) description = `${err.cause?.name || err.name}: ${description}`;
-	const message = (err.plugin ? `(plugin ${err.plugin}) ${description}` : description) || err;
+	const name = err.name || err.cause?.name;
+	const nameSection = name ? `${name}: ` : '';
+	const pluginSection = err.plugin ? `(plugin ${err.plugin}) ` : '';
+	const message = `${pluginSection}${nameSection}${err.message}`;
 
 	stderr(bold(red(`[!] ${bold(message.toString())}`)));
 

--- a/cli/logging.ts
+++ b/cli/logging.ts
@@ -8,7 +8,7 @@ export const stderr = (...args: readonly unknown[]) => process.stderr.write(`${a
 
 export function handleError(err: RollupError, recover = false): void {
 	let description = err.message || err;
-	if (err.name) description = `${err.name}: ${description}`;
+	if (err.name || err.cause?.name) description = `${err.cause?.name || err.name}: ${description}`;
 	const message = (err.plugin ? `(plugin ${err.plugin}) ${description}` : description) || err;
 
 	stderr(bold(red(`[!] ${bold(message.toString())}`)));

--- a/cli/run/build.ts
+++ b/cli/run/build.ts
@@ -3,6 +3,7 @@ import ms from 'pretty-ms';
 import { rollup } from '../../src/node-entry';
 import type { MergedRollupOptions } from '../../src/rollup/types';
 import { bold, cyan, green } from '../../src/utils/colors';
+import { errOnlyInlineSourcemapsForStdout } from '../../src/utils/error';
 import relativeId from '../../src/utils/relativeId';
 import { SOURCEMAPPING_URL } from '../../src/utils/sourceMappingURL';
 import { handleError, stderr } from '../logging';
@@ -34,10 +35,7 @@ export default async function build(
 	if (useStdout) {
 		const output = outputOptions[0];
 		if (output.sourcemap && output.sourcemap !== 'inline') {
-			handleError({
-				code: 'ONLY_INLINE_SOURCEMAPS',
-				message: 'Only inline sourcemaps are supported when bundling to stdout.'
-			});
+			handleError(errOnlyInlineSourcemapsForStdout());
 		}
 
 		const { output: outputs } = await bundle.generate(output);

--- a/cli/run/getConfigPath.ts
+++ b/cli/run/getConfigPath.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import { resolve } from 'path';
 import { cwd } from 'process';
+import { errMissingExternalConfig } from '../../src/utils/error';
 import { handleError } from '../logging';
 
 const DEFAULT_CONFIG_BASE = 'rollup.config';
@@ -18,10 +19,7 @@ export async function getConfigPath(commandConfig: string | true): Promise<strin
 				return require.resolve(pkgName, { paths: [cwd()] });
 			} catch (err: any) {
 				if (err.code === 'MODULE_NOT_FOUND') {
-					handleError({
-						code: 'MISSING_EXTERNAL_CONFIG',
-						message: `Could not resolve config file "${commandConfig}"`
-					});
+					handleError(errMissingExternalConfig(commandConfig));
 				}
 				throw err;
 			}

--- a/cli/run/index.ts
+++ b/cli/run/index.ts
@@ -1,5 +1,6 @@
 import { env } from 'process';
 import type { MergedRollupOptions } from '../../src/rollup/types';
+import { errDuplicateImportOptions, errFailAfterWarnings } from '../../src/utils/error';
 import { isWatchEnabled } from '../../src/utils/options/mergeOptions';
 import { getAliasName } from '../../src/utils/relativeId';
 import { loadFsEvents } from '../../src/watch/fsevents-importer';
@@ -14,10 +15,7 @@ export default async function runRollup(command: Record<string, any>): Promise<v
 	let inputSource;
 	if (command._.length > 0) {
 		if (command.input) {
-			handleError({
-				code: 'DUPLICATE_IMPORT_OPTIONS',
-				message: 'Either use --input, or pass input path as argument'
-			});
+			handleError(errDuplicateImportOptions());
 		}
 		inputSource = command._;
 	} else if (typeof command.input === 'string') {
@@ -67,10 +65,7 @@ export default async function runRollup(command: Record<string, any>): Promise<v
 				}
 				if (command.failAfterWarnings && warnings.warningOccurred) {
 					warnings.flush();
-					handleError({
-						code: 'FAIL_AFTER_WARNINGS',
-						message: 'Warnings occurred and --failAfterWarnings flag present'
-					});
+					handleError(errFailAfterWarnings());
 				}
 			} catch (err: any) {
 				warnings.flush();

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -12,6 +12,8 @@ On a `bundle` object, you can call `bundle.generate` multiple times with differe
 
 Once you're finished with the `bundle` object, you should call `bundle.close()`, which will let plugins clean up their external processes or services via the [`closeBundle`](guide/en/#closebundle) hook.
 
+If an error occurs at either stage, it will return a Promise rejected with an Error, which you can identify via their `code` property. Besides `code` and `message`, many errors have additional properties you can use for custom reporting, see [`utils/error.ts`](https://github.com/rollup/rollup/blob/master/src/utils/error.ts) for a complete list of errors and warnings together with their codes and properties.
+
 ```javascript
 import { rollup } from 'rollup';
 

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -381,7 +381,7 @@ export default {
     if (warning.code === 'UNUSED_EXTERNAL_IMPORT') return;
 
     // throw on others
-    if (warning.code === 'NON_EXISTENT_EXPORT') throw new Error(warning.message);
+    if (warning.code === 'MISSING_EXPORT') throw new Error(warning.message);
 
     // Use default for everything else
     warn(warning);

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -370,7 +370,7 @@ Type: `(warning: RollupWarning, defaultHandler: (warning: string | RollupWarning
 
 A function that will intercept warning messages. If not supplied, warnings will be deduplicated and printed to the console. When using the [`--silent`](guide/en/#--silent) CLI option, this handler is the only way to get notified about warnings.
 
-The function receives two arguments: the warning object and the default handler. Warnings objects have, at a minimum, a `code` and a `message` property, allowing you to control how different kinds of warnings are handled. Other properties are added depending on the type of warning.
+The function receives two arguments: the warning object and the default handler. Warnings objects have, at a minimum, a `code` and a `message` property, allowing you to control how different kinds of warnings are handled. Other properties are added depending on the type of warning. See [`utils/error.ts`](https://github.com/rollup/rollup/blob/master/src/utils/error.ts) for a complete list of errors and warnings together with their codes and properties.
 
 ```js
 // rollup.config.js
@@ -381,7 +381,9 @@ export default {
     if (warning.code === 'UNUSED_EXTERNAL_IMPORT') return;
 
     // throw on others
-    if (warning.code === 'MISSING_EXPORT') throw new Error(warning.message);
+    // Using Object.assign over new Error(warning.message) will make the CLI
+    // print additional information such as warning location and help url.
+    if (warning.code === 'MISSING_EXPORT') throw Object.assign(new Error(), warning);
 
     // Use default for everything else
     warn(warning);

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -47,7 +47,7 @@ const onwarn: WarningHandlerWithDefault = warning => {
 		'Building Rollup produced warnings that need to be resolved. ' +
 			'Please keep in mind that the browser build may never have external dependencies!'
 	);
-	throw new Error(warning.message);
+	throw Object.assign(new Error(), warning);
 };
 
 const moduleAliases = {

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -51,7 +51,6 @@ export default class Bundle {
 
 			timeEnd('initialize render', 2);
 			timeStart('generate chunks', 2);
-
 			const getHashPlaceholder = getHashPlaceholderGenerator();
 			const chunks = await this.generateChunks(outputBundle, getHashPlaceholder);
 			if (chunks.length > 1) {

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -51,6 +51,7 @@ export default class Bundle {
 
 			timeEnd('initialize render', 2);
 			timeStart('generate chunks', 2);
+
 			const getHashPlaceholder = getHashPlaceholderGenerator();
 			const chunks = await this.generateChunks(outputBundle, getHashPlaceholder);
 			if (chunks.length > 1) {

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -32,6 +32,8 @@ import { createAddons } from './utils/addons';
 import { deconflictChunk, type DependenciesToBeDeconflicted } from './utils/deconflictChunk';
 import {
 	errCyclicCrossChunkReexport,
+	errEmptyChunk,
+	errMissingGlobalName,
 	error,
 	errUnexpectedNamedImport,
 	errUnexpectedNamespaceReexport
@@ -138,12 +140,7 @@ function getGlobalName(
 	}
 
 	if (hasExports) {
-		warn({
-			code: 'MISSING_GLOBAL_NAME',
-			guess: chunk.variableName,
-			message: `No name was provided for external module '${chunk.id}' in output.globals – guessing '${chunk.variableName}'`,
-			source: chunk.id
-		});
+		warn(errMissingGlobalName(chunk.id, chunk.variableName));
 		return chunk.variableName;
 	}
 }
@@ -1143,12 +1140,7 @@ export default class Chunk {
 		const renderedSource = compact ? magicString : magicString.trim();
 
 		if (isEmpty && this.getExportNames().length === 0 && dependencies.size === 0) {
-			const chunkName = this.getChunkName();
-			onwarn({
-				chunkName,
-				code: 'EMPTY_BUNDLE',
-				message: `Generated an empty chunk: "${chunkName}"`
-			});
+			onwarn(errEmptyChunk(this.getChunkName()));
 		}
 		return { accessedGlobals, indent, magicString, renderedSource, usedModules, usesTopLevelAwait };
 	}

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1361,4 +1361,28 @@ function getImportedBindingsPerDependency(
 	return importedBindingsPerDependency;
 }
 
+function getImportedBindingsPerDependency(
+	renderedDependencies: RenderedDependencies,
+	resolveFileName: (dependency: Chunk | ExternalChunk) => string
+): {
+	[imported: string]: string[];
+} {
+	const importedBindingsPerDependency: { [imported: string]: string[] } = {};
+	for (const [dependency, declaration] of renderedDependencies) {
+		const specifiers = new Set<string>();
+		if (declaration.imports) {
+			for (const { imported } of declaration.imports) {
+				specifiers.add(imported);
+			}
+		}
+		if (declaration.reexports) {
+			for (const { imported } of declaration.reexports) {
+				specifiers.add(imported);
+			}
+		}
+		importedBindingsPerDependency[resolveFileName(dependency)] = [...specifiers];
+	}
+	return importedBindingsPerDependency;
+}
+
 const QUERY_HASH_REGEX = /[?#]/;

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1353,28 +1353,4 @@ function getImportedBindingsPerDependency(
 	return importedBindingsPerDependency;
 }
 
-function getImportedBindingsPerDependency(
-	renderedDependencies: RenderedDependencies,
-	resolveFileName: (dependency: Chunk | ExternalChunk) => string
-): {
-	[imported: string]: string[];
-} {
-	const importedBindingsPerDependency: { [imported: string]: string[] } = {};
-	for (const [dependency, declaration] of renderedDependencies) {
-		const specifiers = new Set<string>();
-		if (declaration.imports) {
-			for (const { imported } of declaration.imports) {
-				specifiers.add(imported);
-			}
-		}
-		if (declaration.reexports) {
-			for (const { imported } of declaration.reexports) {
-				specifiers.add(imported);
-			}
-		}
-		importedBindingsPerDependency[resolveFileName(dependency)] = [...specifiers];
-	}
-	return importedBindingsPerDependency;
-}
-
 const QUERY_HASH_REGEX = /[?#]/;

--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -1,10 +1,8 @@
 import ExternalVariable from './ast/variables/ExternalVariable';
 import type { CustomPluginOptions, ModuleInfo, NormalizedInputOptions } from './rollup/types';
 import { EMPTY_ARRAY } from './utils/blank';
-import { warnDeprecation } from './utils/error';
+import { errUnusedExternalImports, warnDeprecation } from './utils/error';
 import { makeLegal } from './utils/identifierHelpers';
-import { printQuotedStringList } from './utils/printStringList';
-import relativeId from './utils/relativeId';
 
 export default class ExternalModule {
 	readonly dynamicImporters: string[] = [];
@@ -105,16 +103,6 @@ export default class ExternalModule {
 			}
 		}
 		const importersArray = [...importersSet];
-		this.options.onwarn({
-			code: 'UNUSED_EXTERNAL_IMPORT',
-			message: `${printQuotedStringList(unused, ['is', 'are'])} imported from external module "${
-				this.id
-			}" but never used in ${printQuotedStringList(
-				importersArray.map(importer => relativeId(importer))
-			)}.`,
-			names: unused,
-			source: this.id,
-			sources: importersArray
-		});
+		this.options.onwarn(errUnusedExternalImports(this.id, unused, importersArray));
 	}
 }

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -1,6 +1,7 @@
 import type MagicString from 'magic-string';
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import { BLANK } from '../../utils/blank';
+import { errCannotCallNamespace, errEval } from '../../utils/error';
 import { renderCallArguments } from '../../utils/renderCallArguments';
 import { type NodeRenderOptions, type RenderOptions } from '../../utils/renderHelpers';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
@@ -33,24 +34,11 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 			const variable = this.scope.findVariable(this.callee.name);
 
 			if (variable.isNamespace) {
-				this.context.warn(
-					{
-						code: 'CANNOT_CALL_NAMESPACE',
-						message: `Cannot call a namespace ('${this.callee.name}')`
-					},
-					this.start
-				);
+				this.context.warn(errCannotCallNamespace(this.callee.name), this.start);
 			}
 
 			if (this.callee.name === 'eval') {
-				this.context.warn(
-					{
-						code: 'EVAL',
-						message: `Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification`,
-						url: 'https://rollupjs.org/guide/en/#avoiding-eval'
-					},
-					this.start
-				);
+				this.context.warn(errEval(this.context.module.id), this.start);
 			}
 		}
 		this.interaction = {

--- a/src/ast/nodes/ExpressionStatement.ts
+++ b/src/ast/nodes/ExpressionStatement.ts
@@ -1,4 +1,5 @@
 import type MagicString from 'magic-string';
+import { errModuleLevelDirective } from '../../utils/error';
 import type { RenderOptions } from '../../utils/renderHelpers';
 import type { InclusionContext } from '../ExecutionContext';
 import * as NodeType from './NodeType';
@@ -16,10 +17,7 @@ export default class ExpressionStatement extends StatementBase {
 		) {
 			this.context.warn(
 				// This is necessary, because either way (deleting or not) can lead to errors.
-				{
-					code: 'MODULE_LEVEL_DIRECTIVE',
-					message: `Module level directives cause errors when bundled, '${this.directive}' was ignored.`
-				},
+				errModuleLevelDirective(this.directive, this.context.module.id),
 				this.start
 			);
 		}

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -2,6 +2,7 @@ import isReference, { type NodeWithFieldDefinition } from 'is-reference';
 import type MagicString from 'magic-string';
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
 import { BLANK } from '../../utils/blank';
+import { errIllegalImportReassignment } from '../../utils/error';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
@@ -265,10 +266,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 
 	private disallowImportReassignment(): never {
 		return this.context.error(
-			{
-				code: 'ILLEGAL_REASSIGNMENT',
-				message: `Illegal reassignment to import '${this.name}'`
-			},
+			errIllegalImportReassignment(this.name, this.context.module.id),
 			this.start
 		);
 	}

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -1,4 +1,5 @@
 import type MagicString from 'magic-string';
+import { errCannotCallNamespace } from '../../utils/error';
 import { type RenderOptions } from '../../utils/renderHelpers';
 import type { HasEffectsContext } from '../ExecutionContext';
 import { InclusionContext } from '../ExecutionContext';
@@ -29,13 +30,7 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 			const variable = this.scope.findVariable(name);
 
 			if (variable.isNamespace) {
-				this.context.warn(
-					{
-						code: 'CANNOT_CALL_NAMESPACE',
-						message: `Cannot call a namespace ('${name}')`
-					},
-					this.start
-				);
+				this.context.warn(errCannotCallNamespace(name), this.start);
 			}
 		}
 	}

--- a/src/ast/nodes/ThisExpression.ts
+++ b/src/ast/nodes/ThisExpression.ts
@@ -1,4 +1,5 @@
 import type MagicString from 'magic-string';
+import { errThisIsUndefined } from '../../utils/error';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteraction, NodeInteractionWithThisArg } from '../NodeInteractions';
 import { INTERACTION_ACCESSED } from '../NodeInteractions';
@@ -56,14 +57,7 @@ export default class ThisExpression extends NodeBase {
 		this.alias =
 			this.scope.findLexicalBoundary() instanceof ModuleScope ? this.context.moduleContext : null;
 		if (this.alias === 'undefined') {
-			this.context.warn(
-				{
-					code: 'THIS_IS_UNDEFINED',
-					message: `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`,
-					url: `https://rollupjs.org/guide/en/#error-this-is-undefined`
-				},
-				this.start
-			);
+			this.context.warn(errThisIsUndefined(), this.start);
 		}
 	}
 

--- a/src/finalisers/iife.ts
+++ b/src/finalisers/iife.ts
@@ -1,6 +1,10 @@
 import type { Bundle as MagicStringBundle } from 'magic-string';
 import type { NormalizedOutputOptions } from '../rollup/types';
-import { error } from '../utils/error';
+import {
+	errIllegalIdentifierAsName,
+	errMissingNameOptionForIifeExport,
+	error
+} from '../utils/error';
 import { isLegal } from '../utils/identifierHelpers';
 import { getExportBlock, getNamespaceMarkers } from './shared/getExportBlock';
 import getInteropBlock from './shared/getInteropBlock';
@@ -42,10 +46,7 @@ export default function iife(
 	const useVariableAssignment = !extend && !isNamespaced;
 
 	if (name && useVariableAssignment && !isLegal(name)) {
-		return error({
-			code: 'ILLEGAL_IDENTIFIER_AS_NAME',
-			message: `Given name "${name}" is not a legal JS identifier. If you need this, you can try "output.extend: true".`
-		});
+		return error(errIllegalIdentifierAsName(name));
 	}
 
 	warnOnBuiltins(onwarn, dependencies);
@@ -55,10 +56,7 @@ export default function iife(
 	const args = external.map(m => m.name);
 
 	if (hasExports && !name) {
-		onwarn({
-			code: 'MISSING_NAME_OPTION_FOR_IIFE_EXPORT',
-			message: `If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.`
-		});
+		onwarn(errMissingNameOptionForIifeExport());
 	}
 
 	if (namedExportsMode && hasExports) {

--- a/src/finalisers/shared/warnOnBuiltins.ts
+++ b/src/finalisers/shared/warnOnBuiltins.ts
@@ -1,6 +1,6 @@
 import { ChunkDependency } from '../../Chunk';
 import type { RollupWarning } from '../../rollup/types';
-import { printQuotedStringList } from '../../utils/printStringList';
+import { errMissingNodeBuiltins } from '../../utils/error';
 
 const builtins = {
 	assert: true,
@@ -36,11 +36,5 @@ export default function warnOnBuiltins(
 
 	if (!externalBuiltins.length) return;
 
-	warn({
-		code: 'MISSING_NODE_BUILTINS',
-		message: `Creating a browser bundle that depends on Node.js built-in modules (${printQuotedStringList(
-			externalBuiltins
-		)}). You might need to include https://github.com/FredKSchott/rollup-plugin-polyfill-node`,
-		modules: externalBuiltins
-	});
+	warn(errMissingNodeBuiltins(externalBuiltins));
 }

--- a/src/finalisers/umd.ts
+++ b/src/finalisers/umd.ts
@@ -1,6 +1,6 @@
 import type { Bundle as MagicStringBundle } from 'magic-string';
 import type { NormalizedOutputOptions } from '../rollup/types';
-import { error } from '../utils/error';
+import { errMissingNameOptionForUmdExport, error } from '../utils/error';
 import type { GenerateCodeSnippets } from '../utils/generateCodeSnippets';
 import getCompleteAmdId from './shared/getCompleteAmdId';
 import { getExportBlock, getNamespaceMarkers } from './shared/getExportBlock';
@@ -68,11 +68,7 @@ export default function umd(
 	const globalVar = compact ? 'g' : 'global';
 
 	if (hasExports && !name) {
-		return error({
-			code: 'MISSING_NAME_OPTION_FOR_IIFE_EXPORT',
-			message:
-				'You must supply "output.name" for UMD bundles that have exports so that the exports are accessible in environments without a module loader.'
-		});
+		return error(errMissingNameOptionForUmdExport());
 	}
 
 	warnOnBuiltins(onwarn, dependencies);

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -3,7 +3,12 @@ import Bundle from '../Bundle';
 import Graph from '../Graph';
 import type { PluginDriver } from '../utils/PluginDriver';
 import { ensureArray } from '../utils/ensureArray';
-import { errAlreadyClosed, errCannotEmitFromOptionsHook, error } from '../utils/error';
+import {
+	errAlreadyClosed,
+	errCannotEmitFromOptionsHook,
+	errMissingFileOrDirOption,
+	error
+} from '../utils/error';
 import { promises as fs } from '../utils/fs';
 import { catchUnfinishedHookActions } from '../utils/hookActions';
 import { normalizeInputOptions } from '../utils/options/normalizeInputOptions';
@@ -171,10 +176,7 @@ function handleGenerateWrite(
 		if (isWrite) {
 			timeStart('WRITE', 1);
 			if (!outputOptions.dir && !outputOptions.file) {
-				return error({
-					code: 'MISSING_OPTION',
-					message: 'You must specify "output.file" or "output.dir" for the build.'
-				});
+				return error(errMissingFileOrDirOption());
 			}
 			await Promise.all(
 				Object.values(generated).map(chunk =>

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -1,41 +1,33 @@
 export const VERSION: string;
 
-export interface RollupError extends RollupLogProps {
-	parserError?: Error;
+export interface RollupError extends RollupLog {
+	name?: string;
 	stack?: string;
 	watchFiles?: string[];
 }
 
-export interface RollupWarning extends RollupLogProps {
-	chunkName?: string;
-	cycle?: string[];
-	exportName?: string;
-	exporter?: string;
-	guess?: string;
-	importer?: string;
-	missing?: string;
-	modules?: string[];
-	names?: string[];
-	reexporter?: string;
-	source?: string;
-	sources?: string[];
-}
+export type RollupWarning = RollupLog;
 
-export interface RollupLogProps {
+export interface RollupLog {
+	binding?: string;
+	cause?: Error;
 	code?: string;
+	exporter?: string;
 	frame?: string;
 	hook?: string;
 	id?: string;
+	ids?: string[];
 	loc?: {
 		column: number;
 		file?: string;
 		line: number;
 	};
 	message: string;
-	name?: string;
+	names?: string[];
 	plugin?: string;
 	pluginCode?: string;
 	pos?: number;
+	reexporter?: string;
 	url?: string;
 }
 

--- a/src/utils/PluginCache.ts
+++ b/src/utils/PluginCache.ts
@@ -1,5 +1,5 @@
 import type { PluginCache, SerializablePluginCache } from '../rollup/types';
-import { error } from './error';
+import { errAnonymousPluginCache, errDuplicatePluginName, error } from './error';
 import { ANONYMOUS_OUTPUT_PLUGIN_PREFIX, ANONYMOUS_PLUGIN_PREFIX } from './pluginUtils';
 
 export function createPluginCache(cache: SerializablePluginCache): PluginCache {
@@ -64,16 +64,9 @@ function uncacheablePluginError(pluginName: string): never {
 		pluginName.startsWith(ANONYMOUS_PLUGIN_PREFIX) ||
 		pluginName.startsWith(ANONYMOUS_OUTPUT_PLUGIN_PREFIX)
 	) {
-		return error({
-			code: 'ANONYMOUS_PLUGIN_CACHE',
-			message:
-				'A plugin is trying to use the Rollup cache but is not declaring a plugin name or cacheKey.'
-		});
+		return error(errAnonymousPluginCache());
 	}
-	return error({
-		code: 'DUPLICATE_PLUGIN_NAME',
-		message: `The plugin name ${pluginName} is being used twice in the same build. Plugin names must be distinct or provide a cacheKey (please post an issue to the plugin if you are a plugin user).`
-	});
+	return error(errDuplicatePluginName(pluginName));
 }
 
 export function getCacheForUncacheablePlugin(pluginName: string): PluginCache {

--- a/src/utils/PluginContext.ts
+++ b/src/utils/PluginContext.ts
@@ -11,12 +11,13 @@ import type { FileEmitter } from './FileEmitter';
 import { createPluginCache, getCacheForUncacheablePlugin, NO_CACHE } from './PluginCache';
 import { BLANK } from './blank';
 import { BuildPhase } from './buildPhase';
-import { errInvalidRollupPhaseForAddWatchFile, warnDeprecation } from './error';
 import {
-	ANONYMOUS_OUTPUT_PLUGIN_PREFIX,
-	ANONYMOUS_PLUGIN_PREFIX,
-	throwPluginError
-} from './pluginUtils';
+	errInvalidRollupPhaseForAddWatchFile,
+	error,
+	errPluginError,
+	warnDeprecation
+} from './error';
+import { ANONYMOUS_OUTPUT_PLUGIN_PREFIX, ANONYMOUS_PLUGIN_PREFIX } from './pluginUtils';
 
 export function getPluginContext(
 	plugin: Plugin,
@@ -61,7 +62,7 @@ export function getPluginContext(
 		cache: cacheInstance,
 		emitFile: fileEmitter.emitFile.bind(fileEmitter),
 		error(err): never {
-			return throwPluginError(err, plugin.name);
+			return error(errPluginError(err, plugin.name));
 		},
 		getFileName: fileEmitter.getFileName,
 		getModuleIds: () => graph.modulesById.keys(),

--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -6,7 +6,7 @@ import type {
 	SourceMapSegment,
 	WarningHandler
 } from '../rollup/types';
-import { error } from './error';
+import { error, errSourcemapBroken } from './error';
 import { basename, dirname, relative, resolve } from './path';
 
 class Source {
@@ -155,15 +155,7 @@ function getLinkMap(warn: WarningHandler) {
 			return new Link(map, [source]);
 		}
 
-		warn({
-			code: 'SOURCEMAP_BROKEN',
-			message:
-				`Sourcemap is likely to be incorrect: a plugin (${map.plugin}) was used to transform ` +
-				"files, but didn't generate a sourcemap for the transformation. Consult the plugin " +
-				'documentation for help',
-			plugin: map.plugin,
-			url: `https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect`
-		});
+		warn(errSourcemapBroken(map.plugin));
 
 		return new Link(
 			{

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -3,8 +3,7 @@ import type Module from '../Module';
 import type {
 	InternalModuleFormat,
 	NormalizedInputOptions,
-	RollupError,
-	RollupLogProps,
+	RollupLog,
 	RollupWarning,
 	WarningHandler
 } from '../rollup/types';
@@ -12,13 +11,16 @@ import getCodeFrame from './getCodeFrame';
 import { printQuotedStringList } from './printStringList';
 import relativeId from './relativeId';
 
-export function error(base: Error | RollupError): never {
-	if (!(base instanceof Error)) base = Object.assign(new Error(base.message), base);
+export function error(base: Error | RollupLog): never {
+	if (!(base instanceof Error)) {
+		base = Object.assign(new Error(base.message), base);
+		Object.defineProperty(base, 'name', { value: 'RollupError' });
+	}
 	throw base;
 }
 
 export function augmentCodeLocation(
-	props: RollupLogProps,
+	props: RollupLog,
 	pos: number | { column: number; line: number },
 	source: string,
 	id: string
@@ -38,23 +40,35 @@ export function augmentCodeLocation(
 	}
 }
 
-export const enum Errors {
-	ADDON_ERROR = 'ADDON_ERROR',
+// Error codes should be sorted alphabetically while errors should be sorted by
+// error code below
+const ADDON_ERROR = 'ADDON_ERROR',
 	ALREADY_CLOSED = 'ALREADY_CLOSED',
+	AMBIGUOUS_EXTERNAL_NAMESPACES = 'AMBIGUOUS_EXTERNAL_NAMESPACES',
+	ANONYMOUS_PLUGIN_CACHE = 'ANONYMOUS_PLUGIN_CACHE',
 	ASSET_NOT_FINALISED = 'ASSET_NOT_FINALISED',
 	ASSET_NOT_FOUND = 'ASSET_NOT_FOUND',
 	ASSET_SOURCE_ALREADY_SET = 'ASSET_SOURCE_ALREADY_SET',
 	ASSET_SOURCE_MISSING = 'ASSET_SOURCE_MISSING',
 	BAD_LOADER = 'BAD_LOADER',
+	CANNOT_CALL_NAMESPACE = 'CANNOT_CALL_NAMESPACE',
 	CANNOT_EMIT_FROM_OPTIONS_HOOK = 'CANNOT_EMIT_FROM_OPTIONS_HOOK',
 	CHUNK_NOT_GENERATED = 'CHUNK_NOT_GENERATED',
 	CHUNK_INVALID = 'CHUNK_INVALID',
+	CIRCULAR_DEPENDENCY = 'CIRCULAR_DEPENDENCY',
 	CIRCULAR_REEXPORT = 'CIRCULAR_REEXPORT',
 	CYCLIC_CROSS_CHUNK_REEXPORT = 'CYCLIC_CROSS_CHUNK_REEXPORT',
 	DEPRECATED_FEATURE = 'DEPRECATED_FEATURE',
+	DUPLICATE_IMPORT_OPTIONS = 'DUPLICATE_IMPORT_OPTIONS',
+	DUPLICATE_PLUGIN_NAME = 'DUPLICATE_PLUGIN_NAME',
+	EMPTY_BUNDLE = 'EMPTY_BUNDLE',
+	EVAL = 'EVAL',
 	EXTERNAL_SYNTHETIC_EXPORTS = 'EXTERNAL_SYNTHETIC_EXPORTS',
+	FAIL_AFTER_WARNINGS = 'FAIL_AFTER_WARNINGS',
 	FILE_NAME_CONFLICT = 'FILE_NAME_CONFLICT',
 	FILE_NOT_FOUND = 'FILE_NOT_FOUND',
+	ILLEGAL_IDENTIFIER_AS_NAME = 'ILLEGAL_IDENTIFIER_AS_NAME',
+	ILLEGAL_REASSIGNMENT = 'ILLEGAL_REASSIGNMENT',
 	INPUT_HOOK_IN_OUTPUT_PLUGIN = 'INPUT_HOOK_IN_OUTPUT_PLUGIN',
 	INVALID_CHUNK = 'INVALID_CHUNK',
 	INVALID_EXPORT_OPTION = 'INVALID_EXPORT_OPTION',
@@ -62,51 +76,134 @@ export const enum Errors {
 	INVALID_OPTION = 'INVALID_OPTION',
 	INVALID_PLUGIN_HOOK = 'INVALID_PLUGIN_HOOK',
 	INVALID_ROLLUP_PHASE = 'INVALID_ROLLUP_PHASE',
+	INVALID_SETASSETSOURCE = 'INVALID_SETASSETSOURCE',
 	INVALID_TLA_FORMAT = 'INVALID_TLA_FORMAT',
+	MISSING_CONFIG = 'MISSING_CONFIG',
 	MISSING_EXPORT = 'MISSING_EXPORT',
+	MISSING_EXTERNAL_CONFIG = 'MISSING_EXTERNAL_CONFIG',
+	MISSING_GLOBAL_NAME = 'MISSING_GLOBAL_NAME',
 	MISSING_IMPLICIT_DEPENDANT = 'MISSING_IMPLICIT_DEPENDANT',
+	MISSING_NAME_OPTION_FOR_IIFE_EXPORT = 'MISSING_NAME_OPTION_FOR_IIFE_EXPORT',
+	MISSING_NODE_BUILTINS = 'MISSING_NODE_BUILTINS',
+	MISSING_OPTION = 'MISSING_OPTION',
 	MIXED_EXPORTS = 'MIXED_EXPORTS',
+	MODULE_LEVEL_DIRECTIVE = 'MODULE_LEVEL_DIRECTIVE',
 	NAMESPACE_CONFLICT = 'NAMESPACE_CONFLICT',
-	AMBIGUOUS_EXTERNAL_NAMESPACES = 'AMBIGUOUS_EXTERNAL_NAMESPACES',
+	NO_FS_IN_BROWSER = 'NO_FS_IN_BROWSER',
 	NO_TRANSFORM_MAP_OR_AST_WITHOUT_CODE = 'NO_TRANSFORM_MAP_OR_AST_WITHOUT_CODE',
+	ONLY_INLINE_SOURCEMAPS = 'ONLY_INLINE_SOURCEMAPS',
+	PARSE_ERROR = 'PARSE_ERROR',
 	PLUGIN_ERROR = 'PLUGIN_ERROR',
 	PREFER_NAMED_EXPORTS = 'PREFER_NAMED_EXPORTS',
+	SHIMMED_EXPORT = 'SHIMMED_EXPORT',
+	SOURCEMAP_BROKEN = 'SOURCEMAP_BROKEN',
+	SOURCEMAP_ERROR = 'SOURCEMAP_ERROR',
 	SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT = 'SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT',
+	THIS_IS_UNDEFINED = 'THIS_IS_UNDEFINED',
+	TRANSPILED_ESM_CONFIG = 'TRANSPILED_ESM_CONFIG',
 	UNEXPECTED_NAMED_IMPORT = 'UNEXPECTED_NAMED_IMPORT',
+	UNKNOWN_OPTION = 'UNKNOWN_OPTION',
 	UNRESOLVED_ENTRY = 'UNRESOLVED_ENTRY',
 	UNRESOLVED_IMPORT = 'UNRESOLVED_IMPORT',
-	VALIDATION_ERROR = 'VALIDATION_ERROR'
-}
+	UNUSED_EXTERNAL_IMPORT = 'UNUSED_EXTERNAL_IMPORT',
+	VALIDATION_ERROR = 'VALIDATION_ERROR';
 
-export function errAddonNotGenerated(
-	message: string,
-	hook: string,
-	plugin: string
-): RollupLogProps {
+export function errAddonNotGenerated(message: string, hook: string, plugin: string): RollupLog {
 	return {
-		code: Errors.ADDON_ERROR,
-		message: `Could not retrieve ${hook}. Check configuration of plugin ${plugin}.
+		code: ADDON_ERROR,
+		message: `Could not retrieve "${hook}". Check configuration of plugin "${plugin}".
 \tError Message: ${message}`
 	};
 }
 
-export function errAssetNotFinalisedForFileName(name: string): RollupLogProps {
+export function errAlreadyClosed(): RollupLog {
 	return {
-		code: Errors.ASSET_NOT_FINALISED,
+		code: ALREADY_CLOSED,
+		message: 'Bundle is already closed, no more calls to "generate" or "write" are allowed.'
+	};
+}
+
+export function errAmbiguousExternalNamespaces(
+	binding: string,
+	reexportingModule: string,
+	usedModule: string,
+	sources: string[]
+): RollupLog {
+	return {
+		binding,
+		code: AMBIGUOUS_EXTERNAL_NAMESPACES,
+		ids: sources,
+		message: `Ambiguous external namespace resolution: "${relativeId(
+			reexportingModule
+		)}" re-exports "${binding}" from one of the external modules ${printQuotedStringList(
+			sources.map(module => relativeId(module))
+		)}, guessing "${relativeId(usedModule)}".`,
+		reexporter: reexportingModule
+	};
+}
+
+export function errAnonymousPluginCache(): RollupLog {
+	return {
+		code: ANONYMOUS_PLUGIN_CACHE,
+		message:
+			'A plugin is trying to use the Rollup cache but is not declaring a plugin name or cacheKey.'
+	};
+}
+
+export function errAssetNotFinalisedForFileName(name: string): RollupLog {
+	return {
+		code: ASSET_NOT_FINALISED,
 		message: `Plugin error - Unable to get file name for asset "${name}". Ensure that the source is set and that generate is called first. If you reference assets via import.meta.ROLLUP_FILE_URL_<referenceId>, you need to either have set their source after "renderStart" or need to provide an explicit "fileName" when emitting them.`
 	};
 }
 
-export function errCannotEmitFromOptionsHook(): RollupLogProps {
+export function errAssetReferenceIdNotFoundForSetSource(assetReferenceId: string): RollupLog {
 	return {
-		code: Errors.CANNOT_EMIT_FROM_OPTIONS_HOOK,
+		code: ASSET_NOT_FOUND,
+		message: `Plugin error - Unable to set the source for unknown asset "${assetReferenceId}".`
+	};
+}
+
+export function errAssetSourceAlreadySet(name: string): RollupLog {
+	return {
+		code: ASSET_SOURCE_ALREADY_SET,
+		message: `Unable to set the source for asset "${name}", source already set.`
+	};
+}
+
+export function errNoAssetSourceSet(assetName: string): RollupLog {
+	return {
+		code: ASSET_SOURCE_MISSING,
+		message: `Plugin error creating asset "${assetName}" - no asset source set.`
+	};
+}
+
+export function errBadLoader(id: string): RollupLog {
+	return {
+		code: BAD_LOADER,
+		message: `Error loading "${relativeId(
+			id
+		)}": plugin load hook should return a string, a { code, map } object, or nothing/null.`
+	};
+}
+
+export function errCannotCallNamespace(name: string): RollupLog {
+	return {
+		code: CANNOT_CALL_NAMESPACE,
+		message: `Cannot call a namespace ("${name}").`
+	};
+}
+
+export function errCannotEmitFromOptionsHook(): RollupLog {
+	return {
+		code: CANNOT_EMIT_FROM_OPTIONS_HOOK,
 		message: `Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.`
 	};
 }
 
-export function errChunkNotGeneratedForFileName(name: string): RollupLogProps {
+export function errChunkNotGeneratedForFileName(name: string): RollupLog {
 	return {
-		code: Errors.CHUNK_NOT_GENERATED,
+		code: CHUNK_NOT_GENERATED,
 		message: `Plugin error - Unable to get file name for emitted chunk "${name}". You can only get file names once chunks have been generated after the "renderStart" hook.`
 	};
 }
@@ -114,22 +211,30 @@ export function errChunkNotGeneratedForFileName(name: string): RollupLogProps {
 export function errChunkInvalid(
 	{ fileName, code }: { code: string; fileName: string },
 	exception: { loc: { column: number; line: number }; message: string }
-): RollupLogProps {
+): RollupLog {
 	const errorProps = {
-		code: Errors.CHUNK_INVALID,
+		code: CHUNK_INVALID,
 		message: `Chunk "${fileName}" is not valid JavaScript: ${exception.message}.`
 	};
 	augmentCodeLocation(errorProps, exception.loc, code, fileName);
 	return errorProps;
 }
 
-export function errCircularReexport(exportName: string, importedModule: string): RollupLogProps {
+export function errCircularDependency(cyclePath: string[]): RollupLog {
 	return {
-		code: Errors.CIRCULAR_REEXPORT,
-		id: importedModule,
-		message: `"${exportName}" cannot be exported from ${relativeId(
-			importedModule
-		)} as it is a reexport that references itself.`
+		code: CIRCULAR_DEPENDENCY,
+		ids: cyclePath,
+		message: `Circular dependency: ${cyclePath.map(relativeId).join(' -> ')}`
+	};
+}
+
+export function errCircularReexport(exportName: string, exporter: string): RollupLog {
+	return {
+		code: CIRCULAR_REEXPORT,
+		exporter,
+		message: `"${exportName}" cannot be exported from "${relativeId(
+			exporter
+		)}" as it is a reexport that references itself.`
 	};
 }
 
@@ -138,76 +243,111 @@ export function errCyclicCrossChunkReexport(
 	exporter: string,
 	reexporter: string,
 	importer: string
-): RollupWarning {
+): RollupLog {
 	return {
-		code: Errors.CYCLIC_CROSS_CHUNK_REEXPORT,
+		code: CYCLIC_CROSS_CHUNK_REEXPORT,
 		exporter,
-		importer,
-		message: `Export "${exportName}" of module ${relativeId(
+		id: importer,
+		message: `Export "${exportName}" of module "${relativeId(
 			exporter
-		)} was reexported through module ${relativeId(
+		)}" was reexported through module "${relativeId(
 			reexporter
-		)} while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.\nEither change the import in ${relativeId(
+		)}" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.\nEither change the import in "${relativeId(
 			importer
-		)} to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.`,
+		)}" to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.`,
 		reexporter
 	};
 }
 
-export function errAssetReferenceIdNotFoundForSetSource(assetReferenceId: string): RollupLogProps {
+export function errDeprecation(deprecation: string | RollupWarning): RollupLog {
 	return {
-		code: Errors.ASSET_NOT_FOUND,
-		message: `Plugin error - Unable to set the source for unknown asset "${assetReferenceId}".`
-	};
-}
-
-export function errAssetSourceAlreadySet(name: string): RollupLogProps {
-	return {
-		code: Errors.ASSET_SOURCE_ALREADY_SET,
-		message: `Unable to set the source for asset "${name}", source already set.`
-	};
-}
-
-export function errNoAssetSourceSet(assetName: string): RollupLogProps {
-	return {
-		code: Errors.ASSET_SOURCE_MISSING,
-		message: `Plugin error creating asset "${assetName}" - no asset source set.`
-	};
-}
-
-export function errBadLoader(id: string): RollupLogProps {
-	return {
-		code: Errors.BAD_LOADER,
-		message: `Error loading ${relativeId(
-			id
-		)}: plugin load hook should return a string, a { code, map } object, or nothing/null`
-	};
-}
-
-export function errDeprecation(deprecation: string | RollupWarning): RollupLogProps {
-	return {
-		code: Errors.DEPRECATED_FEATURE,
+		code: DEPRECATED_FEATURE,
 		...(typeof deprecation === 'string' ? { message: deprecation } : deprecation)
 	};
 }
 
-export function errFileReferenceIdNotFoundForFilename(assetReferenceId: string): RollupLogProps {
+export function errDuplicateImportOptions(): RollupLog {
 	return {
-		code: Errors.FILE_NOT_FOUND,
-		message: `Plugin error - Unable to get file name for unknown file "${assetReferenceId}".`
+		code: DUPLICATE_IMPORT_OPTIONS,
+		message: 'Either use --input, or pass input path as argument'
 	};
 }
 
-export function errFileNameConflict(fileName: string): RollupLogProps {
+export function errDuplicatePluginName(plugin: string): RollupLog {
 	return {
-		code: Errors.FILE_NAME_CONFLICT,
+		code: DUPLICATE_PLUGIN_NAME,
+		message: `The plugin name ${plugin} is being used twice in the same build. Plugin names must be distinct or provide a cacheKey (please post an issue to the plugin if you are a plugin user).`
+	};
+}
+
+export function errEmptyChunk(chunkName: string): RollupLog {
+	return {
+		code: EMPTY_BUNDLE,
+		message: `Generated an empty chunk: "${chunkName}".`,
+		names: [chunkName]
+	};
+}
+
+export function errEval(id: string): RollupLog {
+	return {
+		code: EVAL,
+		id,
+		message: `Use of eval in "${relativeId(
+			id
+		)}" is strongly discouraged as it poses security risks and may cause issues with minification.`,
+		url: 'https://rollupjs.org/guide/en/#avoiding-eval'
+	};
+}
+
+export function errExternalSyntheticExports(id: string, importer: string): RollupLog {
+	return {
+		code: EXTERNAL_SYNTHETIC_EXPORTS,
+		exporter: id,
+		message: `External "${id}" cannot have "syntheticNamedExports" enabled (imported by "${relativeId(
+			importer
+		)}").`
+	};
+}
+
+export function errFailAfterWarnings(): RollupLog {
+	return {
+		code: FAIL_AFTER_WARNINGS,
+		message: 'Warnings occurred and --failAfterWarnings flag present.'
+	};
+}
+
+export function errFileNameConflict(fileName: string): RollupLog {
+	return {
+		code: FILE_NAME_CONFLICT,
 		message: `The emitted file "${fileName}" overwrites a previously emitted file of the same name.`
 	};
 }
 
-export function errInputHookInOutputPlugin(pluginName: string, hookName: string): RollupLogProps {
+export function errFileReferenceIdNotFoundForFilename(assetReferenceId: string): RollupLog {
 	return {
-		code: Errors.INPUT_HOOK_IN_OUTPUT_PLUGIN,
+		code: FILE_NOT_FOUND,
+		message: `Plugin error - Unable to get file name for unknown file "${assetReferenceId}".`
+	};
+}
+
+export function errIllegalIdentifierAsName(name: string): RollupLog {
+	return {
+		code: ILLEGAL_IDENTIFIER_AS_NAME,
+		message: `Given name "${name}" is not a legal JS identifier. If you need this, you can try "output.extend: true".`,
+		url: 'https://rollupjs.org/guide/en/#outputextend'
+	};
+}
+
+export function errIllegalImportReassignment(name: string, importingId: string): RollupLog {
+	return {
+		code: ILLEGAL_REASSIGNMENT,
+		message: `Illegal reassignment of import "${name}" in "${relativeId(importingId)}".`
+	};
+}
+
+export function errInputHookInOutputPlugin(pluginName: string, hookName: string): RollupLog {
+	return {
+		code: INPUT_HOOK_IN_OUTPUT_PLUGIN,
 		message: `The "${hookName}" hook used by the output plugin ${pluginName} is a build time hook and will not be run for that plugin. Either this plugin cannot be used as an output plugin, or it should have an option to configure it as an output plugin.`
 	};
 }
@@ -216,19 +356,19 @@ export function errCannotAssignModuleToChunk(
 	moduleId: string,
 	assignToAlias: string,
 	currentAlias: string
-): RollupLogProps {
+): RollupLog {
 	return {
-		code: Errors.INVALID_CHUNK,
-		message: `Cannot assign ${relativeId(
+		code: INVALID_CHUNK,
+		message: `Cannot assign "${relativeId(
 			moduleId
-		)} to the "${assignToAlias}" chunk as it is already in the "${currentAlias}" chunk.`
+		)}" to the "${assignToAlias}" chunk as it is already in the "${currentAlias}" chunk.`
 	};
 }
 
-export function errInvalidExportOptionValue(optionValue: string): RollupLogProps {
+export function errInvalidExportOptionValue(optionValue: string): RollupLog {
 	return {
-		code: Errors.INVALID_EXPORT_OPTION,
-		message: `"output.exports" must be "default", "named", "none", "auto", or left unspecified (defaults to "auto"), received "${optionValue}"`,
+		code: INVALID_EXPORT_OPTION,
+		message: `"output.exports" must be "default", "named", "none", "auto", or left unspecified (defaults to "auto"), received "${optionValue}".`,
 		url: `https://rollupjs.org/guide/en/#outputexports`
 	};
 }
@@ -237,21 +377,22 @@ export function errIncompatibleExportOptionValue(
 	optionValue: string,
 	keys: readonly string[],
 	entryModule: string
-): RollupLogProps {
+): RollupLog {
 	return {
-		code: 'INVALID_EXPORT_OPTION',
+		code: INVALID_EXPORT_OPTION,
 		message: `"${optionValue}" was specified for "output.exports", but entry module "${relativeId(
 			entryModule
-		)}" has the following exports: ${keys.join(', ')}`
+		)}" has the following exports: ${printQuotedStringList(keys)}`,
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	};
 }
 
-export function errInternalIdCannotBeExternal(source: string, importer: string): RollupLogProps {
+export function errInternalIdCannotBeExternal(source: string, importer: string): RollupLog {
 	return {
-		code: Errors.INVALID_EXTERNAL_ID,
-		message: `'${source}' is imported as an external by ${relativeId(
+		code: INVALID_EXTERNAL_ID,
+		message: `"${source}" is imported as an external by "${relativeId(
 			importer
-		)}, but is already an existing non-external module id.`
+		)}", but is already an existing non-external module id.`
 	};
 }
 
@@ -260,9 +401,9 @@ export function errInvalidOption(
 	urlHash: string,
 	explanation: string,
 	value?: string | boolean | null
-): RollupLogProps {
+): RollupLog {
 	return {
-		code: Errors.INVALID_OPTION,
+		code: INVALID_OPTION,
 		message: `Invalid value ${
 			value !== undefined ? `${JSON.stringify(value)} ` : ''
 		}for option "${option}" - ${explanation}.`,
@@ -270,51 +411,95 @@ export function errInvalidOption(
 	};
 }
 
-export function errInvalidRollupPhaseForAddWatchFile(): RollupLogProps {
+export function errInvalidPluginHook(hook: string, plugin: string): RollupLog {
 	return {
-		code: Errors.INVALID_ROLLUP_PHASE,
-		message: `Cannot call addWatchFile after the build has finished.`
+		code: INVALID_PLUGIN_HOOK,
+		hook,
+		message: `Error running plugin hook "${hook}" for "${plugin}", expected a function hook.`,
+		plugin
 	};
 }
 
-export function errInvalidRollupPhaseForChunkEmission(): RollupLogProps {
+export function errInvalidRollupPhaseForAddWatchFile(): RollupLog {
 	return {
-		code: Errors.INVALID_ROLLUP_PHASE,
+		code: INVALID_ROLLUP_PHASE,
+		message: `Cannot call "addWatchFile" after the build has finished.`
+	};
+}
+
+export function errInvalidRollupPhaseForChunkEmission(): RollupLog {
+	return {
+		code: INVALID_ROLLUP_PHASE,
 		message: `Cannot emit chunks after module loading has finished.`
+	};
+}
+
+export function errInvalidSetAssetSourceCall(): RollupLog {
+	return {
+		code: INVALID_SETASSETSOURCE,
+		message: `setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.`
 	};
 }
 
 export function errInvalidFormatForTopLevelAwait(
 	id: string,
 	format: InternalModuleFormat
-): RollupLogProps {
+): RollupLog {
 	return {
-		code: Errors.INVALID_TLA_FORMAT,
+		code: INVALID_TLA_FORMAT,
 		id,
-		message: `Module format ${format} does not support top-level await. Use the "es" or "system" output formats rather.`
+		message: `Module format "${format}" does not support top-level await. Use the "es" or "system" output formats rather.`
+	};
+}
+
+export function errMissingConfig(): RollupLog {
+	return {
+		code: MISSING_CONFIG,
+		message: 'Config file must export an options object, or an array of options objects',
+		url: 'https://rollupjs.org/guide/en/#configuration-files'
 	};
 }
 
 export function errMissingExport(
-	exportName: string,
+	binding: string,
 	importingModule: string,
-	importedModule: string
-): RollupLogProps {
+	exporter: string
+): RollupLog {
 	return {
-		code: Errors.MISSING_EXPORT,
-		message: `'${exportName}' is not exported by ${relativeId(
-			importedModule
-		)}, imported by ${relativeId(importingModule)}`,
+		binding,
+		code: MISSING_EXPORT,
+		exporter,
+		id: importingModule,
+		message: `"${binding}" is not exported by "${relativeId(exporter)}", imported by "${relativeId(
+			importingModule
+		)}".`,
 		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
+	};
+}
+
+export function errMissingExternalConfig(file: string): RollupLog {
+	return {
+		code: MISSING_EXTERNAL_CONFIG,
+		message: `Could not resolve config file "${file}"`
+	};
+}
+
+export function errMissingGlobalName(externalId: string, guess: string): RollupLog {
+	return {
+		code: MISSING_GLOBAL_NAME,
+		id: externalId,
+		message: `No name was provided for external module "${externalId}" in "output.globals" – guessing "${guess}".`,
+		names: [guess],
+		url: 'https://rollupjs.org/guide/en/#outputglobals'
 	};
 }
 
 export function errImplicitDependantCannotBeExternal(
 	unresolvedId: string,
 	implicitlyLoadedBefore: string
-): RollupLogProps {
+): RollupLog {
 	return {
-		code: Errors.MISSING_IMPLICIT_DEPENDANT,
+		code: MISSING_IMPLICIT_DEPENDANT,
 		message: `Module "${relativeId(
 			unresolvedId
 		)}" that should be implicitly loaded before "${relativeId(
@@ -326,9 +511,9 @@ export function errImplicitDependantCannotBeExternal(
 export function errUnresolvedImplicitDependant(
 	unresolvedId: string,
 	implicitlyLoadedBefore: string
-): RollupLogProps {
+): RollupLog {
 	return {
-		code: Errors.MISSING_IMPLICIT_DEPENDANT,
+		code: MISSING_IMPLICIT_DEPENDANT,
 		message: `Module "${relativeId(
 			unresolvedId
 		)}" that should be implicitly loaded before "${relativeId(
@@ -337,12 +522,12 @@ export function errUnresolvedImplicitDependant(
 	};
 }
 
-export function errImplicitDependantIsNotIncluded(module: Module): RollupLogProps {
+export function errImplicitDependantIsNotIncluded(module: Module): RollupLog {
 	const implicitDependencies = Array.from(module.implicitlyLoadedBefore, dependency =>
 		relativeId(dependency.id)
 	).sort();
 	return {
-		code: Errors.MISSING_IMPLICIT_DEPENDANT,
+		code: MISSING_IMPLICIT_DEPENDANT,
 		message: `Module "${relativeId(
 			module.id
 		)}" that should be implicitly loaded before ${printQuotedStringList(
@@ -351,87 +536,202 @@ export function errImplicitDependantIsNotIncluded(module: Module): RollupLogProp
 	};
 }
 
-export function errMixedExport(facadeModuleId: string, name?: string): RollupLogProps {
+export function errMissingNameOptionForIifeExport(): RollupLog {
 	return {
-		code: Errors.MIXED_EXPORTS,
+		code: MISSING_NAME_OPTION_FOR_IIFE_EXPORT,
+		message: `If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.`,
+		url: 'https://rollupjs.org/guide/en/#outputname'
+	};
+}
+
+export function errMissingNameOptionForUmdExport(): RollupLog {
+	return {
+		code: MISSING_NAME_OPTION_FOR_IIFE_EXPORT,
+		message:
+			'You must supply "output.name" for UMD bundles that have exports so that the exports are accessible in environments without a module loader.',
+		url: 'https://rollupjs.org/guide/en/#outputname'
+	};
+}
+
+export function errMissingNodeBuiltins(externalBuiltins: string[]): RollupLog {
+	return {
+		code: MISSING_NODE_BUILTINS,
+		ids: externalBuiltins,
+		message: `Creating a browser bundle that depends on Node.js built-in modules (${printQuotedStringList(
+			externalBuiltins
+		)}). You might need to include https://github.com/FredKSchott/rollup-plugin-polyfill-node`
+	};
+}
+
+export function errMissingFileOrDirOption(): RollupLog {
+	return {
+		code: MISSING_OPTION,
+		message: 'You must specify "output.file" or "output.dir" for the build.',
+		url: 'https://rollupjs.org/guide/en/#outputdir'
+	};
+}
+
+export function errMixedExport(facadeModuleId: string, name?: string): RollupLog {
+	return {
+		code: MIXED_EXPORTS,
 		id: facadeModuleId,
 		message: `Entry module "${relativeId(
 			facadeModuleId
 		)}" is using named and default exports together. Consumers of your bundle will have to use \`${
 			name || 'chunk'
-		}["default"]\` to access the default export, which may not be what you want. Use \`output.exports: "named"\` to disable this warning`,
+		}.default\` to access the default export, which may not be what you want. Use \`output.exports: "named"\` to disable this warning.`,
 		url: `https://rollupjs.org/guide/en/#outputexports`
 	};
 }
 
+export function errModuleLevelDirective(directive: string, id: string): RollupLog {
+	return {
+		code: MODULE_LEVEL_DIRECTIVE,
+		id,
+		message: `Module level directives cause errors when bundled, "${directive}" in "${relativeId(
+			id
+		)}" was ignored.`
+	};
+}
+
 export function errNamespaceConflict(
-	name: string,
+	binding: string,
 	reexportingModuleId: string,
 	sources: string[]
-): RollupWarning {
+): RollupLog {
 	return {
-		code: Errors.NAMESPACE_CONFLICT,
+		binding,
+		code: NAMESPACE_CONFLICT,
+		ids: sources,
 		message: `Conflicting namespaces: "${relativeId(
 			reexportingModuleId
-		)}" re-exports "${name}" from one of the modules ${printQuotedStringList(
+		)}" re-exports "${binding}" from one of the modules ${printQuotedStringList(
 			sources.map(moduleId => relativeId(moduleId))
-		)} (will be ignored)`,
-		name,
-		reexporter: reexportingModuleId,
-		sources
+		)} (will be ignored).`,
+		reexporter: reexportingModuleId
 	};
 }
 
-export function errAmbiguousExternalNamespaces(
-	name: string,
-	reexportingModule: string,
-	usedModule: string,
-	sources: string[]
-): RollupWarning {
+export function errNoFileSystemInBrowser(method: string): RollupLog {
 	return {
-		code: Errors.AMBIGUOUS_EXTERNAL_NAMESPACES,
-		message: `Ambiguous external namespace resolution: "${relativeId(
-			reexportingModule
-		)}" re-exports "${name}" from one of the external modules ${printQuotedStringList(
-			sources.map(module => relativeId(module))
-		)}, guessing "${relativeId(usedModule)}".`,
-		name,
-		reexporter: reexportingModule,
-		sources
+		code: NO_FS_IN_BROWSER,
+		message: `Cannot access the file system (via "${method}") when using the browser build of Rollup. Make sure you supply a plugin with custom resolveId and load hooks to Rollup.`,
+		url: 'https://rollupjs.org/guide/en/#a-simple-example'
 	};
 }
 
-export function errNoTransformMapOrAstWithoutCode(pluginName: string): RollupLogProps {
+export function errNoTransformMapOrAstWithoutCode(pluginName: string): RollupLog {
 	return {
-		code: Errors.NO_TRANSFORM_MAP_OR_AST_WITHOUT_CODE,
+		code: NO_TRANSFORM_MAP_OR_AST_WITHOUT_CODE,
 		message:
 			`The plugin "${pluginName}" returned a "map" or "ast" without returning ` +
 			'a "code". This will be ignored.'
 	};
 }
 
-export function errPreferNamedExports(facadeModuleId: string): RollupLogProps {
+export function errOnlyInlineSourcemapsForStdout(): RollupLog {
+	return {
+		code: ONLY_INLINE_SOURCEMAPS,
+		message: 'Only inline sourcemaps are supported when bundling to stdout.'
+	};
+}
+
+export function errParseError(error: Error, moduleId: string): RollupLog {
+	let message = error.message.replace(/ \(\d+:\d+\)$/, '');
+	if (moduleId.endsWith('.json')) {
+		message += ' (Note that you need @rollup/plugin-json to import JSON files)';
+	} else if (!moduleId.endsWith('.js')) {
+		message += ' (Note that you need plugins to import files that are not JavaScript)';
+	}
+	return {
+		cause: error,
+		code: PARSE_ERROR,
+		id: moduleId,
+		message
+	};
+}
+
+export function errPluginError(
+	error: string | RollupLog,
+	plugin: string,
+	{ hook, id }: { hook?: string; id?: string } = {}
+): RollupLog {
+	if (typeof error === 'string') error = { message: error };
+	if (error.code && error.code !== PLUGIN_ERROR) {
+		error.pluginCode = error.code;
+	}
+	error.code = PLUGIN_ERROR;
+	error.plugin = plugin;
+	if (hook) {
+		error.hook = hook;
+	}
+	if (id) {
+		error.id = id;
+	}
+	return error;
+}
+
+export function errPreferNamedExports(facadeModuleId: string): RollupLog {
 	const file = relativeId(facadeModuleId);
 	return {
-		code: Errors.PREFER_NAMED_EXPORTS,
+		code: PREFER_NAMED_EXPORTS,
 		id: facadeModuleId,
 		message: `Entry module "${file}" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "${file}" to use named exports only.`,
 		url: `https://rollupjs.org/guide/en/#outputexports`
 	};
 }
 
+export function errShimmedExport(id: string, binding: string): RollupLog {
+	return {
+		binding,
+		code: SHIMMED_EXPORT,
+		exporter: id,
+		message: `Missing export "${binding}" has been shimmed in module "${relativeId(id)}".`
+	};
+}
+
+export function errSourcemapBroken(plugin: string): RollupLog {
+	return {
+		code: SOURCEMAP_BROKEN,
+		message: `Sourcemap is likely to be incorrect: a plugin (${plugin}) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
+		plugin,
+		url: `https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect`
+	};
+}
+
+export function errInvalidSourcemapForError(
+	error: Error,
+	id: string,
+	column: number,
+	line: number,
+	pos: number
+): RollupLog {
+	return {
+		cause: error,
+		code: SOURCEMAP_ERROR,
+		id,
+		loc: {
+			column,
+			file: id,
+			line
+		},
+		message: `Error when using sourcemap for reporting an error: ${error.message}`,
+		pos
+	};
+}
+
 export function errSyntheticNamedExportsNeedNamespaceExport(
 	id: string,
 	syntheticNamedExportsOption: boolean | string
-): RollupLogProps {
+): RollupLog {
 	return {
-		code: Errors.SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT,
-		id,
+		code: SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT,
+		exporter: id,
 		message: `Module "${relativeId(
 			id
-		)}" that is marked with 'syntheticNamedExports: ${JSON.stringify(
+		)}" that is marked with \`syntheticNamedExports: ${JSON.stringify(
 			syntheticNamedExportsOption
-		)}' needs ${
+		)}\` needs ${
 			typeof syntheticNamedExportsOption === 'string' && syntheticNamedExportsOption !== 'default'
 				? `an explicit export named "${syntheticNamedExportsOption}"`
 				: 'a default export'
@@ -439,89 +739,121 @@ export function errSyntheticNamedExportsNeedNamespaceExport(
 	};
 }
 
+export function errThisIsUndefined(): RollupLog {
+	return {
+		code: THIS_IS_UNDEFINED,
+		message: `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`,
+		url: `https://rollupjs.org/guide/en/#error-this-is-undefined`
+	};
+}
+
+export function errTranspiledEsmConfig(fileName: string): RollupLog {
+	return {
+		code: TRANSPILED_ESM_CONFIG,
+		message: `While loading the Rollup configuration from "${relativeId(
+			fileName
+		)}", Node tried to require an ES module from a CommonJS file, which is not supported. A common cause is if there is a package.json file with "type": "module" in the same folder. You can try to fix this by changing the extension of your configuration file to ".cjs" or ".mjs" depending on the content, which will prevent Rollup from trying to preprocess the file but rather hand it to Node directly.`
+	};
+}
+
 export function errUnexpectedNamedImport(
 	id: string,
 	imported: string,
 	isReexport: boolean
-): RollupLogProps {
+): RollupLog {
 	const importType = isReexport ? 'reexport' : 'import';
 	return {
-		code: Errors.UNEXPECTED_NAMED_IMPORT,
-		id,
-		message: `The named export "${imported}" was ${importType}ed from the external module ${relativeId(
+		code: UNEXPECTED_NAMED_IMPORT,
+		exporter: id,
+		message: `The named export "${imported}" was ${importType}ed from the external module "${relativeId(
 			id
-		)} even though its interop type is "defaultOnly". Either remove or change this ${importType} or change the value of the "output.interop" option.`,
+		)}" even though its interop type is "defaultOnly". Either remove or change this ${importType} or change the value of the "output.interop" option.`,
 		url: 'https://rollupjs.org/guide/en/#outputinterop'
 	};
 }
 
-export function errUnexpectedNamespaceReexport(id: string): RollupLogProps {
+export function errUnexpectedNamespaceReexport(id: string): RollupLog {
 	return {
-		code: Errors.UNEXPECTED_NAMED_IMPORT,
-		id,
-		message: `There was a namespace "*" reexport from the external module ${relativeId(
+		code: UNEXPECTED_NAMED_IMPORT,
+		exporter: id,
+		message: `There was a namespace "*" reexport from the external module "${relativeId(
 			id
-		)} even though its interop type is "defaultOnly". This will be ignored as namespace reexports only reexport named exports. If this is not intended, either remove or change this reexport or change the value of the "output.interop" option.`,
+		)}" even though its interop type is "defaultOnly". This will be ignored as namespace reexports only reexport named exports. If this is not intended, either remove or change this reexport or change the value of the "output.interop" option.`,
 		url: 'https://rollupjs.org/guide/en/#outputinterop'
 	};
 }
 
-export function errEntryCannotBeExternal(unresolvedId: string): RollupLogProps {
+export function errUnknownOption(
+	optionType: string,
+	unknownOptions: string[],
+	validOptions: string[]
+): RollupLog {
 	return {
-		code: Errors.UNRESOLVED_ENTRY,
-		message: `Entry module cannot be external (${relativeId(unresolvedId)}).`
+		code: UNKNOWN_OPTION,
+		message: `Unknown ${optionType}: ${unknownOptions.join(
+			', '
+		)}. Allowed options: ${validOptions.join(', ')}`
 	};
 }
 
-export function errUnresolvedEntry(unresolvedId: string): RollupLogProps {
+export function errEntryCannotBeExternal(unresolvedId: string): RollupLog {
 	return {
-		code: Errors.UNRESOLVED_ENTRY,
-		message: `Could not resolve entry module (${relativeId(unresolvedId)}).`
+		code: UNRESOLVED_ENTRY,
+		message: `Entry module "${relativeId(unresolvedId)}" cannot be external.`
 	};
 }
 
-export function errUnresolvedImport(source: string, importer: string): RollupLogProps {
+export function errUnresolvedEntry(unresolvedId: string): RollupLog {
 	return {
-		code: Errors.UNRESOLVED_IMPORT,
-		message: `Could not resolve '${source}' from ${relativeId(importer)}`
+		code: UNRESOLVED_ENTRY,
+		message: `Could not resolve entry module "${relativeId(unresolvedId)}".`
 	};
 }
 
-export function errUnresolvedImportTreatedAsExternal(
-	source: string,
-	importer: string
-): RollupWarning {
+export function errUnresolvedImport(source: string, importer: string): RollupLog {
 	return {
-		code: Errors.UNRESOLVED_IMPORT,
-		importer: relativeId(importer),
-		message: `'${source}' is imported by ${relativeId(
+		code: UNRESOLVED_IMPORT,
+		exporter: source,
+		id: importer,
+		message: `Could not resolve "${source}" from "${relativeId(importer)}"`
+	};
+}
+
+export function errUnresolvedImportTreatedAsExternal(source: string, importer: string): RollupLog {
+	return {
+		code: UNRESOLVED_IMPORT,
+		exporter: source,
+		id: importer,
+		message: `"${source}" is imported by "${relativeId(
 			importer
-		)}, but could not be resolved – treating it as an external dependency`,
-		source,
+		)}", but could not be resolved – treating it as an external dependency.`,
 		url: 'https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency'
 	};
 }
 
-export function errExternalSyntheticExports(source: string, importer: string): RollupWarning {
+export function errUnusedExternalImports(
+	externalId: string,
+	names: string[],
+	importers: string[]
+): RollupLog {
 	return {
-		code: Errors.EXTERNAL_SYNTHETIC_EXPORTS,
-		importer: relativeId(importer),
-		message: `External '${source}' can not have 'syntheticNamedExports' enabled.`,
-		source
+		code: UNUSED_EXTERNAL_IMPORT,
+		exporter: externalId,
+		ids: importers,
+		message: `${printQuotedStringList(names, [
+			'is',
+			'are'
+		])} imported from external module "${externalId}" but never used in ${printQuotedStringList(
+			importers.map(importer => relativeId(importer))
+		)}.`,
+		names
 	};
 }
 
-export function errFailedValidation(message: string): RollupLogProps {
+export function errFailedValidation(message: string): RollupLog {
 	return {
-		code: Errors.VALIDATION_ERROR,
+		code: VALIDATION_ERROR,
 		message
-	};
-}
-
-export function errAlreadyClosed(): RollupLogProps {
-	return {
-		code: Errors.ALREADY_CLOSED,
-		message: 'Bundle is already closed, no more calls to "generate" or "write" are allowed.'
 	};
 }
 

--- a/src/utils/executionOrder.ts
+++ b/src/utils/executionOrder.ts
@@ -1,6 +1,5 @@
 import type ExternalModule from '../ExternalModule';
 import Module from '../Module';
-import relativeId from './relativeId';
 
 interface OrderedExecutionUnit {
 	execIndex: number;
@@ -74,12 +73,12 @@ function getCyclePath(
 	parents: ReadonlyMap<Module | ExternalModule, Module | null>
 ): string[] {
 	const cycleSymbol = Symbol(module.id);
-	const path = [relativeId(module.id)];
+	const path = [module.id];
 	let nextModule = parent;
 	module.cycles.add(cycleSymbol);
 	while (nextModule !== module) {
 		nextModule.cycles.add(cycleSymbol);
-		path.push(relativeId(nextModule.id));
+		path.push(nextModule.id);
 		nextModule = parents.get(nextModule)!;
 	}
 	path.push(path[0]);

--- a/src/utils/options/options.ts
+++ b/src/utils/options/options.ts
@@ -6,7 +6,7 @@ import type {
 	OutputOptions,
 	WarningHandler
 } from '../../rollup/types';
-import { errInvalidOption, error } from '../error';
+import { errInvalidOption, error, errUnknownOption } from '../error';
 import { printQuotedStringList } from '../printStringList';
 
 export interface GenericConfigObject {
@@ -27,14 +27,7 @@ export function warnUnknownOptions(
 		key => !(validOptionSet.has(key) || ignoredKeys.test(key))
 	);
 	if (unknownOptions.length > 0) {
-		warn({
-			code: 'UNKNOWN_OPTION',
-			message: `Unknown ${optionType}: ${unknownOptions.join(', ')}. Allowed options: ${[
-				...validOptionSet
-			]
-				.sort()
-				.join(', ')}`
-		});
+		warn(errUnknownOption(optionType, unknownOptions, [...validOptionSet].sort()));
 	}
 }
 

--- a/src/utils/pluginUtils.ts
+++ b/src/utils/pluginUtils.ts
@@ -1,25 +1,2 @@
-import type { RollupError } from '../rollup/types';
-import { error, Errors } from './error';
-
 export const ANONYMOUS_PLUGIN_PREFIX = 'at position ';
 export const ANONYMOUS_OUTPUT_PLUGIN_PREFIX = 'at output position ';
-
-export function throwPluginError(
-	err: string | RollupError,
-	plugin: string,
-	{ hook, id }: { hook?: string; id?: string } = {}
-): never {
-	if (typeof err === 'string') err = { message: err };
-	if (err.code && err.code !== Errors.PLUGIN_ERROR) {
-		err.pluginCode = err.code;
-	}
-	err.code = Errors.PLUGIN_ERROR;
-	err.plugin = plugin;
-	if (hook) {
-		err.hook = hook;
-	}
-	if (id) {
-		err.id = id;
-	}
-	return error(err);
-}

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -18,8 +18,13 @@ import { getTrackedPluginCache } from './PluginCache';
 import type { PluginDriver } from './PluginDriver';
 import { collapseSourcemap } from './collapseSourcemaps';
 import { decodedSourcemap } from './decodedSourcemap';
-import { augmentCodeLocation, errNoTransformMapOrAstWithoutCode } from './error';
-import { throwPluginError } from './pluginUtils';
+import {
+	augmentCodeLocation,
+	errInvalidSetAssetSourceCall,
+	errNoTransformMapOrAstWithoutCode,
+	error,
+	errPluginError
+} from './error';
 
 export default async function transform(
 	source: SourceDescription,
@@ -129,10 +134,7 @@ export default async function transform(
 						});
 					},
 					setAssetSource() {
-						return this.error({
-							code: 'INVALID_SETASSETSOURCE',
-							message: `setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.`
-						});
+						return this.error(errInvalidSetAssetSourceCall());
 					},
 					warn(warning: RollupWarning | string, pos?: number | { column: number; line: number }) {
 						if (typeof warning === 'string') warning = { message: warning };
@@ -145,7 +147,7 @@ export default async function transform(
 			}
 		);
 	} catch (err: any) {
-		throwPluginError(err, pluginName, { hook: 'transform', id });
+		return error(errPluginError(err, pluginName, { hook: 'transform', id }));
 	}
 
 	if (!customTransformCache) {

--- a/test/browser/samples/missing-dependency-resolution/_config.js
+++ b/test/browser/samples/missing-dependency-resolution/_config.js
@@ -10,7 +10,7 @@ console.log(foo);`
 	},
 	error: {
 		message:
-			"Unexpected warnings (UNRESOLVED_IMPORT): 'dep' is imported by main, but could not be resolved – treating it as an external dependency\nIf you expect warnings, list their codes in config.expectedWarnings",
+			'Unexpected warnings (UNRESOLVED_IMPORT): "dep" is imported by "main", but could not be resolved – treating it as an external dependency.\nIf you expect warnings, list their codes in config.expectedWarnings',
 		watchFiles: ['main']
 	}
 };

--- a/test/browser/samples/missing-entry-resolution/_config.js
+++ b/test/browser/samples/missing-entry-resolution/_config.js
@@ -2,6 +2,6 @@ module.exports = {
 	description: 'fails if an entry cannot be resolved',
 	error: {
 		code: 'UNRESOLVED_ENTRY',
-		message: 'Could not resolve entry module (main).'
+		message: 'Could not resolve entry module "main".'
 	}
 };

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
@@ -1,10 +1,6 @@
 define(['require'], (function (require) { 'use strict';
 
 	console.log('main');
-<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
 	new Promise(function (resolve, reject) { require(['./chunk-deb-87ce45a9-amd'], resolve, reject); }).then(console.log);
-========
-	new Promise(function (resolve, reject) { require(['./chunk-deb-faae56f2-amd'], resolve, reject); }).then(console.log);
->>>>>>>> 3030e2f11 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-aaf15a0c-amd.js
 
 }));

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
@@ -1,6 +1,10 @@
 define(['require'], (function (require) { 'use strict';
 
 	console.log('main');
+<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
 	new Promise(function (resolve, reject) { require(['./chunk-deb-87ce45a9-amd'], resolve, reject); }).then(console.log);
+========
+	new Promise(function (resolve, reject) { require(['./chunk-deb-faae56f2-amd'], resolve, reject); }).then(console.log);
+>>>>>>>> 3030e2f11 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-aaf15a0c-amd.js
 
 }));

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
@@ -1,6 +1,10 @@
 define(['require'], (function (require) { 'use strict';
 
 	console.log('main');
+<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
 	new Promise(function (resolve, reject) { require(['./chunk-deb-87ce45a9-amd'], resolve, reject); }).then(console.log);
+========
+	new Promise(function (resolve, reject) { require(['./chunk-deb-faae56f2-amd'], resolve, reject); }).then(console.log);
+>>>>>>>> 113353e74 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-aaf15a0c-amd.js
 
 }));

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
@@ -1,10 +1,6 @@
 define(['require'], (function (require) { 'use strict';
 
 	console.log('main');
-<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-5940aabc-amd.js
 	new Promise(function (resolve, reject) { require(['./chunk-deb-87ce45a9-amd'], resolve, reject); }).then(console.log);
-========
-	new Promise(function (resolve, reject) { require(['./chunk-deb-faae56f2-amd'], resolve, reject); }).then(console.log);
->>>>>>>> 113353e74 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/amd/entry-main-aaf15a0c-amd.js
 
 }));

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
@@ -1,4 +1,8 @@
 'use strict';
 
 console.log('main');
+<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
 Promise.resolve().then(function () { return require('./chunk-deb-69905607-cjs.js'); }).then(console.log);
+========
+Promise.resolve().then(function () { return require('./chunk-deb-2221fa83-cjs.js'); }).then(console.log);
+>>>>>>>> 113353e74 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-69b6552e-cjs.js

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
@@ -1,8 +1,4 @@
 'use strict';
 
 console.log('main');
-<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
 Promise.resolve().then(function () { return require('./chunk-deb-69905607-cjs.js'); }).then(console.log);
-========
-Promise.resolve().then(function () { return require('./chunk-deb-2221fa83-cjs.js'); }).then(console.log);
->>>>>>>> 113353e74 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-69b6552e-cjs.js

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
@@ -1,8 +1,4 @@
 'use strict';
 
 console.log('main');
-<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
 Promise.resolve().then(function () { return require('./chunk-deb-69905607-cjs.js'); }).then(console.log);
-========
-Promise.resolve().then(function () { return require('./chunk-deb-2221fa83-cjs.js'); }).then(console.log);
->>>>>>>> 3030e2f11 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-69b6552e-cjs.js

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
@@ -1,4 +1,8 @@
 'use strict';
 
 console.log('main');
+<<<<<<<< HEAD:test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-9cf3a232-cjs.js
 Promise.resolve().then(function () { return require('./chunk-deb-69905607-cjs.js'); }).then(console.log);
+========
+Promise.resolve().then(function () { return require('./chunk-deb-2221fa83-cjs.js'); }).then(console.log);
+>>>>>>>> 3030e2f11 ([v3.0] New hashing algorithm that "fixes (nearly) everything" (#4543)):test/chunking-form/samples/emit-file/filenames-function-patterns/_expected/cjs/entry-main-69b6552e-cjs.js

--- a/test/cli/samples/config-no-module/_config.js
+++ b/test/cli/samples/config-no-module/_config.js
@@ -8,10 +8,9 @@ module.exports = {
 	stderr: stderr =>
 		assertIncludes(
 			stderr,
-			'[!] Error: While loading the Rollup configuration from "rollup.config.js", Node tried to require an ES module from a CommonJS ' +
+			'[!] RollupError: While loading the Rollup configuration from "rollup.config.js", Node tried to require an ES module from a CommonJS ' +
 				'file, which is not supported. A common cause is if there is a package.json file with "type": "module" in the same folder. You can ' +
 				'try to fix this by changing the extension of your configuration file to ".cjs" or ".mjs" depending on the content, which will ' +
-				'prevent Rollup from trying to preprocess the file but rather hand it to Node directly.\n' +
-				'https://rollupjs.org/guide/en/#using-untranspiled-config-files'
+				'prevent Rollup from trying to preprocess the file but rather hand it to Node directly.'
 		)
 };

--- a/test/cli/samples/empty-chunk-multiple/_config.js
+++ b/test/cli/samples/empty-chunk-multiple/_config.js
@@ -4,5 +4,5 @@ module.exports = {
 	description: 'shows warning when multiple chunks empty',
 	command: 'rollup -c',
 	error: () => true,
-	stderr: stderr => assertIncludes(stderr, '(!) Generated empty chunks\na, b')
+	stderr: stderr => assertIncludes(stderr, '(!) Generated empty chunks\n"a" and "b"')
 };

--- a/test/cli/samples/empty-chunk/_config.js
+++ b/test/cli/samples/empty-chunk/_config.js
@@ -4,5 +4,5 @@ module.exports = {
 	description: 'shows warning when chunk empty',
 	command: 'rollup -c',
 	error: () => true,
-	stderr: stderr => assertIncludes(stderr, '(!) Generated an empty chunk\nmain')
+	stderr: stderr => assertIncludes(stderr, '(!) Generated an empty chunk\n"main"')
 };

--- a/test/cli/samples/generated-code-unknown-preset/_config.js
+++ b/test/cli/samples/generated-code-unknown-preset/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 	stderr: stderr => {
 		assertIncludes(
 			stderr,
-			'[!] Error: Invalid value "unknown" for option "output.generatedCode" - valid values are "es2015" and "es5". You can also supply an object for more fine-grained control.\n' +
+			'[!] RollupError: Invalid value "unknown" for option "output.generatedCode" - valid values are "es2015" and "es5". You can also supply an object for more fine-grained control.\n' +
 				'https://rollupjs.org/guide/en/#outputgeneratedcode'
 		);
 	}

--- a/test/cli/samples/treeshake-unknown-preset/_config.js
+++ b/test/cli/samples/treeshake-unknown-preset/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 	stderr: stderr => {
 		assertIncludes(
 			stderr,
-			'[!] Error: Invalid value "unknown" for option "treeshake" - valid values are false, true, "recommended", "safest" and "smallest". You can also supply an object for more fine-grained control.\n' +
+			'[!] RollupError: Invalid value "unknown" for option "treeshake" - valid values are false, true, "recommended", "safest" and "smallest". You can also supply an object for more fine-grained control.\n' +
 				'https://rollupjs.org/guide/en/#treeshake'
 		);
 	}

--- a/test/cli/samples/warn-broken-sourcemap/_config.js
+++ b/test/cli/samples/warn-broken-sourcemap/_config.js
@@ -12,7 +12,7 @@ module.exports = {
 			stderr,
 			'(!) Broken sourcemap\n' +
 				'https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect\n' +
-				'Plugins that transform code (such as "test-plugin1") should generate accompanying sourcemaps\n'
+				'Plugins that transform code (such as "test-plugin1") should generate accompanying sourcemaps.\n'
 		);
 	}
 };

--- a/test/cli/samples/warn-import-export/_config.js
+++ b/test/cli/samples/warn-import-export/_config.js
@@ -11,22 +11,12 @@ module.exports = {
 				'The following entry modules are using named and default exports together:\n' +
 				'main.js\n' +
 				'\n' +
-				"Consumers of your bundle will have to use chunk['default'] to access their default export, which may not be what you want. Use `output.exports: 'named'` to disable this warning\n"
+				'Consumers of your bundle will have to use chunk.default to access their default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.\n'
 		);
 		assertIncludes(
 			stderr,
 			'(!) Unused external imports\n' +
-				`default imported from external module "external" but never used in "main.js"\n`
-		);
-		assertIncludes(
-			stderr,
-			'(!) Import of non-existent export\n' +
-				'main.js\n' +
-				"1: import unused from 'external';\n" +
-				"2: import * as dep from './dep.js';\n" +
-				"3: import alsoUnused from './dep.js';\n" +
-				'          ^\n' +
-				"4: import 'unresolvedExternal';\n"
+				`default imported from external module "external" but never used in "main.js".\n`
 		);
 		assertIncludes(
 			stderr,
@@ -38,20 +28,27 @@ module.exports = {
 				'5: \n' +
 				'6: export const missing = dep.missing;\n' +
 				'                              ^\n' +
-				'7: export default 42;\n'
+				'7: export default 42;\n' +
+				'main.js\n' +
+				'default is not exported by dep.js\n' +
+				"1: import unused from 'external';\n" +
+				"2: import * as dep from './dep.js';\n" +
+				"3: import alsoUnused from './dep.js';\n" +
+				'          ^\n' +
+				"4: import 'unresolvedExternal';\n"
 		);
 		assertIncludes(
 			stderr,
 			'(!) Conflicting re-exports\n' +
-				'"main.js" re-exports "foo" from both "dep.js" and "dep2.js" (will be ignored)\n' +
-				'"main.js" re-exports "bar" from both "dep.js" and "dep2.js" (will be ignored)\n'
+				'"main.js" re-exports "foo" from both "dep.js" and "dep2.js" (will be ignored).\n' +
+				'"main.js" re-exports "bar" from both "dep.js" and "dep2.js" (will be ignored).\n'
 		);
 		assertIncludes(
 			stderr,
 			'(!) Unresolved dependencies\n' +
 				'https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency\n' +
-				'unresolvedExternal (imported by main.js, dep.js)\n' +
-				'otherUnresolvedExternal (imported by dep.js)\n'
+				'unresolvedExternal (imported by "main.js" and "dep.js")\n' +
+				'otherUnresolvedExternal (imported by "dep.js")\n'
 		);
 	}
 };

--- a/test/cli/samples/warn-missing-global-multiple/_config.js
+++ b/test/cli/samples/warn-missing-global-multiple/_config.js
@@ -7,9 +7,10 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Missing global variable names\n' +
-				'Use output.globals to specify browser global variable names corresponding to external modules\n' +
-				"external1 (guessing 'foo1')\n" +
-				"external2 (guessing 'foo2')\n" +
-				"external3 (guessing 'foo3')"
+				'https://rollupjs.org/guide/en/#outputglobals\n' +
+				'Use "output.globals" to specify browser global variable names corresponding to external modules:\n' +
+				'external1 (guessing "foo1")\n' +
+				'external2 (guessing "foo2")\n' +
+				'external3 (guessing "foo3")'
 		)
 };

--- a/test/cli/samples/warn-missing-global/_config.js
+++ b/test/cli/samples/warn-missing-global/_config.js
@@ -7,7 +7,8 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Missing global variable name\n' +
-				'Use output.globals to specify browser global variable names corresponding to external modules\n' +
-				"external (guessing 'foo')"
+				'https://rollupjs.org/guide/en/#outputglobals\n' +
+				'Use "output.globals" to specify browser global variable names corresponding to external modules:\n' +
+				'external (guessing "foo")'
 		)
 };

--- a/test/cli/samples/warn-mixed-exports-multiple/_config.js
+++ b/test/cli/samples/warn-mixed-exports-multiple/_config.js
@@ -14,7 +14,7 @@ module.exports = {
 				'lib3.js\n' +
 				'...and 3 other entry modules\n' +
 				'\n' +
-				"Consumers of your bundle will have to use chunk['default'] to access their default export, which may not be what you want. Use `output.exports: 'named'` to disable this warning\n"
+				'Consumers of your bundle will have to use chunk.default to access their default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.\n'
 		);
 	}
 };

--- a/test/cli/samples/warn-multiple/_config.js
+++ b/test/cli/samples/warn-multiple/_config.js
@@ -11,20 +11,29 @@ module.exports = {
 		);
 		assertIncludes(
 			stderr,
-			'(!) Import of non-existent exports\n' +
+			'(!) Missing exports\n' +
+				'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module\n' +
 				'main.js\n' +
+				'doesNotExist is not exported by dep.js\n' +
 				"4: import assert from 'assert';\n" +
 				"5: import path from 'path';\n" +
 				"6: import {doesNotExist, alsoNotFound} from './dep.js';\n" +
 				'           ^\n' +
 				'7: \n' +
 				'8: export {url, assert, path};\n' +
-				'...and 1 other occurrence\n'
+				'main.js\n' +
+				'alsoNotFound is not exported by dep.js\n' +
+				"4: import assert from 'assert';\n" +
+				"5: import path from 'path';\n" +
+				"6: import {doesNotExist, alsoNotFound} from './dep.js';\n" +
+				'                         ^\n' +
+				'7: \n' +
+				'8: export {url, assert, path};'
 		);
 		assertIncludes(
 			stderr,
 
-			"(!) Module level directives cause errors when bundled, 'use stuff' was ignored.\n" +
+			'(!) Module level directives cause errors when bundled, "use stuff" in "main.js" was ignored.\n' +
 				'main.js (1:0)\n' +
 				"1: 'use stuff';\n" +
 				'   ^\n' +

--- a/test/cli/samples/warn-this/_config.js
+++ b/test/cli/samples/warn-this/_config.js
@@ -6,7 +6,7 @@ module.exports = {
 	stderr: stderr =>
 		assertIncludes(
 			stderr,
-			'(!) `this` has been rewritten to `undefined`\n' +
+			'(!) "this" has been rewritten to "undefined"\n' +
 				'https://rollupjs.org/guide/en/#error-this-is-undefined\n' +
 				'main.js\n' +
 				'1: console.log(this);\n' +

--- a/test/cli/samples/watch/close-on-generate-error/_config.js
+++ b/test/cli/samples/watch/close-on-generate-error/_config.js
@@ -11,7 +11,7 @@ module.exports = {
 	stderr(stderr) {
 		assertIncludes(
 			stderr,
-			'[!] Error: You must specify "output.file" or "output.dir" for the build.'
+			'[!] RollupError: You must specify "output.file" or "output.dir" for the build.'
 		);
 		assertIncludes(stderr, 'Bundle closed');
 		return false;

--- a/test/cli/samples/watch/no-watched-config/_config.js
+++ b/test/cli/samples/watch/no-watched-config/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 	stderr(stderr) {
 		assertIncludes(
 			stderr,
-			'[!] Error: Invalid value for option "watch" - there must be at least one config where "watch" is not set to "false".'
+			'[!] RollupError: Invalid value for option "watch" - there must be at least one config where "watch" is not set to "false".'
 		);
 	}
 };

--- a/test/function/samples/add-watch-file-generate/_config.js
+++ b/test/function/samples/add-watch-file-generate/_config.js
@@ -13,7 +13,7 @@ module.exports = {
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		hook: 'renderStart',
-		message: 'Cannot call addWatchFile after the build has finished.',
+		message: 'Cannot call "addWatchFile" after the build has finished.',
 		plugin: 'test-plugin',
 		pluginCode: 'INVALID_ROLLUP_PHASE'
 	}

--- a/test/function/samples/already-deshadowed-import/_config.js
+++ b/test/function/samples/already-deshadowed-import/_config.js
@@ -1,11 +1,14 @@
+const path = require('path');
+const ID_BOB = path.join(__dirname, 'bob.js');
+const ID_ALICE = path.join(__dirname, 'alice.js');
+
 module.exports = {
 	description:
 		'handle already module import names correctly if they are have already been deshadowed',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['bob.js', 'alice.js', 'bob.js'],
-			importer: 'bob.js',
+			ids: [ID_BOB, ID_ALICE, ID_BOB],
 			message: 'Circular dependency: bob.js -> alice.js -> bob.js'
 		}
 	]

--- a/test/function/samples/assign-namespace-to-var/_config.js
+++ b/test/function/samples/assign-namespace-to-var/_config.js
@@ -2,9 +2,9 @@ module.exports = {
 	description: 'allows a namespace to be assigned to a variable',
 	warnings: [
 		{
-			chunkName: 'main',
 			code: 'EMPTY_BUNDLE',
-			message: 'Generated an empty chunk: "main"'
+			message: 'Generated an empty chunk: "main".',
+			names: ['main']
 		}
 	]
 };

--- a/test/function/samples/banner-and-footer/_config.js
+++ b/test/function/samples/banner-and-footer/_config.js
@@ -29,6 +29,7 @@ module.exports = {
 	generateError: {
 		code: 'ADDON_ERROR',
 		message:
-			'Could not retrieve banner. Check configuration of plugin at position 3.\n\tError Message: Could not generate banner.'
+			'Could not retrieve "banner". Check configuration of plugin "at position 3".\n' +
+			'\tError Message: Could not generate banner.'
 	}
 };

--- a/test/function/samples/can-import-self-treeshake/_config.js
+++ b/test/function/samples/can-import-self-treeshake/_config.js
@@ -1,16 +1,18 @@
+const path = require('path');
+const ID_LIB = path.join(__dirname, 'lib.js');
+
 module.exports = {
 	description: 'direct self import',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['lib.js', 'lib.js'],
-			importer: 'lib.js',
+			ids: [ID_LIB, ID_LIB],
 			message: 'Circular dependency: lib.js -> lib.js'
 		},
 		{
-			chunkName: 'main',
 			code: 'EMPTY_BUNDLE',
-			message: `Generated an empty chunk: "main"`
+			message: 'Generated an empty chunk: "main".',
+			names: ['main']
 		}
 	]
 };

--- a/test/function/samples/can-import-self/_config.js
+++ b/test/function/samples/can-import-self/_config.js
@@ -1,4 +1,6 @@
 const assert = require('assert');
+const path = require('path');
+const ID_LIB = path.join(__dirname, 'lib.js');
 
 module.exports = {
 	description: 'a module importing its own bindings',
@@ -8,8 +10,7 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['lib.js', 'lib.js'],
-			importer: 'lib.js',
+			ids: [ID_LIB, ID_LIB],
 			message: 'Circular dependency: lib.js -> lib.js'
 		}
 	]

--- a/test/function/samples/cannot-call-external-namespace/_config.js
+++ b/test/function/samples/cannot-call-external-namespace/_config.js
@@ -7,8 +7,8 @@ module.exports = {
 	},
 	warnings(warnings) {
 		assert.deepStrictEqual(warnings.map(String), [
-			"main.js (4:1) Cannot call a namespace ('foo')",
-			"main.js (8:1) Cannot call a namespace ('foo')"
+			'main.js (4:1) Cannot call a namespace ("foo").',
+			'main.js (8:1) Cannot call a namespace ("foo").'
 		]);
 	}
 };

--- a/test/function/samples/cannot-call-internal-namespace/_config.js
+++ b/test/function/samples/cannot-call-internal-namespace/_config.js
@@ -4,8 +4,8 @@ module.exports = {
 	description: 'warns if code calls an internal namespace',
 	warnings(warnings) {
 		assert.deepStrictEqual(warnings.map(String), [
-			"main.js (4:1) Cannot call a namespace ('foo')",
-			"main.js (8:1) Cannot call a namespace ('foo')"
+			'main.js (4:1) Cannot call a namespace ("foo").',
+			'main.js (8:1) Cannot call a namespace ("foo").'
 		]);
 	}
 };

--- a/test/function/samples/cannot-resolve-sourcemap-warning/_config.js
+++ b/test/function/samples/cannot-resolve-sourcemap-warning/_config.js
@@ -13,6 +13,9 @@ module.exports = {
 	},
 	warnings: [
 		{
+			cause: {
+				message: "Can't resolve original location of error."
+			},
 			code: 'SOURCEMAP_ERROR',
 			id: ID_MAIN,
 			loc: {

--- a/test/function/samples/check-resolve-for-entry/_config.js
+++ b/test/function/samples/check-resolve-for-entry/_config.js
@@ -5,6 +5,6 @@ module.exports = {
 	},
 	error: {
 		code: 'UNRESOLVED_ENTRY',
-		message: 'Could not resolve entry module (not/a/path/that/actually/really/exists).'
+		message: 'Could not resolve entry module "not/a/path/that/actually/really/exists".'
 	}
 };

--- a/test/function/samples/circular-default-exports/_config.js
+++ b/test/function/samples/circular-default-exports/_config.js
@@ -1,10 +1,12 @@
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
 module.exports = {
 	description: 'handles circular default exports',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_MAIN],
 			message: 'Circular dependency: main.js -> main.js'
 		}
 	]

--- a/test/function/samples/circular-missed-reexports-2/_config.js
+++ b/test/function/samples/circular-missed-reexports-2/_config.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_DEP1 = path.join(__dirname, 'dep1.js');
+const ID_DEP2 = path.join(__dirname, 'dep2.js');
 
 module.exports = {
 	description: 'handles circular reexports',
@@ -8,13 +11,9 @@ module.exports = {
 	},
 	error: {
 		code: 'CIRCULAR_REEXPORT',
-		id: path.join(__dirname, 'dep1.js'),
+		exporter: ID_DEP1,
 		message:
-			'"doesNotExist" cannot be exported from dep1.js as it is a reexport that references itself.',
-		watchFiles: [
-			path.join(__dirname, 'dep1.js'),
-			path.join(__dirname, 'dep2.js'),
-			path.join(__dirname, 'main.js')
-		]
+			'"doesNotExist" cannot be exported from "dep1.js" as it is a reexport that references itself.',
+		watchFiles: [ID_DEP1, ID_DEP2, ID_MAIN]
 	}
 };

--- a/test/function/samples/circular-missed-reexports/_config.js
+++ b/test/function/samples/circular-missed-reexports/_config.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const ID_MAIN = path.join(__dirname, 'main.js');
 const ID_DEP1 = path.join(__dirname, 'dep1.js');
+const ID_DEP2 = path.join(__dirname, 'dep2.js');
 
 module.exports = {
 	description: 'handles circular reexports',
@@ -12,22 +13,20 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['dep1.js', 'dep2.js', 'dep1.js'],
-			importer: 'dep1.js',
+			ids: [ID_DEP1, ID_DEP2, ID_DEP1],
 			message: 'Circular dependency: dep1.js -> dep2.js -> dep1.js'
 		},
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['dep1.js', 'dep1.js'],
-			importer: 'dep1.js',
+			ids: [ID_DEP1, ID_DEP1],
 			message: 'Circular dependency: dep1.js -> dep1.js'
 		},
 		{
-			code: 'NON_EXISTENT_EXPORT',
-			message: "Non-existent export 'doesNotExist' is imported from dep1.js",
-			name: 'doesNotExist',
-			source: ID_DEP1,
+			binding: 'doesNotExist',
+			code: 'MISSING_EXPORT',
 			id: ID_MAIN,
+			message: '"doesNotExist" is not exported by "dep1.js", imported by "main.js".',
+			exporter: ID_DEP1,
 			pos: 17,
 			loc: {
 				file: ID_MAIN,
@@ -37,7 +36,8 @@ module.exports = {
 			frame: `
 1: import { exists, doesNotExist } from './dep1.js';
                     ^
-2: export { exists };`
+2: export { exists };`,
+			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module'
 		}
 	]
 };

--- a/test/function/samples/circular-preserve-modules/_config.js
+++ b/test/function/samples/circular-preserve-modules/_config.js
@@ -11,30 +11,28 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'first.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_FIRST, ID_MAIN],
 			message: 'Circular dependency: main.js -> first.js -> main.js'
 		},
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'second.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_SECOND, ID_MAIN],
 			message: 'Circular dependency: main.js -> second.js -> main.js'
 		},
 		{
 			code: 'CYCLIC_CROSS_CHUNK_REEXPORT',
 			exporter: ID_SECOND,
-			importer: ID_FIRST,
+			id: ID_FIRST,
 			message:
-				'Export "second" of module second.js was reexported through module main.js while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.\nEither change the import in first.js to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.',
+				'Export "second" of module "second.js" was reexported through module "main.js" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.\nEither change the import in "first.js" to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.',
 			reexporter: ID_MAIN
 		},
 		{
 			code: 'CYCLIC_CROSS_CHUNK_REEXPORT',
 			exporter: ID_FIRST,
-			importer: ID_SECOND,
+			id: ID_SECOND,
 			message:
-				'Export "first" of module first.js was reexported through module main.js while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.\nEither change the import in second.js to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.',
+				'Export "first" of module "first.js" was reexported through module "main.js" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.\nEither change the import in "second.js" to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.',
 			reexporter: ID_MAIN
 		}
 	]

--- a/test/function/samples/circular-reexport/_config.js
+++ b/test/function/samples/circular-reexport/_config.js
@@ -5,8 +5,8 @@ module.exports = {
 	description: 'throws proper error for circular reexports',
 	error: {
 		code: 'CIRCULAR_REEXPORT',
-		id: ID_MAIN,
-		message: '"foo" cannot be exported from main.js as it is a reexport that references itself.',
+		exporter: ID_MAIN,
+		message: '"foo" cannot be exported from "main.js" as it is a reexport that references itself.',
 		watchFiles: [ID_MAIN]
 	}
 };

--- a/test/function/samples/compact/_config.js
+++ b/test/function/samples/compact/_config.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
 module.exports = {
 	description: 'compact output with compact: true',
 	options: {
@@ -10,8 +13,7 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_MAIN],
 			message: 'Circular dependency: main.js -> main.js'
 		}
 	],

--- a/test/function/samples/conflicting-reexports/named-import-external/_config.js
+++ b/test/function/samples/conflicting-reexports/named-import-external/_config.js
@@ -1,24 +1,24 @@
 const path = require('path');
-const REEXPORT_ID = path.join(__dirname, 'reexport.js');
+const ID_REEXPORT = path.join(__dirname, 'reexport.js');
 
 module.exports = {
 	description:
 		'warns when a conflicting binding is imported via a named import from external namespaces',
 	warnings: [
 		{
+			binding: 'foo',
 			code: 'AMBIGUOUS_EXTERNAL_NAMESPACES',
+			ids: ['first', 'second'],
 			message:
 				'Ambiguous external namespace resolution: "reexport.js" re-exports "foo" from one of the external modules "first" and "second", guessing "first".',
-			name: 'foo',
-			reexporter: REEXPORT_ID,
-			sources: ['first', 'second']
+			reexporter: ID_REEXPORT
 		},
 		{
 			code: 'UNUSED_EXTERNAL_IMPORT',
+			exporter: 'second',
+			ids: [ID_REEXPORT],
 			message: '"foo" is imported from external module "second" but never used in "reexport.js".',
-			names: ['foo'],
-			source: 'second',
-			sources: [REEXPORT_ID]
+			names: ['foo']
 		}
 	],
 	options: { external: ['first', 'second'] },

--- a/test/function/samples/conflicting-reexports/named-import/_config.js
+++ b/test/function/samples/conflicting-reexports/named-import/_config.js
@@ -1,30 +1,30 @@
 const path = require('path');
 
 const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_REEXPORT = path.join(__dirname, 'reexport.js');
+const ID_FIRST = path.join(__dirname, 'first.js');
+const ID_SECOND = path.join(__dirname, 'second.js');
 
 module.exports = {
 	description: 'throws when a conflicting binding is imported via a named import',
 	error: {
+		binding: 'foo',
 		code: 'MISSING_EXPORT',
-		frame: `
-1: import { foo } from './reexport.js';
-            ^
-2:
-3: assert.strictEqual(foo, 1);`,
+		exporter: ID_REEXPORT,
 		id: ID_MAIN,
+		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
+		pos: 9,
 		loc: {
 			column: 9,
 			file: ID_MAIN,
 			line: 1
 		},
-		message: "'foo' is not exported by reexport.js, imported by main.js",
-		pos: 9,
-		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
-		watchFiles: [
-			path.join(__dirname, 'first.js'),
-			ID_MAIN,
-			path.join(__dirname, 'reexport.js'),
-			path.join(__dirname, 'second.js')
-		]
+		frame: `
+			1: import { foo } from './reexport.js';
+			            ^
+			2:
+			3: assert.strictEqual(foo, 1);`,
+		watchFiles: [ID_FIRST, ID_MAIN, ID_REEXPORT, ID_SECOND],
+		message: '"foo" is not exported by "reexport.js", imported by "main.js".'
 	}
 };

--- a/test/function/samples/conflicting-reexports/namespace-import/_config.js
+++ b/test/function/samples/conflicting-reexports/namespace-import/_config.js
@@ -1,35 +1,38 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FIRST = path.join(__dirname, 'first.js');
+const ID_SECOND = path.join(__dirname, 'second.js');
+const ID_REEXPORT = path.join(__dirname, 'reexport.js');
 
 module.exports = {
 	description: 'warns when a conflicting binding is imported via a namespace import',
 	warnings: [
 		{
+			binding: 'foo',
 			code: 'NAMESPACE_CONFLICT',
+			ids: [ID_FIRST, ID_SECOND],
 			message:
-				'Conflicting namespaces: "reexport.js" re-exports "foo" from one of the modules "first.js" and "second.js" (will be ignored)',
-			name: 'foo',
-			reexporter: path.join(__dirname, 'reexport.js'),
-			sources: [path.join(__dirname, 'first.js'), path.join(__dirname, 'second.js')]
+				'Conflicting namespaces: "reexport.js" re-exports "foo" from one of the modules "first.js" and "second.js" (will be ignored).',
+			reexporter: ID_REEXPORT
 		},
 		{
+			binding: 'foo',
 			code: 'MISSING_EXPORT',
-			exporter: 'reexport.js',
-			frame: `
-2:
-3: assert.deepStrictEqual(ns, { __proto__: null, bar: 1, baz: 2 });
-4: assert.strictEqual(ns.foo, undefined)
-                         ^`,
-			id: path.join(__dirname, 'main.js'),
-			importer: 'main.js',
+			exporter: ID_REEXPORT,
+			id: ID_MAIN,
+			message: '"foo" is not exported by "reexport.js", imported by "main.js".',
+			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
+			pos: 125,
 			loc: {
 				column: 22,
-				file: path.join(__dirname, 'main.js'),
+				file: ID_MAIN,
 				line: 4
 			},
-			message: "'foo' is not exported by 'reexport.js'",
-			missing: 'foo',
-			pos: 125,
-			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module'
+			frame: `
+				2:
+				3: assert.deepStrictEqual(ns, { __proto__: null, bar: 1, baz: 2 });
+				4: assert.strictEqual(ns.foo, undefined)
+				                         ^`
 		}
 	]
 };

--- a/test/function/samples/cycles-default-anonymous-function-hoisted/_config.js
+++ b/test/function/samples/cycles-default-anonymous-function-hoisted/_config.js
@@ -1,10 +1,13 @@
+const path = require('path');
+const ID_F = path.join(__dirname, 'f.js');
+const ID_G = path.join(__dirname, 'g.js');
+
 module.exports = {
 	description: 'Anonymous function declarations are hoisted',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['f.js', 'g.js', 'f.js'],
-			importer: 'f.js',
+			ids: [ID_F, ID_G, ID_F],
 			message: 'Circular dependency: f.js -> g.js -> f.js'
 		}
 	]

--- a/test/function/samples/cycles-defaults/_config.js
+++ b/test/function/samples/cycles-defaults/_config.js
@@ -1,10 +1,13 @@
+const path = require('path');
+const ID_A = path.join(__dirname, 'a.js');
+const ID_B = path.join(__dirname, 'b.js');
+
 module.exports = {
 	description: 'cycles work with default exports',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['a.js', 'b.js', 'a.js'],
-			importer: 'a.js',
+			ids: [ID_A, ID_B, ID_A],
 			message: 'Circular dependency: a.js -> b.js -> a.js'
 		}
 	]

--- a/test/function/samples/cycles-export-star/_config.js
+++ b/test/function/samples/cycles-export-star/_config.js
@@ -1,4 +1,7 @@
 const assert = require('assert');
+const path = require('path');
+const ID_A = path.join(__dirname, 'a.js');
+const ID_B = path.join(__dirname, 'b.js');
 
 module.exports = {
 	description: 'does not stack overflow on `export * from X` cycles',
@@ -11,8 +14,7 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['a.js', 'b.js', 'a.js'],
-			importer: 'a.js',
+			ids: [ID_A, ID_B, ID_A],
 			message: 'Circular dependency: a.js -> b.js -> a.js'
 		}
 	]

--- a/test/function/samples/cycles-immediate/_config.js
+++ b/test/function/samples/cycles-immediate/_config.js
@@ -1,10 +1,13 @@
+const path = require('path');
+const ID_EVENS = path.join(__dirname, 'evens.js');
+const ID_ODDS = path.join(__dirname, 'odds.js');
+
 module.exports = {
 	description: 'handles cycles where imports are immediately used',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['evens.js', 'odds.js', 'evens.js'],
-			importer: 'evens.js',
+			ids: [ID_EVENS, ID_ODDS, ID_EVENS],
 			message: 'Circular dependency: evens.js -> odds.js -> evens.js'
 		}
 	]

--- a/test/function/samples/cycles-pathological-2/_config.js
+++ b/test/function/samples/cycles-pathological-2/_config.js
@@ -1,22 +1,25 @@
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_B = path.join(__dirname, 'b.js');
+const ID_C = path.join(__dirname, 'c.js');
+const ID_D = path.join(__dirname, 'd.js');
+
 module.exports = {
 	description: 'resolves even more pathological cyclical dependencies gracefully',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'b.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_B, ID_MAIN],
 			message: 'Circular dependency: main.js -> b.js -> main.js'
 		},
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['b.js', 'd.js', 'c.js', 'b.js'],
-			importer: 'b.js',
+			ids: [ID_B, ID_D, ID_C, ID_B],
 			message: 'Circular dependency: b.js -> d.js -> c.js -> b.js'
 		},
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'b.js', 'd.js', 'c.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_B, ID_D, ID_C, ID_MAIN],
 			message: 'Circular dependency: main.js -> b.js -> d.js -> c.js -> main.js'
 		}
 	]

--- a/test/function/samples/cycles-stack-overflow/_config.js
+++ b/test/function/samples/cycles-stack-overflow/_config.js
@@ -1,16 +1,19 @@
+const path = require('path');
+const ID_B = path.join(__dirname, 'b.js');
+const ID_C = path.join(__dirname, 'c.js');
+const ID_D = path.join(__dirname, 'd.js');
+
 module.exports = {
 	description: 'does not stack overflow on crazy cyclical dependencies',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['c.js', 'd.js', 'b.js', 'c.js'],
-			importer: 'c.js',
+			ids: [ID_C, ID_D, ID_B, ID_C],
 			message: 'Circular dependency: c.js -> d.js -> b.js -> c.js'
 		},
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['c.js', 'd.js', 'c.js'],
-			importer: 'c.js',
+			ids: [ID_C, ID_D, ID_C],
 			message: 'Circular dependency: c.js -> d.js -> c.js'
 		}
 	]

--- a/test/function/samples/default-not-reexported/_config.js
+++ b/test/function/samples/default-not-reexported/_config.js
@@ -1,19 +1,20 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
+const ID_BAR = path.join(__dirname, 'bar.js');
 
 module.exports = {
 	description: 'default export is not re-exported with export *',
 	error: {
+		binding: 'default',
 		code: 'MISSING_EXPORT',
-		message: `'default' is not exported by foo.js, imported by main.js`,
-		id: path.join(__dirname, 'main.js'),
+		exporter: ID_FOO,
+		message: '"default" is not exported by "foo.js", imported by "main.js".',
+		id: ID_MAIN,
 		pos: 7,
-		watchFiles: [
-			path.join(__dirname, 'bar.js'),
-			path.join(__dirname, 'foo.js'),
-			path.join(__dirname, 'main.js')
-		],
+		watchFiles: [ID_BAR, ID_FOO, ID_MAIN],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
+			file: ID_MAIN,
 			line: 1,
 			column: 7
 		},

--- a/test/function/samples/default-on-warn/_config.js
+++ b/test/function/samples/default-on-warn/_config.js
@@ -20,8 +20,8 @@ module.exports = {
 	after() {
 		console.warn = oldConsoleWarn;
 		assert.deepStrictEqual(warnings, [
-			'Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification',
-			'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning'
+			'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+			'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.'
 		]);
 	}
 };

--- a/test/function/samples/deprecated/compact/_config.js
+++ b/test/function/samples/deprecated/compact/_config.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
 module.exports = {
 	description: 'compact output with compact: true',
 	options: {
@@ -11,8 +14,7 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_MAIN],
 			message: 'Circular dependency: main.js -> main.js'
 		},
 		{

--- a/test/function/samples/deprecated/manual-chunks-conflict/_config.js
+++ b/test/function/samples/deprecated/manual-chunks-conflict/_config.js
@@ -12,7 +12,7 @@ module.exports = {
 	},
 	generateError: {
 		code: 'INVALID_CHUNK',
-		message: `Cannot assign dep.js to the "dep2" chunk as it is already in the "dep1" chunk.`
+		message: 'Cannot assign "dep.js" to the "dep2" chunk as it is already in the "dep1" chunk.'
 	},
 	warnings: []
 };

--- a/test/function/samples/deprecated/preserveModules/invalid-default-export-mode/_config.js
+++ b/test/function/samples/deprecated/preserveModules/invalid-default-export-mode/_config.js
@@ -11,6 +11,7 @@ module.exports = {
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
-			'"default" was specified for "output.exports", but entry module "lib.js" has the following exports: value'
+			'"default" was specified for "output.exports", but entry module "lib.js" has the following exports: "value"',
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/deprecated/preserveModules/invalid-none-export-mode/_config.js
+++ b/test/function/samples/deprecated/preserveModules/invalid-none-export-mode/_config.js
@@ -11,6 +11,7 @@ module.exports = {
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
-			'"none" was specified for "output.exports", but entry module "lib.js" has the following exports: value'
+			'"none" was specified for "output.exports", but entry module "lib.js" has the following exports: "value"',
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/deprecated/preserveModules/mixed-exports/_config.js
+++ b/test/function/samples/deprecated/preserveModules/mixed-exports/_config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_LIB1 = path.join(__dirname, 'lib1.js');
 
 module.exports = {
 	description: 'warns for mixed exports in all chunks when preserving modules',
@@ -15,16 +17,16 @@ module.exports = {
 		},
 		{
 			code: 'MIXED_EXPORTS',
-			id: path.join(__dirname, 'main.js'),
+			id: ID_MAIN,
 			message:
-				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
+				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.',
 			url: 'https://rollupjs.org/guide/en/#outputexports'
 		},
 		{
 			code: 'MIXED_EXPORTS',
-			id: path.join(__dirname, 'lib1.js'),
+			id: ID_LIB1,
 			message:
-				'Entry module "lib1.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
+				'Entry module "lib1.js" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.',
 			url: 'https://rollupjs.org/guide/en/#outputexports'
 		}
 	]

--- a/test/function/samples/does-not-hang-on-missing-module/_config.js
+++ b/test/function/samples/does-not-hang-on-missing-module/_config.js
@@ -1,14 +1,17 @@
 const assert = require('assert');
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'does not hang on missing module (#53)',
 	warnings: [
 		{
 			code: 'UNRESOLVED_IMPORT',
-			importer: 'main.js',
-			source: 'unlessYouCreatedThisFileForSomeReason',
-			message: `'unlessYouCreatedThisFileForSomeReason' is imported by main.js, but could not be resolved – treating it as an external dependency`,
-			url: `https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency`
+			exporter: 'unlessYouCreatedThisFileForSomeReason',
+			id: ID_MAIN,
+			message:
+				'"unlessYouCreatedThisFileForSomeReason" is imported by "main.js", but could not be resolved – treating it as an external dependency.',
+			url: 'https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency'
 		}
 	],
 	runtimeError(error) {

--- a/test/function/samples/double-default-export/_config.js
+++ b/test/function/samples/double-default-export/_config.js
@@ -1,12 +1,11 @@
 const path = require('path');
+const ID_FOO = path.join(__dirname, 'foo.js');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'throws on double default exports',
 	error: {
-		code: 'PARSE_ERROR',
-		message: `Duplicate export 'default'`,
-		id: path.join(__dirname, 'foo.js'),
-		parserError: {
+		cause: {
 			loc: {
 				column: 7,
 				line: 2
@@ -15,10 +14,13 @@ module.exports = {
 			pos: 25,
 			raisedAt: 34
 		},
+		code: 'PARSE_ERROR',
+		message: `Duplicate export 'default'`,
+		id: ID_FOO,
 		pos: 25,
-		watchFiles: [path.join(__dirname, 'foo.js'), path.join(__dirname, 'main.js')],
+		watchFiles: [ID_FOO, ID_MAIN],
 		loc: {
-			file: path.join(__dirname, 'foo.js'),
+			file: ID_FOO,
 			line: 2,
 			column: 7
 		},

--- a/test/function/samples/double-named-export/_config.js
+++ b/test/function/samples/double-named-export/_config.js
@@ -1,12 +1,11 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
 
 module.exports = {
 	description: 'throws on duplicate named exports',
 	error: {
-		code: 'PARSE_ERROR',
-		message: `Duplicate export 'foo'`,
-		id: path.join(__dirname, 'foo.js'),
-		parserError: {
+		cause: {
 			loc: {
 				column: 9,
 				line: 3
@@ -15,10 +14,13 @@ module.exports = {
 			pos: 38,
 			raisedAt: 43
 		},
+		code: 'PARSE_ERROR',
+		message: `Duplicate export 'foo'`,
+		id: ID_FOO,
 		pos: 38,
-		watchFiles: [path.join(__dirname, 'foo.js'), path.join(__dirname, 'main.js')],
+		watchFiles: [ID_FOO, ID_MAIN],
 		loc: {
-			file: path.join(__dirname, 'foo.js'),
+			file: ID_FOO,
 			line: 3,
 			column: 9
 		},

--- a/test/function/samples/double-named-reexport/_config.js
+++ b/test/function/samples/double-named-reexport/_config.js
@@ -1,12 +1,11 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
 
 module.exports = {
 	description: 'throws on duplicate named exports',
 	error: {
-		code: 'PARSE_ERROR',
-		message: `Duplicate export 'foo'`,
-		id: path.join(__dirname, 'foo.js'),
-		parserError: {
+		cause: {
 			loc: {
 				column: 9,
 				line: 3
@@ -15,10 +14,13 @@ module.exports = {
 			pos: 38,
 			raisedAt: 43
 		},
+		code: 'PARSE_ERROR',
+		message: `Duplicate export 'foo'`,
+		id: ID_FOO,
 		pos: 38,
-		watchFiles: [path.join(__dirname, 'foo.js'), path.join(__dirname, 'main.js')],
+		watchFiles: [ID_FOO, ID_MAIN],
 		loc: {
-			file: path.join(__dirname, 'foo.js'),
+			file: ID_FOO,
 			line: 3,
 			column: 9
 		},

--- a/test/function/samples/duplicate-import-fails/_config.js
+++ b/test/function/samples/duplicate-import-fails/_config.js
@@ -1,12 +1,10 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'disallows duplicate imports',
 	error: {
-		code: 'PARSE_ERROR',
-		message: `Identifier 'a' has already been declared`,
-		id: path.join(__dirname, 'main.js'),
-		parserError: {
+		cause: {
 			loc: {
 				column: 9,
 				line: 2
@@ -15,10 +13,13 @@ module.exports = {
 			pos: 36,
 			raisedAt: 39
 		},
+		code: 'PARSE_ERROR',
+		message: `Identifier 'a' has already been declared`,
+		id: ID_MAIN,
 		pos: 36,
-		watchFiles: [path.join(__dirname, 'main.js')],
+		watchFiles: [ID_MAIN],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
+			file: ID_MAIN,
 			line: 2,
 			column: 9
 		},

--- a/test/function/samples/duplicate-import-specifier-fails/_config.js
+++ b/test/function/samples/duplicate-import-specifier-fails/_config.js
@@ -1,12 +1,10 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'disallows duplicate import specifiers',
 	error: {
-		code: 'PARSE_ERROR',
-		message: `Identifier 'a' has already been declared`,
-		id: path.join(__dirname, 'main.js'),
-		parserError: {
+		cause: {
 			loc: {
 				column: 12,
 				line: 1
@@ -15,10 +13,13 @@ module.exports = {
 			pos: 12,
 			raisedAt: 15
 		},
+		code: 'PARSE_ERROR',
+		message: `Identifier 'a' has already been declared`,
+		id: ID_MAIN,
 		pos: 12,
-		watchFiles: [path.join(__dirname, 'main.js')],
+		watchFiles: [ID_MAIN],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
+			file: ID_MAIN,
 			line: 1,
 			column: 12
 		},

--- a/test/function/samples/dynamic-import-not-found/_config.js
+++ b/test/function/samples/dynamic-import-not-found/_config.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
 module.exports = {
 	description: 'warns if a dynamic import is not found',
 	context: {
@@ -10,10 +13,10 @@ module.exports = {
 	warnings: [
 		{
 			code: 'UNRESOLVED_IMPORT',
-			importer: 'main.js',
+			exporter: 'mod',
+			id: ID_MAIN,
 			message:
-				"'mod' is imported by main.js, but could not be resolved – treating it as an external dependency",
-			source: 'mod',
+				'"mod" is imported by "main.js", but could not be resolved – treating it as an external dependency.',
 			url: 'https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency'
 		}
 	]

--- a/test/function/samples/dynamic-import-relative-not-found/_config.js
+++ b/test/function/samples/dynamic-import-relative-not-found/_config.js
@@ -1,10 +1,13 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'throws if a dynamic relative import is not found',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './mod' from main.js`,
-		watchFiles: [path.join(__dirname, 'main.js')]
+		exporter: './mod',
+		id: ID_MAIN,
+		message: 'Could not resolve "./mod" from "main.js"',
+		watchFiles: [ID_MAIN]
 	}
 };

--- a/test/function/samples/emit-file/chunk-not-found/_config.js
+++ b/test/function/samples/emit-file/chunk-not-found/_config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'Throws if an emitted entry chunk cannot be resolved',
@@ -12,7 +13,7 @@ module.exports = {
 	},
 	error: {
 		code: 'UNRESOLVED_ENTRY',
-		message: 'Could not resolve entry module (not-found.js).',
-		watchFiles: [path.join(__dirname, 'main.js')]
+		watchFiles: [ID_MAIN],
+		message: 'Could not resolve entry module "not-found.js".'
 	}
 };

--- a/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
+++ b/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
@@ -1,5 +1,7 @@
 const path = require('path');
 const MagicString = require('magic-string');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_EMPTY = path.join(__dirname, 'empty.js');
 
 module.exports = {
 	description: 'error after transform should throw with correct location of file',
@@ -19,15 +21,16 @@ module.exports = {
 		]
 	},
 	error: {
+		binding: 'default',
 		code: 'MISSING_EXPORT',
-		message: `'default' is not exported by empty.js, imported by main.js`,
-		id: path.join(__dirname, 'main.js'),
+		exporter: ID_EMPTY,
+		id: ID_MAIN,
+		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
 		pos: 44,
-		watchFiles: [path.join(__dirname, 'empty.js'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 1,
-			column: 7
+			column: 7,
+			file: ID_MAIN,
+			line: 1
 		},
 		frame: `
 			1: import a from './empty.js';
@@ -35,6 +38,7 @@ module.exports = {
 			2:
 			3: Object.assign({}, a);
 		`,
-		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
+		watchFiles: [ID_EMPTY, ID_MAIN],
+		message: '"default" is not exported by "empty.js", imported by "main.js".'
 	}
 };

--- a/test/function/samples/error-missing-umd-name/_config.js
+++ b/test/function/samples/error-missing-umd-name/_config.js
@@ -4,6 +4,7 @@ module.exports = {
 	generateError: {
 		code: 'MISSING_NAME_OPTION_FOR_IIFE_EXPORT',
 		message:
-			'You must supply "output.name" for UMD bundles that have exports so that the exports are accessible in environments without a module loader.'
+			'You must supply "output.name" for UMD bundles that have exports so that the exports are accessible in environments without a module loader.',
+		url: 'https://rollupjs.org/guide/en/#outputname'
 	}
 };

--- a/test/function/samples/error-parse-json/_config.js
+++ b/test/function/samples/error-parse-json/_config.js
@@ -1,33 +1,35 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_JSON = path.join(__dirname, 'file.json');
 
 module.exports = {
 	description:
 		'throws with an extended error message when failing to parse a file with ".json" extension',
 	error: {
-		code: 'PARSE_ERROR',
-		message: 'Unexpected token (Note that you need @rollup/plugin-json to import JSON files)',
-		id: path.join(__dirname, 'file.json'),
-		parserError: {
-			loc: {
-				column: 8,
-				line: 2
-			},
-			message: 'Unexpected token (2:8)',
+		cause: {
 			pos: 10,
-			raisedAt: 11
+			loc: {
+				line: 2,
+				column: 8
+			},
+			raisedAt: 11,
+			message: 'Unexpected token (2:8)'
 		},
+		code: 'PARSE_ERROR',
+		id: ID_JSON,
 		pos: 10,
-		watchFiles: [path.join(__dirname, 'file.json'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'file.json'),
-			line: 2,
-			column: 8
+			column: 8,
+			file: ID_JSON,
+			line: 2
 		},
 		frame: `
 			1: {
 			2:   "JSON": "is not really JavaScript"
 			           ^
 			3: }
-		`
+		`,
+		watchFiles: [ID_JSON, ID_MAIN],
+		message: 'Unexpected token (Note that you need @rollup/plugin-json to import JSON files)'
 	}
 };

--- a/test/function/samples/error-parse-unknown-extension/_config.js
+++ b/test/function/samples/error-parse-unknown-extension/_config.js
@@ -1,34 +1,35 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_CSS = path.join(__dirname, 'file.css');
 
 module.exports = {
 	description:
 		'throws with an extended error message when failing to parse a file without .(m)js extension',
 	error: {
-		code: 'PARSE_ERROR',
-		message:
-			'Unexpected token (Note that you need plugins to import files that are not JavaScript)',
-		id: path.join(__dirname, 'file.css'),
-		parserError: {
-			loc: {
-				column: 0,
-				line: 1
-			},
-			message: 'Unexpected token (1:0)',
+		cause: {
 			pos: 0,
-			raisedAt: 1
+			loc: {
+				line: 1,
+				column: 0
+			},
+			raisedAt: 1,
+			message: 'Unexpected token (1:0)'
 		},
+		code: 'PARSE_ERROR',
+		id: ID_CSS,
 		pos: 0,
-		watchFiles: [path.join(__dirname, 'file.css'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'file.css'),
-			line: 1,
-			column: 0
+			column: 0,
+			file: ID_CSS,
+			line: 1
 		},
 		frame: `
 			1: .special-class {
 			   ^
 			2:     color: black;
 			3: }
-		`
+		`,
+		watchFiles: [ID_CSS, ID_MAIN],
+		message: 'Unexpected token (Note that you need plugins to import files that are not JavaScript)'
 	}
 };

--- a/test/function/samples/export-not-at-top-level-fails/_config.js
+++ b/test/function/samples/export-not-at-top-level-fails/_config.js
@@ -1,32 +1,33 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'disallows non-top-level exports',
 	error: {
-		code: 'PARSE_ERROR',
-		message: `'import' and 'export' may only appear at the top level`,
-		id: path.join(__dirname, 'main.js'),
-		parserError: {
-			loc: {
-				column: 2,
-				line: 2
-			},
-			message: "'import' and 'export' may only appear at the top level (2:2)",
+		cause: {
 			pos: 19,
-			raisedAt: 25
+			loc: {
+				line: 2,
+				column: 2
+			},
+			raisedAt: 25,
+			message: "'import' and 'export' may only appear at the top level (2:2)"
 		},
+		code: 'PARSE_ERROR',
+		id: ID_MAIN,
 		pos: 19,
-		watchFiles: [path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 2,
-			column: 2
+			column: 2,
+			file: ID_MAIN,
+			line: 2
 		},
 		frame: `
 			1: function foo() {
 			2:   export { foo };
 			     ^
 			3: }
-		`
+		`,
+		watchFiles: [ID_MAIN],
+		message: "'import' and 'export' may only appear at the top level"
 	}
 };

--- a/test/function/samples/export-type-mismatch-b/_config.js
+++ b/test/function/samples/export-type-mismatch-b/_config.js
@@ -3,8 +3,8 @@ module.exports = {
 	options: { output: { exports: 'blah' } },
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
+		url: 'https://rollupjs.org/guide/en/#outputexports',
 		message:
-			'"output.exports" must be "default", "named", "none", "auto", or left unspecified (defaults to "auto"), received "blah"',
-		url: 'https://rollupjs.org/guide/en/#outputexports'
+			'"output.exports" must be "default", "named", "none", "auto", or left unspecified (defaults to "auto"), received "blah".'
 	}
 };

--- a/test/function/samples/export-type-mismatch-c/_config.js
+++ b/test/function/samples/export-type-mismatch-c/_config.js
@@ -4,6 +4,7 @@ module.exports = {
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
-			'"none" was specified for "output.exports", but entry module "main.js" has the following exports: default'
+			'"none" was specified for "output.exports", but entry module "main.js" has the following exports: "default"',
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/export-type-mismatch/_config.js
+++ b/test/function/samples/export-type-mismatch/_config.js
@@ -4,6 +4,7 @@ module.exports = {
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
-			'"default" was specified for "output.exports", but entry module "main.js" has the following exports: foo'
+			'"default" was specified for "output.exports", but entry module "main.js" has the following exports: "foo"',
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/external-conflict/_config.js
+++ b/test/function/samples/external-conflict/_config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'external paths from custom resolver remain external (#633)',
@@ -17,8 +18,8 @@ module.exports = {
 	},
 	error: {
 		code: 'INVALID_EXTERNAL_ID',
+		watchFiles: [ID_MAIN, 'dep'],
 		message:
-			"'dep' is imported as an external by dep, but is already an existing non-external module id.",
-		watchFiles: [path.join(__dirname, 'main.js'), 'dep']
+			'"dep" is imported as an external by "dep", but is already an existing non-external module id.'
 	}
 };

--- a/test/function/samples/external-entry-point-object/_config.js
+++ b/test/function/samples/external-entry-point-object/_config.js
@@ -9,6 +9,6 @@ module.exports = {
 	},
 	error: {
 		code: 'UNRESOLVED_ENTRY',
-		message: `Entry module cannot be external (main.js).`
+		message: 'Entry module "main.js" cannot be external.'
 	}
 };

--- a/test/function/samples/external-entry-point/_config.js
+++ b/test/function/samples/external-entry-point/_config.js
@@ -9,6 +9,6 @@ module.exports = {
 	},
 	error: {
 		code: 'UNRESOLVED_ENTRY',
-		message: `Entry module cannot be external (main.js).`
+		message: 'Entry module "main.js" cannot be external.'
 	}
 };

--- a/test/function/samples/fallback-on-warn/_config.js
+++ b/test/function/samples/fallback-on-warn/_config.js
@@ -14,7 +14,7 @@ module.exports = {
 	after() {
 		console.warn = oldConsoleWarn;
 		assert.deepStrictEqual(warnings, [
-			'Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification'
+			'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.'
 		]);
 	}
 };

--- a/test/function/samples/import-not-at-top-level-fails/_config.js
+++ b/test/function/samples/import-not-at-top-level-fails/_config.js
@@ -1,32 +1,33 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'disallows non-top-level imports',
 	error: {
-		code: 'PARSE_ERROR',
-		message: `'import' and 'export' may only appear at the top level`,
-		id: path.join(__dirname, 'main.js'),
-		parserError: {
-			loc: {
-				column: 2,
-				line: 2
-			},
-			message: "'import' and 'export' may only appear at the top level (2:2)",
+		cause: {
 			pos: 19,
-			raisedAt: 25
+			loc: {
+				line: 2,
+				column: 2
+			},
+			raisedAt: 25,
+			message: "'import' and 'export' may only appear at the top level (2:2)"
 		},
+		code: 'PARSE_ERROR',
+		id: ID_MAIN,
 		pos: 19,
-		watchFiles: [path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 2,
-			column: 2
+			column: 2,
+			file: ID_MAIN,
+			line: 2
 		},
 		frame: `
 			1: function foo() {
 			2:   import foo from './foo.js';
 			     ^
 			3: }
-		`
+		`,
+		watchFiles: [ID_MAIN],
+		message: "'import' and 'export' may only appear at the top level"
 	}
 };

--- a/test/function/samples/import-of-unexported-fails/_config.js
+++ b/test/function/samples/import-of-unexported-fails/_config.js
@@ -1,17 +1,20 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_EMPTY = path.join(__dirname, 'empty.js');
 
 module.exports = {
 	description: 'marking an imported, but unexported, identifier should throw',
 	error: {
+		binding: 'default',
 		code: 'MISSING_EXPORT',
-		message: `'default' is not exported by empty.js, imported by main.js`,
-		id: path.join(__dirname, 'main.js'),
+		exporter: ID_EMPTY,
+		id: ID_MAIN,
+		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
 		pos: 7,
-		watchFiles: [path.join(__dirname, 'empty.js'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 1,
-			column: 7
+			column: 7,
+			file: ID_MAIN,
+			line: 1
 		},
 		frame: `
 			1: import a from './empty.js';
@@ -19,6 +22,7 @@ module.exports = {
 			2:
 			3: a();
 		`,
-		url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
+		watchFiles: [ID_EMPTY, ID_MAIN],
+		message: '"default" is not exported by "empty.js", imported by "main.js".'
 	}
 };

--- a/test/function/samples/interop-default-only-named-import/_config.js
+++ b/test/function/samples/interop-default-only-named-import/_config.js
@@ -8,9 +8,9 @@ module.exports = {
 	},
 	generateError: {
 		code: 'UNEXPECTED_NAMED_IMPORT',
-		id: 'external',
+		exporter: 'external',
+		url: 'https://rollupjs.org/guide/en/#outputinterop',
 		message:
-			'The named export "foo" was imported from the external module external even though its interop type is "defaultOnly". Either remove or change this import or change the value of the "output.interop" option.',
-		url: 'https://rollupjs.org/guide/en/#outputinterop'
+			'The named export "foo" was imported from the external module "external" even though its interop type is "defaultOnly". Either remove or change this import or change the value of the "output.interop" option.'
 	}
 };

--- a/test/function/samples/interop-default-only-named-reexport/_config.js
+++ b/test/function/samples/interop-default-only-named-reexport/_config.js
@@ -8,9 +8,9 @@ module.exports = {
 	},
 	generateError: {
 		code: 'UNEXPECTED_NAMED_IMPORT',
-		id: 'external',
+		exporter: 'external',
+		url: 'https://rollupjs.org/guide/en/#outputinterop',
 		message:
-			'The named export "foo" was reexported from the external module external even though its interop type is "defaultOnly". Either remove or change this reexport or change the value of the "output.interop" option.',
-		url: 'https://rollupjs.org/guide/en/#outputinterop'
+			'The named export "foo" was reexported from the external module "external" even though its interop type is "defaultOnly". Either remove or change this reexport or change the value of the "output.interop" option.'
 	}
 };

--- a/test/function/samples/interop-default-only-namespace-reexport/_config.js
+++ b/test/function/samples/interop-default-only-namespace-reexport/_config.js
@@ -9,9 +9,9 @@ module.exports = {
 	warnings: [
 		{
 			code: 'UNEXPECTED_NAMED_IMPORT',
-			id: 'external',
+			exporter: 'external',
 			message:
-				'There was a namespace "*" reexport from the external module external even though its interop type is "defaultOnly". This will be ignored as namespace reexports only reexport named exports. If this is not intended, either remove or change this reexport or change the value of the "output.interop" option.',
+				'There was a namespace "*" reexport from the external module "external" even though its interop type is "defaultOnly". This will be ignored as namespace reexports only reexport named exports. If this is not intended, either remove or change this reexport or change the value of the "output.interop" option.',
 			url: 'https://rollupjs.org/guide/en/#outputinterop'
 		}
 	]

--- a/test/function/samples/invalid-default-export-mode/_config.js
+++ b/test/function/samples/invalid-default-export-mode/_config.js
@@ -8,6 +8,7 @@ module.exports = {
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
-			'"default" was specified for "output.exports", but entry module "main.js" has the following exports: default, foo'
+			'"default" was specified for "output.exports", but entry module "main.js" has the following exports: "default" and "foo"',
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/invalid-top-level-await/_config.js
+++ b/test/function/samples/invalid-top-level-await/_config.js
@@ -1,11 +1,12 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'throws for invalid top-level-await format',
 	generateError: {
 		code: 'INVALID_TLA_FORMAT',
+		id: ID_MAIN,
 		message:
-			'Module format cjs does not support top-level await. Use the "es" or "system" output formats rather.',
-		id: path.join(__dirname, 'main.js')
+			'Module format "cjs" does not support top-level await. Use the "es" or "system" output formats rather.'
 	}
 };

--- a/test/function/samples/load-resolve-dependencies/_config.js
+++ b/test/function/samples/load-resolve-dependencies/_config.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 const path = require('path');
+const ID_FIRST = path.join(__dirname, 'first.js');
+const ID_SECOND = path.join(__dirname, 'second.js');
+const ID_THIRD = path.join(__dirname, 'third.js');
 const DYNAMIC_IMPORT_PROXY_PREFIX = '\0dynamic-import:';
 const chunks = [];
 
@@ -9,12 +12,10 @@ module.exports = {
 	async exports(exports) {
 		assert.deepStrictEqual(chunks, []);
 		const { importSecond } = await exports.importFirst();
-		const expectedFirstChunk = ['first.js', 'second.js', 'third.js'].map(name =>
-			path.join(__dirname, name)
-		);
+		const expectedFirstChunk = [ID_FIRST, ID_SECOND, ID_THIRD];
 		assert.deepStrictEqual(chunks, [expectedFirstChunk]);
 		await importSecond();
-		const expectedSecondChunk = ['second.js', 'third.js'].map(name => path.join(__dirname, name));
+		const expectedSecondChunk = [ID_SECOND, ID_THIRD];
 		assert.deepStrictEqual(chunks, [expectedFirstChunk, expectedSecondChunk]);
 	},
 	options: {
@@ -85,8 +86,7 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['second.js', 'third.js', 'second.js'],
-			importer: 'second.js',
+			ids: [ID_SECOND, ID_THIRD, ID_SECOND],
 			message: 'Circular dependency: second.js -> third.js -> second.js'
 		}
 	]

--- a/test/function/samples/load-returns-string-or-null/_config.js
+++ b/test/function/samples/load-returns-string-or-null/_config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'throws error if load returns something wacky',
@@ -14,7 +15,8 @@ module.exports = {
 	},
 	error: {
 		code: 'BAD_LOADER',
-		message: `Error loading main.js: plugin load hook should return a string, a { code, map } object, or nothing/null`,
-		watchFiles: [path.join(__dirname, 'main.js')]
+		watchFiles: [ID_MAIN],
+		message:
+			'Error loading "main.js": plugin load hook should return a string, a { code, map } object, or nothing/null.'
 	}
 };

--- a/test/function/samples/manual-chunks-conflict/_config.js
+++ b/test/function/samples/manual-chunks-conflict/_config.js
@@ -11,6 +11,6 @@ module.exports = {
 	},
 	generateError: {
 		code: 'INVALID_CHUNK',
-		message: `Cannot assign dep.js to the "dep2" chunk as it is already in the "dep1" chunk.`
+		message: 'Cannot assign "dep.js" to the "dep2" chunk as it is already in the "dep1" chunk.'
 	}
 };

--- a/test/function/samples/module-level-directive/_config.js
+++ b/test/function/samples/module-level-directive/_config.js
@@ -1,21 +1,25 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'module level directives should produce warnings',
 	warnings: [
 		{
 			code: 'MODULE_LEVEL_DIRECTIVE',
-			message: "Module level directives cause errors when bundled, 'use asm' was ignored.",
+			id: ID_MAIN,
+			message:
+				'Module level directives cause errors when bundled, "use asm" in "main.js" was ignored.',
 			pos: 0,
-			id: path.join(__dirname, 'main.js'),
 			loc: {
-				file: path.join(__dirname, 'main.js'),
-				line: 1,
-				column: 0
+				column: 0,
+				file: ID_MAIN,
+				line: 1
 			},
 			frame: `
-			1: "use asm";\n   ^\n2:\n3: export default 1;
-			`
+				1: "use asm";
+				   ^
+				2:
+				3: export default 1;`
 		}
 	]
 };

--- a/test/function/samples/module-side-effects/external-false/_config.js
+++ b/test/function/samples/module-side-effects/external-false/_config.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
 const sideEffects = [];
 
 module.exports = {
@@ -45,10 +47,10 @@ module.exports = {
 	warnings: [
 		{
 			code: 'UNRESOLVED_IMPORT',
-			importer: 'main.js',
+			exporter: 'implicit-external',
+			id: ID_MAIN,
 			message:
-				"'implicit-external' is imported by main.js, but could not be resolved – treating it as an external dependency",
-			source: 'implicit-external',
+				'"implicit-external" is imported by "main.js", but could not be resolved – treating it as an external dependency.',
 			url: 'https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency'
 		}
 	]

--- a/test/function/samples/module-tree/_config.js
+++ b/test/function/samples/module-tree/_config.js
@@ -34,9 +34,9 @@ module.exports = {
 	},
 	warnings: [
 		{
-			chunkName: 'main',
 			code: 'EMPTY_BUNDLE',
-			message: 'Generated an empty chunk: "main"'
+			message: 'Generated an empty chunk: "main".',
+			names: ['main']
 		}
 	]
 };

--- a/test/function/samples/namespace-missing-export/_config.js
+++ b/test/function/samples/namespace-missing-export/_config.js
@@ -1,28 +1,28 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_EMPTY = path.join(__dirname, 'empty.js');
 
 module.exports = {
 	description: 'replaces missing namespace members with undefined and warns about them',
 	warnings: [
 		{
+			binding: 'foo',
 			code: 'MISSING_EXPORT',
-			exporter: 'empty.js',
-			importer: 'main.js',
-			id: path.join(__dirname, 'main.js'),
-			missing: 'foo',
-			message: `'foo' is not exported by 'empty.js'`,
+			exporter: ID_EMPTY,
+			id: ID_MAIN,
+			message: '"foo" is not exported by "empty.js", imported by "main.js".',
+			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
 			pos: 61,
 			loc: {
-				file: require('path').resolve(__dirname, 'main.js'),
-				line: 3,
-				column: 25
+				column: 25,
+				file: ID_MAIN,
+				line: 3
 			},
 			frame: `
 				1: import * as mod from './empty.js';
 				2:
 				3: assert.equal( typeof mod.foo, 'undefined' );
-				                            ^
-			`,
-			url: `https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module`
+				                            ^`
 		}
 	]
 };

--- a/test/function/samples/namespace-reassign-import-fails/_config.js
+++ b/test/function/samples/namespace-reassign-import-fails/_config.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const path = require('path');
 const { assertIncludes } = require('../../../utils.js');
 const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
 
 module.exports = {
 	description: 'warns for reassignments to namespace exports',
@@ -13,8 +14,7 @@ module.exports = {
 		{
 			binding: 'bar',
 			code: 'MISSING_EXPORT',
-			exporter:
-				'/Users/lukastaegert/Github/rollup/test/function/samples/namespace-reassign-import-fails/foo.js',
+			exporter: ID_FOO,
 			id: ID_MAIN,
 			message: '"bar" is not exported by "foo.js", imported by "main.js".',
 			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',

--- a/test/function/samples/namespace-reassign-import-fails/_config.js
+++ b/test/function/samples/namespace-reassign-import-fails/_config.js
@@ -1,7 +1,6 @@
 const assert = require('assert');
 const path = require('path');
 const { assertIncludes } = require('../../../utils.js');
-
 const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
@@ -12,60 +11,57 @@ module.exports = {
 	},
 	warnings: [
 		{
+			binding: 'bar',
 			code: 'MISSING_EXPORT',
-			exporter: 'foo.js',
-			frame: `
-			2:
-			3: exp.foo = 2;
-			4: exp.bar = 3;
-			       ^
-		`,
+			exporter:
+				'/Users/lukastaegert/Github/rollup/test/function/samples/namespace-reassign-import-fails/foo.js',
 			id: ID_MAIN,
-			importer: 'main.js',
+			message: '"bar" is not exported by "foo.js", imported by "main.js".',
+			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
+			pos: 48,
 			loc: {
 				column: 4,
 				file: ID_MAIN,
 				line: 4
 			},
-			message: "'bar' is not exported by 'foo.js'",
-			missing: 'bar',
-			pos: 48,
-			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module'
+			frame: `
+				2:
+				3: exp.foo = 2;
+				4: exp.bar = 3;
+				       ^`
 		},
 		{
-			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
-			message: `Illegal reassignment to import 'exp'`,
+			code: 'ILLEGAL_REASSIGNMENT',
+			message: 'Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 31,
 			loc: {
+				column: 0,
 				file: ID_MAIN,
-				line: 3,
-				column: 0
+				line: 3
 			},
 			frame: `
-			1: import * as exp from './foo';
-			2:
-			3: exp.foo = 2;
-			   ^
-			4: exp.bar = 3;
-		`
+				1: import * as exp from './foo';
+				2:
+				3: exp.foo = 2;
+				   ^
+				4: exp.bar = 3;`
 		},
 		{
-			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
-			message: `Illegal reassignment to import 'exp'`,
+			code: 'ILLEGAL_REASSIGNMENT',
+			message: 'Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 44,
 			loc: {
+				column: 0,
 				file: ID_MAIN,
-				line: 4,
-				column: 0
+				line: 4
 			},
 			frame: `
-			2:
-			3: exp.foo = 2;
-			4: exp.bar = 3;
-			   ^
-		`
+				2:
+				3: exp.foo = 2;
+				4: exp.bar = 3;
+				   ^`
 		}
 	],
 	runtimeError(error) {

--- a/test/function/samples/namespace-update-import-fails/_config.js
+++ b/test/function/samples/namespace-update-import-fails/_config.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const path = require('path');
 const { assertIncludes } = require('../../../utils.js');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'disallows updates to namespace exports',
@@ -9,21 +10,20 @@ module.exports = {
 	},
 	warnings: [
 		{
-			code: 'ILLEGAL_NAMESPACE_REASSIGNMENT',
-			message: `Illegal reassignment to import 'exp'`,
-			id: path.join(__dirname, 'main.js'),
+			code: 'ILLEGAL_REASSIGNMENT',
+			message: 'Illegal reassignment of import "exp" in "main.js".',
+			id: ID_MAIN,
 			pos: 31,
 			loc: {
-				file: path.join(__dirname, 'main.js'),
-				line: 3,
-				column: 0
+				column: 0,
+				file: ID_MAIN,
+				line: 3
 			},
 			frame: `
-			1: import * as exp from './foo';
-			2:
-			3: exp['foo']++;
-			   ^
-		`
+				1: import * as exp from './foo';
+				2:
+				3: exp['foo']++;
+				   ^`
 		}
 	],
 	runtimeError(error) {

--- a/test/function/samples/nested-inlined-dynamic-import-2/_config.js
+++ b/test/function/samples/nested-inlined-dynamic-import-2/_config.js
@@ -1,12 +1,14 @@
 const assert = require('assert');
+const path = require('path');
+const ID_LIB1 = path.join(__dirname, 'lib1.js');
+const ID_LIB2 = path.join(__dirname, 'lib2.js');
 
 module.exports = {
 	description: 'deconflicts variables when nested dynamic imports are inlined',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['lib1.js', 'lib2.js', 'lib1.js'],
-			importer: 'lib1.js',
+			ids: [ID_LIB1, ID_LIB2, ID_LIB1],
 			message: 'Circular dependency: lib1.js -> lib2.js -> lib1.js'
 		}
 	],

--- a/test/function/samples/no-relative-external/_config.js
+++ b/test/function/samples/no-relative-external/_config.js
@@ -1,10 +1,13 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'missing relative imports are an error, not a warning',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './missing.js' from main.js`,
-		watchFiles: [path.join(__dirname, 'main.js')]
+		exporter: './missing.js',
+		id: ID_MAIN,
+		watchFiles: [ID_MAIN],
+		message: 'Could not resolve "./missing.js" from "main.js"'
 	}
 };

--- a/test/function/samples/non-function-hook-async/_config.js
+++ b/test/function/samples/non-function-hook-async/_config.js
@@ -8,8 +8,8 @@ module.exports = {
 	error: {
 		code: 'PLUGIN_ERROR',
 		hook: 'resolveId',
-		message: 'Error running plugin hook resolveId for at position 1, expected a function hook.',
 		plugin: 'at position 1',
-		pluginCode: 'INVALID_PLUGIN_HOOK'
+		pluginCode: 'INVALID_PLUGIN_HOOK',
+		message: 'Error running plugin hook "resolveId" for "at position 1", expected a function hook.'
 	}
 };

--- a/test/function/samples/non-function-hook-sync/_config.js
+++ b/test/function/samples/non-function-hook-sync/_config.js
@@ -8,8 +8,9 @@ module.exports = {
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		hook: 'outputOptions',
-		message: 'Error running plugin hook outputOptions for at position 1, expected a function hook.',
 		plugin: 'at position 1',
-		pluginCode: 'INVALID_PLUGIN_HOOK'
+		pluginCode: 'INVALID_PLUGIN_HOOK',
+		message:
+			'Error running plugin hook "outputOptions" for "at position 1", expected a function hook.'
 	}
 };

--- a/test/function/samples/paths-are-case-sensitive/_config.js
+++ b/test/function/samples/paths-are-case-sensitive/_config.js
@@ -1,10 +1,13 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'insists on correct casing for imports',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './foo.js' from main.js`,
-		watchFiles: [path.join(__dirname, 'main.js')]
+		exporter: './foo.js',
+		id: ID_MAIN,
+		watchFiles: [ID_MAIN],
+		message: 'Could not resolve "./foo.js" from "main.js"'
 	}
 };

--- a/test/function/samples/preload-cyclic-module/_config.js
+++ b/test/function/samples/preload-cyclic-module/_config.js
@@ -1,10 +1,13 @@
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_PROXY = path.join(__dirname, 'main.js?proxy');
+
 module.exports = {
 	description: 'handles pre-loading a cyclic module in the resolveId hook',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'main.js?proxy', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_PROXY, ID_MAIN],
 			message: 'Circular dependency: main.js -> main.js?proxy -> main.js'
 		}
 	],

--- a/test/function/samples/preserve-modules-circular-order/_config.js
+++ b/test/function/samples/preserve-modules-circular-order/_config.js
@@ -1,4 +1,8 @@
 const assert = require('assert');
+const path = require('path');
+const ID_INDEX = path.join(__dirname, 'index.js');
+const ID_DATA = path.join(__dirname, 'data.js');
+const ID_TAG = path.join(__dirname, 'tag.js');
 const executionOrder = [];
 
 module.exports = {
@@ -20,20 +24,17 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['data.js', 'tag.js', 'data.js'],
-			importer: 'data.js',
+			ids: [ID_DATA, ID_TAG, ID_DATA],
 			message: 'Circular dependency: data.js -> tag.js -> data.js'
 		},
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['data.js', 'tag.js', 'index.js', 'data.js'],
-			importer: 'data.js',
+			ids: [ID_DATA, ID_TAG, ID_INDEX, ID_DATA],
 			message: 'Circular dependency: data.js -> tag.js -> index.js -> data.js'
 		},
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['tag.js', 'index.js', 'tag.js'],
-			importer: 'tag.js',
+			ids: [ID_TAG, ID_INDEX, ID_TAG],
 			message: 'Circular dependency: tag.js -> index.js -> tag.js'
 		}
 	]

--- a/test/function/samples/preserve-modules/invalid-default-export-mode/_config.js
+++ b/test/function/samples/preserve-modules/invalid-default-export-mode/_config.js
@@ -10,6 +10,7 @@ module.exports = {
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
-			'"default" was specified for "output.exports", but entry module "lib.js" has the following exports: value'
+			'"default" was specified for "output.exports", but entry module "lib.js" has the following exports: "value"',
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/preserve-modules/invalid-none-export-mode/_config.js
+++ b/test/function/samples/preserve-modules/invalid-none-export-mode/_config.js
@@ -10,6 +10,7 @@ module.exports = {
 	generateError: {
 		code: 'INVALID_EXPORT_OPTION',
 		message:
-			'"none" was specified for "output.exports", but entry module "lib.js" has the following exports: value'
+			'"none" was specified for "output.exports", but entry module "lib.js" has the following exports: "value"',
+		url: 'https://rollupjs.org/guide/en/#outputexports'
 	}
 };

--- a/test/function/samples/preserve-modules/mixed-exports/_config.js
+++ b/test/function/samples/preserve-modules/mixed-exports/_config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_LIB1 = path.join(__dirname, 'lib1.js');
 
 module.exports = {
 	description: 'warns for mixed exports in all chunks when preserving modules',
@@ -9,16 +11,16 @@ module.exports = {
 	warnings: [
 		{
 			code: 'MIXED_EXPORTS',
-			id: path.join(__dirname, 'main.js'),
+			id: ID_MAIN,
 			message:
-				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
+				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.',
 			url: 'https://rollupjs.org/guide/en/#outputexports'
 		},
 		{
 			code: 'MIXED_EXPORTS',
-			id: path.join(__dirname, 'lib1.js'),
+			id: ID_LIB1,
 			message:
-				'Entry module "lib1.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
+				'Entry module "lib1.js" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.',
 			url: 'https://rollupjs.org/guide/en/#outputexports'
 		}
 	]

--- a/test/function/samples/reassign-import-fails/_config.js
+++ b/test/function/samples/reassign-import-fails/_config.js
@@ -1,24 +1,25 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
 
 module.exports = {
 	description: 'disallows assignments to imported bindings',
 	error: {
 		code: 'ILLEGAL_REASSIGNMENT',
-		message: `Illegal reassignment to import 'x'`,
-		id: path.join(__dirname, 'main.js'),
+		id: ID_MAIN,
 		pos: 113,
-		watchFiles: [path.join(__dirname, 'foo.js'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 8,
-			column: 0
+			column: 0,
+			file: ID_MAIN,
+			line: 8
 		},
 		frame: `
 			6: });
 			7:
 			8: x = 10;
-			   ^
-		`
+			   ^`,
+		watchFiles: [ID_FOO, ID_MAIN],
+		message: 'Illegal reassignment of import "x" in "main.js".'
 	}
 };
 

--- a/test/function/samples/reassign-import-not-at-top-level-fails/_config.js
+++ b/test/function/samples/reassign-import-not-at-top-level-fails/_config.js
@@ -1,25 +1,26 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
 
 module.exports = {
 	description: 'disallows assignments to imported bindings not at the top level',
 	error: {
 		code: 'ILLEGAL_REASSIGNMENT',
-		message: `Illegal reassignment to import 'x'`,
-		id: path.join(__dirname, 'main.js'),
+		id: ID_MAIN,
 		pos: 95,
-		watchFiles: [path.join(__dirname, 'foo.js'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 7,
-			column: 2
+			column: 2,
+			file: ID_MAIN,
+			line: 7
 		},
 		frame: `
 			5: }
 			6: export function bar () {
 			7:   x = 1;
 			     ^
-			8: }
-		`
+			8: }`,
+		watchFiles: [ID_FOO, ID_MAIN],
+		message: 'Illegal reassignment of import "x" in "main.js".'
 	}
 };
 

--- a/test/function/samples/recursive-reexports/_config.js
+++ b/test/function/samples/recursive-reexports/_config.js
@@ -1,4 +1,8 @@
 const assert = require('assert');
+const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_OTHER = path.join(__dirname, 'other.js');
+
 module.exports = {
 	description: 'handles recursive namespace reexports',
 	exports(exports) {
@@ -7,8 +11,7 @@ module.exports = {
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['main.js', 'other.js', 'main.js'],
-			importer: 'main.js',
+			ids: [ID_MAIN, ID_OTHER, ID_MAIN],
 			message: 'Circular dependency: main.js -> other.js -> main.js'
 		}
 	]

--- a/test/function/samples/reexport-missing-error/_config.js
+++ b/test/function/samples/reexport-missing-error/_config.js
@@ -1,22 +1,25 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_EMPTY = path.join(__dirname, 'empty.js');
 
 module.exports = {
 	description: 'reexporting a missing identifier should print an error',
 	error: {
+		binding: 'foo',
 		code: 'MISSING_EXPORT',
-		message: `'foo' is not exported by empty.js, imported by main.js`,
-		id: path.join(__dirname, 'main.js'),
+		exporter: ID_EMPTY,
+		id: ID_MAIN,
+		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
 		pos: 9,
-		watchFiles: [path.join(__dirname, 'empty.js'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 1,
-			column: 9
+			column: 9,
+			file: ID_MAIN,
+			line: 1
 		},
 		frame: `
 			1: export { foo as bar } from './empty.js';
-			            ^
-		`,
-		url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module'
+			            ^`,
+		watchFiles: [ID_EMPTY, ID_MAIN],
+		message: '"foo" is not exported by "empty.js", imported by "main.js".'
 	}
 };

--- a/test/function/samples/shims-missing-exports/_config.js
+++ b/test/function/samples/shims-missing-exports/_config.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const ID_DEP1 = path.join(__dirname, 'dep1.js');
+
 module.exports = {
 	description: 'shims missing exports',
 	options: {
@@ -5,10 +8,10 @@ module.exports = {
 	},
 	warnings: [
 		{
+			binding: 'missing',
 			code: 'SHIMMED_EXPORT',
-			message: 'Missing export "missing" has been shimmed in module dep1.js.',
-			exporter: 'dep1.js',
-			exportName: 'missing'
+			exporter: ID_DEP1,
+			message: 'Missing export "missing" has been shimmed in module "dep1.js".'
 		}
 	]
 };

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports/_config.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports/_config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_DEP = path.join(__dirname, 'dep.js');
 
 module.exports = {
 	description: 'handles circular synthetic exports',
@@ -14,8 +16,9 @@ module.exports = {
 	},
 	error: {
 		code: 'SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT',
-		id: path.join(__dirname, 'main.js'),
-		message: `Module "main.js" that is marked with 'syntheticNamedExports: "__synthetic"' needs an explicit export named "__synthetic" that does not reexport an unresolved named export of the same module.`,
-		watchFiles: [path.join(__dirname, 'dep.js'), path.join(__dirname, 'main.js')]
+		exporter: ID_MAIN,
+		watchFiles: [ID_DEP, ID_MAIN],
+		message:
+			'Module "main.js" that is marked with `syntheticNamedExports: "__synthetic"` needs an explicit export named "__synthetic" that does not reexport an unresolved named export of the same module.'
 	}
 };

--- a/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/_config.js
+++ b/test/function/samples/synthetic-named-exports/circular-synthetic-exports2/_config.js
@@ -1,10 +1,13 @@
+const path = require('path');
+const ID_DEP1 = path.join(__dirname, 'dep1.js');
+const ID_DEP2 = path.join(__dirname, 'dep2.js');
+
 module.exports = {
 	description: 'handles circular synthetic exports',
 	warnings: [
 		{
 			code: 'CIRCULAR_DEPENDENCY',
-			cycle: ['dep1.js', 'dep2.js', 'dep1.js'],
-			importer: 'dep1.js',
+			ids: [ID_DEP1, ID_DEP2, ID_DEP1],
 			message: 'Circular dependency: dep1.js -> dep2.js -> dep1.js'
 		}
 	]

--- a/test/function/samples/synthetic-named-exports/external-synthetic-exports/_config.js
+++ b/test/function/samples/synthetic-named-exports/external-synthetic-exports/_config.js
@@ -18,9 +18,8 @@ module.exports = {
 	warnings: [
 		{
 			code: 'EXTERNAL_SYNTHETIC_EXPORTS',
-			importer: 'main.js',
-			source: 'dep',
-			message: "External 'dep' can not have 'syntheticNamedExports' enabled."
+			exporter: 'dep',
+			message: 'External "dep" cannot have "syntheticNamedExports" enabled (imported by "main.js").'
 		}
 	],
 	context: {

--- a/test/function/samples/synthetic-named-exports/synthetic-exports-need-default/_config.js
+++ b/test/function/samples/synthetic-named-exports/synthetic-exports-need-default/_config.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_DEP = path.join(__dirname, 'dep.js');
 
 module.exports = {
 	description: 'synthetic named exports modules need a default export',
@@ -13,8 +15,9 @@ module.exports = {
 	},
 	error: {
 		code: 'SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT',
-		id: path.join(__dirname, 'dep.js'),
-		message: `Module "dep.js" that is marked with 'syntheticNamedExports: true' needs a default export that does not reexport an unresolved named export of the same module.`,
-		watchFiles: [path.join(__dirname, 'dep.js'), path.join(__dirname, 'main.js')]
+		exporter: ID_DEP,
+		watchFiles: [ID_DEP, ID_MAIN],
+		message:
+			'Module "dep.js" that is marked with `syntheticNamedExports: true` needs a default export that does not reexport an unresolved named export of the same module.'
 	}
 };

--- a/test/function/samples/synthetic-named-exports/synthetic-exports-need-fallback-export/_config.js
+++ b/test/function/samples/synthetic-named-exports/synthetic-exports-need-fallback-export/_config.js
@@ -1,5 +1,6 @@
 const path = require('path');
-const DEP_ID = path.join(__dirname, 'dep.js');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_DEP = path.join(__dirname, 'dep.js');
 
 module.exports = {
 	description: 'synthetic named exports modules need their fallback export',
@@ -16,8 +17,9 @@ module.exports = {
 	},
 	error: {
 		code: 'SYNTHETIC_NAMED_EXPORTS_NEED_NAMESPACE_EXPORT',
-		id: DEP_ID,
-		message: `Module "dep.js" that is marked with 'syntheticNamedExports: "__synthetic"' needs an explicit export named "__synthetic" that does not reexport an unresolved named export of the same module.`,
-		watchFiles: [DEP_ID, path.join(__dirname, 'main.js')]
+		exporter: ID_DEP,
+		watchFiles: [ID_DEP, ID_MAIN],
+		message:
+			'Module "dep.js" that is marked with `syntheticNamedExports: "__synthetic"` needs an explicit export named "__synthetic" that does not reexport an unresolved named export of the same module.'
 	}
 };

--- a/test/function/samples/throws-not-found-module/_config.js
+++ b/test/function/samples/throws-not-found-module/_config.js
@@ -1,10 +1,13 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'throws error if module is not found',
 	error: {
 		code: 'UNRESOLVED_IMPORT',
-		message: `Could not resolve './mod' from main.js`,
-		watchFiles: [path.join(__dirname, 'main.js')]
+		exporter: './mod',
+		id: ID_MAIN,
+		watchFiles: [ID_MAIN],
+		message: 'Could not resolve "./mod" from "main.js"'
 	}
 };

--- a/test/function/samples/unused-import/_config.js
+++ b/test/function/samples/unused-import/_config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'warns on unused imports ([#595])',
@@ -13,10 +14,11 @@ module.exports = {
 	warnings: [
 		{
 			code: 'UNUSED_EXTERNAL_IMPORT',
-			source: 'external',
-			names: ['notused', 'neverused'],
-			message: `"notused" and "neverused" are imported from external module "external" but never used in "main.js".`,
-			sources: [path.resolve(__dirname, './main.js')]
+			exporter: 'external',
+			ids: [ID_MAIN],
+			message:
+				'"notused" and "neverused" are imported from external module "external" but never used in "main.js".',
+			names: ['notused', 'neverused']
 		}
 	]
 };

--- a/test/function/samples/update-expression-of-import-fails/_config.js
+++ b/test/function/samples/update-expression-of-import-fails/_config.js
@@ -1,24 +1,25 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
 
 module.exports = {
 	description: 'disallows updates to imported bindings',
 	error: {
 		code: 'ILLEGAL_REASSIGNMENT',
-		message: `Illegal reassignment to import 'a'`,
-		id: path.join(__dirname, 'main.js'),
+		id: ID_MAIN,
 		pos: 28,
-		watchFiles: [path.join(__dirname, 'foo.js'), path.join(__dirname, 'main.js')],
 		loc: {
-			file: path.join(__dirname, 'main.js'),
-			line: 3,
-			column: 0
+			column: 0,
+			file: ID_MAIN,
+			line: 3
 		},
 		frame: `
 			1: import { a } from './foo';
 			2:
 			3: a++;
-			   ^
-		`
+			   ^`,
+		watchFiles: [ID_FOO, ID_MAIN],
+		message: 'Illegal reassignment of import "a" in "main.js".'
 	}
 };
 

--- a/test/function/samples/vars-with-init-in-dead-branch/_config.js
+++ b/test/function/samples/vars-with-init-in-dead-branch/_config.js
@@ -2,9 +2,9 @@ module.exports = {
 	description: 'handles vars with init in dead branch (#1198)',
 	warnings: [
 		{
-			chunkName: 'main',
 			code: 'EMPTY_BUNDLE',
-			message: 'Generated an empty chunk: "main"'
+			message: 'Generated an empty chunk: "main".',
+			names: ['main']
 		}
 	]
 };

--- a/test/function/samples/warn-missing-iife-name/_config.js
+++ b/test/function/samples/warn-missing-iife-name/_config.js
@@ -5,7 +5,8 @@ module.exports = {
 		{
 			code: 'MISSING_NAME_OPTION_FOR_IIFE_EXPORT',
 			message:
-				'If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.'
+				'If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.',
+			url: 'https://rollupjs.org/guide/en/#outputname'
 		}
 	]
 };

--- a/test/function/samples/warn-on-auto-named-default-exports/_config.js
+++ b/test/function/samples/warn-on-auto-named-default-exports/_config.js
@@ -1,13 +1,14 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'warns if default and named exports are used in auto mode',
 	warnings: [
 		{
 			code: 'MIXED_EXPORTS',
-			id: path.join(__dirname, 'main.js'),
+			id: ID_MAIN,
 			message:
-				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk["default"]` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning',
+				'Entry module "main.js" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.',
 			url: 'https://rollupjs.org/guide/en/#outputexports'
 		}
 	]

--- a/test/function/samples/warn-on-empty-bundle/_config.js
+++ b/test/function/samples/warn-on-empty-bundle/_config.js
@@ -2,9 +2,9 @@ module.exports = {
 	description: 'warns if empty bundle is generated  (#444)',
 	warnings: [
 		{
-			chunkName: 'main',
 			code: 'EMPTY_BUNDLE',
-			message: 'Generated an empty chunk: "main"'
+			message: 'Generated an empty chunk: "main".',
+			names: ['main']
 		}
 	]
 };

--- a/test/function/samples/warn-on-eval/_config.js
+++ b/test/function/samples/warn-on-eval/_config.js
@@ -1,23 +1,24 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {
 	description: 'warns about use of eval',
 	warnings: [
 		{
 			code: 'EVAL',
-			id: path.join(__dirname, 'main.js'),
-			message: `Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification`,
+			id: ID_MAIN,
+			message:
+				'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+			url: 'https://rollupjs.org/guide/en/#avoiding-eval',
 			pos: 13,
 			loc: {
 				column: 13,
-				file: require('path').resolve(__dirname, 'main.js'),
+				file: ID_MAIN,
 				line: 1
 			},
 			frame: `
 				1: var result = eval( '1 + 1' );
-				                ^
-			`,
-			url: 'https://rollupjs.org/guide/en/#avoiding-eval'
+				                ^`
 		}
 	]
 };

--- a/test/function/samples/warn-on-namespace-conflict/_config.js
+++ b/test/function/samples/warn-on-namespace-conflict/_config.js
@@ -1,14 +1,18 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
+const ID_BAR = path.join(__dirname, 'bar.js');
 
 module.exports = {
 	description: 'warns on duplicate export * from',
 	warnings: [
 		{
+			binding: 'foo',
 			code: 'NAMESPACE_CONFLICT',
-			name: 'foo',
-			reexporter: path.join(__dirname, 'main.js'),
-			sources: [path.join(__dirname, 'foo.js'), path.join(__dirname, 'bar.js')],
-			message: `Conflicting namespaces: "main.js" re-exports "foo" from one of the modules "foo.js" and "bar.js" (will be ignored)`
+			ids: [ID_FOO, ID_BAR],
+			message:
+				'Conflicting namespaces: "main.js" re-exports "foo" from one of the modules "foo.js" and "bar.js" (will be ignored).',
+			reexporter: ID_MAIN
 		}
 	]
 };

--- a/test/function/samples/warn-on-unused-missing-imports/_config.js
+++ b/test/function/samples/warn-on-unused-missing-imports/_config.js
@@ -1,26 +1,28 @@
 const path = require('path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_FOO = path.join(__dirname, 'foo.js');
 
 module.exports = {
 	description: 'warns on missing (but unused) imports',
 	warnings: [
 		{
-			code: 'NON_EXISTENT_EXPORT',
-			id: path.join(__dirname, 'main.js'),
-			source: path.join(__dirname, 'foo.js'),
-			name: 'b',
-			message: `Non-existent export 'b' is imported from foo.js`,
+			binding: 'b',
+			code: 'MISSING_EXPORT',
+			exporter: ID_FOO,
+			id: ID_MAIN,
+			message: '"b" is not exported by "foo.js", imported by "main.js".',
+			url: 'https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module',
 			pos: 12,
 			loc: {
-				file: path.join(__dirname, 'main.js'),
-				line: 1,
-				column: 12
+				column: 12,
+				file: ID_MAIN,
+				line: 1
 			},
 			frame: `
 				1: import { a, b } from './foo.js';
 				               ^
 				2:
-				3: assert.equal( a, 42 );
-			`
+				3: assert.equal( a, 42 );`
 		}
 	]
 };

--- a/test/function/samples/warnings-to-string/_config.js
+++ b/test/function/samples/warnings-to-string/_config.js
@@ -13,7 +13,7 @@ module.exports = {
 	warnings(warnings) {
 		assert.deepStrictEqual(warnings.map(String), [
 			'(test-plugin plugin) main.js (1:6) This might be removed',
-			'Generated an empty chunk: "main"'
+			'Generated an empty chunk: "main".'
 		]);
 	}
 };

--- a/test/misc/iife.js
+++ b/test/misc/iife.js
@@ -106,7 +106,8 @@ describe('The IIFE wrapper with an illegal name', () => {
 				compareError(error, {
 					code: 'ILLEGAL_IDENTIFIER_AS_NAME',
 					message:
-						'Given name "1name" is not a legal JS identifier. If you need this, you can try "output.extend: true".'
+						'Given name "1name" is not a legal JS identifier. If you need this, you can try "output.extend: true".',
+					url: 'https://rollupjs.org/guide/en/#outputextend'
 				})
 			));
 
@@ -119,7 +120,8 @@ describe('The IIFE wrapper with an illegal name', () => {
 				compareError(error, {
 					code: 'ILLEGAL_IDENTIFIER_AS_NAME',
 					message:
-						'Given name "my=name" is not a legal JS identifier. If you need this, you can try "output.extend: true".'
+						'Given name "my=name" is not a legal JS identifier. If you need this, you can try "output.extend: true".',
+					url: 'https://rollupjs.org/guide/en/#outputextend'
 				})
 			));
 

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -80,10 +80,11 @@ describe('misc', () => {
 				assert.deepEqual(warnings, [
 					{
 						code: 'MISSING_GLOBAL_NAME',
-						guess: '_',
+						id: 'lodash',
 						message:
-							"No name was provided for external module 'lodash' in output.globals – guessing '_'",
-						source: 'lodash'
+							'No name was provided for external module "lodash" in "output.globals" – guessing "_".',
+						names: ['_'],
+						url: 'https://rollupjs.org/guide/en/#outputglobals'
 					}
 				]);
 			});
@@ -271,7 +272,7 @@ console.log(x);
 			});
 		} catch (err) {
 			assert.notDeepStrictEqual(err.message, 'Maximum call stack size exceeded');
-			assert.strictEqual(err.name, 'Error');
+			assert.strictEqual(err.name, 'RollupError');
 		}
 	});
 

--- a/test/misc/sanity-checks.js
+++ b/test/misc/sanity-checks.js
@@ -33,7 +33,7 @@ describe('sanity checks', () => {
 		assert.equal(args[0].code, 'EVAL');
 		assert.equal(
 			args[0].message,
-			'Use of eval is strongly discouraged, as it poses security risks and may cause issues with minification'
+			'Use of eval in "x" is strongly discouraged as it poses security risks and may cause issues with minification.'
 		);
 		assert.equal(typeof args[1], 'function');
 	});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This PR unifies a lot of error and warning handling and finally puts all errors and warnings together in a [single file](https://github.com/rollup/rollup/blob/refine-errors/src/utils/error.ts).

Furthermore, the following changes are included:
* Error messages have been refined to more consistently use quotes and periods.
* Errors now have a `name: RollupError` property that will also show up in the stack trace, making it clearer that it is a custom error type that has additional properties.
* Error properties that reference modules (such as `id` and `ids`) will now always contain the full ids. Only the error message will use shortened ids (i.e. resolved relative to `process.cwd()`)
* The properties attached to some errors have been changed so that there are fewer different possible properties with consistent types
* Errors that are thrown in response to other errors (e.g. parse errors thrown by `acorn`) will now use the standardized `cause` property to reference the original error.
* Some errors have been replaced by others (ILLEGAL_NAMESPACE_REASSIGNMENT -> ILLEGAL_REASSIGNMENT, NON_EXISTENT_EXPORT -> MISSING_EXPORT)