### PR TITLE
Fix test/form/samples/quote-id on Windows

### DIFF
--- a/test/form/samples/quote-id/_config.js
+++ b/test/form/samples/quote-id/_config.js
@@ -9,7 +9,7 @@ module.exports = {
 	options: {
 		output: {
 			paths: id => {
-				if (id.startsWith('C:')) return id;
+				if (id === external3) return id;
 				return path.relative(__dirname, id);
 			},
 			name: 'Q',


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

Don't know if this is the right fix?

Failure looks like:

```
  1) rollup
       form
         quote-id: handles escaping for external ids
           generates amd:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected ... Lines skipped

  "define(['quoted\\'\\\r\\\n" +
+   "\\ \\ external1', './C:/code/others/rollup/test/form/samples/quote-id/quoted\\'\\\r\\\n" +
-   "\\ \\ external1', './quoted\\'\\\r\\\n" +
    "\\ \\ external2', './C:/File/Path'], (function (quoted_____external1, quoted_____external2, Path_js) { 'use strict';\n" +
...
    '\tconsole.log(quoted_____external1.foo, quoted_____external2.bar, Path_js.baz);\n' +
    '\n' +
    '}));'
      + expected - actual

\      define(['quoted\'\
\     -\ \ external1', './C:/code/others/rollup/test/form/samples/quote-id/quoted\'\
\     +\ \ external1', './quoted\'\
       \ \ external2', './C:/File/Path'], (function (quoted_____external1, quoted_____external2, Path_js) { 'use strict';

        console.log(quoted_____external1.foo, quoted_____external2.bar, Path_js.baz);


      at generateAndTestBundle (test\form\index.js:113:9)
      at runRollupTest (test\form\index.js:33:6)
```