### PR TITLE
Only consider Object.freeze a side effect if the argument is used

### DIFF
--- a/src/ast/nodes/shared/knownGlobals.ts
+++ b/src/ast/nodes/shared/knownGlobals.ts
@@ -214,6 +214,7 @@ const knownGlobals: GlobalDescription = {
 		// deoptimizes everything anyway
 		defineProperty: MUTATES_ARG_WITHOUT_ACCESSOR,
 		defineProperties: MUTATES_ARG_WITHOUT_ACCESSOR,
+		freeze: MUTATES_ARG_WITHOUT_ACCESSOR,
 		getOwnPropertyDescriptor: PF,
 		getOwnPropertyNames: PF,
 		getOwnPropertySymbols: PF,

--- a/test/form/samples/big-int/_config.js
+++ b/test/form/samples/big-int/_config.js
@@ -1,4 +1,3 @@
 module.exports = {
-	description: 'supports bigint via acorn plugin',
-	options: {}
+	description: 'supports bigint via acorn plugin'
 };

--- a/test/form/samples/object-freeze-effects/_config.js
+++ b/test/form/samples/object-freeze-effects/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Only treats Object.freeze as a side effect if the argument is used'
+};

--- a/test/form/samples/object-freeze-effects/_expected.js
+++ b/test/form/samples/object-freeze-effects/_expected.js
@@ -1,0 +1,6 @@
+const b = Object.freeze({ foo: 'bar' });
+console.log(b);
+
+const c = { foo: 'bar' };
+Object.freeze(c); // retained
+console.log(c);

--- a/test/form/samples/object-freeze-effects/main.js
+++ b/test/form/samples/object-freeze-effects/main.js
@@ -1,0 +1,11 @@
+Object.freeze({ foo: 'bar' }); // removed
+
+const a = { foo: 'bar' }; // removed
+Object.freeze(a); // removed
+
+const b = Object.freeze({ foo: 'bar' });
+console.log(b);
+
+const c = { foo: 'bar' };
+Object.freeze(c); // retained
+console.log(c);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- See https://github.com/rollup/rollup/issues/4327#issuecomment-1321482349
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This will change the side effect logic used for `Object.freeze` to be similar to the logic we currently use for `Object.defineProperty`: If the argument or return value is used, it is included in the bundle, otherwise it is removed. Also, we assume that the argument is deoptimized, i.e. all properties are treated as "unknown" after being passed to that function.
