### PR TITLE
Support emitting files via manualChunks in output

### DIFF
--- a/test/function/samples/emit-chunk-manual-asset-source/_config.js
+++ b/test/function/samples/emit-chunk-manual-asset-source/_config.js
@@ -1,0 +1,27 @@
+const assert = require('node:assert');
+let referenceId;
+
+module.exports = {
+	description: 'supports setting asset sources as side effect of the manual chunks option',
+	options: {
+		output: {
+			manualChunks: { foo: ['manual.js'] },
+			assetFileNames: '[name]-[hash][extname]'
+		},
+		plugins: {
+			transform(code, id) {
+				if (id.endsWith('manual.js')) {
+					referenceId = this.emitFile({ type: 'asset', name: 'emitted.txt' });
+				}
+			},
+			moduleParsed({ id }) {
+				if (id.endsWith('manual.js')) {
+					this.setAssetSource(referenceId, 'emitted');
+				}
+			},
+			generateBundle() {
+				assert.strictEqual(this.getFileName(referenceId), 'emitted-f57bfbce.txt');
+			}
+		}
+	}
+};

--- a/test/function/samples/emit-chunk-manual-asset-source/main.js
+++ b/test/function/samples/emit-chunk-manual-asset-source/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);

--- a/test/function/samples/emit-chunk-manual-asset-source/manual.js
+++ b/test/function/samples/emit-chunk-manual-asset-source/manual.js
@@ -1,0 +1,1 @@
+import './main';

--- a/test/function/samples/emit-chunk-manual/_config.js
+++ b/test/function/samples/emit-chunk-manual/_config.js
@@ -1,0 +1,22 @@
+const assert = require('node:assert');
+let referenceId;
+
+module.exports = {
+	description: 'supports emitting chunks as side effect of the manual chunks option',
+	options: {
+		output: {
+			manualChunks: { foo: ['manual.js'] },
+			assetFileNames: '[name]-[hash][extname]'
+		},
+		plugins: {
+			transform(code, id) {
+				if (id.endsWith('manual.js')) {
+					referenceId = this.emitFile({ type: 'asset', name: 'emitted.txt', source: 'emitted' });
+				}
+			},
+			generateBundle() {
+				assert.strictEqual(this.getFileName(referenceId), 'emitted-f57bfbce.txt');
+			}
+		}
+	}
+};

--- a/test/function/samples/emit-chunk-manual/main.js
+++ b/test/function/samples/emit-chunk-manual/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);

--- a/test/function/samples/emit-chunk-manual/manual.js
+++ b/test/function/samples/emit-chunk-manual/manual.js
@@ -1,0 +1,1 @@
+import './main';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4746

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This changes the logic for emitting files to handle files emitted during output generation phase via a transform hooks that is triggered for the first time by the `manualChunks` option of that output. This may not be exactly what users expect, but it is difficult to differentiate legitimate uses of the file emitter from illegitimate uses, especially with new features in the pipeline.
As a follow-up, it would be worthwhile to add a way for assets to obey tree-shaking in so far that assets that are never referenced are not emitted.