### PR TITLE
Rework tree-shaking support for optional chaining

### DIFF
--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -21,9 +21,13 @@ import type SpreadElement from './SpreadElement';
 import type Super from './Super';
 import CallExpressionBase from './shared/CallExpressionBase';
 import { type ExpressionEntity, UNKNOWN_RETURN_EXPRESSION } from './shared/Expression';
+import type { ChainElement } from './shared/Node';
 import { type ExpressionNode, INCLUDE_PARAMETERS, type IncludeChildren } from './shared/Node';
 
-export default class CallExpression extends CallExpressionBase implements DeoptimizableEntity {
+export default class CallExpression
+	extends CallExpressionBase
+	implements DeoptimizableEntity, ChainElement
+{
 	declare arguments: (ExpressionNode | SpreadElement)[];
 	declare callee: ExpressionNode | Super;
 	declare optional: boolean;
@@ -88,6 +92,14 @@ export default class CallExpression extends CallExpressionBase implements Deopti
 			this.callee.include(context, false);
 		}
 		this.callee.includeCallArguments(context, this.arguments);
+	}
+
+	isSkippedAsOptional(origin: DeoptimizableEntity): boolean {
+		return (
+			(this.callee as ExpressionNode).isSkippedAsOptional?.(origin) ||
+			(this.optional &&
+				this.callee.getLiteralValueAtPath(EMPTY_PATH, SHARED_RECURSION_TRACKER, origin) == null)
+		);
 	}
 
 	render(

--- a/src/ast/nodes/ChainExpression.ts
+++ b/src/ast/nodes/ChainExpression.ts
@@ -1,42 +1,30 @@
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext } from '../ExecutionContext';
-import { SHARED_RECURSION_TRACKER } from '../utils/PathTracker';
-import { EMPTY_PATH } from '../utils/PathTracker';
+import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import type CallExpression from './CallExpression';
 import type MemberExpression from './MemberExpression';
 import type * as NodeType from './NodeType';
 import type { LiteralValueOrUnknown } from './shared/Expression';
-import { UnknownValue } from './shared/Expression';
 import { NodeBase } from './shared/Node';
-
-const unset = Symbol('unset');
 
 export default class ChainExpression extends NodeBase implements DeoptimizableEntity {
 	declare expression: CallExpression | MemberExpression;
 	declare type: NodeType.tChainExpression;
-	private objectValue: LiteralValueOrUnknown | typeof unset = unset;
 
-	deoptimizeCache(): void {
-		this.objectValue = UnknownValue;
-	}
+	// deoptimizations are not relevant as we are not caching values
+	deoptimizeCache(): void {}
 
-	getLiteralValueAtPath(): LiteralValueOrUnknown {
-		if (this.getObjectValue() == null) return undefined;
-		return UnknownValue;
+	getLiteralValueAtPath(
+		path: ObjectPath,
+		recursionTracker: PathTracker,
+		origin: DeoptimizableEntity
+	): LiteralValueOrUnknown {
+		if (this.expression.isSkippedAsOptional(origin)) return undefined;
+		return this.expression.getLiteralValueAtPath(path, recursionTracker, origin);
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {
-		if (this.getObjectValue() == null) return false;
+		if (this.expression.isSkippedAsOptional(this)) return false;
 		return this.expression.hasEffects(context);
-	}
-
-	private getObjectValue() {
-		if (this.objectValue === unset) {
-			let object =
-				this.expression.type === 'CallExpression' ? this.expression.callee : this.expression.object;
-			if (object.type === 'MemberExpression') object = (object as MemberExpression).object;
-			this.objectValue = object.getLiteralValueAtPath(EMPTY_PATH, SHARED_RECURSION_TRACKER, this);
-		}
-		return this.objectValue;
 	}
 }

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -4,6 +4,7 @@ import type MagicString from 'magic-string';
 import type { AstContext } from '../../../Module';
 import { ANNOTATION_KEY, INVALID_COMMENT_KEY } from '../../../utils/pureComments';
 import type { NodeRenderOptions, RenderOptions } from '../../../utils/renderHelpers';
+import type { DeoptimizableEntity } from '../../DeoptimizableEntity';
 import type { Entity } from '../../Entity';
 import {
 	createHasEffectsContext,
@@ -113,7 +114,14 @@ export interface Node extends Entity {
 
 export type StatementNode = Node;
 
-export interface ExpressionNode extends ExpressionEntity, Node {}
+export interface ExpressionNode extends ExpressionEntity, Node {
+	isSkippedAsOptional?(origin: DeoptimizableEntity): boolean;
+}
+
+export interface ChainElement extends ExpressionNode {
+	optional: boolean;
+	isSkippedAsOptional(origin: DeoptimizableEntity): boolean;
+}
 
 export class NodeBase extends ExpressionEntity implements ExpressionNode {
 	declare annotations?: acorn.Comment[];

--- a/test/form/samples/optional-chaining-namespace/_config.js
+++ b/test/form/samples/optional-chaining-namespace/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'supports optional chaining with namespace objects',
+	expectedWarnings: ['MISSING_EXPORT']
+};

--- a/test/form/samples/optional-chaining-namespace/_expected.js
+++ b/test/form/samples/optional-chaining-namespace/_expected.js
@@ -1,0 +1,5 @@
+const foo = { nullVal: null };
+
+foo?.x.x; // retained
+
+undefined.x; // retained

--- a/test/form/samples/optional-chaining-namespace/main.js
+++ b/test/form/samples/optional-chaining-namespace/main.js
@@ -1,0 +1,32 @@
+import * as util from './util';
+
+util.foo.x; // removed
+util.foo.nullVal; // removed
+util.foo.nullVal?.x; // removed
+util.foo.nullVal?.x.y; // removed
+util.foo.nullVal?.(); // removed
+util.foo.nullVal?.().x(); // removed
+
+util.foo?.x.x; // retained
+
+util.x; // removed
+util.x?.x; // removed
+util.x?.x.y; // removed
+util.x?.(); // removed
+util.x?.().x(); // removed
+
+util?.x.x; // retained
+
+if (
+	util.foo.nullVal ||
+	util.foo.nullVal?.x ||
+	util.foo.nullVal?.x.y ||
+	util.foo.nullVal?.() ||
+	util.foo.nullVal?.().x()
+) {
+	console.log('removed');
+}
+
+if (util.x || util.x?.x || util.x?.x.y || util.x?.() || util.x?.().x()) {
+	console.log('removed');
+}

--- a/test/form/samples/optional-chaining-namespace/util.js
+++ b/test/form/samples/optional-chaining-namespace/util.js
@@ -1,0 +1,1 @@
+export const foo = { nullVal: null };

--- a/test/form/samples/optional-chaining/_expected.js
+++ b/test/form/samples/optional-chaining/_expected.js
@@ -1,3 +1,8 @@
-const obj = { __proto__: null };
-obj.foo?.bar;
-obj.foo?.();
+Object.defineProperty(Object.prototype, 'foo', {
+	get bar() {
+		console.log('effect');
+	}
+});
+const obj2 = {};
+obj2.foo?.bar;
+obj2.foo?.();

--- a/test/form/samples/optional-chaining/main.js
+++ b/test/form/samples/optional-chaining/main.js
@@ -2,3 +2,12 @@ const obj = { __proto__: null };
 obj?.foo;
 obj.foo?.bar;
 obj.foo?.();
+
+Object.defineProperty(Object.prototype, 'foo', {
+	get bar() {
+		console.log('effect');
+	}
+});
+const obj2 = {};
+obj2.foo?.bar;
+obj2.foo?.();

--- a/test/function/samples/optional-chaining-side-effect/_config.js
+++ b/test/function/samples/optional-chaining-side-effect/_config.js
@@ -1,0 +1,9 @@
+const assert = require('node:assert');
+
+module.exports = {
+	description: 'handles side effects in optional chaining (#4806)',
+	exports({ get, set }) {
+		set(['test']);
+		assert.strictEqual(get('test'), 't');
+	}
+};

--- a/test/function/samples/optional-chaining-side-effect/main.js
+++ b/test/function/samples/optional-chaining-side-effect/main.js
@@ -1,0 +1,13 @@
+var value;
+
+export function get(v) {
+	let g = value?.find(b => v === b);
+	if (!g) {
+		return;
+	}
+	return g.charAt(0);
+}
+
+export function set(a) {
+	value = a;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- Resolves #4810 
- Resolves #4806 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This PR reworks the support for tree-shaking in optional chaining by better reflecting the optional chaining logic and adding proper support for properties of namespaces.

Missing properties of namespaces are now also treated as `undefined` for optional chaining.