### PR TITLE
Preserve rendered class names

### DIFF
--- a/src/ast/nodes/ClassDeclaration.ts
+++ b/src/ast/nodes/ClassDeclaration.ts
@@ -37,20 +37,18 @@ export default class ClassDeclaration extends ClassNode {
 		} = options;
 		if (this.id) {
 			const { variable, name } = this.id;
+			if (format === 'system' && exportNamesByVariable.has(variable)) {
+				code.appendLeft(this.end, `${_}${getSystemExportStatement([variable], options)};`);
+			}
 			const renderedVariable = variable.getName(getPropertyAccess);
 			if (renderedVariable !== name) {
 				this.superClass?.render(code, options);
 				this.body.render(code, options);
 				code.prependRight(this.start, `let ${renderedVariable}${_}=${_}`);
-				code.appendLeft(this.end, ';');
-			} else {
-				super.render(code, options);
+				code.prependLeft(this.end, ';');
+				return;
 			}
-		} else {
-			super.render(code, options);
 		}
-		if (format === 'system' && this.id && exportNamesByVariable.has(this.id.variable)) {
-			code.appendLeft(this.end, `${_}${getSystemExportStatement([this.id.variable], options)};`);
-		}
+		super.render(code, options);
 	}
 }

--- a/src/ast/nodes/ClassDeclaration.ts
+++ b/src/ast/nodes/ClassDeclaration.ts
@@ -33,11 +33,24 @@ export default class ClassDeclaration extends ClassNode {
 		const {
 			exportNamesByVariable,
 			format,
-			snippets: { _ }
+			snippets: { _, getPropertyAccess }
 		} = options;
+		if (this.id) {
+			const { variable, name } = this.id;
+			const renderedVariable = variable.getName(getPropertyAccess);
+			if (renderedVariable !== name) {
+				this.superClass?.render(code, options);
+				this.body.render(code, options);
+				code.prependRight(this.start, `let ${renderedVariable}${_}=${_}`);
+				code.appendLeft(this.end, ';');
+			} else {
+				super.render(code, options);
+			}
+		} else {
+			super.render(code, options);
+		}
 		if (format === 'system' && this.id && exportNamesByVariable.has(this.id.variable)) {
 			code.appendLeft(this.end, `${_}${getSystemExportStatement([this.id.variable], options)};`);
 		}
-		super.render(code, options);
 	}
 }

--- a/test/chunking-form/samples/circular-entry-points/_expected/amd/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points/_expected/amd/generated-main1.js
@@ -1,10 +1,10 @@
 define(['exports'], (function (exports) { 'use strict';
 
-  class C$1 {
+  let C$1 = class C {
     fn (num) {
       console.log(num - p);
     }
-  }
+  };
 
   var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points/_expected/cjs/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points/_expected/cjs/generated-main1.js
@@ -1,10 +1,10 @@
 'use strict';
 
-class C$1 {
+let C$1 = class C {
   fn (num) {
     console.log(num - p);
   }
-}
+};
 
 var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points/_expected/es/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points/_expected/es/generated-main1.js
@@ -1,8 +1,8 @@
-class C$1 {
+let C$1 = class C {
   fn (num) {
     console.log(num - p);
   }
-}
+};
 
 var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points/_expected/system/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points/_expected/system/generated-main1.js
@@ -3,11 +3,11 @@ System.register([], (function (exports) {
   return {
     execute: (function () {
 
-      class C$1 {
+      let C$1 = class C {
         fn (num) {
           console.log(num - p);
         }
-      }
+      };
 
       var p$1 = exports('p', 43);
 

--- a/test/chunking-form/samples/circular-entry-points2/_expected/amd/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/amd/main2.js
@@ -1,10 +1,10 @@
 define(['exports'], (function (exports) { 'use strict';
 
-  class C$1 {
+  let C$1 = class C {
     fn (num) {
       console.log(num - p);
     }
-  }
+  };
 
   var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points2/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/cjs/main2.js
@@ -1,10 +1,10 @@
 'use strict';
 
-class C$1 {
+let C$1 = class C {
   fn (num) {
     console.log(num - p);
   }
-}
+};
 
 var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points2/_expected/es/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/es/main2.js
@@ -1,8 +1,8 @@
-class C$1 {
+let C$1 = class C {
   fn (num) {
     console.log(num - p);
   }
-}
+};
 
 var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points2/_expected/system/main2.js
+++ b/test/chunking-form/samples/circular-entry-points2/_expected/system/main2.js
@@ -3,11 +3,11 @@ System.register([], (function (exports) {
   return {
     execute: (function () {
 
-      class C$1 {
+      let C$1 = class C {
         fn (num) {
           console.log(num - p);
         }
-      }
+      };
 
       var p$1 = exports('p', 43);
 

--- a/test/chunking-form/samples/circular-entry-points3/_expected/amd/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/amd/generated-main1.js
@@ -1,10 +1,10 @@
 define(['exports'], (function (exports) { 'use strict';
 
-  class C$1 {
+  let C$1 = class C {
     fn (num) {
       console.log(num - p);
     }
-  }
+  };
 
   var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points3/_expected/cjs/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/cjs/generated-main1.js
@@ -1,10 +1,10 @@
 'use strict';
 
-class C$1 {
+let C$1 = class C {
   fn (num) {
     console.log(num - p);
   }
-}
+};
 
 var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points3/_expected/es/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/es/generated-main1.js
@@ -1,8 +1,8 @@
-class C$1 {
+let C$1 = class C {
   fn (num) {
     console.log(num - p);
   }
-}
+};
 
 var p$1 = 43;
 

--- a/test/chunking-form/samples/circular-entry-points3/_expected/system/generated-main1.js
+++ b/test/chunking-form/samples/circular-entry-points3/_expected/system/generated-main1.js
@@ -3,11 +3,11 @@ System.register([], (function (exports) {
   return {
     execute: (function () {
 
-      class C$1 {
+      let C$1 = class C {
         fn (num) {
           console.log(num - p);
         }
-      } exports('C', C$1);
+      }; exports('C', C$1);
 
       var p$1 = exports('p', 43);
 

--- a/test/form/samples/exported-class-declaration-conflict/_config.js
+++ b/test/form/samples/exported-class-declaration-conflict/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'handles exporting class declarations with name conflicts in SystemJS',
+	options: { output: { name: 'bundle' } }
+};

--- a/test/form/samples/exported-class-declaration-conflict/_expected/amd.js
+++ b/test/form/samples/exported-class-declaration-conflict/_expected/amd.js
@@ -1,0 +1,10 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	let Foo$1 = class Foo {};
+
+	class Foo {}
+
+	exports.First = Foo$1;
+	exports.Second = Foo;
+
+}));

--- a/test/form/samples/exported-class-declaration-conflict/_expected/cjs.js
+++ b/test/form/samples/exported-class-declaration-conflict/_expected/cjs.js
@@ -1,0 +1,8 @@
+'use strict';
+
+let Foo$1 = class Foo {};
+
+class Foo {}
+
+exports.First = Foo$1;
+exports.Second = Foo;

--- a/test/form/samples/exported-class-declaration-conflict/_expected/es.js
+++ b/test/form/samples/exported-class-declaration-conflict/_expected/es.js
@@ -1,0 +1,5 @@
+let Foo$1 = class Foo {};
+
+class Foo {}
+
+export { Foo$1 as First, Foo as Second };

--- a/test/form/samples/exported-class-declaration-conflict/_expected/iife.js
+++ b/test/form/samples/exported-class-declaration-conflict/_expected/iife.js
@@ -1,0 +1,13 @@
+var bundle = (function (exports) {
+	'use strict';
+
+	let Foo$1 = class Foo {};
+
+	class Foo {}
+
+	exports.First = Foo$1;
+	exports.Second = Foo;
+
+	return exports;
+
+})({});

--- a/test/form/samples/exported-class-declaration-conflict/_expected/system.js
+++ b/test/form/samples/exported-class-declaration-conflict/_expected/system.js
@@ -1,0 +1,12 @@
+System.register('bundle', [], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			let Foo$1 = class Foo {}; exports('First', Foo$1);
+
+			class Foo {} exports('Second', Foo);
+
+		})
+	};
+}));

--- a/test/form/samples/exported-class-declaration-conflict/_expected/umd.js
+++ b/test/form/samples/exported-class-declaration-conflict/_expected/umd.js
@@ -1,0 +1,14 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.bundle = {}));
+})(this, (function (exports) { 'use strict';
+
+	let Foo$1 = class Foo {};
+
+	class Foo {}
+
+	exports.First = Foo$1;
+	exports.Second = Foo;
+
+}));

--- a/test/form/samples/exported-class-declaration-conflict/first.js
+++ b/test/form/samples/exported-class-declaration-conflict/first.js
@@ -1,0 +1,2 @@
+class Foo {}
+export { Foo };

--- a/test/form/samples/exported-class-declaration-conflict/main.js
+++ b/test/form/samples/exported-class-declaration-conflict/main.js
@@ -1,0 +1,2 @@
+export { Foo as First } from './first';
+export { Foo as Second } from './second';

--- a/test/form/samples/exported-class-declaration-conflict/second.js
+++ b/test/form/samples/exported-class-declaration-conflict/second.js
@@ -1,0 +1,2 @@
+class Foo {}
+export { Foo };

--- a/test/function/samples/class-name-conflict/_config.js
+++ b/test/function/samples/class-name-conflict/_config.js
@@ -1,5 +1,3 @@
 module.exports = {
-	solo: true,
-	show: true,
 	description: 'preserves class names even if the class is renamed'
 };

--- a/test/function/samples/class-name-conflict/_config.js
+++ b/test/function/samples/class-name-conflict/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	solo: true,
+	show: true,
+	description: 'preserves class names even if the class is renamed'
+};

--- a/test/function/samples/class-name-conflict/declaration1.js
+++ b/test/function/samples/class-name-conflict/declaration1.js
@@ -1,0 +1,3 @@
+class foo {}
+
+assert.strictEqual(foo.name, 'foo');

--- a/test/function/samples/class-name-conflict/declaration2.js
+++ b/test/function/samples/class-name-conflict/declaration2.js
@@ -1,0 +1,3 @@
+class foo {}
+
+assert.strictEqual(foo.name, 'foo');

--- a/test/function/samples/class-name-conflict/expression1.js
+++ b/test/function/samples/class-name-conflict/expression1.js
@@ -1,0 +1,3 @@
+let foo = class {};
+
+assert.strictEqual(foo.name, 'foo');

--- a/test/function/samples/class-name-conflict/expression2.js
+++ b/test/function/samples/class-name-conflict/expression2.js
@@ -1,0 +1,3 @@
+let foo = class {};
+
+assert.strictEqual(foo.name, 'foo');

--- a/test/function/samples/class-name-conflict/main.js
+++ b/test/function/samples/class-name-conflict/main.js
@@ -1,4 +1,4 @@
-// import './expression1';
+import './expression1';
 import './declaration1';
-// import './expression2';
+import './expression2';
 import './declaration2';

--- a/test/function/samples/class-name-conflict/main.js
+++ b/test/function/samples/class-name-conflict/main.js
@@ -1,0 +1,4 @@
+// import './expression1';
+import './declaration1';
+// import './expression2';
+import './declaration2';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- Resolves #4637

<!--
If this PR resolves any issues, list them as

 - resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This PR preserves the `name` property of classes even if the class needs to be renamed due to conflicts. The solution is to rewrite both `class foo {}` and `let foo = class {}` to e.g. `let foo$1 = class foo {}` if `foo` needs to be renamed.
