### PR TITLE
[v3.0] Change default for systemNullSetters

### DIFF
--- a/cli/help.md
+++ b/cli/help.md
@@ -64,7 +64,7 @@ Basic options:
 --no-stdin                  Do not read "-" from stdin
 --no-strict                 Don't emit `"use strict";` in the generated modules
 --strictDeprecations        Throw errors for deprecated features
---systemNullSetters         Replace empty SystemJS setters with `null`
+--no-systemNullSetters      Do not replace empty SystemJS setters with `null`
 --no-treeshake              Disable tree-shaking optimisations
 --no-treeshake.annotations  Ignore pure call annotations
 --no-treeshake.moduleSideEffects Assume modules have no side-effects

--- a/docs/01-command-line-reference.md
+++ b/docs/01-command-line-reference.md
@@ -395,7 +395,7 @@ Many options have command line equivalents. In those cases, any arguments passed
 --no-stdin                  Do not read "-" from stdin
 --no-strict                 Don't emit `"use strict";` in the generated modules
 --strictDeprecations        Throw errors for deprecated features
---systemNullSetters         Replace empty SystemJS setters with `null`
+--no-systemNullSetters      Do not replace empty SystemJS setters with `null`
 --no-treeshake              Disable tree-shaking optimisations
 --no-treeshake.annotations  Ignore pure call annotations
 --no-treeshake.moduleSideEffects Assume modules have no side-effects

--- a/docs/999-big-list-of-options.md
+++ b/docs/999-big-list-of-options.md
@@ -1558,9 +1558,9 @@ Whether to include the 'use strict' pragma at the top of generated non-ES bundle
 
 #### output.systemNullSetters
 
-Type: `boolean`<br> CLI: `--systemNullSetters`/`--no-systemNullSetters`<br> Default: `false`
+Type: `boolean`<br> CLI: `--systemNullSetters`/`--no-systemNullSetters`<br> Default: `true`
 
-When outputting the `system` module format, this will replace empty setter functions with `null` as an output simplification. This is _only supported in SystemJS 6.3.3 and above_.
+When outputting the `system` module format, by default, empty setter functions are replaced with `null` as an output simplification. This is incompatible with SystemJS before v6.3.3. Deactivate this option to output empty functions instead that older SystemJS versions support.
 
 #### preserveSymlinks
 

--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -84,7 +84,7 @@ export function normalizeOutputOptions(
 			| SourcemapPathTransformOption
 			| undefined,
 		strict: config.strict ?? true,
-		systemNullSetters: config.systemNullSetters || false,
+		systemNullSetters: config.systemNullSetters ?? true,
 		validate: config.validate || false
 	};
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main1.js
@@ -5,7 +5,7 @@ System.register(['./generated-shared2.js', './generated-dep1.js', './generated-d
 		setters: [function (module) {
 			x = module.x;
 			y = module.y;
-		}, function () {}, function () {}],
+		}, null, null],
 		execute: (function () {
 
 			console.log(x + y);

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-shared2.js', './generated-dep1.js', './generated-dep2.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}, function () {}],
+		setters: [null, null, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main3.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main3.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep1.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main4.js
+++ b/test/chunking-form/samples/chunk-deshadowing-reassignment/_expected/system/main4.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep2.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/chunk-execution-order/_expected/system/generated-dep11.js
+++ b/test/chunking-form/samples/chunk-execution-order/_expected/system/generated-dep11.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep111.js', './generated-dep112.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			console.log('11');

--- a/test/chunking-form/samples/chunk-execution-order/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunk-execution-order/_expected/system/main1.js
@@ -2,9 +2,9 @@ System.register(['./generated-dep11.js', './generated-dep112.js', './generated-d
 	'use strict';
 	var x;
 	return {
-		setters: [function () {}, function (module) {
+		setters: [null, function (module) {
 			x = module.x;
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 			console.log('1');

--- a/test/chunking-form/samples/chunk-execution-order/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-execution-order/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep11.js', './generated-dep111.js', './generated-dep112.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}, function () {}],
+		setters: [null, null, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/chunk-execution-order/_expected/system/main3.js
+++ b/test/chunking-form/samples/chunk-execution-order/_expected/system/main3.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep111.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/chunk-execution-order/_expected/system/main4.js
+++ b/test/chunking-form/samples/chunk-execution-order/_expected/system/main4.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep112.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/chunk-import-deshadowing/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunk-import-deshadowing/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-lib.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('dep2');

--- a/test/chunking-form/samples/chunking-reexport/_expected/system/generated-dep.js
+++ b/test/chunking-form/samples/chunking-reexport/_expected/system/generated-dep.js
@@ -1,7 +1,7 @@
 System.register(['external'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('dep');

--- a/test/chunking-form/samples/chunking-reexport/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-reexport/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep.js', 'external'], (function (exports) {
 	'use strict';
 	return {
-		setters: [function () {}, function (module) {
+		setters: [null, function (module) {
 			exports('dep', module.asdf);
 		}],
 		execute: (function () {

--- a/test/chunking-form/samples/chunking-reexport/_expected/system/main2.js
+++ b/test/chunking-form/samples/chunking-reexport/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep.js', 'external'], (function (exports) {
 	'use strict';
 	return {
-		setters: [function () {}, function (module) {
+		setters: [null, function (module) {
 			exports('dep', module.asdf);
 		}],
 		execute: (function () {

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/generated-dep.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/generated-dep.js
@@ -1,7 +1,7 @@
 System.register(['starexternal2', 'external2'], (function (exports) {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			var dep = exports('d', 'dep');

--- a/test/chunking-form/samples/chunking-star-external/_expected/system/main1.js
+++ b/test/chunking-form/samples/chunking-star-external/_expected/system/main1.js
@@ -17,7 +17,7 @@ System.register(['starexternal1', 'external1', './generated-dep.js', 'starextern
 			exports('e', module.e);
 		}, function (module) {
 			exports('dep', module.d);
-		}, function () {}, function () {}],
+		}, null, null],
 		execute: (function () {
 
 			var main = exports('main', '1');

--- a/test/chunking-form/samples/circular-manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./generated-lib1.js', './generated-lib2.js'], (function (expor
 	return {
 		setters: [function (module) {
 			exports('lib1', module.l);
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/deprecated/circular-manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/deprecated/circular-manual-chunks/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./generated-lib1.js', './generated-lib2.js'], (function (expor
 	return {
 		setters: [function (module) {
 			exports('lib1', module.l);
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/deprecated/empty-module-no-treeshake/_expected/system/main1.js
+++ b/test/chunking-form/samples/deprecated/empty-module-no-treeshake/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-emptyTransformed.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main1');

--- a/test/chunking-form/samples/deprecated/empty-module-no-treeshake/_expected/system/main2.js
+++ b/test/chunking-form/samples/deprecated/empty-module-no-treeshake/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-emptyTransformed.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main2');

--- a/test/chunking-form/samples/deprecated/manual-chunk-contains-entry-conflict/_expected/system/main2.js
+++ b/test/chunking-form/samples/deprecated/manual-chunk-contains-entry-conflict/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./main.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/deprecated/manual-chunk-is-entry-conflict/_expected/system/main2.js
+++ b/test/chunking-form/samples/deprecated/manual-chunk-is-entry-conflict/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./main.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/deprecated/manual-chunks-different-nested/_expected/system/generated-manual-middle.js
+++ b/test/chunking-form/samples/deprecated/manual-chunks-different-nested/_expected/system/generated-manual-middle.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual-inner.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('middle');

--- a/test/chunking-form/samples/deprecated/manual-chunks-different-nested/_expected/system/generated-manual-outer.js
+++ b/test/chunking-form/samples/deprecated/manual-chunks-different-nested/_expected/system/generated-manual-outer.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual-middle.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('outer');

--- a/test/chunking-form/samples/deprecated/manual-chunks-different-nested/_expected/system/main.js
+++ b/test/chunking-form/samples/deprecated/manual-chunks-different-nested/_expected/system/main.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual-outer.js', './generated-manual-middle.js', './generated-manual-inner.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}, function () {}],
+		setters: [null, null, null],
 		execute: (function () {
 
 			console.log('main');

--- a/test/chunking-form/samples/deprecated/manual-chunks-function/_expected/system/generated-chunk-c.js
+++ b/test/chunking-form/samples/deprecated/manual-chunks-function/_expected/system/generated-chunk-c.js
@@ -1,7 +1,7 @@
 System.register(['./generated-chunk-b.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('dep-c');

--- a/test/chunking-form/samples/deprecated/manual-chunks-function/_expected/system/main-a.js
+++ b/test/chunking-form/samples/deprecated/manual-chunks-function/_expected/system/main-a.js
@@ -1,7 +1,7 @@
 System.register(['./generated-chunk-c.js', './generated-chunk-b.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			console.log('dep1');

--- a/test/chunking-form/samples/deprecated/manual-chunks-nested/_expected/system/main.js
+++ b/test/chunking-form/samples/deprecated/manual-chunks-nested/_expected/system/main.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main');

--- a/test/chunking-form/samples/deprecated/manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/deprecated/manual-chunks/_expected/system/main.js
@@ -5,7 +5,7 @@ System.register(['./generated-deps2and3.js', './generated-lib1.js'], (function (
     setters: [function (module) {
       fn$1 = module.f;
       fn$2 = module.a;
-    }, function () {}],
+    }, null],
     execute: (function () {
 
       function fn () {

--- a/test/chunking-form/samples/deprecated/preserve-modules-commonjs/_expected/system/commonjs.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-commonjs/_expected/system/commonjs.js
@@ -4,7 +4,7 @@ System.register(['external', './other.js', './_virtual/other.js'], (function (ex
 	return {
 		setters: [function (module) {
 			require$$0 = module.default;
-		}, function () {}, function (module) {
+		}, null, function (module) {
 			other = module.__exports;
 		}],
 		execute: (function () {

--- a/test/chunking-form/samples/deprecated/preserve-modules-nested-export/_expected/system/main.js
+++ b/test/chunking-form/samples/deprecated/preserve-modules-nested-export/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./inner/more_inner/something.js', './inner/some_effect.js'], (
 	return {
 		setters: [function (module) {
 			exports('Something', module.Something);
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/dynamic-import-chunking/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-chunking/_expected/system/main.js
@@ -1,7 +1,7 @@
 System.register(['./generated-main.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/system/main1.js
+++ b/test/chunking-form/samples/dynamic-import-inline-colouring/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-separate.js'], (function (exports, module) {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			var inlined$1 = 'inlined';

--- a/test/chunking-form/samples/emit-file/emit-chunk-name-conflict/_expected/system/other.js
+++ b/test/chunking-form/samples/emit-file/emit-chunk-name-conflict/_expected/system/other.js
@@ -1,7 +1,7 @@
 System.register(['./generated-name.js', './generated-firstName.js', './generated-name2.js', './mainChunk.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}, function () {}, function () {}],
+		setters: [null, null, null, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/empty-module-no-treeshake/_expected/system/main1.js
+++ b/test/chunking-form/samples/empty-module-no-treeshake/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-emptyTransformed.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main1');

--- a/test/chunking-form/samples/empty-module-no-treeshake/_expected/system/main2.js
+++ b/test/chunking-form/samples/empty-module-no-treeshake/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-emptyTransformed.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main2');

--- a/test/chunking-form/samples/entry-point-without-own-code/_expected/system/main.js
+++ b/test/chunking-form/samples/entry-point-without-own-code/_expected/system/main.js
@@ -4,7 +4,7 @@ System.register(['./generated-m1.js', './m2.js'], (function () {
 	return {
 		setters: [function (module) {
 			ms = module.m;
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 			console.log(ms);

--- a/test/chunking-form/samples/hashing/hash-size/_expected/system/main1-c5eecf00.js
+++ b/test/chunking-form/samples/hashing/hash-size/_expected/system/main1-c5eecf00.js
@@ -1,10 +1,10 @@
-System.register(['./generated-chunk-b.js'], (function () {
+System.register(['./dep-626bb5df3105f7.js'], (function () {
 	'use strict';
 	return {
 		setters: [null],
 		execute: (function () {
 
-			console.log('dep-c');
+			console.log('main1');
 
 		})
 	};

--- a/test/chunking-form/samples/hashing/hash-size/_expected/system/main2-842e475e5e.js
+++ b/test/chunking-form/samples/hashing/hash-size/_expected/system/main2-842e475e5e.js
@@ -1,10 +1,10 @@
 System.register(['./dep-626bb5df3105f7.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
-			console.log('main1');
+			console.log('main2');
 
 		})
 	};

--- a/test/chunking-form/samples/improved-dynamic-chunks/dynamic-not-in-memory/_expected/system/main1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/dynamic-not-in-memory/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-shared.js', './generated-dep.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			console.log('main1');

--- a/test/chunking-form/samples/improved-dynamic-chunks/dynamic-not-in-memory/_expected/system/main2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/dynamic-not-in-memory/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-shared.js', './generated-dep.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			console.log('main2');

--- a/test/chunking-form/samples/improved-dynamic-chunks/multi-entry-partly-already-loaded-dynamic/_expected/system/generated-dynamic1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/multi-entry-partly-already-loaded-dynamic/_expected/system/generated-dynamic1.js
@@ -5,7 +5,7 @@ System.register(['./main1.js', './generated-dep2.js'], (function (exports) {
 		setters: [function (module) {
 			value1 = module.value1;
 			exports('value1', module.value1);
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 			console.log('dynamic1', value1);

--- a/test/chunking-form/samples/improved-dynamic-chunks/multi-entry-shared-static-with-dynamic-import/_expected/system/main1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/multi-entry-shared-static-with-dynamic-import/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-shared.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main1');

--- a/test/chunking-form/samples/improved-dynamic-chunks/multi-entry-shared-static-with-dynamic-import/_expected/system/main2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/multi-entry-shared-static-with-dynamic-import/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-shared.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main2');

--- a/test/chunking-form/samples/manual-chunk-contains-entry-conflict/_expected/system/main2.js
+++ b/test/chunking-form/samples/manual-chunk-contains-entry-conflict/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./main.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/manual-chunk-is-entry-conflict/_expected/system/main2.js
+++ b/test/chunking-form/samples/manual-chunk-is-entry-conflict/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./main.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/manual-chunks-different-nested/_expected/system/generated-manual-middle.js
+++ b/test/chunking-form/samples/manual-chunks-different-nested/_expected/system/generated-manual-middle.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual-inner.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('middle');

--- a/test/chunking-form/samples/manual-chunks-different-nested/_expected/system/generated-manual-outer.js
+++ b/test/chunking-form/samples/manual-chunks-different-nested/_expected/system/generated-manual-outer.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual-middle.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('outer');

--- a/test/chunking-form/samples/manual-chunks-different-nested/_expected/system/main.js
+++ b/test/chunking-form/samples/manual-chunks-different-nested/_expected/system/main.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual-outer.js', './generated-manual-middle.js', './generated-manual-inner.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}, function () {}],
+		setters: [null, null, null],
 		execute: (function () {
 
 			console.log('main');

--- a/test/chunking-form/samples/manual-chunks-function/_expected/system/main-a.js
+++ b/test/chunking-form/samples/manual-chunks-function/_expected/system/main-a.js
@@ -1,7 +1,7 @@
 System.register(['./generated-chunk-c.js', './generated-chunk-b.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			console.log('dep1');

--- a/test/chunking-form/samples/manual-chunks-nested/_expected/system/main.js
+++ b/test/chunking-form/samples/manual-chunks-nested/_expected/system/main.js
@@ -1,7 +1,7 @@
 System.register(['./generated-manual.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main');

--- a/test/chunking-form/samples/manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/manual-chunks/_expected/system/main.js
@@ -5,7 +5,7 @@ System.register(['./generated-deps2and3.js', './generated-lib1.js'], (function (
     setters: [function (module) {
       fn$1 = module.f;
       fn$2 = module.a;
-    }, function () {}],
+    }, null],
     execute: (function () {
 
       function fn () {

--- a/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/system/main1.js
+++ b/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/system/main1.js
@@ -4,7 +4,7 @@ System.register(['./generated-index.js', './generated-dep.js', 'external'], (fun
 	return {
 		setters: [function (module) {
 			lib = module.l;
-		}, function () {}, function () {}],
+		}, null, null],
 		execute: (function () {
 
 			console.log(lib);

--- a/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/system/main2.js
+++ b/test/chunking-form/samples/namespace-reexport-name-conflict/_expected/system/main2.js
@@ -2,9 +2,9 @@ System.register(['./generated-index.js', './generated-dep.js', 'external'], (fun
 	'use strict';
 	var reexported;
 	return {
-		setters: [function () {}, function (module) {
+		setters: [null, function (module) {
 			reexported = module.r;
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 			console.log(reexported);

--- a/test/chunking-form/samples/namespace-reexports/_expected/system/index.js
+++ b/test/chunking-form/samples/namespace-reexports/_expected/system/index.js
@@ -3,7 +3,7 @@ System.register(['./hsl2hsv.js', './generated-index.js'], (function (exports) {
 	return {
 		setters: [function (module) {
 			exports('hsl2hsv', module.default);
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/no-treeshake-imports/_expected/system/main1.js
+++ b/test/chunking-form/samples/no-treeshake-imports/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-empty.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main1');

--- a/test/chunking-form/samples/no-treeshake-imports/_expected/system/main2.js
+++ b/test/chunking-form/samples/no-treeshake-imports/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-empty.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main2');

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/commonjs.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/commonjs.js
@@ -4,7 +4,7 @@ System.register(['external', './other.js', './_virtual/other.js'], (function (ex
 	return {
 		setters: [function (module) {
 			require$$0 = module.default;
-		}, function () {}, function (module) {
+		}, null, function (module) {
 			other = module.__exports;
 		}],
 		execute: (function () {

--- a/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-nested-export/_expected/system/main.js
@@ -3,7 +3,7 @@ System.register(['./inner/more_inner/something.js', './inner/some_effect.js'], (
 	return {
 		setters: [function (module) {
 			exports('Something', module.Something);
-		}, function () {}],
+		}, null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/preserve-modules-root/_expected/system/below/module2.js
+++ b/test/chunking-form/samples/preserve-modules-root/_expected/system/below/module2.js
@@ -2,7 +2,7 @@ System.register(['../custom_modules/@my-scope/my-base-pkg/index.js', '../_virtua
   'use strict';
   var myBasePkg;
   return {
-    setters: [function () {}, function (module) {
+    setters: [null, function (module) {
       myBasePkg = module.__exports;
     }],
     execute: (function () {

--- a/test/chunking-form/samples/preserve-modules-root/_expected/system/under-build2.js
+++ b/test/chunking-form/samples/preserve-modules-root/_expected/system/under-build2.js
@@ -2,7 +2,7 @@ System.register(['./custom_modules/@my-scope/my-base-pkg/index.js', './_virtual/
 	'use strict';
 	var myBasePkg;
 	return {
-		setters: [function () {}, function (module) {
+		setters: [null, function (module) {
 			myBasePkg = module.__exports;
 		}],
 		execute: (function () {

--- a/test/chunking-form/samples/preserve-modules-special-chunk-names/_expected/system/main-entry.js
+++ b/test/chunking-form/samples/preserve-modules-special-chunk-names/_expected/system/main-entry.js
@@ -1,7 +1,7 @@
 System.register(['./a.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main');

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main2.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep2.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/reexport-shortpaths/_expected/system/main3.js
+++ b/test/chunking-form/samples/reexport-shortpaths/_expected/system/main3.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep2.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/chunking-form/samples/resolve-dynamic-import/_expected/system/main.js
+++ b/test/chunking-form/samples/resolve-dynamic-import/_expected/system/main.js
@@ -1,7 +1,7 @@
 System.register(['./direct-relative-external', 'to-indirect-relative-external', 'direct-absolute-external', 'to-indirect-absolute-external'], (function (exports, module) {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}, function () {}, function () {}],
+		setters: [null, null, null, null],
 		execute: (function () {
 
 			// nested

--- a/test/chunking-form/samples/side-effect-free-dependencies/avoid-side-effect-free-empty-imports/_expected/system/main1.js
+++ b/test/chunking-form/samples/side-effect-free-dependencies/avoid-side-effect-free-empty-imports/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['external-side-effect'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			function onlyUsedByOne() {

--- a/test/chunking-form/samples/side-effect-free-dependencies/avoid-side-effect-free-empty-imports/_expected/system/main2.js
+++ b/test/chunking-form/samples/side-effect-free-dependencies/avoid-side-effect-free-empty-imports/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['external-side-effect'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main2');

--- a/test/chunking-form/samples/side-effect-free-dependencies/hoist-side-effect-modules/_expected/system/main1.js
+++ b/test/chunking-form/samples/side-effect-free-dependencies/hoist-side-effect-modules/_expected/system/main1.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep2-effect.js', './generated-dep4-effect.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			var value = 42;

--- a/test/chunking-form/samples/side-effect-free-dependencies/hoist-side-effect-modules/_expected/system/main2.js
+++ b/test/chunking-form/samples/side-effect-free-dependencies/hoist-side-effect-modules/_expected/system/main2.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep2-effect.js', './generated-dep4-effect.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}, function () {}],
+		setters: [null, null],
 		execute: (function () {
 
 			console.log('main2');

--- a/test/chunking-form/samples/side-effect-free-dependencies/hoist-side-effect-modules/_expected/system/main3.js
+++ b/test/chunking-form/samples/side-effect-free-dependencies/hoist-side-effect-modules/_expected/system/main3.js
@@ -1,7 +1,7 @@
 System.register(['./generated-dep4-effect.js'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main3');

--- a/test/form/samples/compact-empty-external/_expected/system.js
+++ b/test/form/samples/compact-empty-external/_expected/system.js
@@ -1,1 +1,1 @@
-System.register(['external'],(function(){'use strict';return{setters:[function(){}],execute:(function(){})}}));
+System.register(['external'],(function(){'use strict';return{setters:[null],execute:(function(){})}}));

--- a/test/form/samples/compact-multiple-imports/_expected/system.js
+++ b/test/form/samples/compact-multiple-imports/_expected/system.js
@@ -1,2 +1,2 @@
-System.register(['external-1','external-2','external-3','external-4','external-5'],(function(){'use strict';var value,value$1;return{setters:[function(){},function(){},function(module){value=module.value;},function(module){value$1=module.value;},function(){}],execute:(function(){assert.equal(value, '3');
+System.register(['external-1','external-2','external-3','external-4','external-5'],(function(){'use strict';var value,value$1;return{setters:[null,null,function(module){value=module.value;},function(module){value$1=module.value;},null],execute:(function(){assert.equal(value, '3');
 assert.equal(value$1, '4');})}}));

--- a/test/form/samples/external-empty-import-no-global-b/_expected/system.js
+++ b/test/form/samples/external-empty-import-no-global-b/_expected/system.js
@@ -2,7 +2,7 @@ System.register('myBundle', ['babel-polyfill', 'other'], (function (exports) {
 	'use strict';
 	var x;
 	return {
-		setters: [function () {}, function (module) {
+		setters: [null, function (module) {
 			x = module.x;
 		}],
 		execute: (function () {

--- a/test/form/samples/external-empty-import-no-global/_expected/system.js
+++ b/test/form/samples/external-empty-import-no-global/_expected/system.js
@@ -1,7 +1,7 @@
 System.register('myBundle', ['babel-polyfill'], (function (exports) {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			var main = exports('default', new WeakMap());

--- a/test/form/samples/generated-code-compact/arrow-functions-false/_config.js
+++ b/test/form/samples/generated-code-compact/arrow-functions-false/_config.js
@@ -25,7 +25,8 @@ module.exports = {
 				return 'compat';
 			},
 			name: 'bundle',
-			noConflict: true
+			noConflict: true,
+			systemNullSetters: false
 		}
 	},
 	expectedWarnings: ['DEPRECATED_FEATURE']

--- a/test/form/samples/generated-code-compact/arrow-functions-true/_config.js
+++ b/test/form/samples/generated-code-compact/arrow-functions-true/_config.js
@@ -25,7 +25,8 @@ module.exports = {
 				return 'compat';
 			},
 			name: 'bundle',
-			noConflict: true
+			noConflict: true,
+			systemNullSetters: false
 		}
 	},
 	expectedWarnings: ['DEPRECATED_FEATURE']

--- a/test/form/samples/generated-code/arrow-functions-false/_config.js
+++ b/test/form/samples/generated-code/arrow-functions-false/_config.js
@@ -24,7 +24,8 @@ module.exports = {
 				return 'compat';
 			},
 			name: 'bundle',
-			noConflict: true
+			noConflict: true,
+			systemNullSetters: false
 		}
 	},
 	expectedWarnings: ['DEPRECATED_FEATURE']

--- a/test/form/samples/generated-code/arrow-functions-true/_config.js
+++ b/test/form/samples/generated-code/arrow-functions-true/_config.js
@@ -24,7 +24,8 @@ module.exports = {
 				return 'compat';
 			},
 			name: 'bundle',
-			noConflict: true
+			noConflict: true,
+			systemNullSetters: false
 		}
 	},
 	expectedWarnings: ['DEPRECATED_FEATURE']

--- a/test/form/samples/prune-pure-unused-import-array/_expected/system.js
+++ b/test/form/samples/prune-pure-unused-import-array/_expected/system.js
@@ -1,7 +1,7 @@
 System.register(['other'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/form/samples/prune-pure-unused-import-function/_expected/system.js
+++ b/test/form/samples/prune-pure-unused-import-function/_expected/system.js
@@ -1,7 +1,7 @@
 System.register(['other'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 

--- a/test/form/samples/system-null-setters/_config.js
+++ b/test/form/samples/system-null-setters/_config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	description: 'allows to avoid null setters for side effect only imports',
+	options: {
+		external: ['external'],
+		output: {
+			format: 'system',
+			systemNullSetters: false
+		}
+	}
+};

--- a/test/form/samples/system-null-setters/_expected.js
+++ b/test/form/samples/system-null-setters/_expected.js
@@ -1,10 +1,10 @@
-System.register(['./dep-626bb5df3105f7.js'], (function () {
+System.register(['external'], (function () {
 	'use strict';
 	return {
 		setters: [function () {}],
 		execute: (function () {
 
-			console.log('main2');
+
 
 		})
 	};

--- a/test/form/samples/system-null-setters/main.js
+++ b/test/form/samples/system-null-setters/main.js
@@ -1,0 +1,2 @@
+import 'external';
+

--- a/test/form/samples/treeshake-namespace-access/_expected/system.js
+++ b/test/form/samples/treeshake-namespace-access/_expected/system.js
@@ -1,7 +1,7 @@
 System.register(['external'], (function () {
 	'use strict';
 	return {
-		setters: [function () {}],
+		setters: [null],
 		execute: (function () {
 
 			console.log('main');

--- a/test/form/samples/unused-import/_config.js
+++ b/test/form/samples/unused-import/_config.js
@@ -3,8 +3,7 @@ module.exports = {
 	options: {
 		external: ['external'],
 		output: {
-			globals: { external: 'external' },
-			systemNullSetters: true
+			globals: { external: 'external' }
 		}
 	}
 };

--- a/test/form/samples/unused-import/main.js
+++ b/test/form/samples/unused-import/main.js
@@ -1,4 +1,4 @@
-import { unused } from 'external';
+import 'external';
 
 function alsoUnused () {
 	unused();

--- a/test/function/samples/output-options-hook/_config.js
+++ b/test/function/samples/output-options-hook/_config.js
@@ -53,7 +53,7 @@ module.exports = {
 					sourcemap: false,
 					sourcemapExcludeSources: false,
 					strict: true,
-					systemNullSetters: false,
+					systemNullSetters: true,
 					validate: false
 				});
 				assert.strictEqual(options.banner(), 'exports.bar = 43;');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
One last change I stumbled upon when looking through the options. The `systemNullSetters` was introduced to generate slightly simplified output for SystemJS >= 6.3.3. I reckon it makes sense to enable it by default now.