### PR TITLE
Provide hashed file name when using this.getFileName in generateBundle

### DIFF
--- a/src/utils/FileEmitter.ts
+++ b/src/utils/FileEmitter.ts
@@ -144,8 +144,7 @@ function getChunkFileName(
 		return file.fileName;
 	}
 	if (facadeChunkByModule) {
-		const chunk = facadeChunkByModule.get(file.module!)!;
-		return chunk.id || chunk.getFileName();
+		return facadeChunkByModule.get(file.module!)!.getFileName();
 	}
 	return error(errorChunkNotGeneratedForFileName(file.fileName || file.name));
 }

--- a/src/utils/renderChunks.ts
+++ b/src/utils/renderChunks.ts
@@ -309,7 +309,7 @@ function addChunksToBundle(
 			map.file = replacePlaceholders(map.file, hashesByPlaceholder);
 			updatedCode += emitSourceMapAndGetComment(finalFileName, map, pluginDriver, options);
 		}
-		bundle[finalFileName] = chunk.generateOutputChunk(updatedCode, map, hashesByPlaceholder);
+		bundle[finalFileName] = chunk.finalizeChunk(updatedCode, map, hashesByPlaceholder);
 	}
 	for (const { chunk, code, fileName, map } of nonHashedChunksWithPlaceholders) {
 		let updatedCode =
@@ -317,7 +317,7 @@ function addChunksToBundle(
 		if (map) {
 			updatedCode += emitSourceMapAndGetComment(fileName, map, pluginDriver, options);
 		}
-		bundle[fileName] = chunk.generateOutputChunk(updatedCode, map, hashesByPlaceholder);
+		bundle[fileName] = chunk.finalizeChunk(updatedCode, map, hashesByPlaceholder);
 	}
 }
 

--- a/test/function/samples/emit-chunk-hash/_config.js
+++ b/test/function/samples/emit-chunk-hash/_config.js
@@ -1,0 +1,20 @@
+const assert = require('node:assert');
+let referenceId;
+
+module.exports = {
+	description: 'gives access to the hashed filed name via this.getFileName in generateBundle',
+	options: {
+		input: 'main',
+		output: {
+			chunkFileNames: '[name]-[hash].js'
+		},
+		plugins: {
+			buildStart() {
+				referenceId = this.emitFile({ type: 'chunk', id: 'emitted' });
+			},
+			generateBundle() {
+				assert.strictEqual(this.getFileName(referenceId), 'emitted-38bdd9b2.js');
+			}
+		}
+	}
+};

--- a/test/function/samples/emit-chunk-hash/emitted.js
+++ b/test/function/samples/emit-chunk-hash/emitted.js
@@ -1,0 +1,1 @@
+assert.ok(true);

--- a/test/function/samples/emit-chunk-hash/main.js
+++ b/test/function/samples/emit-chunk-hash/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4744

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
I completely forgot about `this.getFileName` with the new hashing logic. Now you get the file name with the hash instead of the placeholder in `generateBundle`.