### PR TITLE
Improve chunking performance

### DIFF
--- a/build-plugins/add-cli-entry.ts
+++ b/build-plugins/add-cli-entry.ts
@@ -16,7 +16,6 @@ export default function addCliEntry(): Plugin {
 			});
 		},
 		name: 'add-cli-entry',
-		//@ts-expect-error sourcesContent was changed to allow for null elements in recent versions of magic-string.
 		renderChunk(code, chunkInfo) {
 			if (chunkInfo.fileName === CLI_CHUNK) {
 				const magicString = new MagicString(code);

--- a/build-plugins/conditional-fsevents-import.ts
+++ b/build-plugins/conditional-fsevents-import.ts
@@ -13,7 +13,6 @@ export default function conditionalFsEventsImport(): Plugin {
 			}
 		},
 		name: 'conditional-fs-events-import',
-		//@ts-expect-error sourcesContent was changed to allow for null elements in recent versions of magic-string.
 		transform(code, id) {
 			if (id.endsWith('fsevents-handler.js')) {
 				transformed = true;

--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -2504,6 +2504,18 @@ _Use the [`renderDynamicImport`](../plugin-development/index.md#renderdynamicimp
 
 This will rename the dynamic import function to the chosen name when outputting ES bundles. This is useful for generating code that uses a dynamic import polyfill such as [this one](https://github.com/uupaa/dynamic-import-polyfill).
 
+### output.experimentalDeepDynamicChunkOptimization
+
+_This option is no longer needed._
+
+|  |  |
+| --: | :-- |
+| Type: | `boolean` |
+| CLI: | `--experimentalDeepDynamicChunkOptimization`/`--no-experimentalDeepDynamicChunkOptimization` |
+| Default: | `false` |
+
+This option was used to prevent performance issues with the full chunk optimization algorithm. As the algorithm is much faster now, this option is now ignored by Rollup and should no longer be used.
+
 ### output.preferConst
 
 _Use the [`output.generatedCode.constBindings`](#output-generatedcode-constbindings) option instead._

--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -2318,16 +2318,6 @@ These options reflect new features that have not yet been fully finalized. Avail
 
 Determines after how many runs cached assets that are no longer used by plugins should be removed.
 
-### experimentalDeepDynamicChunkOptimization
-
-|  |  |
-| --: | :-- |
-| Type: | `boolean` |
-| CLI: | `--experimentalDeepDynamicChunkOptimization`/`--no-experimentalDeepDynamicChunkOptimization` |
-| Default: | `false` |
-
-Currently, chunk generation may create too many chunks if many dynamic imports are used. This is because the algorithm aborts optimization when certain thresholds are surpassed to avoid performance issues. Set this flag to `true` to create potentially fewer chunks at the cost of build performance.
-
 ### experimentalMinChunkSize
 
 |          |                                     |

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "pretty-bytes": "^6.0.0",
         "pretty-ms": "^8.0.0",
         "requirejs": "^2.3.6",
-        "rollup": "^3.9.1",
+        "rollup": "^3.16.0",
         "rollup-plugin-license": "^3.0.1",
         "rollup-plugin-string": "^3.0.0",
         "rollup-plugin-thatworks": "^1.0.4",
@@ -9176,9 +9176,9 @@
       "peer": true
     },
     "node_modules/rollup": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
-      "integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.16.0.tgz",
+      "integrity": "sha512-9wE1H5N1SJqnROpQanBGJ7lrIitwlUYGj4Va4eyf3+vNhoIHLPLag2/CUGIiq3V9lHOBJB6zTsGsPvc50oeihg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -17613,9 +17613,9 @@
       "peer": true
     },
     "rollup": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.1.tgz",
-      "integrity": "sha512-GswCYHXftN8ZKGVgQhTFUJB/NBXxrRGgO2NCy6E8s1rwEJ4Q9/VttNqcYfEvx4dTo4j58YqdC3OVztPzlKSX8w==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.16.0.tgz",
+      "integrity": "sha512-9wE1H5N1SJqnROpQanBGJ7lrIitwlUYGj4Va4eyf3+vNhoIHLPLag2/CUGIiq3V9lHOBJB6zTsGsPvc50oeihg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "pretty-bytes": "^6.0.0",
     "pretty-ms": "^8.0.0",
     "requirejs": "^2.3.6",
-    "rollup": "^3.9.1",
+    "rollup": "^3.16.0",
     "rollup-plugin-license": "^3.0.1",
     "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-thatworks": "^1.0.4",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -75,7 +75,6 @@ export default async function (
 			freeze: false,
 			generatedCode: 'es2015',
 			interop: 'default',
-			manualChunks: { rollup: ['src/node-entry.ts'] },
 			sourcemap: true
 		},
 		plugins: [

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -165,13 +165,8 @@ export default class Bundle {
 		bundle: OutputBundleWithPlaceholders,
 		getHashPlaceholder: HashPlaceholderGenerator
 	): Promise<Chunk[]> {
-		const {
-			experimentalDeepDynamicChunkOptimization,
-			experimentalMinChunkSize,
-			inlineDynamicImports,
-			manualChunks,
-			preserveModules
-		} = this.outputOptions;
+		const { experimentalMinChunkSize, inlineDynamicImports, manualChunks, preserveModules } =
+			this.outputOptions;
 		const manualChunkAliasByEntry =
 			typeof manualChunks === 'object'
 				? await this.addManualChunks(manualChunks)
@@ -193,8 +188,7 @@ export default class Bundle {
 			: getChunkAssignments(
 					this.graph.entryModules,
 					manualChunkAliasByEntry,
-					experimentalMinChunkSize,
-					experimentalDeepDynamicChunkOptimization
+					experimentalMinChunkSize
 			  )) {
 			sortByExecutionOrder(modules);
 			const chunk = new Chunk(

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -166,10 +166,10 @@ function getVariableForExportNameRecursive(
 }
 
 function getAndExtendSideEffectModules(variable: Variable, module: Module): Set<Module> {
-	const sideEffectModules = getOrCreate<Variable, Set<Module>>(
+	const sideEffectModules = getOrCreate(
 		module.sideEffectDependenciesByVariable,
 		variable,
-		getNewSet
+		getNewSet<Module>
 	);
 	let currentVariable: Variable | null = variable;
 	const referencedVariables = new Set([currentVariable]);
@@ -616,7 +616,7 @@ export default class Module {
 				getOrCreate(
 					importerForSideEffects.sideEffectDependenciesByVariable,
 					variable,
-					getNewSet
+					getNewSet<Module>
 				).add(this);
 				setAlternativeExporterIfCyclic(variable, importerForSideEffects, this);
 			}

--- a/src/ast/utils/PathTracker.ts
+++ b/src/ast/utils/PathTracker.ts
@@ -98,7 +98,11 @@ export class DiscriminatedPathTracker {
 				currentPaths[pathSegment] ||
 				Object.create(null, { [EntitiesKey]: { value: new Map<unknown, Set<Entity>>() } });
 		}
-		const trackedEntities = getOrCreate(currentPaths[EntitiesKey], discriminator, getNewSet);
+		const trackedEntities = getOrCreate(
+			currentPaths[EntitiesKey],
+			discriminator,
+			getNewSet<Entity>
+		);
 		if (trackedEntities.has(entity)) return true;
 		trackedEntities.add(entity);
 		return false;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -653,6 +653,8 @@ export interface OutputOptions {
 	dynamicImportInCjs?: boolean;
 	entryFileNames?: string | ((chunkInfo: PreRenderedChunk) => string);
 	esModule?: boolean | 'if-default-prop';
+	/** @deprecated This option is no longer needed and ignored. */
+	experimentalDeepDynamicChunkOptimization?: boolean;
 	experimentalMinChunkSize?: number;
 	exports?: 'default' | 'named' | 'none' | 'auto';
 	extend?: boolean;
@@ -707,6 +709,8 @@ export interface NormalizedOutputOptions {
 	dynamicImportInCjs: boolean;
 	entryFileNames: string | ((chunkInfo: PreRenderedChunk) => string);
 	esModule: boolean | 'if-default-prop';
+	/** @deprecated This option is no longer needed and ignored. */
+	experimentalDeepDynamicChunkOptimization: boolean;
 	experimentalMinChunkSize: number;
 	exports: 'default' | 'named' | 'none' | 'auto';
 	extend: boolean;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -653,7 +653,6 @@ export interface OutputOptions {
 	dynamicImportInCjs?: boolean;
 	entryFileNames?: string | ((chunkInfo: PreRenderedChunk) => string);
 	esModule?: boolean | 'if-default-prop';
-	experimentalDeepDynamicChunkOptimization?: boolean;
 	experimentalMinChunkSize?: number;
 	exports?: 'default' | 'named' | 'none' | 'auto';
 	extend?: boolean;
@@ -708,7 +707,6 @@ export interface NormalizedOutputOptions {
 	dynamicImportInCjs: boolean;
 	entryFileNames: string | ((chunkInfo: PreRenderedChunk) => string);
 	esModule: boolean | 'if-default-prop';
-	experimentalDeepDynamicChunkOptimization: boolean;
 	experimentalMinChunkSize: number;
 	exports: 'default' | 'named' | 'none' | 'auto';
 	extend: boolean;

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -105,7 +105,6 @@ export function getChunkAssignments(
 		chunkMask <<= 1n;
 	}
 
-	// TODO Lukas debug why this is not yet working
 	const optimizedChunkModules: {
 		[chunkSignature: string]: Module[];
 	} = Object.create(null);
@@ -119,10 +118,13 @@ export function getChunkAssignments(
 	}
 
 	// TODO Lukas add minChunkSize optimization
-	return Object.values(optimizedChunkModules).map(modules => ({
-		alias: null,
-		modules
-	}));
+	chunkDefinitions.push(
+		...Object.values(optimizedChunkModules).map(modules => ({
+			alias: null,
+			modules
+		}))
+	);
+	return chunkDefinitions;
 }
 
 function addStaticDependenciesToManualChunk(

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -356,9 +356,8 @@ function removeUnnecessaryDependentEntries(
 	// The indices correspond to the indices in allEntries. The chunks correspond
 	// to bits in the bigint values where chunk 0 is the lowest bit.
 	const staticDependenciesPerEntry: bigint[] = allEntries.map(() => 0n);
-	const allChunksLoaded = (1n << BigInt(chunks.length)) - 1n;
-	const alreadyLoadedChunksPerEntry = allEntries.map((_entry, entryIndex) =>
-		dynamicallyDependentEntriesByDynamicEntry.has(entryIndex) ? allChunksLoaded : 0n
+	const alreadyLoadedChunksPerEntry: bigint[] = allEntries.map((_entry, entryIndex) =>
+		dynamicallyDependentEntriesByDynamicEntry.has(entryIndex) ? -1n : 0n
 	);
 
 	// This toggles the bits for each chunk that is a dependency of an entry

--- a/src/utils/options/mergeOptions.ts
+++ b/src/utils/options/mergeOptions.ts
@@ -235,7 +235,6 @@ async function mergeOutputOptions(
 		dynamicImportInCjs: getOption('dynamicImportInCjs'),
 		entryFileNames: getOption('entryFileNames'),
 		esModule: getOption('esModule'),
-		experimentalDeepDynamicChunkOptimization: getOption('experimentalDeepDynamicChunkOptimization'),
 		experimentalMinChunkSize: getOption('experimentalMinChunkSize'),
 		exports: getOption('exports'),
 		extend: getOption('extend'),

--- a/src/utils/options/mergeOptions.ts
+++ b/src/utils/options/mergeOptions.ts
@@ -235,6 +235,7 @@ async function mergeOutputOptions(
 		dynamicImportInCjs: getOption('dynamicImportInCjs'),
 		entryFileNames: getOption('entryFileNames'),
 		esModule: getOption('esModule'),
+		experimentalDeepDynamicChunkOptimization: getOption('experimentalDeepDynamicChunkOptimization'),
 		experimentalMinChunkSize: getOption('experimentalMinChunkSize'),
 		exports: getOption('exports'),
 		extend: getOption('extend'),

--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -21,6 +21,7 @@ import {
 	URL_OUTPUT_AMD_ID,
 	URL_OUTPUT_DIR,
 	URL_OUTPUT_DYNAMICIMPORTFUNCTION,
+	URL_OUTPUT_EXPERIMENTALDEEPCHUNKOPTIMIZATION,
 	URL_OUTPUT_FORMAT,
 	URL_OUTPUT_GENERATEDCODE,
 	URL_OUTPUT_GENERATEDCODE_CONSTBINDINGS,
@@ -67,6 +68,10 @@ export async function normalizeOutputOptions(
 		dynamicImportInCjs: config.dynamicImportInCjs ?? true,
 		entryFileNames: getEntryFileNames(config, unsetOptions),
 		esModule: config.esModule ?? 'if-default-prop',
+		experimentalDeepDynamicChunkOptimization: getExperimentalDeepDynamicChunkOptimization(
+			config,
+			inputOptions
+		),
 		experimentalMinChunkSize: config.experimentalMinChunkSize || 0,
 		exports: getExports(config, unsetOptions),
 		extend: config.extend || false,
@@ -368,6 +373,23 @@ const getEntryFileNames = (
 	}
 	return configEntryFileNames ?? '[name].js';
 };
+
+function getExperimentalDeepDynamicChunkOptimization(
+	config: OutputOptions,
+	inputOptions: NormalizedInputOptions
+) {
+	const configExperimentalDeepDynamicChunkOptimization =
+		config.experimentalDeepDynamicChunkOptimization;
+	if (configExperimentalDeepDynamicChunkOptimization != null) {
+		warnDeprecation(
+			`The "output.experimentalDeepDynamicChunkOptimization" option is deprecated as Rollup always runs the full chunking algorithm now. The option should be removed.`,
+			URL_OUTPUT_EXPERIMENTALDEEPCHUNKOPTIMIZATION,
+			true,
+			inputOptions
+		);
+	}
+	return configExperimentalDeepDynamicChunkOptimization || false;
+}
 
 function getExports(
 	config: OutputOptions,

--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -67,8 +67,6 @@ export async function normalizeOutputOptions(
 		dynamicImportInCjs: config.dynamicImportInCjs ?? true,
 		entryFileNames: getEntryFileNames(config, unsetOptions),
 		esModule: config.esModule ?? 'if-default-prop',
-		experimentalDeepDynamicChunkOptimization:
-			config.experimentalDeepDynamicChunkOptimization || false,
 		experimentalMinChunkSize: config.experimentalMinChunkSize || 0,
 		exports: getExports(config, unsetOptions),
 		extend: config.extend || false,

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -18,6 +18,8 @@ export const URL_OUTPUT_EXPORTS = 'configuration-options/#output-exports';
 export const URL_OUTPUT_EXTEND = 'configuration-options/#output-extend';
 export const URL_OUTPUT_FORMAT = 'configuration-options/#output-format';
 export const URL_OUTPUT_GENERATEDCODE = 'configuration-options/#output-generatedcode';
+export const URL_OUTPUT_EXPERIMENTALDEEPCHUNKOPTIMIZATION =
+	'configuration-options/#output-experimentaldeepdynamicchunkoptimization';
 export const URL_OUTPUT_GENERATEDCODE_CONSTBINDINGS =
 	'configuration-options/#output-generatedcode-constbindings';
 export const URL_OUTPUT_GENERATEDCODE_SYMBOLS =

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_config.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	description: 'handles dynamic imports in manual chunks',
+	options: {
+		input: 'main.js',
+		output: {
+			manualChunks: {
+				manual: ['manual.js']
+			}
+		}
+	}
+};

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-dynamic.js
@@ -1,0 +1,5 @@
+define(['./main', './generated-manual'], (function (main, manual) { 'use strict';
+
+	console.log(main.dep1, manual.dep2);
+
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-manual.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-manual.js
@@ -1,0 +1,10 @@
+define(['require', 'exports'], (function (require, exports) { 'use strict';
+
+	const dep2 = 'dep2';
+
+	console.log(dep2);
+	new Promise(function (resolve, reject) { require(['./generated-dynamic'], resolve, reject); });
+
+	exports.dep2 = dep2;
+
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/main.js
@@ -1,0 +1,9 @@
+define(['exports', './generated-manual'], (function (exports, manual) { 'use strict';
+
+	const dep1 = 'dep1';
+
+	console.log(dep1);
+
+	exports.dep1 = dep1;
+
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-dynamic.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var main = require('./main.js');
+var manual = require('./generated-manual.js');
+
+console.log(main.dep1, manual.dep2);

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-manual.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-manual.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const dep2 = 'dep2';
+
+console.log(dep2);
+Promise.resolve().then(function () { return require('./generated-dynamic.js'); });
+
+exports.dep2 = dep2;

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/main.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('./generated-manual.js');
+
+const dep1 = 'dep1';
+
+console.log(dep1);
+
+exports.dep1 = dep1;

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-dynamic.js
@@ -1,0 +1,4 @@
+import { d as dep1 } from './main.js';
+import { d as dep2 } from './generated-manual.js';
+
+console.log(dep1, dep2);

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-manual.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-manual.js
@@ -1,0 +1,6 @@
+const dep2 = 'dep2';
+
+console.log(dep2);
+import('./generated-dynamic.js');
+
+export { dep2 as d };

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/main.js
@@ -1,0 +1,7 @@
+import './generated-manual.js';
+
+const dep1 = 'dep1';
+
+console.log(dep1);
+
+export { dep1 as d };

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-dynamic.js
@@ -1,0 +1,16 @@
+System.register(['./main.js', './generated-manual.js'], (function () {
+	'use strict';
+	var dep1, dep2;
+	return {
+		setters: [function (module) {
+			dep1 = module.d;
+		}, function (module) {
+			dep2 = module.d;
+		}],
+		execute: (function () {
+
+			console.log(dep1, dep2);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-manual.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-manual.js
@@ -1,0 +1,13 @@
+System.register([], (function (exports, module) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const dep2 = exports('d', 'dep2');
+
+			console.log(dep2);
+			module.import('./generated-dynamic.js');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/main.js
@@ -1,0 +1,13 @@
+System.register(['./generated-manual.js'], (function (exports) {
+	'use strict';
+	return {
+		setters: [null],
+		execute: (function () {
+
+			const dep1 = exports('d', 'dep1');
+
+			console.log(dep1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/dep1.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/dep1.js
@@ -1,0 +1,1 @@
+export const dep1 = 'dep1';

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/dep2.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/dep2.js
@@ -1,0 +1,1 @@
+export const dep2 = 'dep2';

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/dynamic.js
@@ -1,0 +1,4 @@
+import { dep1 } from './dep1';
+import { dep2 } from './dep2';
+
+console.log(dep1, dep2);

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/main.js
@@ -1,0 +1,4 @@
+import { dep1 } from './dep1';
+import './manual';
+
+console.log(dep1);

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/manual.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/manual.js
@@ -1,0 +1,4 @@
+import { dep2 } from './dep2';
+
+console.log(dep2);
+import('./dynamic');

--- a/test/chunking-form/samples/render-chunk/_expected/amd/chunk-dep2-af768b5f.js
+++ b/test/chunking-form/samples/render-chunk/_expected/amd/chunk-dep2-af768b5f.js
@@ -1,17 +1,14 @@
-System.register([], (function (exports, module) {
-	'use strict';
-	return {
-		execute: (function () {
+define(['require', 'exports'], (function (require, exports) { 'use strict';
 
-			var num = exports('n', 2);
-			console.log('referenced asset', new URL('asset-test-9f86d081', module.meta.url).href);
+	var num = 2;
+	console.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);
 
-		})
-	};
+	exports.num = num;
+
 }));
 console.log({
   "exports": [
-    "n"
+    "num"
   ],
   "facadeModuleId": null,
   "isDynamicEntry": false,
@@ -23,24 +20,24 @@ console.log({
   "name": "dep2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "chunk-dep2-ea1348fd.js",
+  "fileName": "chunk-dep2-af768b5f.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {},
   "imports": [],
   "modules": {
     "**/dep2.js": {
-      "code": "\t\t\tvar num = exports('n', 2);\n\t\t\tconsole.log('referenced asset', new URL('asset-test-9f86d081', module.meta.url).href);",
+      "code": "\tvar num = 2;\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
         "num"
       ],
-      "renderedLength": 113
+      "renderedLength": 117
     }
   },
   "referencedFiles": [
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-118e1de4.js","chunk-dep2-ea1348fd.js","entry-main2-34191286.js"])
+console.log('all chunks', ["entry-main1-62378d9a.js","entry-main2-d26bed01.js","chunk-dep2-af768b5f.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/amd/entry-main1-62378d9a.js
+++ b/test/chunking-form/samples/render-chunk/_expected/amd/entry-main1-62378d9a.js
@@ -1,38 +1,38 @@
-define(['require', './chunk-dep2-88c5c49b'], (function (require, dep2) { 'use strict';
+define(['require', './chunk-dep2-af768b5f'], (function (require, dep2) { 'use strict';
 
-	var num = 3;
+	var num = 1;
 	console.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);
 
-	console.log(dep2.num + num);
+	console.log(num + dep2.num);
 	console.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);
 
 }));
 console.log({
   "exports": [],
-  "facadeModuleId": "**/main2.js",
+  "facadeModuleId": "**/main1.js",
   "isDynamicEntry": false,
   "isEntry": true,
   "isImplicitEntry": false,
   "moduleIds": [
-    "**/dep3.js",
-    "**/main2.js"
+    "**/dep1.js",
+    "**/main1.js"
   ],
-  "name": "main2",
+  "name": "main1",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main2-71e00327.js",
+  "fileName": "entry-main1-62378d9a.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-88c5c49b.js": [
+    "chunk-dep2-af768b5f.js": [
       "num"
     ]
   },
   "imports": [
-    "chunk-dep2-88c5c49b.js"
+    "chunk-dep2-af768b5f.js"
   ],
   "modules": {
-    "**/dep3.js": {
-      "code": "\tvar num = 3;\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
+    "**/dep1.js": {
+      "code": "\tvar num = 1;\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
@@ -40,8 +40,8 @@ console.log({
       ],
       "renderedLength": 117
     },
-    "**/main2.js": {
-      "code": "\tconsole.log(dep2.num + num);\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
+    "**/main1.js": {
+      "code": "\tconsole.log(num + dep2.num);\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
       "originalLength": 102,
       "removedExports": [],
       "renderedExports": [],
@@ -52,5 +52,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-87907a68.js","chunk-dep2-88c5c49b.js","entry-main2-71e00327.js"])
+console.log('all chunks', ["entry-main1-62378d9a.js","entry-main2-d26bed01.js","chunk-dep2-af768b5f.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/amd/entry-main2-d26bed01.js
+++ b/test/chunking-form/samples/render-chunk/_expected/amd/entry-main2-d26bed01.js
@@ -1,38 +1,38 @@
-define(['require', './chunk-dep2-88c5c49b'], (function (require, dep2) { 'use strict';
+define(['require', './chunk-dep2-af768b5f'], (function (require, dep2) { 'use strict';
 
-	var num = 1;
+	var num = 3;
 	console.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);
 
-	console.log(num + dep2.num);
+	console.log(dep2.num + num);
 	console.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);
 
 }));
 console.log({
   "exports": [],
-  "facadeModuleId": "**/main1.js",
+  "facadeModuleId": "**/main2.js",
   "isDynamicEntry": false,
   "isEntry": true,
   "isImplicitEntry": false,
   "moduleIds": [
-    "**/dep1.js",
-    "**/main1.js"
+    "**/dep3.js",
+    "**/main2.js"
   ],
-  "name": "main1",
+  "name": "main2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main1-87907a68.js",
+  "fileName": "entry-main2-d26bed01.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-88c5c49b.js": [
+    "chunk-dep2-af768b5f.js": [
       "num"
     ]
   },
   "imports": [
-    "chunk-dep2-88c5c49b.js"
+    "chunk-dep2-af768b5f.js"
   ],
   "modules": {
-    "**/dep1.js": {
-      "code": "\tvar num = 1;\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
+    "**/dep3.js": {
+      "code": "\tvar num = 3;\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
@@ -40,8 +40,8 @@ console.log({
       ],
       "renderedLength": 117
     },
-    "**/main1.js": {
-      "code": "\tconsole.log(num + dep2.num);\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
+    "**/main2.js": {
+      "code": "\tconsole.log(dep2.num + num);\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
       "originalLength": 102,
       "removedExports": [],
       "renderedExports": [],
@@ -52,5 +52,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-87907a68.js","chunk-dep2-88c5c49b.js","entry-main2-71e00327.js"])
+console.log('all chunks', ["entry-main1-62378d9a.js","entry-main2-d26bed01.js","chunk-dep2-af768b5f.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/cjs/chunk-dep2-d1b4d6a3.js
+++ b/test/chunking-form/samples/render-chunk/_expected/cjs/chunk-dep2-d1b4d6a3.js
@@ -18,7 +18,7 @@ console.log({
   "name": "dep2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "chunk-dep2-970ee28f.js",
+  "fileName": "chunk-dep2-d1b4d6a3.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {},
   "imports": [],
@@ -37,5 +37,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-6d518561.js","chunk-dep2-970ee28f.js","entry-main2-a4b8e424.js"])
+console.log('all chunks', ["entry-main1-7c0fb7d4.js","entry-main2-51ea6de1.js","chunk-dep2-d1b4d6a3.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/cjs/entry-main1-7c0fb7d4.js
+++ b/test/chunking-form/samples/render-chunk/_expected/cjs/entry-main1-7c0fb7d4.js
@@ -1,38 +1,38 @@
 'use strict';
 
-var dep2 = require('./chunk-dep2-970ee28f.js');
+var dep2 = require('./chunk-dep2-d1b4d6a3.js');
 
-var num = 3;
+var num = 1;
 console.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));
 
-console.log(dep2.num + num);
+console.log(num + dep2.num);
 console.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));
 console.log({
   "exports": [],
-  "facadeModuleId": "**/main2.js",
+  "facadeModuleId": "**/main1.js",
   "isDynamicEntry": false,
   "isEntry": true,
   "isImplicitEntry": false,
   "moduleIds": [
-    "**/dep3.js",
-    "**/main2.js"
+    "**/dep1.js",
+    "**/main1.js"
   ],
-  "name": "main2",
+  "name": "main1",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main2-a4b8e424.js",
+  "fileName": "entry-main1-7c0fb7d4.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-970ee28f.js": [
+    "chunk-dep2-d1b4d6a3.js": [
       "num"
     ]
   },
   "imports": [
-    "chunk-dep2-970ee28f.js"
+    "chunk-dep2-d1b4d6a3.js"
   ],
   "modules": {
-    "**/dep3.js": {
-      "code": "var num = 3;\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
+    "**/dep1.js": {
+      "code": "var num = 1;\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
@@ -40,8 +40,8 @@ console.log({
       ],
       "renderedLength": 275
     },
-    "**/main2.js": {
-      "code": "console.log(dep2.num + num);\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
+    "**/main1.js": {
+      "code": "console.log(num + dep2.num);\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
       "originalLength": 102,
       "removedExports": [],
       "renderedExports": [],
@@ -52,5 +52,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-6d518561.js","chunk-dep2-970ee28f.js","entry-main2-a4b8e424.js"])
+console.log('all chunks', ["entry-main1-7c0fb7d4.js","entry-main2-51ea6de1.js","chunk-dep2-d1b4d6a3.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/cjs/entry-main2-51ea6de1.js
+++ b/test/chunking-form/samples/render-chunk/_expected/cjs/entry-main2-51ea6de1.js
@@ -1,38 +1,38 @@
 'use strict';
 
-var dep2 = require('./chunk-dep2-970ee28f.js');
+var dep2 = require('./chunk-dep2-d1b4d6a3.js');
 
-var num = 1;
+var num = 3;
 console.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));
 
-console.log(num + dep2.num);
+console.log(dep2.num + num);
 console.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));
 console.log({
   "exports": [],
-  "facadeModuleId": "**/main1.js",
+  "facadeModuleId": "**/main2.js",
   "isDynamicEntry": false,
   "isEntry": true,
   "isImplicitEntry": false,
   "moduleIds": [
-    "**/dep1.js",
-    "**/main1.js"
+    "**/dep3.js",
+    "**/main2.js"
   ],
-  "name": "main1",
+  "name": "main2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main1-6d518561.js",
+  "fileName": "entry-main2-51ea6de1.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-970ee28f.js": [
+    "chunk-dep2-d1b4d6a3.js": [
       "num"
     ]
   },
   "imports": [
-    "chunk-dep2-970ee28f.js"
+    "chunk-dep2-d1b4d6a3.js"
   ],
   "modules": {
-    "**/dep1.js": {
-      "code": "var num = 1;\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
+    "**/dep3.js": {
+      "code": "var num = 3;\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
@@ -40,8 +40,8 @@ console.log({
       ],
       "renderedLength": 275
     },
-    "**/main1.js": {
-      "code": "console.log(num + dep2.num);\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
+    "**/main2.js": {
+      "code": "console.log(dep2.num + num);\nconsole.log('referenced asset', (typeof document === 'undefined' ? new (require('u' + 'rl').URL)('file:' + __dirname + '/asset-test-9f86d081').href : new URL('asset-test-9f86d081', document.currentScript && document.currentScript.src || document.baseURI).href));",
       "originalLength": 102,
       "removedExports": [],
       "renderedExports": [],
@@ -52,5 +52,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-6d518561.js","chunk-dep2-970ee28f.js","entry-main2-a4b8e424.js"])
+console.log('all chunks', ["entry-main1-7c0fb7d4.js","entry-main2-51ea6de1.js","chunk-dep2-d1b4d6a3.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/es/chunk-dep2-0da9d5f1.js
+++ b/test/chunking-form/samples/render-chunk/_expected/es/chunk-dep2-0da9d5f1.js
@@ -16,7 +16,7 @@ console.log({
   "name": "dep2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "chunk-dep2-f4e7f39c.js",
+  "fileName": "chunk-dep2-0da9d5f1.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {},
   "imports": [],
@@ -35,5 +35,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-bb9f9ac2.js","chunk-dep2-f4e7f39c.js","entry-main2-2ba44c5c.js"])
+console.log('all chunks', ["entry-main1-f3f64fb9.js","entry-main2-d0add96f.js","chunk-dep2-0da9d5f1.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/es/entry-main1-f3f64fb9.js
+++ b/test/chunking-form/samples/render-chunk/_expected/es/entry-main1-f3f64fb9.js
@@ -1,36 +1,36 @@
-import { n as num$1 } from './chunk-dep2-f4e7f39c.js';
+import { n as num$1 } from './chunk-dep2-0da9d5f1.js';
 
-var num = 3;
+var num = 1;
 console.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);
 
-console.log(num$1 + num);
+console.log(num + num$1);
 console.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);
 console.log({
   "exports": [],
-  "facadeModuleId": "**/main2.js",
+  "facadeModuleId": "**/main1.js",
   "isDynamicEntry": false,
   "isEntry": true,
   "isImplicitEntry": false,
   "moduleIds": [
-    "**/dep3.js",
-    "**/main2.js"
+    "**/dep1.js",
+    "**/main1.js"
   ],
-  "name": "main2",
+  "name": "main1",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main2-2ba44c5c.js",
+  "fileName": "entry-main1-f3f64fb9.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-f4e7f39c.js": [
+    "chunk-dep2-0da9d5f1.js": [
       "n"
     ]
   },
   "imports": [
-    "chunk-dep2-f4e7f39c.js"
+    "chunk-dep2-0da9d5f1.js"
   ],
   "modules": {
-    "**/dep3.js": {
-      "code": "var num = 3;\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
+    "**/dep1.js": {
+      "code": "var num = 1;\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
@@ -38,8 +38,8 @@ console.log({
       ],
       "renderedLength": 99
     },
-    "**/main2.js": {
-      "code": "console.log(num$1 + num);\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
+    "**/main1.js": {
+      "code": "console.log(num + num$1);\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
       "originalLength": 102,
       "removedExports": [],
       "renderedExports": [],
@@ -50,5 +50,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-bb9f9ac2.js","chunk-dep2-f4e7f39c.js","entry-main2-2ba44c5c.js"])
+console.log('all chunks', ["entry-main1-f3f64fb9.js","entry-main2-d0add96f.js","chunk-dep2-0da9d5f1.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/es/entry-main2-d0add96f.js
+++ b/test/chunking-form/samples/render-chunk/_expected/es/entry-main2-d0add96f.js
@@ -1,36 +1,36 @@
-import { n as num$1 } from './chunk-dep2-f4e7f39c.js';
+import { n as num$1 } from './chunk-dep2-0da9d5f1.js';
 
-var num = 1;
+var num = 3;
 console.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);
 
-console.log(num + num$1);
+console.log(num$1 + num);
 console.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);
 console.log({
   "exports": [],
-  "facadeModuleId": "**/main1.js",
+  "facadeModuleId": "**/main2.js",
   "isDynamicEntry": false,
   "isEntry": true,
   "isImplicitEntry": false,
   "moduleIds": [
-    "**/dep1.js",
-    "**/main1.js"
+    "**/dep3.js",
+    "**/main2.js"
   ],
-  "name": "main1",
+  "name": "main2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main1-bb9f9ac2.js",
+  "fileName": "entry-main2-d0add96f.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-f4e7f39c.js": [
+    "chunk-dep2-0da9d5f1.js": [
       "n"
     ]
   },
   "imports": [
-    "chunk-dep2-f4e7f39c.js"
+    "chunk-dep2-0da9d5f1.js"
   ],
   "modules": {
-    "**/dep1.js": {
-      "code": "var num = 1;\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
+    "**/dep3.js": {
+      "code": "var num = 3;\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
@@ -38,8 +38,8 @@ console.log({
       ],
       "renderedLength": 99
     },
-    "**/main1.js": {
-      "code": "console.log(num + num$1);\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
+    "**/main2.js": {
+      "code": "console.log(num$1 + num);\nconsole.log('referenced asset', new URL('asset-test-9f86d081', import.meta.url).href);",
       "originalLength": 102,
       "removedExports": [],
       "renderedExports": [],
@@ -50,5 +50,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-bb9f9ac2.js","chunk-dep2-f4e7f39c.js","entry-main2-2ba44c5c.js"])
+console.log('all chunks', ["entry-main1-f3f64fb9.js","entry-main2-d0add96f.js","chunk-dep2-0da9d5f1.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/system/chunk-dep2-be1287c1.js
+++ b/test/chunking-form/samples/render-chunk/_expected/system/chunk-dep2-be1287c1.js
@@ -1,14 +1,17 @@
-define(['require', 'exports'], (function (require, exports) { 'use strict';
+System.register([], (function (exports, module) {
+	'use strict';
+	return {
+		execute: (function () {
 
-	var num = 2;
-	console.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);
+			var num = exports('n', 2);
+			console.log('referenced asset', new URL('asset-test-9f86d081', module.meta.url).href);
 
-	exports.num = num;
-
+		})
+	};
 }));
 console.log({
   "exports": [
-    "num"
+    "n"
   ],
   "facadeModuleId": null,
   "isDynamicEntry": false,
@@ -20,24 +23,24 @@ console.log({
   "name": "dep2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "chunk-dep2-88c5c49b.js",
+  "fileName": "chunk-dep2-be1287c1.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {},
   "imports": [],
   "modules": {
     "**/dep2.js": {
-      "code": "\tvar num = 2;\n\tconsole.log('referenced asset', new URL(require.toUrl('./asset-test-9f86d081'), document.baseURI).href);",
+      "code": "\t\t\tvar num = exports('n', 2);\n\t\t\tconsole.log('referenced asset', new URL('asset-test-9f86d081', module.meta.url).href);",
       "originalLength": 19,
       "removedExports": [],
       "renderedExports": [
         "num"
       ],
-      "renderedLength": 117
+      "renderedLength": 113
     }
   },
   "referencedFiles": [
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-87907a68.js","chunk-dep2-88c5c49b.js","entry-main2-71e00327.js"])
+console.log('all chunks', ["entry-main1-f0891ef8.js","entry-main2-ef5991ab.js","chunk-dep2-be1287c1.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/system/entry-main1-f0891ef8.js
+++ b/test/chunking-form/samples/render-chunk/_expected/system/entry-main1-f0891ef8.js
@@ -1,4 +1,4 @@
-System.register(['./chunk-dep2-ea1348fd.js'], (function (exports, module) {
+System.register(['./chunk-dep2-be1287c1.js'], (function (exports, module) {
 	'use strict';
 	var num$1;
 	return {
@@ -29,15 +29,15 @@ console.log({
   "name": "main1",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main1-118e1de4.js",
+  "fileName": "entry-main1-f0891ef8.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-ea1348fd.js": [
+    "chunk-dep2-be1287c1.js": [
       "n"
     ]
   },
   "imports": [
-    "chunk-dep2-ea1348fd.js"
+    "chunk-dep2-be1287c1.js"
   ],
   "modules": {
     "**/dep1.js": {
@@ -61,5 +61,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-118e1de4.js","chunk-dep2-ea1348fd.js","entry-main2-34191286.js"])
+console.log('all chunks', ["entry-main1-f0891ef8.js","entry-main2-ef5991ab.js","chunk-dep2-be1287c1.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/chunking-form/samples/render-chunk/_expected/system/entry-main2-ef5991ab.js
+++ b/test/chunking-form/samples/render-chunk/_expected/system/entry-main2-ef5991ab.js
@@ -1,4 +1,4 @@
-System.register(['./chunk-dep2-ea1348fd.js'], (function (exports, module) {
+System.register(['./chunk-dep2-be1287c1.js'], (function (exports, module) {
 	'use strict';
 	var num$1;
 	return {
@@ -29,15 +29,15 @@ console.log({
   "name": "main2",
   "type": "chunk",
   "dynamicImports": [],
-  "fileName": "entry-main2-34191286.js",
+  "fileName": "entry-main2-ef5991ab.js",
   "implicitlyLoadedBefore": [],
   "importedBindings": {
-    "chunk-dep2-ea1348fd.js": [
+    "chunk-dep2-be1287c1.js": [
       "n"
     ]
   },
   "imports": [
-    "chunk-dep2-ea1348fd.js"
+    "chunk-dep2-be1287c1.js"
   ],
   "modules": {
     "**/dep3.js": {
@@ -61,5 +61,5 @@ console.log({
     "asset-test-9f86d081"
   ]
 });
-console.log('all chunks', ["entry-main1-118e1de4.js","chunk-dep2-ea1348fd.js","entry-main2-34191286.js"])
+console.log('all chunks', ["entry-main1-f0891ef8.js","entry-main2-ef5991ab.js","chunk-dep2-be1287c1.js"])
 console.log('referenced asset in renderChunk', 'asset-test-9f86d081');

--- a/test/function/samples/deprecations/experimentalDeepDynamicChunkOptimization/_config.js
+++ b/test/function/samples/deprecations/experimentalDeepDynamicChunkOptimization/_config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	description: 'marks the "output.experimentalDeepDynamicChunkOptimization" option as deprecated',
+	options: {
+		output: {
+			experimentalDeepDynamicChunkOptimization: true
+		}
+	},
+	generateError: {
+		code: 'DEPRECATED_FEATURE',
+		message:
+			'The "output.experimentalDeepDynamicChunkOptimization" option is deprecated as Rollup always runs the full chunking algorithm now. The option should be removed.',
+		url: 'https://rollupjs.org/configuration-options/#output-experimentaldeepdynamicchunkoptimization'
+	}
+};

--- a/test/function/samples/deprecations/experimentalDeepDynamicChunkOptimization/main.js
+++ b/test/function/samples/deprecations/experimentalDeepDynamicChunkOptimization/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);

--- a/test/function/samples/output-options-hook/_config.js
+++ b/test/function/samples/output-options-hook/_config.js
@@ -27,7 +27,6 @@ module.exports = {
 					dynamicImportInCjs: true,
 					entryFileNames: '[name].js',
 					esModule: 'if-default-prop',
-					experimentalDeepDynamicChunkOptimization: false,
 					experimentalMinChunkSize: 0,
 					exports: 'auto',
 					extend: false,

--- a/test/function/samples/output-options-hook/_config.js
+++ b/test/function/samples/output-options-hook/_config.js
@@ -27,6 +27,7 @@ module.exports = {
 					dynamicImportInCjs: true,
 					entryFileNames: '[name].js',
 					esModule: 'if-default-prop',
+					experimentalDeepDynamicChunkOptimization: false,
 					experimentalMinChunkSize: 0,
 					exports: 'auto',
 					extend: false,

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -920,14 +920,14 @@ describe('hooks', () => {
 						modules: ['d', 'a']
 					},
 					{
-						fileName: 'generated-c.js',
-						imports: [],
-						modules: ['c']
-					},
-					{
 						fileName: 'generated-b.js',
 						imports: ['generated-c.js'],
 						modules: ['b']
+					},
+					{
+						fileName: 'generated-c.js',
+						imports: [],
+						modules: ['c']
 					}
 				]);
 			});

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -234,7 +234,7 @@ console.log(x);
 			]
 		});
 		const {
-			output: [main, feature, subfeature, subsubfeature]
+			output: [feature, subfeature, subsubfeature, main]
 		} = await bundle.generate({
 			entryFileNames: `[name]`,
 			chunkFileNames: `[name]`,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no, but the `output.experimentalDeepDynamicChunkOptimization` is deprecated and no longer doing anything and shows a warning instead.

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Rollup has an advanced chunking algorithm that can detect if a dependency of a dynamic entry that is shared with the dynamic importer must already be in memory when the dynamic import is loaded. In such a scenario, it will not create a separate chunk for the dependency but import it from the importing chunk.
This can avoid quite a few chunks, but as #4740 showed, the algorithm has a big problem: There is at least a `O(e*d*m)` complexity with `d` the number of dynamic imports, `e` the number of entry points and `m` the number of modules. And as it turned out for large projects, this could completely blow up.

A stop-gap measure was to introduce the `output.experimentalDeepDynamicChunkOptimization` option to make the algorithm "dumber" but much faster. This helped performance, but it created quite a few unnecessary chunks for some.

However, I managed to completely rewrite the original algorithm to solve all problems! And part of the solution was to use

**BigInt as a high-performance Set replacement!**

How does it work? Assume you have a fixed number of objects that you can index with numbers. As BigInts have arbitrary precision, you can then assign each object a bit in the BigInt. So to add element 24, I would do

```js
bigIntSet |= 1n << 24n
```

Note the single `|` which is a bitwise OR. But the true power is if I have to compare, merge or intersect such sets:

```js
// comparison: trivial!
bigIntSetA === bigIntSetB

// intersection: trivial, and it is naturally non-mutating!
const intersection = bigIntSetA & bigIntSetB;

// merge: trivial, and again it is naturally non-mutating!
const merged = bigIntSetA | bigIntSetB;
```

The only thing that is worse for BigInt sets is that you cannot easily iterate Set elements. Either you iterate over all bits, which is unnecessarily many, or one devises some devilish divide-and-conquer scheme that still has for a Set with a single element O(log n) complexity. But luckily, I did not need iteration everywhere.

By restructuring the algorithm make heavy use of such intersections and merges and some other algorithmic improvements, I was able to severely improve performance. Using the example of #4740 as a baseline, I got the following numbers:

#4740 has 1 static entry, 1450 dynamic entries and no manual chunks.

- `getChunkAssignments` with the current algorithm and `experimentalDeepDynamicChunkOptimization` disabled:
  - takes 3.9s
  - creates 1874 chunks
- with `experimentalDeepDynamicChunkOptimization` enabled:
  - takes over 2 hours (!)
  - creates 1742 chunks
- with the new algorithm:
  - takes 3.3s, so *faster* then the "dumbed down" algorithm. The part that took 2 hours now actually takes only about 600ms!
  - creates 1742 chunks