### PR TITLE
Add `needsCodeReference` property to `EmittedAsset`

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -135,6 +135,7 @@ export interface MinimalPluginContext {
 export interface EmittedAsset {
 	fileName?: string;
 	name?: string;
+	needsCodeReference?: boolean;
 	source?: string | Uint8Array;
 	type: 'asset';
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

#4805 introduced `needsCodeReference` property. The documentation describes it is intended to be used like:
```js
const referenceId = this.emitFile({
	type: 'asset',
	name: path.basename(id),
	needsCodeReference: true,
	source: fs.readFileSync(id)
});
```

But because `EmittedAsset` doesn't have `needsCodeReference` property, I get a type error.
https://github.com/rollup/rollup/blob/e0701d799b7ab0ede72a789c4359b79faf08f03d/src/rollup/types.d.ts#L187
https://github.com/rollup/rollup/blob/e0701d799b7ab0ede72a789c4359b79faf08f03d/src/rollup/types.d.ts#L154
https://github.com/rollup/rollup/blob/e0701d799b7ab0ede72a789c4359b79faf08f03d/src/rollup/types.d.ts#L152
https://github.com/rollup/rollup/blob/e0701d799b7ab0ede72a789c4359b79faf08f03d/src/rollup/types.d.ts#L135-L140

This PR adds `needsCodeReference` property to `EmittedAsset` to fix that.
