### PR TITLE
Update magic-string and adjust types.

### DIFF
--- a/build-plugins/add-cli-entry.ts
+++ b/build-plugins/add-cli-entry.ts
@@ -16,6 +16,7 @@ export default function addCliEntry(): Plugin {
 			});
 		},
 		name: 'add-cli-entry',
+		//@ts-expect-error sourcesContent was changed to allow for null elements in recent versions of magic-string.
 		renderChunk(code, chunkInfo) {
 			if (chunkInfo.fileName === CLI_CHUNK) {
 				const magicString = new MagicString(code);

--- a/build-plugins/conditional-fsevents-import.ts
+++ b/build-plugins/conditional-fsevents-import.ts
@@ -13,6 +13,7 @@ export default function conditionalFsEventsImport(): Plugin {
 			}
 		},
 		name: 'conditional-fs-events-import',
+		//@ts-expect-error sourcesContent was changed to allow for null elements in recent versions of magic-string.
 		transform(code, id) {
 			if (id.endsWith('fsevents-handler.js')) {
 				transformed = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "is-reference": "^3.0.1",
         "lint-staged": "^13.1.0",
         "locate-character": "^2.0.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
         "pinia": "^2.0.29",
@@ -1524,6 +1524,18 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.0.0.tgz",
@@ -1588,6 +1600,18 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rollup/plugin-terser": {
@@ -7121,9 +7145,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+      "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.13"
@@ -12011,6 +12035,15 @@
           "requires": {
             "@types/estree": "*"
           }
+        },
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
         }
       }
     },
@@ -12045,6 +12078,17 @@
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
         "magic-string": "^0.27.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@rollup/plugin-terser": {
@@ -16111,9 +16155,9 @@
       }
     },
     "magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+      "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.13"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "is-reference": "^3.0.1",
     "lint-staged": "^13.1.0",
     "locate-character": "^2.0.5",
-    "magic-string": "^0.27.0",
+    "magic-string": "^0.29.0",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "pinia": "^2.0.29",

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -52,7 +52,7 @@ export interface ExistingDecodedSourceMap {
 	names: string[];
 	sourceRoot?: string;
 	sources: string[];
-	sourcesContent?: string[];
+	sourcesContent?: (string | null)[];
 	version: number;
 }
 
@@ -62,7 +62,7 @@ export interface ExistingRawSourceMap {
 	names: string[];
 	sourceRoot?: string;
 	sources: string[];
-	sourcesContent?: string[];
+	sourcesContent?: (string | null)[];
 	version: number;
 }
 
@@ -79,7 +79,7 @@ export interface SourceMap {
 	mappings: string;
 	names: string[];
 	sources: string[];
-	sourcesContent: string[];
+	sourcesContent: (string | null)[];
 	version: number;
 	toString(): string;
 	toUrl(): string;

--- a/src/utils/collapseSourcemaps.ts
+++ b/src/utils/collapseSourcemaps.ts
@@ -10,11 +10,11 @@ import { error, errorConflictingSourcemapSources, errorSourcemapBroken } from '.
 import { basename, dirname, relative, resolve } from './path';
 
 class Source {
-	readonly content: string;
+	readonly content: string | null;
 	readonly filename: string;
 	isOriginal = true;
 
-	constructor(filename: string, content: string) {
+	constructor(filename: string, content: string | null) {
 		this.filename = filename;
 		this.content = content;
 	}
@@ -48,7 +48,7 @@ class Link {
 	traceMappings() {
 		const sources: string[] = [];
 		const sourceIndexMap = new Map<string, number>();
-		const sourcesContent: string[] = [];
+		const sourcesContent: (string | null)[] = [];
 		const names: string[] = [];
 		const nameIndexMap = new Map<string, number>();
 


### PR DESCRIPTION
The type of `sourcesContent` changed to allow for `null` elements, and rollup needs to be adjusted to that as well.

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

### Description

This PR updates `magic-string` past 0.27, addressing the breaking change in the `sourcesContent` type (going from `string[]` to `(string|null)[]`).