### PR TITLE
Fix handling of namespace reexports when preserving modules

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -782,6 +782,9 @@ export default class Chunk {
 							continue;
 						}
 						const chunkDep = this.renderedDependencies!.get(chunk)!;
+						if (!chunkDep) {
+							continue;
+						}
 						const { imports, reexports } = chunkDep;
 						const importedByReexported = reexports?.find(
 							({ reexported }) => reexported === exportName

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_config.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	description: 'handles doing a namespace reexport of a reexport',
+	options: {
+		output: {
+			preserveModules: true
+		}
+	}
+};

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/amd/dep.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/amd/dep.js
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	const value = 'foo';
+
+	exports.value = value;
+
+}));

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/amd/main.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(['./reexport', './dep'], (function (reexport, dep) { 'use strict';
+
+	console.log(dep.value);
+
+}));

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/amd/reexport.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/amd/reexport.js
@@ -1,0 +1,5 @@
+define((function () { 'use strict';
+
+	console.log('reexport');
+
+}));

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/cjs/dep.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/cjs/dep.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const value = 'foo';
+
+exports.value = value;

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/cjs/main.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/cjs/main.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('./reexport.js');
+var dep = require('./dep.js');
+
+console.log(dep.value);

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/cjs/reexport.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/cjs/reexport.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('reexport');

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/es/dep.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/es/dep.js
@@ -1,0 +1,3 @@
+const value = 'foo';
+
+export { value };

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/es/main.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/es/main.js
@@ -1,0 +1,4 @@
+import './reexport.js';
+import { value } from './dep.js';
+
+console.log(value);

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/es/reexport.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/es/reexport.js
@@ -1,0 +1,1 @@
+console.log('reexport');

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/system/dep.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/system/dep.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const value = exports('value', 'foo');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/system/main.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register(['./reexport.js', './dep.js'], (function () {
+	'use strict';
+	var value;
+	return {
+		setters: [null, function (module) {
+			value = module.value;
+		}],
+		execute: (function () {
+
+			console.log(value);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/system/reexport.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/_expected/system/reexport.js
@@ -1,0 +1,10 @@
+System.register([], (function () {
+	'use strict';
+	return {
+		execute: (function () {
+
+			console.log('reexport');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/dep.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/dep.js
@@ -1,0 +1,1 @@
+export const value = 'foo';

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/main.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/main.js
@@ -1,0 +1,3 @@
+import { value } from './reexport2';
+
+console.log(value);

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/reexport.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/reexport.js
@@ -1,0 +1,2 @@
+export { value } from './dep.js';
+console.log('reexport');

--- a/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/reexport2.js
+++ b/test/chunking-form/samples/preserve-modules-namespace-reexport-reexport/reexport2.js
@@ -1,0 +1,1 @@
+export * from './reexport.js';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4765

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Apparently, one assumption from me was wrong about what does or does not occur in a chunks dependencies.
