### PR TITLE
Take first resolve id attributes

### DIFF
--- a/test/form/samples/quote-id/_config.js
+++ b/test/form/samples/quote-id/_config.js
@@ -9,7 +9,7 @@ module.exports = {
 	options: {
 		output: {
 			paths: id => {
-				if (id.startsWith('C:')) return id;
+				if (id === external3) return id;
 				return path.relative(__dirname, id);
 			},
 			name: 'Q',

--- a/test/function/samples/module-side-effects/first-resolve-id-wins/_config.js
+++ b/test/function/samples/module-side-effects/first-resolve-id-wins/_config.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+const path = require('path');
+const { getObject } = require('../../../../utils');
+
+const sideEffects = [];
+
+module.exports = {
+	description: 'does not include modules without used exports if moduleSideEffect is false',
+	context: {
+		sideEffects
+	},
+	exports() {
+		assert.deepStrictEqual(sideEffects, [
+			'sideeffects-false-usereffects-false-used-import',
+			'sideeffects-null-usereffects-false-used-import',
+			'sideeffects-true-usereffects-false',
+			'sideeffects-true-usereffects-false-unused-import',
+			'sideeffects-true-usereffects-false-used-import',
+			'sideeffects-false-usereffects-true-used-import',
+			'sideeffects-null-usereffects-true',
+			'sideeffects-null-usereffects-true-unused-import',
+			'sideeffects-null-usereffects-true-used-import',
+			'sideeffects-true-usereffects-true',
+			'sideeffects-true-usereffects-true-unused-import',
+			'sideeffects-true-usereffects-true-used-import'
+		]);
+	},
+	options: {
+		treeshake: {
+			moduleSideEffects(id) {
+				if (id.includes('main')) return true;
+				return JSON.parse(id.split('-')[3]);
+			}
+		},
+		plugins: [
+			{
+				name: 'resolving-plugin',
+				async resolveId(id, importer) {
+					await this.resolve(id, importer, { skipSelf: true });
+					if (!path.isAbsolute(id)) {
+						return { id };
+					}
+				}
+			},
+			{
+				name: 'test-plugin',
+				resolveId(id) {
+					if (!path.isAbsolute(id)) {
+						return {
+							id,
+							external: false,
+							moduleSideEffects: JSON.parse(id.split('-')[1])
+						};
+					}
+				},
+				load(id) {
+					if (!path.isAbsolute(id)) {
+						const sideEffects = JSON.parse(id.split('-')[1]);
+						const userEffects = JSON.parse(id.split('-')[3]);
+						assert.strictEqual(
+							this.getModuleInfo(id).moduleSideEffects,
+							typeof sideEffects === 'boolean' ? sideEffects : userEffects
+						);
+						return `export const value = '${id}'; sideEffects.push(value);`;
+					}
+				},
+				buildEnd() {
+					assert.deepStrictEqual(
+						getObject(
+							[...this.getModuleIds()]
+								.filter(id => !path.isAbsolute(id))
+								.sort()
+								.map(id => [id, this.getModuleInfo(id).moduleSideEffects])
+						),
+						{
+							'sideeffects-false-usereffects-false': false,
+							'sideeffects-false-usereffects-false-unused-import': false,
+							'sideeffects-false-usereffects-false-used-import': false,
+							'sideeffects-false-usereffects-true': false,
+							'sideeffects-false-usereffects-true-unused-import': false,
+							'sideeffects-false-usereffects-true-used-import': false,
+							'sideeffects-null-usereffects-false': false,
+							'sideeffects-null-usereffects-false-unused-import': false,
+							'sideeffects-null-usereffects-false-used-import': false,
+							'sideeffects-null-usereffects-true': true,
+							'sideeffects-null-usereffects-true-unused-import': true,
+							'sideeffects-null-usereffects-true-used-import': true,
+							'sideeffects-true-usereffects-false': true,
+							'sideeffects-true-usereffects-false-unused-import': true,
+							'sideeffects-true-usereffects-false-used-import': true,
+							'sideeffects-true-usereffects-true': true,
+							'sideeffects-true-usereffects-true-unused-import': true,
+							'sideeffects-true-usereffects-true-used-import': true
+						}
+					);
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/module-side-effects/first-resolve-id-wins/main.js
+++ b/test/function/samples/module-side-effects/first-resolve-id-wins/main.js
@@ -1,0 +1,25 @@
+import 'sideeffects-false-usereffects-false';
+import { value as unusedValue1 } from 'sideeffects-false-usereffects-false-unused-import';
+import { value as usedValue1 } from 'sideeffects-false-usereffects-false-used-import';
+
+import 'sideeffects-null-usereffects-false';
+import { value as unusedValue2 } from 'sideeffects-null-usereffects-false-unused-import';
+import { value as usedValue2 } from 'sideeffects-null-usereffects-false-used-import';
+
+import 'sideeffects-true-usereffects-false';
+import { value as unusedValue3 } from 'sideeffects-true-usereffects-false-unused-import';
+import { value as usedValue3 } from 'sideeffects-true-usereffects-false-used-import';
+
+import 'sideeffects-false-usereffects-true';
+import { value as unusedValue4 } from 'sideeffects-false-usereffects-true-unused-import';
+import { value as usedValue4 } from 'sideeffects-false-usereffects-true-used-import';
+
+import 'sideeffects-null-usereffects-true';
+import { value as unusedValue5 } from 'sideeffects-null-usereffects-true-unused-import';
+import { value as usedValue5 } from 'sideeffects-null-usereffects-true-used-import';
+
+import 'sideeffects-true-usereffects-true';
+import { value as unusedValue6 } from 'sideeffects-true-usereffects-true-unused-import';
+import { value as usedValue6 } from 'sideeffects-true-usereffects-true-used-import';
+
+export const values = [usedValue1, usedValue2, usedValue3, usedValue4, usedValue5, usedValue6];


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

resolves #1244

### Description

A (test for an) attempt at suggestion 2 of https://github.com/rollup/plugins/issues/1244#issuecomment-1220286796

Take the attributes of first `moduleSideEffects` returned from `resolveId`.