### PR TITLE
Include side effects of re-exporters unless they have no moduleSideEffects

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -598,6 +598,13 @@ export default class Module {
 			}
 			if (importerForSideEffects) {
 				setAlternativeExporterIfCyclic(variable, importerForSideEffects, this);
+				if (this.info.moduleSideEffects) {
+					getOrCreate(
+						importerForSideEffects.sideEffectDependenciesByVariable,
+						variable,
+						getNewSet<Module>
+					).add(this);
+				}
 			}
 			return [variable];
 		}
@@ -613,12 +620,12 @@ export default class Module {
 				searchedNamesAndModules
 			})!;
 			if (importerForSideEffects) {
+				setAlternativeExporterIfCyclic(variable, importerForSideEffects, this);
 				getOrCreate(
 					importerForSideEffects.sideEffectDependenciesByVariable,
 					variable,
 					getNewSet<Module>
 				).add(this);
-				setAlternativeExporterIfCyclic(variable, importerForSideEffects, this);
 			}
 			return [variable];
 		}

--- a/test/function/samples/module-side-effect-reexport/_config.js
+++ b/test/function/samples/module-side-effect-reexport/_config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	description: 'includes side effects of re-exporters unless they have moduleSideEffects: false',
+	options: {
+		plugins: [
+			{
+				name: 'ignore-side-effects',
+				transform(_code, id) {
+					return { moduleSideEffects: id.endsWith('effect.js') };
+				}
+			}
+		]
+	}
+};

--- a/test/function/samples/module-side-effect-reexport/foo.js
+++ b/test/function/samples/module-side-effect-reexport/foo.js
@@ -1,0 +1,1 @@
+export const foo = true;

--- a/test/function/samples/module-side-effect-reexport/index.js
+++ b/test/function/samples/module-side-effect-reexport/index.js
@@ -1,0 +1,2 @@
+export { foo } from './reexport-effect';
+global.indexEffect = true;

--- a/test/function/samples/module-side-effect-reexport/main.js
+++ b/test/function/samples/module-side-effect-reexport/main.js
@@ -1,0 +1,12 @@
+import { foo } from './index';
+
+assert.ok(foo, 'foo');
+
+// effects in reexporters without side effects are ignored
+assert.equal(global.indexEffect, undefined, 'indexEffect');
+
+// effects in reexporters with side effects are retained
+assert.ok(global.reexportEffect, 'reexportEffect');
+
+// cleanup
+delete global.reexportEffect;

--- a/test/function/samples/module-side-effect-reexport/reexport-effect.js
+++ b/test/function/samples/module-side-effect-reexport/reexport-effect.js
@@ -1,0 +1,2 @@
+export { foo } from './foo';
+global.reexportEffect = true;


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4470
- resolves vitejs/vite#7635
- resolves vitejs/vite#10735
- resolves rollup/plugins#1159

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
If a module with `moduleSideEffects:false` is reexporting from a module with `moduleSideEffects:true` that again is reexporting from another file, currently neither side effects in the first reexporter nor in the second reexporter are included.

As this defeats expectations of many, this PR changes the logic so that in this case, side effects of the reexporter with `moduleSideEffects:true` ARE indeed included, hopefully solving the issues that many people had.

Note that as before, side effects are always included if the module does not use a reexport but rather imports the value and then directly exports it, independent of the `moduleSideEffects` value.