### PR TITLE
feat: mark files in a `node_modules` as ignore-listed by default

### DIFF
--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -1415,9 +1415,9 @@ The location of the generated bundle. If this is an absolute path, all the `sour
 
 ### output.sourcemapIgnoreList
 
-|       |                                                                  |
-| ----: | :--------------------------------------------------------------- |
-| Type: | `(relativeSourcePath: string, sourcemapPath: string) => boolean` |
+|  |  |
+| --: | :-- |
+| Type: | `boolean \| (relativeSourcePath: string, sourcemapPath: string) => boolean` |
 
 A predicate to decide whether or not to ignore-list source files in a sourcemap, used to populate the [`x_google_ignoreList` source map extension](https://developer.chrome.com/blog/devtools-better-angular-debugging/#the-x_google_ignorelist-source-map-extension). `relativeSourcePath` is a relative path from the generated `.map` file to the corresponding source file while `sourcemapPath` is the fully resolved path of the generated sourcemap file.
 
@@ -1438,6 +1438,8 @@ export default {
 	]
 };
 ```
+
+When you don't specify this option explicitly, by default it will put all files with `node_modules` in their path on the ignore list. You can specify `false` here to turn off the ignore-listing completely.
 
 ### output.sourcemapPathTransform
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -691,7 +691,7 @@ export interface OutputOptions {
 	sourcemapBaseUrl?: string;
 	sourcemapExcludeSources?: boolean;
 	sourcemapFile?: string;
-	sourcemapIgnoreList?: SourcemapIgnoreListOption;
+	sourcemapIgnoreList?: boolean | SourcemapIgnoreListOption;
 	sourcemapPathTransform?: SourcemapPathTransformOption;
 	strict?: boolean;
 	systemNullSetters?: boolean;
@@ -746,7 +746,7 @@ export interface NormalizedOutputOptions {
 	sourcemapBaseUrl: string | undefined;
 	sourcemapExcludeSources: boolean;
 	sourcemapFile: string | undefined;
-	sourcemapIgnoreList: SourcemapIgnoreListOption | undefined;
+	sourcemapIgnoreList: SourcemapIgnoreListOption;
 	sourcemapPathTransform: SourcemapPathTransformOption | undefined;
 	strict: boolean;
 	systemNullSetters: boolean;

--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -4,7 +4,6 @@ import type {
 	NormalizedInputOptions,
 	NormalizedOutputOptions,
 	OutputOptions,
-	SourcemapIgnoreListOption,
 	SourcemapPathTransformOption
 } from '../../rollup/types';
 import {
@@ -109,7 +108,12 @@ export async function normalizeOutputOptions(
 		sourcemapBaseUrl: getSourcemapBaseUrl(config),
 		sourcemapExcludeSources: config.sourcemapExcludeSources || false,
 		sourcemapFile: config.sourcemapFile,
-		sourcemapIgnoreList: config.sourcemapIgnoreList as SourcemapIgnoreListOption | undefined,
+		sourcemapIgnoreList:
+			typeof config.sourcemapIgnoreList === 'function'
+				? config.sourcemapIgnoreList
+				: config.sourcemapIgnoreList === false
+				? () => false
+				: relativeSourcePath => relativeSourcePath.includes('node_modules'),
 		sourcemapPathTransform: config.sourcemapPathTransform as
 			| SourcemapPathTransformOption
 			| undefined,

--- a/src/utils/renderChunks.ts
+++ b/src/utils/renderChunks.ts
@@ -1,6 +1,5 @@
 import type { Bundle as MagicStringBundle, SourceMap } from 'magic-string';
-import type { ChunkRenderResult } from '../Chunk';
-import type Chunk from '../Chunk';
+import type { default as Chunk, ChunkRenderResult } from '../Chunk';
 import type Module from '../Module';
 import type {
 	DecodedSourceMapOrMissing,
@@ -162,18 +161,16 @@ async function transformChunk(
 		for (let sourcesIndex = 0; sourcesIndex < map.sources.length; ++sourcesIndex) {
 			let sourcePath = map.sources[sourcesIndex];
 			const sourcemapPath = `${resultingFile}.map`;
-			if (sourcemapIgnoreList) {
-				const ignoreList = sourcemapIgnoreList(sourcePath, sourcemapPath);
-				if (typeof ignoreList !== 'boolean') {
-					error(errorFailedValidation('sourcemapIgnoreList function must return a boolean.'));
+			const ignoreList = sourcemapIgnoreList(sourcePath, sourcemapPath);
+			if (typeof ignoreList !== 'boolean') {
+				error(errorFailedValidation('sourcemapIgnoreList function must return a boolean.'));
+			}
+			if (ignoreList) {
+				if (map.x_google_ignoreList === undefined) {
+					map.x_google_ignoreList = [];
 				}
-				if (ignoreList) {
-					if (map.x_google_ignoreList === undefined) {
-						map.x_google_ignoreList = [];
-					}
-					if (!map.x_google_ignoreList.includes(sourcesIndex)) {
-						map.x_google_ignoreList.push(sourcesIndex);
-					}
+				if (!map.x_google_ignoreList.includes(sourcesIndex)) {
+					map.x_google_ignoreList.push(sourcesIndex);
 				}
 			}
 			if (sourcemapPathTransform) {

--- a/test/sourcemaps/samples/ignore-list-default/_config.js
+++ b/test/sourcemaps/samples/ignore-list-default/_config.js
@@ -1,0 +1,17 @@
+const assert = require('node:assert');
+const path = require('node:path');
+
+module.exports = {
+	description: 'defaults to adding files within node_modules to the ignore list',
+	options: {
+		output: {
+			name: 'myModule',
+			file: path.resolve(__dirname, '_actual/bundle.js'),
+			sourcemapPathTransform: sourcePath => path.basename(sourcePath)
+		}
+	},
+	test(code, map) {
+		assert.deepEqual(map.sources, ['lib.js', 'main.js']);
+		assert.deepEqual(map.x_google_ignoreList, [0]);
+	}
+};

--- a/test/sourcemaps/samples/ignore-list-default/main.js
+++ b/test/sourcemaps/samples/ignore-list-default/main.js
@@ -1,0 +1,3 @@
+import one from './node_modules/lib.js';
+
+export default one * 2;

--- a/test/sourcemaps/samples/ignore-list-default/node_modules/lib.js
+++ b/test/sourcemaps/samples/ignore-list-default/node_modules/lib.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/test/sourcemaps/samples/ignore-list-false/_config.js
+++ b/test/sourcemaps/samples/ignore-list-false/_config.js
@@ -1,0 +1,19 @@
+const assert = require('node:assert');
+const path = require('node:path');
+
+module.exports = {
+	description:
+		'accepts false for `sourcemapIgnoreList` to disable the default ignore-listing of node_modules',
+	options: {
+		output: {
+			name: 'myModule',
+			file: path.resolve(__dirname, '_actual/bundle.js'),
+			sourcemapPathTransform: sourcePath => path.basename(sourcePath),
+			sourcemapIgnoreList: false
+		}
+	},
+	test(code, map) {
+		assert.deepEqual(map.sources, ['lib.js', 'main.js']);
+		assert.strictEqual(map.x_google_ignoreList, undefined);
+	}
+};

--- a/test/sourcemaps/samples/ignore-list-false/main.js
+++ b/test/sourcemaps/samples/ignore-list-false/main.js
@@ -1,0 +1,3 @@
+import one from './node_modules/lib.js';
+
+export default one * 5;

--- a/test/sourcemaps/samples/ignore-list-false/node_modules/lib.js
+++ b/test/sourcemaps/samples/ignore-list-false/node_modules/lib.js
@@ -1,0 +1,1 @@
+export default 1;


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

https://github.com/rollup/rollup/issues/4847

### Description

Following up on the addition of the `sourcemapIgnoreList` output option, this adds a default which marks all files within a `node_modules` folder as ignore-listed. This way most projects using rollup will need no additional configuration regarding the ignore-listing and automatically benefit.

Doc: https://goo.gle/devtools-ignoreList-adoption