### PR TITLE
Add 'version' property on Plugin type

### DIFF
--- a/docs/05-plugin-development.md
+++ b/docs/05-plugin-development.md
@@ -64,6 +64,12 @@ export default ({
 
 The name of the plugin, for use in error messages and warnings.
 
+#### `version?`
+
+**Type:** `string | undefined`
+
+The version of the plugin, for use in inter-plugin communication scenarios.
+
 ### Build Hooks
 
 To interact with the build process, your plugin object includes "hooks". Hooks are functions which are called at various stages of the build. Hooks can affect how a build is run, provide information about a build, or modify a build once complete. There are different kinds of hooks:

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -456,6 +456,7 @@ export interface OutputPlugin
 		Partial<{ [K in AddonHooks]: ObjectHook<AddonHook> }> {
 	cacheKey?: string;
 	name: string;
+	version?: string;
 }
 
 export interface Plugin extends OutputPlugin, Partial<PluginHooks> {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Checking the version of a fellow plugin is a common task in inter-plugin communication scenarios - as an example, [`@rollup/plugin-commonjs` checks what version of `@rollup/plugin-node-resolve` is present](https://github.com/rollup/plugins/blob/master/packages/commonjs/src/index.js#L203):

```javascript
const nodeResolve = plugins.find(({ name }) => name === 'node-resolve');
if (nodeResolve) {
  validateVersion(nodeResolve.version, '^13.0.6', '@rollup/plugin-node-resolve');
}
```

This works because `@rollup/plugin-node-resolve` has an unofficial `version` field added to it. This PR just proposes to make this property official (and discoverable for Intellisense users) by adding a `version?: string` property to the `OutputPlugin` type.

The docs are updated accordingly.
