### PR TITLE
Remove default acorn options + other fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,10 +50,6 @@ module.exports = {
 		}
 	],
 	parser: '@typescript-eslint/parser',
-	parserOptions: {
-		ecmaVersion: 2018,
-		sourceType: 'module'
-	},
 	plugins: ['@typescript-eslint'],
 	rules: {
 		'@typescript-eslint/consistent-type-assertions': [

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -142,7 +142,6 @@ export default class Bundle {
 				if ('code' in file) {
 					try {
 						this.graph.contextParse(file.code, {
-							allowHashBang: true,
 							ecmaVersion: 'latest'
 						});
 					} catch (error_: any) {

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -910,14 +910,6 @@ export default class Module {
 		return null;
 	}
 
-	tryParse(): acorn.Node {
-		try {
-			return this.graph.contextParse(this.info.code!);
-		} catch (error_: any) {
-			return this.error(errorParseError(error_, this.id), error_.pos);
-		}
-	}
-
 	updateOptions({
 		meta,
 		moduleSideEffects,
@@ -1258,6 +1250,14 @@ export default class Module {
 	private shimMissingExport(name: string): void {
 		this.options.onwarn(errorShimmedExport(this.id, name));
 		this.exports.set(name, MISSING_EXPORT_SHIM_DESCRIPTION);
+	}
+
+	private tryParse(): acorn.Node {
+		try {
+			return this.graph.contextParse(this.info.code!);
+		} catch (error_: any) {
+			return this.error(errorParseError(error_, this.id), error_.pos);
+		}
 	}
 }
 

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -771,12 +771,12 @@ export default class Module {
 		this.transformDependencies = transformDependencies;
 		this.customTransformCache = customTransformCache;
 		this.updateOptions(moduleOptions);
-		const moduleAst = ast || this.tryParse();
+		const moduleAst = ast ?? this.tryParse();
 
 		timeEnd('generate ast', 3);
 		timeStart('analyze ast', 3);
 
-		this.resolvedIds = resolvedIds || Object.create(null);
+		this.resolvedIds = resolvedIds ?? Object.create(null);
 
 		// By default, `id` is the file name. Custom resolvers and loaders
 		// can change that, but it makes sense to use it for the source file name

--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -306,7 +306,7 @@ export class PluginDriver {
 		replaceContext?: ReplaceContext | null
 	): Promise<unknown> {
 		// We always filter for plugins that support the hook before running it
-		const hook = plugin[hookName]!;
+		const hook = plugin[hookName];
 		const handler = typeof hook === 'object' ? hook.handler : hook;
 
 		let context = this.pluginContexts.get(plugin)!;

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -206,10 +206,7 @@ const getModuleContext = (
 	config: InputOptions,
 	context: string
 ): NormalizedInputOptions['moduleContext'] => {
-	const configModuleContext = config.moduleContext as
-		| ((id: string) => string | null | undefined)
-		| { [id: string]: string }
-		| undefined;
+	const configModuleContext = config.moduleContext;
 	if (typeof configModuleContext === 'function') {
 		return id => configModuleContext(id) ?? context;
 	}

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -217,7 +217,7 @@ const getModuleContext = (
 		for (const [key, moduleContext] of Object.entries(configModuleContext)) {
 			contextByModuleId[resolve(key)] = moduleContext;
 		}
-		return id => contextByModuleId[id] || context;
+		return id => contextByModuleId[id] ?? context;
 	}
 	return () => context;
 };

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -96,9 +96,7 @@ const getOnwarn = (config: InputOptions): NormalizedInputOptions['onwarn'] => {
 };
 
 const getAcorn = (config: InputOptions): acorn.Options => ({
-	allowAwaitOutsideFunction: true,
 	ecmaVersion: 'latest',
-	preserveParens: false,
 	sourceType: 'module',
 	...config.acorn
 });

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -214,7 +214,9 @@ const getModuleContext = (
 		return id => configModuleContext(id) ?? context;
 	}
 	if (configModuleContext) {
-		const contextByModuleId = Object.create(null);
+		const contextByModuleId: {
+			[key: string]: string;
+		} = Object.create(null);
 		for (const [key, moduleContext] of Object.entries(configModuleContext)) {
 			contextByModuleId[resolve(key)] = moduleContext;
 		}

--- a/test/function/samples/options-hook/_config.js
+++ b/test/function/samples/options-hook/_config.js
@@ -10,9 +10,7 @@ module.exports = {
 			buildStart(options) {
 				assert.deepStrictEqual(JSON.parse(JSON.stringify(options)), {
 					acorn: {
-						allowAwaitOutsideFunction: true,
 						ecmaVersion: 'latest',
-						preserveParens: false,
 						sourceType: 'module'
 					},
 					acornInjectPlugins: [null],


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->


just some stuff I noticed when looking through: https://github.com/rollup/rollup/issues/4784

`allowHashBang` and `allowAwaitOutsideFunction` are default with `ecmaVersion: "latest"`