### PR TITLE
Handle generating outputs with non-inlined dynamic imports after inlined ones

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,11 +15,8 @@ module.exports = {
 	ignorePatterns: [
 		'node_modules',
 		'dist',
-		'/test',
 		'perf',
-		'!/test/*.js',
-		'!/test/*/*.js',
-		'/test/node_modules',
+		'/test/*/samples/**/*.*',
 		'!/test/*/samples/**/_config.js',
 		'!/test/*/samples/**/rollup.config.js'
 	],

--- a/src/ast/nodes/ImportExpression.ts
+++ b/src/ast/nodes/ImportExpression.ts
@@ -102,6 +102,7 @@ export default class ImportExpression extends NodeBase {
 		accessedGlobalsByScope: Map<ChildScope, Set<string>>
 	): void {
 		const { format } = options;
+		this.inlineNamespace = null;
 		this.resolution = resolution;
 		const accessedGlobals = [...(accessedImportGlobals[format] || [])];
 		let helper: string | null;

--- a/test/cli/node_modules_rename_me/bar/lib/config.js
+++ b/test/cli/node_modules_rename_me/bar/lib/config.js
@@ -1,11 +1,9 @@
-const replace = require( '@rollup/plugin-replace' );
+const replace = require('@rollup/plugin-replace');
 
 module.exports = {
 	input: 'main.js',
 	output: {
 		format: 'cjs'
 	},
-	plugins: [
-		replace( { preventAssignment: true, ANSWER: 42 } )
-	]
+	plugins: [replace({ preventAssignment: true, ANSWER: 42 })]
 };

--- a/test/cli/node_modules_rename_me/rollup-config-foo/lib/config.js
+++ b/test/cli/node_modules_rename_me/rollup-config-foo/lib/config.js
@@ -1,11 +1,9 @@
-const replace = require( '@rollup/plugin-replace' );
+const replace = require('@rollup/plugin-replace');
 
 module.exports = {
 	input: 'main.js',
 	output: {
 		format: 'cjs'
 	},
-	plugins: [
-		replace( { preventAssignment: true, ANSWER: 42 } )
-	]
+	plugins: [replace({ preventAssignment: true, ANSWER: 42 })]
 };

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -274,4 +274,18 @@ console.log(x);
 			assert.strictEqual(err.name, 'Error');
 		}
 	});
+
+	it('supports rendering es after rendering iife with inlined dynamic imports', async () => {
+		const bundle = await rollup.rollup({
+			input: 'main.js',
+			plugins: [
+				loader({
+					'main.js': "import('other.js');",
+					'other.js': "export const foo = 'bar';"
+				})
+			]
+		});
+		const first = await bundle.generate({ format: 'iife', inlineDynamicImports: true });
+		const second = await bundle.generate({ format: 'es', exports: 'auto' });
+	});
 });

--- a/test/typescript/index.ts
+++ b/test/typescript/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import * as rollup from './dist/rollup';
 
 // Plugin API
@@ -32,24 +33,24 @@ const amdOutputOptions: rollup.OutputOptions['amd'][] = [
 		autoId: false
 	},
 	{
-		// @ts-expect-error
+		// @ts-expect-error for "basePath", "autoId" needs to be true
 		autoId: false,
 		basePath: '',
-		// @ts-expect-error
+		// @ts-expect-error cannot combine "id" and "basePath"
 		id: 'a'
 	},
 	{
-		// @ts-expect-error
+		// @ts-expect-error cannot combine "id" and "autoId"
 		autoId: true,
-		// @ts-expect-error
+		// @ts-expect-error cannot combine "id" and "autoId"
 		id: 'a'
 	},
 	{
 		basePath: '',
-		// @ts-expect-error
+		// @ts-expect-error cannot combine "id" and "basePath"
 		id: 'a'
 	},
-	// @ts-expect-error
+	// @ts-expect-error needs "autoId" for "basePath"
 	{
 		basePath: ''
 	}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- Resolves #4586
- Resolves #4415
- Resolves vitejs/vite#9310

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The problem was that when Rollup generated an output with `inlineDynamicImports: true`, it would leave a flag on the (shared) ImportExpression AST node that would mark it is `inlined` which would not be removed for the next output. The result was that for the next output, the import would be rendered both as "inlined" and as "non-inlined", resulting in an error. The fix was indeed simple.
Admittedly, the state handling behind this is not ideal, but resolving this is a much bigger topic for another time.