### PR TITLE
Ensure the initializer of a destructuring declaration is always included if the id is included

### DIFF
--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -15,8 +15,10 @@ import {
 import type { InclusionContext } from '../ExecutionContext';
 import { EMPTY_PATH } from '../utils/PathTracker';
 import type Variable from '../variables/Variable';
+import ArrayPattern from './ArrayPattern';
 import Identifier, { type IdentifierWithVariable } from './Identifier';
 import * as NodeType from './NodeType';
+import ObjectPattern from './ObjectPattern';
 import type VariableDeclarator from './VariableDeclarator';
 import type { InclusionOptions } from './shared/Expression';
 import { type IncludeChildren, NodeBase } from './shared/Node';
@@ -62,8 +64,17 @@ export default class VariableDeclaration extends NodeBase {
 		for (const declarator of this.declarations) {
 			if (includeChildrenRecursively || declarator.shouldBeIncluded(context))
 				declarator.include(context, includeChildrenRecursively);
+			const { id, init } = declarator;
 			if (asSingleStatement) {
-				declarator.id.include(context, includeChildrenRecursively);
+				id.include(context, includeChildrenRecursively);
+			}
+			if (
+				init &&
+				id.included &&
+				!init.included &&
+				(id instanceof ObjectPattern || id instanceof ArrayPattern)
+			) {
+				init.include(context, includeChildrenRecursively);
 			}
 		}
 	}

--- a/test/function/samples/for-loop-parameter/_config.js
+++ b/test/function/samples/for-loop-parameter/_config.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+
+module.exports = {
+	description: 'includes for-loop parameters',
+	exports({ checkObject, checkArray }) {
+		assert.strictEqual(checkObject({ foo: 1 }), 1, 'object');
+		assert.strictEqual(checkArray([2]), 2, 'array');
+	}
+};

--- a/test/function/samples/for-loop-parameter/main.js
+++ b/test/function/samples/for-loop-parameter/main.js
@@ -1,0 +1,19 @@
+export function checkObject(p) {
+	return getFromObjectInLoop(p);
+}
+
+export function checkArray(p) {
+	return getFromArrayInLoop(p);
+}
+
+function getFromObjectInLoop(path) {
+	for (let { foo } = path;;) {
+		return foo;
+	}
+}
+
+function getFromArrayInLoop(path) {
+	for (let [ foo ] = path;;) {
+		return foo;
+	}
+}

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -61,10 +61,11 @@ describe('rollup.watch', () => {
 						}
 					});
 				} else {
-					Promise.resolve()
-						.then(() => wait(timeout)) // gah, this appears to be necessary to fix random errors
-						.then(() => next(event))
-						.then(go)
+					wait(timeout) // gah, this appears to be necessary to fix random errors
+						.then(() => {
+							next(event);
+							go();
+						})
 						.catch(error => {
 							watcher.close();
 							reject(error);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4654

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There were cases where in a declaration `let { x } = y`, `y` would not be included. This can result in invalid code or broken, which is hereby fixed.