### PR TITLE
fix: style optimization in dark mode

### DIFF
--- a/docs/repl/components/BundleOptions.vue
+++ b/docs/repl/components/BundleOptions.vue
@@ -51,7 +51,6 @@
 			</section>
 		</div>
 		<div v-if="optionsStore.additionalAvailableOptions.length > 0" class="add-option">
-			<span class="icon-plus"></span>
 			<select
 				@input="
 					optionsStore.addOption($event.target.value);
@@ -67,6 +66,7 @@
 					{{ option }}
 				</option>
 			</select>
+			<span class="icon-plus"></span>
 		</div>
 	</div>
 </template>
@@ -165,7 +165,7 @@ select {
 	position: relative;
 	cursor: pointer;
 	appearance: none;
-	background: transparent;
+	background: var(--vp-c-bg);
 	padding-right: 20px;
 	width: 100px;
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->



![image](https://user-images.githubusercontent.com/41646242/220050278-4acb08c9-3f24-4d2c-8b83-13fa0db62d45.png)


### In the dark mode, `add option` will display a blank on one side. I fixed it by the way 😊