### PR TITLE
[v3.0] Custom awaiting watch emitter

### DIFF
--- a/docs/02-javascript-api.md
+++ b/docs/02-javascript-api.md
@@ -223,6 +223,8 @@ watcher.on('event', event => {
   //                    bundle object for output generation errors. As with
   //                    "BUNDLE_END", you should call "event.result.close()" if
   //                    present once you are done.
+  // If you return a Promise from your event handler, Rollup will wait until the
+  // Promise is resolved before continuing.
 });
 
 // This will make sure that bundles are properly closed after each run
@@ -232,7 +234,13 @@ watcher.on('event', ({ result }) => {
   }
 });
 
-// stop watching
+// Additionally, you can hook into the following. Again, return a Promise to
+// make Rollup wait at that stage:
+watcher.on('change', (id, { event }) => { /* a file was modified */ })
+watcher.on('restart', () => { /* a new run was triggered */ })
+watcher.on('close', () => { /* the watcher was closed, see below */ })
+
+// to stop watching
 watcher.close();
 ```
 

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -87,8 +87,8 @@ export default class Graph {
 			const handleChange = (...args: Parameters<WatchChangeHook>) =>
 				this.pluginDriver.hookParallel('watchChange', args);
 			const handleClose = () => this.pluginDriver.hookParallel('closeWatcher', []);
-			watcher.onCurrentAwaited('change', handleChange);
-			watcher.onCurrentAwaited('close', handleClose);
+			watcher.onCurrentRun('change', handleChange);
+			watcher.onCurrentRun('close', handleClose);
 		}
 		this.pluginDriver = new PluginDriver(this, options, options.plugins, this.pluginCache);
 		this.acornParser = acorn.Parser.extend(...(options.acornInjectPlugins as any));

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -839,40 +839,37 @@ export interface RollupWatchOptions extends InputOptions {
 	watch?: WatcherOptions | false;
 }
 
-interface TypedEventEmitter<T extends { [event: string]: (...args: any) => any }> {
-	addListener<K extends keyof T>(event: K, listener: T[K]): this;
-	emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): boolean;
-	eventNames(): Array<keyof T>;
-	getMaxListeners(): number;
-	listenerCount(type: keyof T): number;
-	listeners<K extends keyof T>(event: K): Array<T[K]>;
-	off<K extends keyof T>(event: K, listener: T[K]): this;
-	on<K extends keyof T>(event: K, listener: T[K]): this;
-	once<K extends keyof T>(event: K, listener: T[K]): this;
-	prependListener<K extends keyof T>(event: K, listener: T[K]): this;
-	prependOnceListener<K extends keyof T>(event: K, listener: T[K]): this;
-	rawListeners<K extends keyof T>(event: K): Array<T[K]>;
-	removeAllListeners<K extends keyof T>(event?: K): this;
-	removeListener<K extends keyof T>(event: K, listener: T[K]): this;
-	setMaxListeners(n: number): this;
-}
+export type AwaitedEventListener<
+	T extends { [event: string]: (...args: any) => any },
+	K extends keyof T
+> = (...args: Parameters<T[K]>) => void | Promise<void>;
 
-export interface RollupAwaitingEmitter<T extends { [event: string]: (...args: any) => any }>
-	extends TypedEventEmitter<T> {
+export interface AwaitingEventEmitter<T extends { [event: string]: (...args: any) => any }> {
 	close(): Promise<void>;
-	emitAndAwait<K extends keyof T>(event: K, ...args: Parameters<T[K]>): Promise<ReturnType<T[K]>[]>;
+	emit<K extends keyof T>(event: K, ...args: Parameters<T[K]>): Promise<unknown>;
 	/**
-	 * Registers an event listener that will be awaited before Rollup continues
-	 * for events emitted via emitAndAwait. All listeners will be awaited in
-	 * parallel while rejections are tracked via Promise.all.
-	 * Listeners are removed automatically when removeAwaited is called, which
-	 * happens automatically after each run.
+	 * Removes an event listener.
 	 */
-	onCurrentAwaited<K extends keyof T>(
+	off<K extends keyof T>(event: K, listener: AwaitedEventListener<T, K>): this;
+	/**
+	 * Registers an event listener that will be awaited before Rollup continues.
+	 * All listeners will be awaited in parallel while rejections are tracked via
+	 * Promise.all.
+	 */
+	on<K extends keyof T>(event: K, listener: AwaitedEventListener<T, K>): this;
+	/**
+	 * Registers an event listener that will be awaited before Rollup continues.
+	 * All listeners will be awaited in parallel while rejections are tracked via
+	 * Promise.all.
+	 * Listeners are removed automatically when removeListenersForCurrentRun is
+	 * called, which happens automatically after each run.
+	 */
+	onCurrentRun<K extends keyof T>(
 		event: K,
 		listener: (...args: Parameters<T[K]>) => Promise<ReturnType<T[K]>>
 	): this;
-	removeAwaited(): this;
+	removeAllListeners(): this;
+	removeListenersForCurrentRun(): this;
 }
 
 export type RollupWatcherEvent =
@@ -888,7 +885,7 @@ export type RollupWatcherEvent =
 	| { code: 'END' }
 	| { code: 'ERROR'; error: RollupError; result: RollupBuild | null };
 
-export type RollupWatcher = RollupAwaitingEmitter<{
+export type RollupWatcher = AwaitingEventEmitter<{
 	change: (id: string, change: { event: ChangeEvent }) => void;
 	close: () => void;
 	event: (event: RollupWatcherEvent) => void;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This replaces the watch emitter, that used to be based on a NodeJS event emitter, with a custom implementation that allows the user to return a Promise from any listener to make Rollup wait at that stage before continuing.