### PR TITLE
Improve performance of chunk naming collision check

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -51,6 +51,7 @@ import {
 	isDefaultAProperty,
 	namespaceInteropHelpersByInteropType
 } from './utils/interopHelpers';
+import { OutputBundleWithPlaceholders } from './utils/outputBundle';
 import { dirname, extname, isAbsolute, normalize, resolve } from './utils/path';
 import relativeId, { getAliasName, getImportPath } from './utils/relativeId';
 import renderChunk from './utils/renderChunk';
@@ -410,7 +411,7 @@ export default class Chunk {
 	generateId(
 		addons: Addons,
 		options: NormalizedOutputOptions,
-		existingNames: Record<string, unknown>,
+		bundle: OutputBundleWithPlaceholders,
 		includeHash: boolean
 	): string {
 		if (this.fileName !== null) {
@@ -428,19 +429,19 @@ export default class Chunk {
 					format: () => options.format,
 					hash: () =>
 						includeHash
-							? this.computeContentHashWithDependencies(addons, options, existingNames)
+							? this.computeContentHashWithDependencies(addons, options, bundle)
 							: '[hash]',
 					name: () => this.getChunkName()
 				}
 			),
-			existingNames
+			bundle
 		);
 	}
 
 	generateIdPreserveModules(
 		preserveModulesRelativeDir: string,
 		options: NormalizedOutputOptions,
-		existingNames: Record<string, unknown>,
+		bundle: OutputBundleWithPlaceholders,
 		unsetOptions: ReadonlySet<string>
 	): string {
 		const [{ id }] = this.orderedModules;
@@ -480,7 +481,7 @@ export default class Chunk {
 			});
 			path = `_virtual/${fileName}`;
 		}
-		return makeUnique(normalize(path), existingNames);
+		return makeUnique(normalize(path), bundle);
 	}
 
 	getChunkInfo(): PreRenderedChunk {
@@ -885,7 +886,7 @@ export default class Chunk {
 	private computeContentHashWithDependencies(
 		addons: Addons,
 		options: NormalizedOutputOptions,
-		existingNames: Record<string, unknown>
+		bundle: OutputBundleWithPlaceholders
 	): string {
 		const hash = createHash();
 		hash.update([addons.intro, addons.outro, addons.banner, addons.footer].join(':'));
@@ -896,7 +897,7 @@ export default class Chunk {
 				hash.update(`:${current.renderPath}`);
 			} else {
 				hash.update(current.getRenderedHash());
-				hash.update(current.generateId(addons, options, existingNames, false));
+				hash.update(current.generateId(addons, options, bundle, false));
 			}
 			if (current instanceof ExternalModule) continue;
 			for (const dependency of [...current.dependencies, ...current.dynamicDependencies]) {

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -1,8 +1,8 @@
 import { version as rollupVersion } from 'package.json';
 import Bundle from '../Bundle';
 import Graph from '../Graph';
-import { getSortedValidatedPlugins } from '../utils/PluginDriver';
 import type { PluginDriver } from '../utils/PluginDriver';
+import { getSortedValidatedPlugins } from '../utils/PluginDriver';
 import { ensureArray } from '../utils/ensureArray';
 import { errAlreadyClosed, errCannotEmitFromOptionsHook, error } from '../utils/error';
 import { promises as fs } from '../utils/fs';
@@ -26,6 +26,7 @@ import type {
 	RollupOutput,
 	RollupWatcher
 } from './types';
+import { OutputBundle } from './types';
 
 export default function rollup(rawInputOptions: GenericConfigObject): Promise<RollupBuild> {
 	return rollupInternal(rawInputOptions, null);
@@ -233,21 +234,17 @@ function getOutputOptions(
 	);
 }
 
-function createOutput(
-	outputBundle: Record<string, OutputChunk | OutputAsset | Record<string, never>>
-): RollupOutput {
+function createOutput(outputBundle: OutputBundle): RollupOutput {
 	return {
 		output: (
 			Object.values(outputBundle).filter(outputFile => Object.keys(outputFile).length > 0) as (
 				| OutputChunk
 				| OutputAsset
 			)[]
-		).sort((outputFileA, outputFileB) => {
-			const fileTypeA = getSortingFileType(outputFileA);
-			const fileTypeB = getSortingFileType(outputFileB);
-			if (fileTypeA === fileTypeB) return 0;
-			return fileTypeA < fileTypeB ? -1 : 1;
-		}) as [OutputChunk, ...(OutputChunk | OutputAsset)[]]
+		).sort(
+			(outputFileA, outputFileB) =>
+				getSortingFileType(outputFileA) - getSortingFileType(outputFileB)
+		) as [OutputChunk, ...(OutputChunk | OutputAsset)[]]
 	};
 }
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -358,14 +358,6 @@ export interface OutputBundle {
 	[fileName: string]: OutputAsset | OutputChunk;
 }
 
-export interface FilePlaceholder {
-	type: 'placeholder';
-}
-
-export interface OutputBundleWithPlaceholders {
-	[fileName: string]: OutputAsset | OutputChunk | FilePlaceholder;
-}
-
 export interface FunctionPluginHooks {
 	augmentChunkHash: (this: PluginContext, chunk: PreRenderedChunk) => string | void;
 	buildEnd: (this: PluginContext, err?: Error) => void;

--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -10,7 +10,6 @@ import type {
 	FunctionPluginHooks,
 	NormalizedInputOptions,
 	NormalizedOutputOptions,
-	OutputBundleWithPlaceholders,
 	ParallelPluginHooks,
 	Plugin,
 	PluginContext,
@@ -28,6 +27,7 @@ import {
 	error
 } from './error';
 import { getOrCreate } from './getOrCreate';
+import { OutputBundleWithPlaceholders } from './outputBundle';
 import { throwPluginError, warnDeprecatedHooks } from './pluginUtils';
 
 /**

--- a/src/utils/outputBundle.ts
+++ b/src/utils/outputBundle.ts
@@ -1,0 +1,36 @@
+import { OutputAsset, OutputBundle, OutputChunk } from '../rollup/types';
+
+export const lowercaseBundleKeys = Symbol('bundleKeys');
+
+export const FILE_PLACEHOLDER = {
+	type: 'placeholder' as const
+};
+
+export interface OutputBundleWithPlaceholders {
+	[fileName: string]: OutputAsset | OutputChunk | typeof FILE_PLACEHOLDER;
+	[lowercaseBundleKeys]: Set<string>;
+}
+
+export const getOutputBundle = (outputBundleBase: OutputBundle): OutputBundleWithPlaceholders => {
+	const reservedLowercaseBundleKeys = new Set<string>();
+	return new Proxy(outputBundleBase, {
+		deleteProperty(target, key) {
+			if (typeof key === 'string') {
+				reservedLowercaseBundleKeys.delete(key.toLowerCase());
+			}
+			return Reflect.deleteProperty(target, key);
+		},
+		get(target, key) {
+			if (key === lowercaseBundleKeys) {
+				return reservedLowercaseBundleKeys;
+			}
+			return Reflect.get(target, key);
+		},
+		set(target, key, value) {
+			if (typeof key === 'string') {
+				reservedLowercaseBundleKeys.add(key.toLowerCase());
+			}
+			return Reflect.set(target, key, value);
+		}
+	}) as OutputBundleWithPlaceholders;
+};

--- a/src/utils/renderNamePattern.ts
+++ b/src/utils/renderNamePattern.ts
@@ -1,4 +1,5 @@
 import { errFailedValidation, error } from './error';
+import { lowercaseBundleKeys, OutputBundleWithPlaceholders } from './outputBundle';
 import { extname } from './path';
 import { isPathFragment } from './relativeId';
 
@@ -30,14 +31,15 @@ export function renderNamePattern(
 	});
 }
 
-export function makeUnique(name: string, existingNames: Record<string, unknown>): string {
-	const existingNamesLowercase = new Set(Object.keys(existingNames).map(key => key.toLowerCase()));
-	if (!existingNamesLowercase.has(name.toLocaleLowerCase())) return name;
-
+export function makeUnique(
+	name: string,
+	{ [lowercaseBundleKeys]: reservedLowercaseBundleKeys }: OutputBundleWithPlaceholders
+): string {
+	if (!reservedLowercaseBundleKeys.has(name.toLowerCase())) return name;
 	const ext = extname(name);
 	name = name.substring(0, name.length - ext.length);
 	let uniqueName: string,
 		uniqueIndex = 1;
-	while (existingNamesLowercase.has((uniqueName = name + ++uniqueIndex + ext).toLowerCase()));
+	while (reservedLowercaseBundleKeys.has((uniqueName = name + ++uniqueIndex + ext).toLowerCase()));
 	return uniqueName;
 }

--- a/test/function/samples/generate-bundle-mutation/_config.js
+++ b/test/function/samples/generate-bundle-mutation/_config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	description: 'handles adding or deleting symbols in generateBundle',
+	options: {
+		plugins: [
+			{
+				name: 'test',
+				generateBundle(options, bundle) {
+					const myKey = Symbol('test');
+					bundle[myKey] = 42;
+					delete bundle[myKey];
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/generate-bundle-mutation/main.js
+++ b/test/function/samples/generate-bundle-mutation/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4642 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When creating many chunks (> 1000), the name collision check for case-insensitive file systems was exploding, leading to terrible performance. This is solved by using a proxy to build a lower-case looking table for file names as the bundle is created.