### PR TITLE
fix: Fix 'Cannot read properties of undefined (reading '0')'

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -711,9 +711,10 @@ export default class Chunk {
 				if (alternativeReexportModule) {
 					const exportingChunk = this.chunkByModule.get(alternativeReexportModule);
 					if (exportingChunk && exportingChunk !== exportChunk) {
+						const variableNames = variableModule.getExportNamesByVariable().get(variable);
 						this.inputOptions.onwarn(
 							errorCyclicCrossChunkReexport(
-								variableModule.getExportNamesByVariable().get(variable)![0],
+								variableNames?.[0] ?? '????',
 								variableModule.id,
 								alternativeReexportModule.id,
 								importingModule.id


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

I have no idea how to test this - suggestions welcome.  But, this is hopefully a pretty obivously "safe" change.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

I was going to raise an issue, but I don't have a minimal reproduction.  :P

### Description

When bundling my project (via vite), I get:

```
Cannot read properties of undefined (reading '0')
error during build:
TypeError: Cannot read properties of undefined (reading '0')
    at Chunk.checkCircularDependencyImport (file:///Users/jwalton/solink/video-discovery-web/node_modules/rollup/dist/es/shared/rollup.js:15363:135)
    at Chunk.setUpChunkImportsAndExportsForModule (file:///Users/jwalton/solink/video-discovery-web/node_modules/rollup/dist/es/shared/rollup.js:15909:26)
    at Chunk.link (file:///Users/jwalton/solink/video-discovery-web/node_modules/rollup/dist/es/shared/rollup.js:15253:18)
    at Bundle.generateChunks (file:///Users/jwalton/solink/video-discovery-web/node_modules/rollup/dist/es/shared/rollup.js:16830:19)
    at async Bundle.generate (file:///Users/jwalton/solink/video-discovery-web/node_modules/rollup/dist/es/shared/rollup.js:16731:28)
    at async file:///Users/jwalton/solink/video-discovery-web/node_modules/rollup/dist/es/shared/rollup.js:24977:27
    at async catchUnfinishedHookActions (file:///Users/jwalton/solink/video-discovery-web/node_modules/rollup/dist/es/shared/rollup.js:24066:20)
    at async doBuild (file:///Users/jwalton/solink/video-discovery-web/node_modules/vite/dist/node/chunks/dep-5e7f419b.js:44518:22)
    at async build (file:///Users/jwalton/solink/video-discovery-web/node_modules/vite/dist/node/chunks/dep-5e7f419b.js:44347:16)
    at async CAC.<anonymous> (file:///Users/jwalton/solink/video-discovery-web/node_modules/vite/dist/node/cli.js:808:9)
```

Rollup is trying to print this warning:

> Export "XXX" of module "YYY.js" was reexported through module "ZZZ.js" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
Either change the import in "ZZZ.jsx" to point directly to the exporting module or do not use "preserveModules" to ensure these modules end up in the same chunk.

The problem here is that this snippet:

```
variableModule.getExportNamesByVariable().get(variable)![0]
```

fails, because despite the `!`, `get(variable)` does in fact return undefined in my case.  This doesn't fix the underlying issue here, but it at least stops rollup from crashing.