### PR TITLE
docs: fix minor typo in migration documentation

### DIFF
--- a/docs/09-migration.md
+++ b/docs/09-migration.md
@@ -58,7 +58,7 @@ In general, though, the new default values are our recommended settings. Refer t
 ### More Changed Options
 
 - [`output.banner/footer`](guide/en/#outputbanneroutputfooter)[`/intro/outro`](guide/en/#outputintrooutputoutro) are now called per chunk and thus should not do any performance-heavy operations.
-- [`entryFileNames`](guide/en/#outputentryfilenames) and [`chunkFileNames`](guide/en/#outputchunkfilenames) functions now longer have access to the rendered module information via `modules`, but only to a list of included `moduleIds`.
+- [`entryFileNames`](guide/en/#outputentryfilenames) and [`chunkFileNames`](guide/en/#outputchunkfilenames) functions no longer have access to the rendered module information via `modules`, but only to a list of included `moduleIds`.
 - When using [`output.preserveModules`](guide/en/#outputpreservemodules) and `entryFileNames`, you can no longer use the `[ext]`, `[extName]` and `[assetExtName]` file name placeholders. Also, the path of a module is no longer prepended to the file name automatically but is included in the `[name]` placeholder.
 
 ### Dynamic Import in CommonJS Output


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: no

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

I think this is the correct change, I assume it was meant to be "no longer" instead of "now longer"
