### PR TITLE
Prevent using "arguments" for generated variable names

### DIFF
--- a/src/utils/identifierHelpers.ts
+++ b/src/utils/identifierHelpers.ts
@@ -4,8 +4,11 @@ const illegalCharacters = /[^$_a-zA-Z0-9]/g;
 
 const startsWithDigit = (str: string): boolean => /\d/.test(str[0]);
 
+const needsEscape = (str: string) =>
+	startsWithDigit(str) || RESERVED_NAMES.has(str) || str === 'arguments';
+
 export function isLegal(str: string): boolean {
-	if (startsWithDigit(str) || RESERVED_NAMES.has(str)) {
+	if (needsEscape(str)) {
 		return false;
 	}
 	return !illegalCharacters.test(str);
@@ -14,7 +17,7 @@ export function isLegal(str: string): boolean {
 export function makeLegal(str: string): string {
 	str = str.replace(/-(\w)/g, (_, letter) => letter.toUpperCase()).replace(illegalCharacters, '_');
 
-	if (startsWithDigit(str) || RESERVED_NAMES.has(str)) str = `_${str}`;
+	if (needsEscape(str)) str = `_${str}`;
 
 	return str || '_';
 }

--- a/test/function/samples/escape-arguments/_config.js
+++ b/test/function/samples/escape-arguments/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'does not use "arguments" as a placeholder variable for a default export',
+	exports(exports) {
+		assert.deepStrictEqual(exports, { foo: { __proto__: null, default: 42 } });
+	}
+};

--- a/test/function/samples/escape-arguments/arguments.js
+++ b/test/function/samples/escape-arguments/arguments.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/function/samples/escape-arguments/main.js
+++ b/test/function/samples/escape-arguments/main.js
@@ -1,0 +1,1 @@
+export * as foo from './arguments.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #4612

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
While "arguments" is not a reserved word in JavaScript, it cannot be used for declaring variables in strict mode, so this adds some special logic to prevent this.