### PR TITLE
Ignore hashhbang comments

### DIFF
--- a/src/ast/nodes/Program.ts
+++ b/src/ast/nodes/Program.ts
@@ -32,8 +32,13 @@ export default class Program extends NodeBase {
 	}
 
 	render(code: MagicString, options: RenderOptions): void {
+		let start = this.start;
+		if (code.original.startsWith('#!')) {
+			start = Math.min(code.original.indexOf('\n') + 1, this.end);
+			code.remove(0, start);
+		}
 		if (this.body.length > 0) {
-			renderStatementList(this.body, code, this.start, this.end, options);
+			renderStatementList(this.body, code, start, this.end, options);
 		} else {
 			super.render(code, options);
 		}

--- a/test/form/samples/hashbang/_config.js
+++ b/test/form/samples/hashbang/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'supports input files with leading hashbang comment'
+};

--- a/test/form/samples/hashbang/_expected.js
+++ b/test/form/samples/hashbang/_expected.js
@@ -1,0 +1,3 @@
+console.log('other');
+
+console.log('main');

--- a/test/form/samples/hashbang/main.js
+++ b/test/form/samples/hashbang/main.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import './other';
+console.log('main');

--- a/test/form/samples/hashbang/other.js
+++ b/test/form/samples/hashbang/other.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('other');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- Resolves #4672

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This supports hashbang comments in input files by adjusting the rendering so they are always removed. In the future, it could be an interesting idea to preserve them in entry points for certain output formats, but I will postpone this investigation for another day. For now if you want a hashbang in your output, add it in a `renderChunk` hook.
