### PR TITLE
Do not mark variable access in files without side effects as TDZ

### DIFF
--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -209,9 +209,14 @@ export default class Identifier extends NodeBase implements PatternNode {
 		if (this.isTDZAccess !== null) return this.isTDZAccess;
 
 		if (
-			!(this.variable instanceof LocalVariable) ||
-			!this.variable.kind ||
-			!(this.variable.kind in tdzVariableKinds)
+			!(
+				this.variable instanceof LocalVariable &&
+				this.variable.kind &&
+				this.variable.kind in tdzVariableKinds &&
+				// we ignore possible TDZs due to circular module dependencies as
+				// otherwise we get many false positives
+				this.variable.module === this.context.module
+			)
 		) {
 			return (this.isTDZAccess = false);
 		}

--- a/test/form/samples/super-class-no-side-effects/_config.js
+++ b/test/form/samples/super-class-no-side-effects/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description:
+		'Does not wrongly attribute side effects when the super class of an unused class is in a file without side effects (#4808)',
+	options: { treeshake: { moduleSideEffects: false } }
+};

--- a/test/form/samples/super-class-no-side-effects/_expected.js
+++ b/test/form/samples/super-class-no-side-effects/_expected.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/test/form/samples/super-class-no-side-effects/main.js
+++ b/test/form/samples/super-class-no-side-effects/main.js
@@ -1,0 +1,10 @@
+import { ExternalElement } from './other.js';
+
+class MyClass extends ExternalElement {
+	constructor() {
+    super();
+		console.log('MyClassExtendsExternalClass');
+	}
+}
+
+console.log('main');

--- a/test/form/samples/super-class-no-side-effects/other.js
+++ b/test/form/samples/super-class-no-side-effects/other.js
@@ -1,0 +1,2 @@
+const win = typeof window !== 'undefined' ? window : {};
+export const ExternalElement = win.HTMLElement || class {};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4808 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The logic to deoptimize variables when accessed in their temporal dead zone did not take module boundaries into account, leading to falsely deoptimized variables and wrongly attributed side effects.
