### PR TITLE
Return correct values for unkown namespace members

### DIFF
--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -1,11 +1,14 @@
-import type { AstContext } from '../../Module';
 import type Module from '../../Module';
+import type { AstContext } from '../../Module';
 import { getToStringTagValue, MERGE_NAMESPACES_VARIABLE } from '../../utils/interopHelpers';
 import type { RenderOptions } from '../../utils/renderHelpers';
 import { getSystemExportStatement } from '../../utils/systemJsRendering';
 import type Identifier from '../nodes/Identifier';
 import type { LiteralValueOrUnknown } from '../nodes/shared/Expression';
+import { UnknownValue } from '../nodes/shared/Expression';
 import type ChildScope from '../scopes/ChildScope';
+import type { ObjectPath } from '../utils/PathTracker';
+import { SymbolToStringTag } from '../utils/PathTracker';
 import Variable from './Variable';
 
 export default class NamespaceVariable extends Variable {
@@ -29,9 +32,11 @@ export default class NamespaceVariable extends Variable {
 		this.name = identifier.name;
 	}
 
-	getLiteralValueAtPath(): LiteralValueOrUnknown {
-		// This can only happen for Symbol.toStringTag right now
-		return 'Module';
+	getLiteralValueAtPath(path: ObjectPath): LiteralValueOrUnknown {
+		if (path[0] === SymbolToStringTag) {
+			return 'Module';
+		}
+		return UnknownValue;
 	}
 
 	getMemberVariables(): { [name: string]: Variable } {

--- a/test/function/samples/namespace-literal-value/_config.js
+++ b/test/function/samples/namespace-literal-value/_config.js
@@ -1,0 +1,9 @@
+const assert = require('node:assert');
+
+module.exports = {
+	description: 'does not simplify accessing unknown properties from namespaces',
+	exports({ isNull }) {
+		assert.strictEqual(isNull('a'), true);
+		assert.strictEqual(isNull('b'), false);
+	}
+};

--- a/test/function/samples/namespace-literal-value/main.js
+++ b/test/function/samples/namespace-literal-value/main.js
@@ -1,0 +1,3 @@
+import * as ns from './namespace';
+
+export const isNull = prop => (ns[prop] === null ? true : false);

--- a/test/function/samples/namespace-literal-value/namespace.js
+++ b/test/function/samples/namespace-literal-value/namespace.js
@@ -1,0 +1,2 @@
+export const a = null;
+export const b = true;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4680

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
For some reason, I assumed the logic to retrieve explicit values from namespaces would only be relevant for `Symbol.toStringTag`. No idea why I thought that, here is the fix.