### PR TITLE
Use @jridgewell/sourcemap-codec

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -628,35 +628,6 @@ Repository: https://github.com/tapjs/signal-exit.git
 
 ---------------------------------------
 
-## sourcemap-codec
-License: MIT
-By: Rich Harris
-Repository: https://github.com/Rich-Harris/sourcemap-codec
-
-> The MIT License
-> 
-> Copyright (c) 2015 Rich Harris
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
 ## time-zone
 License: MIT
 By: Sindre Sorhus

--- a/browser/LICENSE.md
+++ b/browser/LICENSE.md
@@ -226,32 +226,3 @@ Repository: https://github.com/calvinmetcalf/minimalistic-assert.git
 > LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
 > OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 > PERFORMANCE OF THIS SOFTWARE.
-
----------------------------------------
-
-## sourcemap-codec
-License: MIT
-By: Rich Harris
-Repository: https://github.com/Rich-Harris/sourcemap-codec
-
-> The MIT License
-> 
-> Copyright (c) 2015 Rich Harris
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "rollup": "dist/bin/rollup"
       },
       "devDependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.14",
         "@rollup/plugin-alias": "^4.0.2",
         "@rollup/plugin-buble": "^1.0.1",
         "@rollup/plugin-commonjs": "^24.0.0",
@@ -70,7 +71,6 @@
         "signal-exit": "^3.0.7",
         "source-map": "^0.7.4",
         "source-map-support": "^0.5.21",
-        "sourcemap-codec": "^1.4.8",
         "systemjs": "^6.13.0",
         "terser": "^5.16.1",
         "tslib": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "fsevents": "~2.3.2"
   },
   "devDependencies": {
+    "@jridgewell/sourcemap-codec": "^1.4.14",
     "@rollup/plugin-alias": "^4.0.2",
     "@rollup/plugin-buble": "^1.0.1",
     "@rollup/plugin-commonjs": "^24.0.0",
@@ -116,7 +117,6 @@
     "signal-exit": "^3.0.7",
     "source-map": "^0.7.4",
     "source-map-support": "^0.5.21",
-    "sourcemap-codec": "^1.4.8",
     "systemjs": "^6.13.0",
     "terser": "^5.16.1",
     "tslib": "^2.4.1",

--- a/src/utils/decodedSourcemap.ts
+++ b/src/utils/decodedSourcemap.ts
@@ -1,4 +1,4 @@
-import { decode } from 'sourcemap-codec';
+import { decode } from '@jridgewell/sourcemap-codec';
 import type {
 	ExistingDecodedSourceMap,
 	ExistingRawSourceMap,

--- a/test/function/samples/warning-low-resolution-location/_config.js
+++ b/test/function/samples/warning-low-resolution-location/_config.js
@@ -1,5 +1,5 @@
 const path = require('node:path');
-const { encode } = require('sourcemap-codec');
+const { encode } = require('@jridgewell/sourcemap-codec');
 const ID_MAIN = path.join(__dirname, 'main.js');
 
 module.exports = {

--- a/test/sourcemaps/samples/transform-low-resolution/_config.js
+++ b/test/sourcemaps/samples/transform-low-resolution/_config.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 const MagicString = require('magic-string');
 const { SourceMapConsumer } = require('source-map');
-const { encode } = require('sourcemap-codec');
+const { encode } = require('@jridgewell/sourcemap-codec');
 const getLocation = require('../../getLocation');
 
 module.exports = {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

none

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The `sourcemap-codec` package has been deprecated in favour of `jridgewell/sourcemap-codec`, which provides extra perf optimizations. The API is interchangable so it's a matter of renaming the imports.

Though Rollup only [uses the decode API](https://github.com/bluwy/rollup/blob/09bcf369f8b5dea7f3937b98ce2d25062ba0c1e3/src/utils/decodedSourcemap.ts#L1), and there's only [slight decode perf](https://github.com/jridgewell/sourcemap-codec#benchmarks), I think it's still worth the change.
