### PR TITLE
Improve test stability

### DIFF
--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -7,8 +7,7 @@ const { copySync, removeSync, statSync } = require('fs-extra');
 const {
 	normaliseOutput,
 	runTestSuiteWithSamples,
-	assertDirectoriesAreEqual,
-	getFileNamesAndRemoveOutput
+	assertDirectoriesAreEqual
 } = require('../utils.js');
 
 const cwd = process.cwd();
@@ -20,131 +19,126 @@ runTestSuiteWithSamples(
 	'cli',
 	resolve(__dirname, 'samples'),
 	(directory, config) => {
-		// allow to repeat flaky tests for debugging on CLI
-		for (let pass = 0; pass < (config.repeat || 1); pass++) {
-			runTest(directory, config, pass);
-		}
+		(config.skip ? it.skip : config.solo ? it.only : it)(
+			basename(directory) + ': ' + config.description,
+			() => {
+				process.chdir(config.cwd || directory);
+				const command = config.command.replace(
+					/(^| )rollup($| )/g,
+					`node ${resolve(__dirname, '../../dist/bin')}${sep}rollup `
+				);
+				return runTest(config, command);
+			}
+		).timeout(50_000);
 	},
 	() => process.chdir(cwd)
 );
 
-function runTest(directory, config, pass) {
-	const name = basename(directory) + ': ' + config.description;
-	(config.skip ? it.skip : config.solo ? it.only : it)(
-		pass > 0 ? `${name} (pass ${pass + 1})` : name,
-		done => {
-			process.chdir(config.cwd || directory);
-			if (pass > 0) {
-				getFileNamesAndRemoveOutput(directory);
-			}
-			const command = config.command.replace(
-				/(^| )rollup($| )/g,
-				`node ${resolve(__dirname, '../../dist/bin')}${sep}rollup `
-			);
+async function runTest(config, command) {
+	if (config.before) {
+		await config.before();
+	}
+	return new Promise((resolve, reject) => {
+		const childProcess = exec(
+			command,
+			{
+				timeout: 40_000,
+				env: { ...process.env, FORCE_COLOR: '0', ...config.env }
+			},
+			(error, code, stderr) => {
+				if (config.after) config.after(error, code, stderr);
+				if (error && !error.killed) {
+					if (config.error) {
+						const shouldContinue = config.error(error);
+						if (!shouldContinue) return resolve();
+					} else {
+						throw error;
+					}
+				}
 
-			Promise.resolve(config.before && config.before()).then(() => {
-				const childProcess = exec(
-					command,
-					{
-						timeout: 40_000,
-						env: { ...process.env, FORCE_COLOR: '0', ...config.env }
-					},
-					(error, code, stderr) => {
-						if (config.after) config.after(error, code, stderr);
-						if (error && !error.killed) {
-							if (config.error) {
-								const shouldContinue = config.error(error);
-								if (!shouldContinue) return done();
-							} else {
-								throw error;
-							}
+				if ('stderr' in config) {
+					const shouldContinue = config.stderr(stderr);
+					if (!shouldContinue) return resolve();
+				} else if (stderr) {
+					console.error(stderr);
+				}
+
+				let unintendedError;
+
+				if (config.execute) {
+					try {
+						const function_ = new Function('require', 'module', 'exports', 'assert', code);
+						const module = {
+							exports: {}
+						};
+						function_(require, module, module.exports, assert);
+
+						if (config.error) {
+							unintendedError = new Error('Expected an error while executing output');
 						}
 
-						if ('stderr' in config) {
-							const shouldContinue = config.stderr(stderr);
-							if (!shouldContinue) return done();
-						} else if (stderr) {
-							console.error(stderr);
+						if (config.exports) {
+							config.exports(module.exports);
 						}
-
-						let unintendedError;
-
-						if (config.execute) {
-							try {
-								const function_ = new Function('require', 'module', 'exports', 'assert', code);
-								const module = {
-									exports: {}
-								};
-								function_(require, module, module.exports, assert);
-
-								if (config.error) {
-									unintendedError = new Error('Expected an error while executing output');
-								}
-
-								if (config.exports) {
-									config.exports(module.exports);
-								}
-							} catch (error) {
-								if (config.error) {
-									config.error(error);
-								} else {
-									unintendedError = error;
-								}
-							}
-
-							if (config.show || unintendedError) {
-								console.log(code + '\n\n\n');
-							}
-
-							if (config.solo) console.groupEnd();
-
-							unintendedError ? done(unintendedError) : done();
-						} else if (config.result) {
-							try {
-								config.result(code);
-								done();
-							} catch (error) {
-								done(error);
-							}
-						} else if (config.test) {
-							try {
-								config.test();
-								done();
-							} catch (error) {
-								done(error);
-							}
-						} else if (existsSync('_expected') && statSync('_expected').isDirectory()) {
-							try {
-								assertDirectoriesAreEqual('_actual', '_expected');
-								done();
-							} catch (error) {
-								done(error);
-							}
+					} catch (error) {
+						if (config.error) {
+							config.error(error);
 						} else {
-							const expected = readFileSync('_expected.js', 'utf8');
-							try {
-								assert.equal(normaliseOutput(code), normaliseOutput(expected));
-								done();
-							} catch (error) {
-								done(error);
-							}
+							unintendedError = error;
 						}
 					}
-				);
 
-				childProcess.stderr.on('data', async data => {
-					if (config.abortOnStderr) {
-						try {
-							if (await config.abortOnStderr(data)) {
-								childProcess.kill('SIGTERM');
-							}
-						} catch (error) {
-							childProcess.kill('SIGTERM');
-							done(error);
-						}
+					if (config.show || unintendedError) {
+						console.log(code + '\n\n\n');
 					}
-				});
-			});
-		}
-	).timeout(50_000);
+
+					if (config.solo) console.groupEnd();
+
+					unintendedError ? reject(unintendedError) : resolve();
+				} else if (config.result) {
+					try {
+						config.result(code);
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
+				} else if (config.test) {
+					try {
+						config.test();
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
+				} else if (existsSync('_expected') && statSync('_expected').isDirectory()) {
+					try {
+						assertDirectoriesAreEqual('_actual', '_expected');
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
+				} else {
+					const expected = readFileSync('_expected.js', 'utf8');
+					try {
+						assert.equal(normaliseOutput(code), normaliseOutput(expected));
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
+				}
+			}
+		);
+
+		childProcess.stderr.on('data', async data => {
+			if (config.abortOnStderr) {
+				try {
+					if (await config.abortOnStderr(data)) {
+						childProcess.kill('SIGTERM');
+					}
+				} catch (error) {
+					childProcess.kill('SIGTERM');
+					reject(error);
+				}
+			}
+		});
+	});
 }

--- a/test/cli/samples/watch/watch-event-hooks/_config.js
+++ b/test/cli/samples/watch/watch-event-hooks/_config.js
@@ -2,6 +2,7 @@ const { assertIncludes } = require('../../../../utils.js');
 
 module.exports = {
 	description: 'event hook shell commands write to stderr',
+	retry: true,
 	command:
 		'node wrapper.js -cw --watch.onStart "echo start" --watch.onBundleStart "echo bundleStart" --watch.onBundleEnd "echo bundleEnd" --watch.onEnd "echo end"',
 	abortOnStderr(data) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Lately, there have been a lot of test failures for watch-related CLI tests on MacOS. For now, this will slightly improve timeout handling and add a "retry" option to tests so that certain tests will be retried once before failing.
Of course this is only a stop-gap measure until we figure out why those tests fail, but this..