### PR TITLE
fix: use the original class name in the class body

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1164,7 +1164,8 @@ export default class Chunk {
 			indent,
 			namespaceToStringTag,
 			pluginDriver,
-			snippets
+			snippets,
+			useOriginalName: null
 		};
 
 		let usesTopLevelAwait = false;

--- a/src/ast/nodes/ClassDeclaration.ts
+++ b/src/ast/nodes/ClassDeclaration.ts
@@ -2,6 +2,7 @@ import type MagicString from 'magic-string';
 import type { RenderOptions } from '../../utils/renderHelpers';
 import { getSystemExportStatement } from '../../utils/systemJsRendering';
 import type ChildScope from '../scopes/ChildScope';
+import type Variable from '../variables/Variable';
 import Identifier, { type IdentifierWithVariable } from './Identifier';
 import type * as NodeType from './NodeType';
 import ClassNode from './shared/ClassNode';
@@ -43,7 +44,10 @@ export default class ClassDeclaration extends ClassNode {
 			const renderedVariable = variable.getName(getPropertyAccess);
 			if (renderedVariable !== name) {
 				this.superClass?.render(code, options);
-				this.body.render(code, options);
+				this.body.render(code, {
+					...options,
+					useOriginalName: (_variable: Variable) => _variable === variable
+				});
 				code.prependRight(this.start, `let ${renderedVariable}${_}=${_}`);
 				code.prependLeft(this.end, ';');
 				return;

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -244,11 +244,11 @@ export default class Identifier extends NodeBase implements PatternNode {
 
 	render(
 		code: MagicString,
-		{ snippets: { getPropertyAccess } }: RenderOptions,
+		{ snippets: { getPropertyAccess }, useOriginalName }: RenderOptions,
 		{ renderedParentType, isCalleeOfRenderedParent, isShorthandProperty }: NodeRenderOptions = BLANK
 	): void {
 		if (this.variable) {
-			const name = this.variable.getName(getPropertyAccess);
+			const name = this.variable.getName(getPropertyAccess, useOriginalName);
 
 			if (name !== this.name) {
 				code.overwrite(this.start, this.end, name, {

--- a/src/ast/nodes/StaticBlock.ts
+++ b/src/ast/nodes/StaticBlock.ts
@@ -3,7 +3,10 @@ import { type RenderOptions, renderStatementList } from '../../utils/renderHelpe
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import BlockScope from '../scopes/BlockScope';
 import type Scope from '../scopes/Scope';
+import type Variable from '../variables/Variable';
+import type ClassBody from './ClassBody';
 import type * as NodeType from './NodeType';
+import type ClassNode from './shared/ClassNode';
 import { type IncludeChildren, StatementBase, type StatementNode } from './shared/Node';
 
 export default class StaticBlock extends StatementBase {
@@ -30,6 +33,12 @@ export default class StaticBlock extends StatementBase {
 	}
 
 	render(code: MagicString, options: RenderOptions): void {
+		const classVariable = ((this.parent as ClassBody).parent as ClassNode).id!.variable;
+		const useOriginalName = (variable: Variable) => variable === classVariable;
+		options = {
+			...options,
+			useOriginalName
+		};
 		if (this.body.length > 0) {
 			renderStatementList(this.body, code, this.start + 1, this.end - 1, options);
 		} else {

--- a/src/ast/nodes/StaticBlock.ts
+++ b/src/ast/nodes/StaticBlock.ts
@@ -3,10 +3,7 @@ import { type RenderOptions, renderStatementList } from '../../utils/renderHelpe
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import BlockScope from '../scopes/BlockScope';
 import type Scope from '../scopes/Scope';
-import type Variable from '../variables/Variable';
-import type ClassBody from './ClassBody';
 import type * as NodeType from './NodeType';
-import type ClassNode from './shared/ClassNode';
 import { type IncludeChildren, StatementBase, type StatementNode } from './shared/Node';
 
 export default class StaticBlock extends StatementBase {
@@ -33,12 +30,6 @@ export default class StaticBlock extends StatementBase {
 	}
 
 	render(code: MagicString, options: RenderOptions): void {
-		const classVariable = ((this.parent as ClassBody).parent as ClassNode).id!.variable;
-		const useOriginalName = (variable: Variable) => variable === classVariable;
-		options = {
-			...options,
-			useOriginalName
-		};
 		if (this.body.length > 0) {
 			renderStatementList(this.body, code, this.start + 1, this.end - 1, options);
 		} else {

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -1,5 +1,6 @@
 import type ExternalModule from '../../ExternalModule';
 import type Module from '../../Module';
+import type { RenderOptions } from '../../utils/renderHelpers';
 import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteraction } from '../NodeInteractions';
 import { INTERACTION_ACCESSED } from '../NodeInteractions';
@@ -42,8 +43,11 @@ export default class Variable extends ExpressionEntity {
 		return this.renderBaseName || this.renderName || this.name;
 	}
 
-	getName(getPropertyAccess: (name: string) => string): string {
-		const name = this.renderName || this.name;
+	getName(
+		getPropertyAccess: (name: string) => string,
+		useOriginalName?: RenderOptions['useOriginalName']
+	): string {
+		const name = useOriginalName?.(this) ? this.name : this.renderName || this.name;
 		return this.renderBaseName ? `${this.renderBaseName}${getPropertyAccess(name)}` : name;
 	}
 

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -15,7 +15,7 @@ export interface RenderOptions {
 	namespaceToStringTag: boolean;
 	pluginDriver: PluginDriver;
 	snippets: GenerateCodeSnippets;
-	useOriginalName?: (variable: Variable) => boolean;
+	useOriginalName: ((variable: Variable) => boolean) | null;
 }
 
 export interface NodeRenderOptions {

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -15,6 +15,7 @@ export interface RenderOptions {
 	namespaceToStringTag: boolean;
 	pluginDriver: PluginDriver;
 	snippets: GenerateCodeSnippets;
+	useOriginalName?: (variable: Variable) => boolean;
 }
 
 export interface NodeRenderOptions {

--- a/test/form/samples/use-class-name-in-static-block/_config.js
+++ b/test/form/samples/use-class-name-in-static-block/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'use class name instead of renderName in static block',
+	solo: true
+};

--- a/test/form/samples/use-class-name-in-static-block/_config.js
+++ b/test/form/samples/use-class-name-in-static-block/_config.js
@@ -1,4 +1,3 @@
 module.exports = {
-	description: 'use class name instead of renderName in static block',
-	solo: true
+	description: 'use class name instead of renderName in static block'
 };

--- a/test/form/samples/use-class-name-in-static-block/_config.js
+++ b/test/form/samples/use-class-name-in-static-block/_config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	description: 'use class name instead of renderName in static block'
+	description: 'use the original class name instead of renderName in class body'
 };

--- a/test/form/samples/use-class-name-in-static-block/_expected/amd.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/amd.js
@@ -1,16 +1,32 @@
 define((function () { 'use strict';
 
 	let Test$1 = class Test {
+		constructor() {
+			assert.ok(Test.test);
+			assert.ok(this.getText());
+		}
+		getText() {
+			return Test.test;
+		}
 		static test = 'Test1';
 		static {
 			assert.ok(Test.test);
+			new Test();
 		}
 	};
 
 	class Test {
+		constructor() {
+			assert.ok(Test.test);
+			assert.ok(this.getText());
+		}
+		getText() {
+			return Test.test;
+		}
 		static test = 'Test2';
 		static {
 			assert.ok(Test.test);
+			new Test();
 		}
 	}
 

--- a/test/form/samples/use-class-name-in-static-block/_expected/amd.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/amd.js
@@ -1,0 +1,20 @@
+define((function () { 'use strict';
+
+	let Test$1 = class Test {
+		static test = 'Test1';
+		static {
+			assert.ok(Test.test);
+		}
+	};
+
+	class Test {
+		static test = 'Test2';
+		static {
+			assert.ok(Test.test);
+		}
+	}
+
+	assert.ok(Test$1.test);
+	assert.ok(Test.test);
+
+}));

--- a/test/form/samples/use-class-name-in-static-block/_expected/cjs.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/cjs.js
@@ -1,0 +1,18 @@
+'use strict';
+
+let Test$1 = class Test {
+	static test = 'Test1';
+	static {
+		assert.ok(Test.test);
+	}
+};
+
+class Test {
+	static test = 'Test2';
+	static {
+		assert.ok(Test.test);
+	}
+}
+
+assert.ok(Test$1.test);
+assert.ok(Test.test);

--- a/test/form/samples/use-class-name-in-static-block/_expected/cjs.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/cjs.js
@@ -1,16 +1,32 @@
 'use strict';
 
 let Test$1 = class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test1';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 };
 
 class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test2';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 }
 

--- a/test/form/samples/use-class-name-in-static-block/_expected/es.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/es.js
@@ -1,14 +1,30 @@
 let Test$1 = class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test1';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 };
 
 class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test2';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 }
 

--- a/test/form/samples/use-class-name-in-static-block/_expected/es.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/es.js
@@ -1,0 +1,16 @@
+let Test$1 = class Test {
+	static test = 'Test1';
+	static {
+		assert.ok(Test.test);
+	}
+};
+
+class Test {
+	static test = 'Test2';
+	static {
+		assert.ok(Test.test);
+	}
+}
+
+assert.ok(Test$1.test);
+assert.ok(Test.test);

--- a/test/form/samples/use-class-name-in-static-block/_expected/iife.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/iife.js
@@ -2,16 +2,32 @@
 	'use strict';
 
 	let Test$1 = class Test {
+		constructor() {
+			assert.ok(Test.test);
+			assert.ok(this.getText());
+		}
+		getText() {
+			return Test.test;
+		}
 		static test = 'Test1';
 		static {
 			assert.ok(Test.test);
+			new Test();
 		}
 	};
 
 	class Test {
+		constructor() {
+			assert.ok(Test.test);
+			assert.ok(this.getText());
+		}
+		getText() {
+			return Test.test;
+		}
 		static test = 'Test2';
 		static {
 			assert.ok(Test.test);
+			new Test();
 		}
 	}
 

--- a/test/form/samples/use-class-name-in-static-block/_expected/iife.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/iife.js
@@ -1,0 +1,21 @@
+(function () {
+	'use strict';
+
+	let Test$1 = class Test {
+		static test = 'Test1';
+		static {
+			assert.ok(Test.test);
+		}
+	};
+
+	class Test {
+		static test = 'Test2';
+		static {
+			assert.ok(Test.test);
+		}
+	}
+
+	assert.ok(Test$1.test);
+	assert.ok(Test.test);
+
+})();

--- a/test/form/samples/use-class-name-in-static-block/_expected/system.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/system.js
@@ -1,0 +1,25 @@
+System.register([], (function () {
+	'use strict';
+	return {
+		execute: (function () {
+
+			let Test$1 = class Test {
+				static test = 'Test1';
+				static {
+					assert.ok(Test.test);
+				}
+			};
+
+			class Test {
+				static test = 'Test2';
+				static {
+					assert.ok(Test.test);
+				}
+			}
+
+			assert.ok(Test$1.test);
+			assert.ok(Test.test);
+
+		})
+	};
+}));

--- a/test/form/samples/use-class-name-in-static-block/_expected/system.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/system.js
@@ -4,16 +4,32 @@ System.register([], (function () {
 		execute: (function () {
 
 			let Test$1 = class Test {
+				constructor() {
+					assert.ok(Test.test);
+					assert.ok(this.getText());
+				}
+				getText() {
+					return Test.test;
+				}
 				static test = 'Test1';
 				static {
 					assert.ok(Test.test);
+					new Test();
 				}
 			};
 
 			class Test {
+				constructor() {
+					assert.ok(Test.test);
+					assert.ok(this.getText());
+				}
+				getText() {
+					return Test.test;
+				}
 				static test = 'Test2';
 				static {
 					assert.ok(Test.test);
+					new Test();
 				}
 			}
 

--- a/test/form/samples/use-class-name-in-static-block/_expected/umd.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/umd.js
@@ -1,0 +1,23 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+})((function () { 'use strict';
+
+	let Test$1 = class Test {
+		static test = 'Test1';
+		static {
+			assert.ok(Test.test);
+		}
+	};
+
+	class Test {
+		static test = 'Test2';
+		static {
+			assert.ok(Test.test);
+		}
+	}
+
+	assert.ok(Test$1.test);
+	assert.ok(Test.test);
+
+}));

--- a/test/form/samples/use-class-name-in-static-block/_expected/umd.js
+++ b/test/form/samples/use-class-name-in-static-block/_expected/umd.js
@@ -4,16 +4,32 @@
 })((function () { 'use strict';
 
 	let Test$1 = class Test {
+		constructor() {
+			assert.ok(Test.test);
+			assert.ok(this.getText());
+		}
+		getText() {
+			return Test.test;
+		}
 		static test = 'Test1';
 		static {
 			assert.ok(Test.test);
+			new Test();
 		}
 	};
 
 	class Test {
+		constructor() {
+			assert.ok(Test.test);
+			assert.ok(this.getText());
+		}
+		getText() {
+			return Test.test;
+		}
 		static test = 'Test2';
 		static {
 			assert.ok(Test.test);
+			new Test();
 		}
 	}
 

--- a/test/form/samples/use-class-name-in-static-block/main.js
+++ b/test/form/samples/use-class-name-in-static-block/main.js
@@ -1,0 +1,5 @@
+import { Test } from './test1.js';
+import { Test as Test2 } from './test2.js';
+
+assert.ok(Test.test);
+assert.ok(Test2.test);

--- a/test/form/samples/use-class-name-in-static-block/test1.js
+++ b/test/form/samples/use-class-name-in-static-block/test1.js
@@ -1,6 +1,14 @@
 export class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test1';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 }

--- a/test/form/samples/use-class-name-in-static-block/test1.js
+++ b/test/form/samples/use-class-name-in-static-block/test1.js
@@ -1,0 +1,6 @@
+export class Test {
+	static test = 'Test1';
+	static {
+		assert.ok(Test.test);
+	}
+}

--- a/test/form/samples/use-class-name-in-static-block/test2.js
+++ b/test/form/samples/use-class-name-in-static-block/test2.js
@@ -1,6 +1,14 @@
 export class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test2';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 }

--- a/test/form/samples/use-class-name-in-static-block/test2.js
+++ b/test/form/samples/use-class-name-in-static-block/test2.js
@@ -1,0 +1,6 @@
+export class Test {
+	static test = 'Test2';
+	static {
+		assert.ok(Test.test);
+	}
+}

--- a/test/function/samples/use-class-name-in-static-block/_config.js
+++ b/test/function/samples/use-class-name-in-static-block/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'use class name instead of renderName in static block'
+};

--- a/test/function/samples/use-class-name-in-static-block/_config.js
+++ b/test/function/samples/use-class-name-in-static-block/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
-	description: 'use class name instead of renderName in static block',
+	description: 'use the original class name instead of renderName in class body',
 	minNodeVersion: 16
 };

--- a/test/function/samples/use-class-name-in-static-block/_config.js
+++ b/test/function/samples/use-class-name-in-static-block/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'use class name instead of renderName in static block',
-	minNodeVersion: '16.11.0'
+	minNodeVersion: 16
 };

--- a/test/function/samples/use-class-name-in-static-block/_config.js
+++ b/test/function/samples/use-class-name-in-static-block/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	description: 'use class name instead of renderName in static block'
+	description: 'use class name instead of renderName in static block',
+	minNodeVersion: '16.11.0'
 };

--- a/test/function/samples/use-class-name-in-static-block/main.js
+++ b/test/function/samples/use-class-name-in-static-block/main.js
@@ -1,0 +1,5 @@
+import { Test } from './test1.js';
+import { Test as Test2 } from './test2.js';
+
+assert.ok(Test.test);
+assert.ok(Test2.test);

--- a/test/function/samples/use-class-name-in-static-block/test1.js
+++ b/test/function/samples/use-class-name-in-static-block/test1.js
@@ -1,6 +1,14 @@
 export class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test1';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 }

--- a/test/function/samples/use-class-name-in-static-block/test1.js
+++ b/test/function/samples/use-class-name-in-static-block/test1.js
@@ -1,0 +1,6 @@
+export class Test {
+	static test = 'Test1';
+	static {
+		assert.ok(Test.test);
+	}
+}

--- a/test/function/samples/use-class-name-in-static-block/test2.js
+++ b/test/function/samples/use-class-name-in-static-block/test2.js
@@ -1,6 +1,14 @@
 export class Test {
+	constructor() {
+		assert.ok(Test.test);
+		assert.ok(this.getText());
+	}
+	getText() {
+		return Test.test;
+	}
 	static test = 'Test2';
 	static {
 		assert.ok(Test.test);
+		new Test();
 	}
 }

--- a/test/function/samples/use-class-name-in-static-block/test2.js
+++ b/test/function/samples/use-class-name-in-static-block/test2.js
@@ -1,0 +1,6 @@
+export class Test {
+	static test = 'Test2';
+	static {
+		assert.ok(Test.test);
+	}
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #4811 
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The `Variable` renders a proper name according to the return of the `useOriginalName` function.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
