### PR TITLE
Improve chunk assignment performance

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -1,6 +1,6 @@
 import type { RollupWarning } from '../../src/rollup/types';
 import { bold, gray, yellow } from '../../src/utils/colors';
-import { getOrCreate } from '../../src/utils/getOrCreate';
+import { getNewArray, getOrCreate } from '../../src/utils/getOrCreate';
 import { printQuotedStringList } from '../../src/utils/printStringList';
 import relativeId from '../../src/utils/relativeId';
 import { stderr } from '../logging';
@@ -23,7 +23,7 @@ export default function batchWarnings(): BatchWarnings {
 			warningOccurred = true;
 
 			if (warning.code! in deferredHandlers) {
-				getOrCreate(deferredWarnings, warning.code!, () => []).push(warning);
+				getOrCreate(deferredWarnings, warning.code!, getNewArray).push(warning);
 			} else if (warning.code! in immediateHandlers) {
 				immediateHandlers[warning.code!](warning);
 			} else {
@@ -220,7 +220,7 @@ const deferredHandlers: {
 
 		const dependencies = new Map<string, string[]>();
 		for (const warning of warnings) {
-			getOrCreate(dependencies, relativeId(warning.exporter!), () => []).push(
+			getOrCreate(dependencies, relativeId(warning.exporter!), getNewArray).push(
 				relativeId(warning.id!)
 			);
 		}

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -41,7 +41,7 @@ import { assignExportsToMangledNames, assignExportsToNames } from './utils/expor
 import type { GenerateCodeSnippets } from './utils/generateCodeSnippets';
 import getExportMode from './utils/getExportMode';
 import getIndentString from './utils/getIndentString';
-import { getOrCreate } from './utils/getOrCreate';
+import { getNewArray, getOrCreate } from './utils/getOrCreate';
 import { getStaticDependencies } from './utils/getStaticDependencies';
 import type { HashPlaceholderGenerator } from './utils/hashPlaceholders';
 import { replacePlaceholders } from './utils/hashPlaceholders';
@@ -911,7 +911,7 @@ export default class Chunk {
 				dependency = this.chunkByModule.get(module)!;
 				imported = dependency.getVariableExportName(variable);
 			}
-			getOrCreate(importsByDependency, dependency, () => []).push({
+			getOrCreate(importsByDependency, dependency, getNewArray).push({
 				imported,
 				local: variable.getName(this.snippets.getPropertyAccess)
 			});
@@ -1023,7 +1023,7 @@ export default class Chunk {
 						(imported !== 'default' || isDefaultAProperty(interop(module.id), true));
 				}
 			}
-			getOrCreate(reexportSpecifiers, dependency, () => []).push({
+			getOrCreate(reexportSpecifiers, dependency, getNewArray).push({
 				imported,
 				needsLiveBinding,
 				reexported: exportName

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -63,7 +63,7 @@ import {
 	warnDeprecation
 } from './utils/error';
 import { getId } from './utils/getId';
-import { getOrCreate } from './utils/getOrCreate';
+import { getNewSet, getOrCreate } from './utils/getOrCreate';
 import { getOriginalLocation } from './utils/getOriginalLocation';
 import { makeLegal } from './utils/identifierHelpers';
 import {
@@ -164,10 +164,10 @@ function getVariableForExportNameRecursive(
 }
 
 function getAndExtendSideEffectModules(variable: Variable, module: Module): Set<Module> {
-	const sideEffectModules = getOrCreate(
+	const sideEffectModules = getOrCreate<Variable, Set<Module>>(
 		module.sideEffectDependenciesByVariable,
 		variable,
-		() => new Set()
+		getNewSet
 	);
 	let currentVariable: Variable | null = variable;
 	const referencedVariables = new Set([currentVariable]);
@@ -613,7 +613,7 @@ export default class Module {
 				getOrCreate(
 					importerForSideEffects.sideEffectDependenciesByVariable,
 					variable,
-					() => new Set()
+					getNewSet
 				).add(this);
 				setAlternativeExporterIfCyclic(variable, importerForSideEffects, this);
 			}

--- a/src/ast/utils/PathTracker.ts
+++ b/src/ast/utils/PathTracker.ts
@@ -1,4 +1,4 @@
-import { getOrCreate } from '../../utils/getOrCreate';
+import { getNewSet, getOrCreate } from '../../utils/getOrCreate';
 import type { Entity } from '../Entity';
 
 export const UnknownKey = Symbol('Unknown Key');
@@ -98,7 +98,7 @@ export class DiscriminatedPathTracker {
 				currentPaths[pathSegment] ||
 				Object.create(null, { [EntitiesKey]: { value: new Map<unknown, Set<Entity>>() } });
 		}
-		const trackedEntities = getOrCreate(currentPaths[EntitiesKey], discriminator, () => new Set());
+		const trackedEntities = getOrCreate(currentPaths[EntitiesKey], discriminator, getNewSet);
 		if (trackedEntities.has(entity)) return true;
 		trackedEntities.add(entity);
 		return false;

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -1,6 +1,7 @@
 import ExternalModule from '../ExternalModule';
 import Module from '../Module';
-import { getOrCreate } from './getOrCreate';
+import { EMPTY_ARRAY } from './blank';
+import { getNewSet, getOrCreate } from './getOrCreate';
 import { concatLazy } from './iterators';
 import { timeEnd, timeStart } from './timers';
 
@@ -78,7 +79,7 @@ function analyzeModuleGraph(entries: Iterable<Module>): {
 	for (const currentEntry of allEntries) {
 		const modulesToHandle = new Set([currentEntry]);
 		for (const module of modulesToHandle) {
-			getOrCreate(dependentEntriesByModule, module, () => new Set()).add(currentEntry);
+			getOrCreate(dependentEntriesByModule, module, getNewSet).add(currentEntry);
 			for (const dependency of module.getDependenciesToBeIncluded()) {
 				if (!(dependency instanceof ExternalModule)) {
 					modulesToHandle.add(dependency);
@@ -121,7 +122,7 @@ function getDynamicallyDependentEntriesByDynamicEntry(
 		const dynamicallyDependentEntries = getOrCreate(
 			dynamicallyDependentEntriesByDynamicEntry,
 			dynamicEntry,
-			() => new Set()
+			getNewSet
 		);
 		for (const importer of [
 			...dynamicEntry.includedDynamicImporters,
@@ -146,7 +147,7 @@ function assignEntryToStaticDependencies(
 	const dynamicallyDependentEntries = dynamicallyDependentEntriesByDynamicEntry.get(entry);
 	const modulesToHandle = new Set([entry]);
 	for (const module of modulesToHandle) {
-		const assignedEntries = getOrCreate(assignedEntriesByModule, module, () => new Set());
+		const assignedEntries = getOrCreate(assignedEntriesByModule, module, getNewSet);
 		if (
 			dynamicallyDependentEntries &&
 			isModuleAlreadyLoaded(
@@ -200,6 +201,8 @@ function isModuleAlreadyLoaded(
 	}
 	return true;
 }
+
+EMPTY_ARRAY;
 
 interface ChunkDescription {
 	alias: null;

--- a/src/utils/getOrCreate.ts
+++ b/src/utils/getOrCreate.ts
@@ -7,3 +7,11 @@ export function getOrCreate<K, V>(map: Map<K, V>, key: K, init: () => V): V {
 	map.set(key, value);
 	return value;
 }
+
+export function getNewSet<T>() {
+	return new Set<T>();
+}
+
+export function getNewArray<T>(): T[] {
+	return [];
+}

--- a/src/utils/getOrCreate.ts
+++ b/src/utils/getOrCreate.ts
@@ -1,6 +1,6 @@
 export function getOrCreate<K, V>(map: Map<K, V>, key: K, init: () => V): V {
 	const existing = map.get(key);
-	if (existing) {
+	if (existing !== undefined) {
 		return existing;
 	}
 	const value = init();

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_config.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	description:
+		'does not avoid separate chunks if too many modules dynamically import the same chunk',
+	options: {
+		input: ['main1', 'main2', 'main3', 'main4']
+	}
+};

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/generated-dep.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/generated-dep.js
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	const value = 'shared';
+
+	exports.value = value;
+
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/generated-dynamic1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/generated-dynamic1.js
@@ -1,0 +1,6 @@
+define(['require', './generated-dep'], (function (require, dep) { 'use strict';
+
+	console.log('dynamic1', dep.value);
+	new Promise(function (resolve, reject) { require(['./generated-dynamic2'], resolve, reject); });
+
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/generated-dynamic2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/generated-dynamic2.js
@@ -1,0 +1,5 @@
+define(['./generated-dep'], (function (dep) { 'use strict';
+
+	console.log('dynamic2', dep.value);
+
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main1.js
@@ -1,0 +1,6 @@
+define(['require', './generated-dep'], (function (require, dep) { 'use strict';
+
+	console.log('main1', dep.value);
+	new Promise(function (resolve, reject) { require(['./generated-dynamic1'], resolve, reject); });
+
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main2.js
@@ -1,0 +1,6 @@
+define(['require', './generated-dep'], (function (require, dep) { 'use strict';
+
+	console.log('main1', dep.value);
+	new Promise(function (resolve, reject) { require(['./generated-dynamic1'], resolve, reject); });
+
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main3.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main3.js
@@ -1,0 +1,6 @@
+define(['require', './generated-dep'], (function (require, dep) { 'use strict';
+
+	console.log('main1', dep.value);
+	new Promise(function (resolve, reject) { require(['./generated-dynamic1'], resolve, reject); });
+
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main4.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/amd/main4.js
@@ -1,0 +1,6 @@
+define(['require', './generated-dep'], (function (require, dep) { 'use strict';
+
+	console.log('main1', dep.value);
+	new Promise(function (resolve, reject) { require(['./generated-dynamic1'], resolve, reject); });
+
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/generated-dep.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/generated-dep.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const value = 'shared';
+
+exports.value = value;

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/generated-dynamic1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/generated-dynamic1.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+
+console.log('dynamic1', dep.value);
+Promise.resolve().then(function () { return require('./generated-dynamic2.js'); });

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/generated-dynamic2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/generated-dynamic2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+
+console.log('dynamic2', dep.value);

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main1.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+
+console.log('main1', dep.value);
+Promise.resolve().then(function () { return require('./generated-dynamic1.js'); });

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main2.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+
+console.log('main1', dep.value);
+Promise.resolve().then(function () { return require('./generated-dynamic1.js'); });

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main3.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main3.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+
+console.log('main1', dep.value);
+Promise.resolve().then(function () { return require('./generated-dynamic1.js'); });

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main4.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/cjs/main4.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep = require('./generated-dep.js');
+
+console.log('main1', dep.value);
+Promise.resolve().then(function () { return require('./generated-dynamic1.js'); });

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/generated-dep.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/generated-dep.js
@@ -1,0 +1,3 @@
+const value = 'shared';
+
+export { value as v };

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/generated-dynamic1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/generated-dynamic1.js
@@ -1,0 +1,4 @@
+import { v as value } from './generated-dep.js';
+
+console.log('dynamic1', value);
+import('./generated-dynamic2.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/generated-dynamic2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/generated-dynamic2.js
@@ -1,0 +1,3 @@
+import { v as value } from './generated-dep.js';
+
+console.log('dynamic2', value);

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main1.js
@@ -1,0 +1,4 @@
+import { v as value } from './generated-dep.js';
+
+console.log('main1', value);
+import('./generated-dynamic1.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main2.js
@@ -1,0 +1,4 @@
+import { v as value } from './generated-dep.js';
+
+console.log('main1', value);
+import('./generated-dynamic1.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main3.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main3.js
@@ -1,0 +1,4 @@
+import { v as value } from './generated-dep.js';
+
+console.log('main1', value);
+import('./generated-dynamic1.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main4.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/es/main4.js
@@ -1,0 +1,4 @@
+import { v as value } from './generated-dep.js';
+
+console.log('main1', value);
+import('./generated-dynamic1.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/generated-dep.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/generated-dep.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const value = exports('v', 'shared');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/generated-dynamic1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/generated-dynamic1.js
@@ -1,0 +1,15 @@
+System.register(['./generated-dep.js'], (function (exports, module) {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log('dynamic1', value);
+			module.import('./generated-dynamic2.js');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/generated-dynamic2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/generated-dynamic2.js
@@ -1,0 +1,14 @@
+System.register(['./generated-dep.js'], (function () {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log('dynamic2', value);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main1.js
@@ -1,0 +1,15 @@
+System.register(['./generated-dep.js'], (function (exports, module) {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log('main1', value);
+			module.import('./generated-dynamic1.js');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main2.js
@@ -1,0 +1,15 @@
+System.register(['./generated-dep.js'], (function (exports, module) {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log('main1', value);
+			module.import('./generated-dynamic1.js');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main3.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main3.js
@@ -1,0 +1,15 @@
+System.register(['./generated-dep.js'], (function (exports, module) {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log('main1', value);
+			module.import('./generated-dynamic1.js');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main4.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/_expected/system/main4.js
@@ -1,0 +1,15 @@
+System.register(['./generated-dep.js'], (function (exports, module) {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log('main1', value);
+			module.import('./generated-dynamic1.js');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/dep.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/dep.js
@@ -1,0 +1,1 @@
+export const value = 'shared';

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/dynamic1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/dynamic1.js
@@ -1,0 +1,4 @@
+import { value } from './dep.js';
+console.log('dynamic1', value);
+import('./dynamic2.js');
+

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/dynamic2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/dynamic2.js
@@ -1,0 +1,2 @@
+import { value } from './dep.js';
+console.log('dynamic2', value);

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main1.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main1.js
@@ -1,0 +1,3 @@
+import { value } from './dep.js';
+console.log('main1', value);
+import('./dynamic1.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main2.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main2.js
@@ -1,0 +1,3 @@
+import { value } from './dep.js';
+console.log('main1', value);
+import('./dynamic1.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main3.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main3.js
@@ -1,0 +1,3 @@
+import { value } from './dep.js';
+console.log('main1', value);
+import('./dynamic1.js');

--- a/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main4.js
+++ b/test/chunking-form/samples/improved-dynamic-chunks/cut-off/main4.js
@@ -1,0 +1,3 @@
+import { value } from './dep.js';
+console.log('main1', value);
+import('./dynamic1.js');

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -7,6 +7,8 @@ const { loader, wait } = require('../utils.js');
 const TEMP_DIR = path.join(__dirname, 'tmp');
 
 describe('hooks', () => {
+	before(() => remove(TEMP_DIR));
+
 	it('allows to replace file with dir in the outputOptions hook', async () => {
 		const bundle = await rollup.rollup({
 			input: 'input',


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- Resolves #4732

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This refactors the chunk generation algorithm to hopefully improve the performance for very large projects. Basically instead of doing an ad-hoc reverse search for each module in each dynamic chunk if it may already be in memory when the chunk is loaded, when pre-create a table of modules that are in memory for each dynamic chunk. It has still some run time complexity, but my hope is that it will perform much better than the old algorithm.