### PR TITLE
[v3.0] Use node: prefix for builtin imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For example, with CommonJS, the _entire tool or library must be imported_.
 
 ```js
 // import the entire utils object with CommonJS
-var utils = require('utils');
+var utils = require('node:utils');
 var query = 'Rollup';
 // use the ajax method of the utils object
 utils.ajax('https://api.example.com?search=' + query).then(handleResponse);
@@ -86,7 +86,7 @@ But with ES modules, instead of importing the whole `utils` object, we can just 
 
 ```js
 // import the ajax function with an ES import statement
-import { ajax } from 'utils';
+import { ajax } from 'node:utils';
 var query = 'Rollup';
 // call the ajax function
 ajax('https://api.example.com?search=' + query).then(handleResponse);

--- a/build-plugins/add-cli-entry.ts
+++ b/build-plugins/add-cli-entry.ts
@@ -1,5 +1,5 @@
-import { chmod } from 'fs/promises';
-import { resolve } from 'path';
+import { chmod } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import MagicString from 'magic-string';
 import type { Plugin } from 'rollup';
 

--- a/build-plugins/copy-types.ts
+++ b/build-plugins/copy-types.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { readFile } from 'fs-extra';
 import type { Plugin } from 'rollup';
 

--- a/build-plugins/generate-license-file.ts
+++ b/build-plugins/generate-license-file.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
-import { join } from 'path';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import type { PluginImpl } from 'rollup';
 import license, { type Dependency, type Person } from 'rollup-plugin-license';
 

--- a/build-plugins/get-banner.ts
+++ b/build-plugins/get-banner.ts
@@ -1,6 +1,6 @@
-import { exec } from 'child_process';
-import { env } from 'process';
-import { promisify } from 'util';
+import { exec } from 'node:child_process';
+import { env } from 'node:process';
+import { promisify } from 'node:util';
 import { version } from '../package.json';
 
 const execPromise = promisify(exec);

--- a/build-plugins/replace-browser-modules.ts
+++ b/build-plugins/replace-browser-modules.ts
@@ -1,4 +1,4 @@
-import { dirname, join, resolve } from 'path';
+import { dirname, join, resolve } from 'node:path';
 import type { Plugin } from 'rollup';
 
 const resolutions = {

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -1,4 +1,4 @@
-import process from 'process';
+import process from 'node:process';
 import help from 'help.md';
 import { version } from 'package.json';
 import argParser from 'yargs-parser';

--- a/cli/logging.ts
+++ b/cli/logging.ts
@@ -1,4 +1,4 @@
-import process from 'process';
+import process from 'node:process';
 import type { RollupError } from '../src/rollup/types';
 import { bold, cyan, dim, red } from '../src/utils/colors';
 import relativeId from '../src/utils/relativeId';

--- a/cli/run/build.ts
+++ b/cli/run/build.ts
@@ -1,4 +1,4 @@
-import process from 'process';
+import process from 'node:process';
 import ms from 'pretty-ms';
 import { rollup } from '../../src/node-entry';
 import type { MergedRollupOptions } from '../../src/rollup/types';

--- a/cli/run/commandPlugins.ts
+++ b/cli/run/commandPlugins.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path';
-import { pathToFileURL } from 'url';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { InputOptions } from '../../src/rollup/types';
 import { stdinPlugin } from './stdin';
 import { waitForInputPlugin } from './waitForInput';

--- a/cli/run/getConfigPath.ts
+++ b/cli/run/getConfigPath.ts
@@ -1,6 +1,6 @@
-import { promises as fs } from 'fs';
-import { resolve } from 'path';
-import { cwd } from 'process';
+import { promises as fs } from 'node:fs';
+import { resolve } from 'node:path';
+import { cwd } from 'node:process';
 import { errMissingExternalConfig } from '../../src/utils/error';
 import { handleError } from '../logging';
 

--- a/cli/run/index.ts
+++ b/cli/run/index.ts
@@ -1,4 +1,4 @@
-import { env } from 'process';
+import { env } from 'node:process';
 import type { MergedRollupOptions } from '../../src/rollup/types';
 import { errDuplicateImportOptions, errFailAfterWarnings } from '../../src/utils/error';
 import { isWatchEnabled } from '../../src/utils/options/mergeOptions';

--- a/cli/run/loadConfigFile.ts
+++ b/cli/run/loadConfigFile.ts
@@ -1,5 +1,5 @@
-import { extname, isAbsolute } from 'path';
-import { pathToFileURL } from 'url';
+import { extname, isAbsolute } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import getPackageType from 'get-package-type';
 import * as rollup from '../../src/node-entry';
 import type { MergedRollupOptions } from '../../src/rollup/types';

--- a/cli/run/loadConfigFromCommand.ts
+++ b/cli/run/loadConfigFromCommand.ts
@@ -1,4 +1,4 @@
-import process from 'process';
+import process from 'node:process';
 import type { MergedRollupOptions } from '../../src/rollup/types';
 import { mergeOptions } from '../../src/utils/options/mergeOptions';
 import batchWarnings, { type BatchWarnings } from './batchWarnings';

--- a/cli/run/stdin.ts
+++ b/cli/run/stdin.ts
@@ -1,4 +1,4 @@
-import process from 'process';
+import process from 'node:process';
 import type { Plugin } from '../../src/rollup/types';
 
 export const stdinName = '-';

--- a/cli/run/watch-cli.ts
+++ b/cli/run/watch-cli.ts
@@ -1,5 +1,5 @@
-import { promises as fs, type FSWatcher } from 'fs';
-import process from 'process';
+import { promises as fs, type FSWatcher } from 'node:fs';
+import process from 'node:process';
 import chokidar from 'chokidar';
 import dateTime from 'date-time';
 import ms from 'pretty-ms';

--- a/cli/run/watchHooks.ts
+++ b/cli/run/watchHooks.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 import type { RollupWatchHooks } from '../../src/rollup/types';
 import { bold, cyan } from '../../src/utils/colors';
 import { stderr } from '../logging';

--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -284,7 +284,7 @@ With CommonJS files, people often use `__dirname` to access the current director
 
 ```js
 // rollup.config.js
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 export default {
   ...,
@@ -311,7 +311,7 @@ It can be useful to import your package file to e.g. mark your dependencies as "
 - For older Node versions, you can use `createRequire`
 
   ```js
-  import { createRequire } from 'module';
+  import { createRequire } from 'node:module';
   const require = createRequire(import.meta.url);
   const pkg = require('./package.json');
 
@@ -322,7 +322,7 @@ It can be useful to import your package file to e.g. mark your dependencies as "
 
   ```js
   // rollup.config.mjs
-  import { readFileSync } from 'fs';
+  import { readFileSync } from 'node:fs';
 
   // Use import.meta.url to make the path relative to the current source file instead of process.cwd()
   // For more info: https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaurl

--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -263,7 +263,7 @@ In order to aid in generating such a config, rollup exposes the helper it uses t
 
 ```js
 const { loadConfigFile } = require('rollup/loadConfigFile');
-const path = require('path');
+const path = require('node:path');
 const rollup = require('rollup');
 
 // load the config file next to the current script;

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -15,7 +15,7 @@ Either a function that takes an `id` and returns `true` (external) or `false` (n
 
 ```js
 // rollup.config.js
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 export default {
   ...,
@@ -95,8 +95,8 @@ If you want to convert a set of file to another format while maintaining the fil
 
 ```js
 import glob from 'glob';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export default {
   input: Object.fromEntries(
@@ -208,7 +208,7 @@ To tell Rollup that a local file should be replaced by a global variable, use an
 
 ```js
 // rollup.config.js
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 const externalId = fileURLToPath(new URL('src/some-local-file-that-should-not-be-bundled.js', import.meta.url))
 
 export default {
@@ -1132,7 +1132,7 @@ Type: `(relativeSourcePath: string, sourcemapPath: string) => string`
 A transformation to apply to each path in a sourcemap. `relativeSourcePath` is a relative path from the generated `.map` file to the corresponding source file while `sourcemapPath` is the fully resolved path of the generated sourcemap file.
 
 ```js
-import path from 'path';
+import path from 'node:path';
 export default {
   input: 'src/main',
   output: [

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "dist/es/package.json"
   ],
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=14.13.1",
     "npm": ">=8.0.0"
   },
   "exports": {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { readFile, writeFile } from 'fs/promises';
+import { chdir, exit } from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { chdir, exit } from 'process';
 import GitHub from 'github-api';
 import inquirer from 'inquirer';
 import semverInc from 'semver/functions/inc.js';

--- a/src/finalisers/shared/warnOnBuiltins.ts
+++ b/src/finalisers/shared/warnOnBuiltins.ts
@@ -3,27 +3,27 @@ import type { RollupWarning } from '../../rollup/types';
 import { errMissingNodeBuiltins } from '../../utils/error';
 
 const builtins = {
-	assert: true,
-	buffer: true,
-	console: true,
-	constants: true,
-	domain: true,
-	events: true,
-	http: true,
-	https: true,
-	os: true,
-	path: true,
-	process: true,
-	punycode: true,
-	querystring: true,
-	stream: true,
-	string_decoder: true,
-	timers: true,
-	tty: true,
-	url: true,
-	util: true,
-	vm: true,
-	zlib: true
+	assert: 1,
+	buffer: 1,
+	console: 1,
+	constants: 1,
+	domain: 1,
+	events: 1,
+	http: 1,
+	https: 1,
+	os: 1,
+	path: 1,
+	process: 1,
+	punycode: 1,
+	querystring: 1,
+	stream: 1,
+	string_decoder: 1,
+	timers: 1,
+	tty: 1,
+	url: 1,
+	util: 1,
+	vm: 1,
+	zlib: 1
 };
 
 export default function warnOnBuiltins(
@@ -32,7 +32,7 @@ export default function warnOnBuiltins(
 ): void {
 	const externalBuiltins = dependencies
 		.map(({ importPath }) => importPath)
-		.filter(importPath => importPath in builtins);
+		.filter(importPath => importPath in builtins || importPath.startsWith('node:'));
 
 	if (!externalBuiltins.length) return;
 

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,4 +1,4 @@
-import { env } from 'process';
+import { env } from 'node:process';
 import { createColors } from 'colorette';
 
 // @see https://no-color.org

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,3 +1,3 @@
-import { createHash as cryptoCreateHash, type Hash } from 'crypto';
+import { createHash as cryptoCreateHash, type Hash } from 'node:crypto';
 
 export const createHash = (): Hash => cryptoCreateHash('sha256');

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,1 +1,1 @@
-export * from 'fs';
+export * from 'node:fs';

--- a/src/utils/hookActions.ts
+++ b/src/utils/hookActions.ts
@@ -1,5 +1,5 @@
-import { EventEmitter } from 'events';
-import process from 'process';
+import { EventEmitter } from 'node:events';
+import process from 'node:process';
 import { HookAction, PluginDriver } from './PluginDriver';
 
 function formatAction([pluginName, hookName, args]: HookAction): string {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -15,4 +15,4 @@ export function normalize(path: string): string {
 	return path.replace(BACKSLASH_REGEX, '/');
 }
 
-export { basename, dirname, extname, relative, resolve } from 'path';
+export { basename, dirname, extname, relative, resolve } from 'node:path';

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -1,1 +1,1 @@
-export { performance as default } from 'perf_hooks';
+export { performance as default } from 'node:perf_hooks';

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,1 +1,1 @@
-export { default } from 'process';
+export { default } from 'node:process';

--- a/src/watch/WatchEmitter.ts
+++ b/src/watch/WatchEmitter.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 
 type PromiseReturn<T extends (...args: any) => any> = (
 	...args: Parameters<T>

--- a/src/watch/fileWatcher.ts
+++ b/src/watch/fileWatcher.ts
@@ -1,4 +1,4 @@
-import { platform } from 'os';
+import { platform } from 'node:os';
 import chokidar, { type FSWatcher } from 'chokidar';
 import type { ChangeEvent, ChokidarOptions } from '../rollup/types';
 import type { Task } from './watch';

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -1,5 +1,5 @@
-import { resolve } from 'path';
-import process from 'process';
+import { resolve } from 'node:path';
+import process from 'node:process';
 import { createFilter } from '@rollup/pluginutils';
 import { rollupInternal } from '../rollup/rollup';
 import type {

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -3,7 +3,7 @@
 // available globally in all supported platforms. [currently global for node.js v16+].
 global.performance = require('perf_hooks').performance;
 
-const { basename, resolve } = require('path');
+const { basename, resolve } = require('node:path');
 const fixturify = require('fixturify');
 const { rollup } = require('../../browser/dist/rollup.browser.js');
 const { assertFilesAreEqual, runTestSuiteWithSamples, compareError } = require('../utils.js');

--- a/test/chunking-form/index.js
+++ b/test/chunking-form/index.js
@@ -1,5 +1,5 @@
-const { basename, resolve } = require('path');
-const { chdir } = require('process');
+const { basename, resolve } = require('node:path');
+const { chdir } = require('node:process');
 const { rollup } = require('../../dist/rollup');
 const { runTestSuiteWithSamples, assertDirectoriesAreEqual } = require('../utils.js');
 
@@ -63,7 +63,7 @@ async function generateAndTestBundle(bundle, outputOptions, expectedDir, config)
 	if (outputOptions.format === 'amd' && config.runAmd) {
 		try {
 			const exports = await new Promise((resolve, reject) => {
-				global.assert = require('assert');
+				global.assert = require('node:assert');
 				const requirejs = require('requirejs');
 				requirejs.config({ baseUrl: outputOptions.dir });
 				requirejs([config.nestedDir ? `${config.nestedDir}/main` : 'main'], resolve, reject);

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -1,8 +1,8 @@
-const assert = require('assert');
-const { exec } = require('child_process');
-const { existsSync, readFileSync } = require('fs');
-const { basename, resolve, sep } = require('path');
-const process = require('process');
+const assert = require('node:assert');
+const { exec } = require('node:child_process');
+const { existsSync, readFileSync } = require('node:fs');
+const { basename, resolve, sep } = require('node:path');
+const process = require('node:process');
 const { copySync, removeSync, statSync } = require('fs-extra');
 const {
 	normaliseOutput,

--- a/test/cli/samples/warn-multiple/_config.js
+++ b/test/cli/samples/warn-multiple/_config.js
@@ -7,7 +7,7 @@ module.exports = {
 		assertIncludes(
 			stderr,
 			'(!) Missing shims for Node.js built-ins\n' +
-				'Creating a browser bundle that depends on "url", "assert" and "path". You might need to include https://github.com/FredKSchott/rollup-plugin-polyfill-node\n'
+				'Creating a browser bundle that depends on "url", "assert" and "node:path". You might need to include https://github.com/FredKSchott/rollup-plugin-polyfill-node\n'
 		);
 		assertIncludes(
 			stderr,
@@ -16,7 +16,7 @@ module.exports = {
 				'main.js\n' +
 				'doesNotExist is not exported by dep.js\n' +
 				"4: import assert from 'assert';\n" +
-				"5: import path from 'path';\n" +
+				"5: import path from 'node:path';\n" +
 				"6: import {doesNotExist, alsoNotFound} from './dep.js';\n" +
 				'           ^\n' +
 				'7: \n' +
@@ -24,7 +24,7 @@ module.exports = {
 				'main.js\n' +
 				'alsoNotFound is not exported by dep.js\n' +
 				"4: import assert from 'assert';\n" +
-				"5: import path from 'path';\n" +
+				"5: import path from 'node:path';\n" +
 				"6: import {doesNotExist, alsoNotFound} from './dep.js';\n" +
 				'                         ^\n' +
 				'7: \n' +

--- a/test/cli/samples/warn-multiple/main.js
+++ b/test/cli/samples/warn-multiple/main.js
@@ -2,7 +2,7 @@
 
 import url from 'url';
 import assert from 'assert';
-import path from 'path';
+import path from 'node:path';
 import {doesNotExist, alsoNotFound} from './dep.js';
 
 export {url, assert, path};

--- a/test/file-hashes/index.js
+++ b/test/file-hashes/index.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const rollup = require('../../dist/rollup');
 const { runTestSuiteWithSamples } = require('../utils.js');
 

--- a/test/form/index.js
+++ b/test/form/index.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const { existsSync, readFileSync } = require('fs');
-const { basename, resolve } = require('path');
+const assert = require('node:assert');
+const { existsSync, readFileSync } = require('node:fs');
+const { basename, resolve } = require('node:path');
 const { rollup } = require('../../dist/rollup');
 const { normaliseOutput, runTestSuiteWithSamples } = require('../utils.js');
 

--- a/test/function/index.js
+++ b/test/function/index.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const path = require('path');
+const assert = require('node:assert');
+const path = require('node:path');
 const rollup = require('../../dist/rollup');
 const { compareError, compareWarnings, runTestSuiteWithSamples } = require('../utils.js');
 

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const { readdirSync } = require('fs');
-const path = require('path');
+const assert = require('node:assert');
+const { readdirSync } = require('node:fs');
+const path = require('node:path');
 const { removeSync } = require('fs-extra');
 const rollup = require('../../dist/rollup.js');
 const { loader } = require('../utils.js');

--- a/test/incremental/index.js
+++ b/test/incremental/index.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const acorn = require('acorn');
 const rollup = require('../../dist/rollup');
 const { executeBundle, getObject } = require('../utils.js');

--- a/test/leak/index.js
+++ b/test/leak/index.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const weak = require('weak-napi');
 const rollup = require('../..');
 const { wait } = require('../utils');

--- a/test/load-config-file/index.js
+++ b/test/load-config-file/index.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const path = require('path');
+const assert = require('node:assert');
+const path = require('node:path');
 const { loadConfigFile } = require('../../dist/loadConfigFile.js');
 
 describe('loadConfigFile', () => {

--- a/test/misc/acorn-plugins.js
+++ b/test/misc/acorn-plugins.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const rollup = require('../../dist/rollup');
 const { executeBundle, loader } = require('../utils.js');
 

--- a/test/misc/bundle-information.js
+++ b/test/misc/bundle-information.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const rollup = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 

--- a/test/misc/deprecations.js
+++ b/test/misc/deprecations.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const rollup = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 

--- a/test/misc/iife.js
+++ b/test/misc/iife.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const { rollup } = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 const { compareError } = require('../utils.js');

--- a/test/misc/in-memory-sourcemaps.js
+++ b/test/misc/in-memory-sourcemaps.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const path = require('path');
+const assert = require('node:assert');
+const path = require('node:path');
 const { getLocator } = require('locate-character');
 const { SourceMapConsumer } = require('source-map');
 const rollup = require('../../dist/rollup');

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const rollup = require('../../dist/rollup');
 const { assertIncludes, loader } = require('../utils.js');
 

--- a/test/misc/sanity-checks.js
+++ b/test/misc/sanity-checks.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const rollup = require('../../dist/rollup');
 const { loader, compareError } = require('../utils.js');
 

--- a/test/misc/umd.js
+++ b/test/misc/umd.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const { rollup } = require('../../dist/rollup');
 const { loader } = require('../utils.js');
 

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const rollup = require('../../dist/rollup');
 const { compareWarnings, runTestSuiteWithSamples } = require('../utils.js');
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const {
 	closeSync,
 	fsyncSync,
@@ -8,9 +8,9 @@ const {
 	unlinkSync,
 	writeFileSync,
 	writeSync
-} = require('fs');
-const { basename, join } = require('path');
-const { platform, version } = require('process');
+} = require('node:fs');
+const { basename, join } = require('node:path');
+const { platform, version } = require('node:process');
 const fixturify = require('fixturify');
 const { removeSync } = require('fs-extra');
 

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('node:assert');
 const {
 	existsSync,
 	promises: fs,
@@ -6,8 +6,8 @@ const {
 	readFileSync,
 	unlinkSync,
 	writeFileSync
-} = require('fs');
-const { resolve } = require('path');
+} = require('node:fs');
+const { resolve } = require('node:path');
 const { chdir, cwd, hrtime } = require('process');
 const { copy, removeSync } = require('fs-extra');
 const rollup = require('../../dist/rollup');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:
- resolves #4595

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This adds the "node:" prefix to all builtin imports like "fs". It also extends the error that warns about using builtins in a browser bundle to imports starting with "node:".

Breaking change: I raised the compatibility target for Node to `14.13.1`, which is the first version supporting this. Considering that older versions are probably not considered LTS, I think it should be acceptable.