### PR TITLE
fix: correct incorrect assertions

### DIFF
--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -160,25 +160,31 @@ export default class LocalVariable extends Variable {
 		switch (interaction.type) {
 			case INTERACTION_ACCESSED: {
 				if (this.isReassigned) return true;
-				return (this.init &&
+				return !!(
+					this.init &&
 					!context.accessed.trackEntityAtPathAndGetIfTracked(path, this) &&
-					this.init.hasEffectsOnInteractionAtPath(path, interaction, context))!;
+					this.init.hasEffectsOnInteractionAtPath(path, interaction, context)
+				);
 			}
 			case INTERACTION_ASSIGNED: {
 				if (this.included) return true;
 				if (path.length === 0) return false;
 				if (this.isReassigned) return true;
-				return (this.init &&
+				return !!(
+					this.init &&
 					!context.assigned.trackEntityAtPathAndGetIfTracked(path, this) &&
-					this.init.hasEffectsOnInteractionAtPath(path, interaction, context))!;
+					this.init.hasEffectsOnInteractionAtPath(path, interaction, context)
+				);
 			}
 			case INTERACTION_CALLED: {
 				if (this.isReassigned) return true;
-				return (this.init &&
+				return !!(
+					this.init &&
 					!(
 						interaction.withNew ? context.instantiated : context.called
 					).trackEntityAtPathAndGetIfTracked(path, interaction.args, this) &&
-					this.init.hasEffectsOnInteractionAtPath(path, interaction, context))!;
+					this.init.hasEffectsOnInteractionAtPath(path, interaction, context)
+				);
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
I think these assertions are incorrect, because the result could be `null`. To align with the boolean returned by the `hasEffectsOnInteractionAtPath` function, I added a `!!` operation.