### PR TITLE
Prevent class ids from shadowing other variables

### DIFF
--- a/src/ast/nodes/ClassDeclaration.ts
+++ b/src/ast/nodes/ClassDeclaration.ts
@@ -51,4 +51,17 @@ export default class ClassDeclaration extends ClassNode {
 		}
 		super.render(code, options);
 	}
+
+	protected applyDeoptimizations(): void {
+		super.applyDeoptimizations();
+		const { id, scope } = this;
+		if (id) {
+			const { name, variable } = id;
+			for (const accessedVariable of scope.accessedOutsideVariables.values()) {
+				if (accessedVariable !== variable) {
+					accessedVariable.forbidName(name);
+				}
+			}
+		}
+	}
 }

--- a/src/ast/scopes/ChildScope.ts
+++ b/src/ast/scopes/ChildScope.ts
@@ -90,7 +90,7 @@ export default class ChildScope extends Scope {
 		}
 		for (const [name, variable] of this.variables) {
 			if (variable.included || variable.alwaysRendered) {
-				variable.setRenderNames(null, getSafeName(name, usedNames));
+				variable.setRenderNames(null, getSafeName(name, usedNames, variable.forbiddenNames));
 			}
 		}
 		for (const scope of this.children) {

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -9,6 +9,7 @@ import type { ObjectPath } from '../utils/PathTracker';
 
 export default class Variable extends ExpressionEntity {
 	alwaysRendered = false;
+	forbiddenNames: Set<string> | null = null;
 	initReached = false;
 	isId = false;
 	// both NamespaceVariable and ExternalVariable can be namespaces
@@ -28,6 +29,14 @@ export default class Variable extends ExpressionEntity {
 	 * Necessary to be able to change variable names.
 	 */
 	addReference(_identifier: Identifier): void {}
+
+	/**
+	 * Prevent this variable from being renamed to this name to avoid name
+	 * collisions
+	 */
+	forbidName(name: string) {
+		(this.forbiddenNames ||= new Set()).add(name);
+	}
 
 	getBaseVariableName(): string {
 		return this.renderBaseName || this.renderName || this.name;

--- a/src/utils/safeName.ts
+++ b/src/utils/safeName.ts
@@ -1,10 +1,14 @@
 import RESERVED_NAMES from './RESERVED_NAMES';
 import { toBase64 } from './base64';
 
-export function getSafeName(baseName: string, usedNames: Set<string>): string {
+export function getSafeName(
+	baseName: string,
+	usedNames: Set<string>,
+	forbiddenNames: Set<string> | null
+): string {
 	let safeName = baseName;
 	let count = 1;
-	while (usedNames.has(safeName) || RESERVED_NAMES.has(safeName)) {
+	while (usedNames.has(safeName) || RESERVED_NAMES.has(safeName) || forbiddenNames?.has(safeName)) {
 		safeName = `${baseName}$${toBase64(count++)}`;
 	}
 	usedNames.add(safeName);

--- a/test/function/samples/class-name-conflict2/_config.js
+++ b/test/function/samples/class-name-conflict2/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'does not shadow variables when preserving class names'
+};

--- a/test/function/samples/class-name-conflict2/bar.js
+++ b/test/function/samples/class-name-conflict2/bar.js
@@ -1,0 +1,3 @@
+export class bar {
+	static base = true;
+}

--- a/test/function/samples/class-name-conflict2/declaration.js
+++ b/test/function/samples/class-name-conflict2/declaration.js
@@ -1,9 +1,12 @@
 import { foo as foo$ } from './foo.js';
 
 {
-  class foo extends foo$ {
-  }
+	class foo extends foo$ {
+		static test() {
+			assert.ok(foo.base);
+		}
+	}
 
-  assert.strictEqual(foo.name, 'foo');
-  assert.ok(foo.base);
+	assert.strictEqual(foo.name, 'foo');
+	foo.test();
 }

--- a/test/function/samples/class-name-conflict2/declaration.js
+++ b/test/function/samples/class-name-conflict2/declaration.js
@@ -1,0 +1,9 @@
+import { foo as foo$ } from './foo.js';
+
+{
+  class foo extends foo$ {
+  }
+
+  assert.strictEqual(foo.name, 'foo');
+  assert.ok(foo.base);
+}

--- a/test/function/samples/class-name-conflict2/expression.js
+++ b/test/function/samples/class-name-conflict2/expression.js
@@ -1,0 +1,9 @@
+import { bar as bar$ } from './bar.js';
+
+{
+  let bar = class extends bar$ {
+  };
+
+  assert.strictEqual(bar.name, 'bar');
+  assert.ok(bar.base);
+}

--- a/test/function/samples/class-name-conflict2/expression.js
+++ b/test/function/samples/class-name-conflict2/expression.js
@@ -1,9 +1,12 @@
 import { bar as bar$ } from './bar.js';
 
 {
-  let bar = class extends bar$ {
-  };
+	let bar = class extends bar$ {
+		static test() {
+			assert.ok(bar.base);
+		}
+	};
 
-  assert.strictEqual(bar.name, 'bar');
-  assert.ok(bar.base);
+	assert.strictEqual(bar.name, 'bar');
+	bar.test();
 }

--- a/test/function/samples/class-name-conflict2/foo.js
+++ b/test/function/samples/class-name-conflict2/foo.js
@@ -1,0 +1,3 @@
+export class foo {
+	static base = true;
+}

--- a/test/function/samples/class-name-conflict2/main.js
+++ b/test/function/samples/class-name-conflict2/main.js
@@ -1,0 +1,2 @@
+import './expression';
+import './declaration';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- Resolves #4696

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
In #4674, we introduced a logic that would rewrite classes to have an id so that in case of name conflicts, they would retain the correct `class.name`. Unfortunately, this could lead to shadowed variables because the name of this new id was not considered when deconflicting variable names. This is now fixed.