### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/repl-artefacts.yml
+++ b/.github/workflows/repl-artefacts.yml
@@ -4,8 +4,13 @@ on:
   pull_request_target:
     types: [synchronize, opened, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   upload:
+    permissions:
+      issues: write # for peter-evans/find-comment and peter-evans/create-or-update-comment
     if: ${{ github.event.pull_request.head.repo.full_name == 'rollup/rollup' || contains( toJson(github.event.pull_request.labels), 'x⁸ ⚙️ build repl artefacts' ) }}
     runs-on: ubuntu-latest
     name: Upload


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.