### PR TITLE
Only set asset names when finalizing

### DIFF
--- a/src/utils/FileEmitter.ts
+++ b/src/utils/FileEmitter.ts
@@ -21,6 +21,7 @@ import {
 	errorInvalidRollupPhaseForChunkEmission,
 	errorNoAssetSourceSet
 } from './error';
+import { getOrCreate } from './getOrCreate';
 import { defaultHashSize } from './hashPlaceholders';
 import type { OutputBundleWithPlaceholders } from './outputBundle';
 import { FILE_PLACEHOLDER, lowercaseBundleKeys } from './outputBundle';
@@ -74,6 +75,7 @@ interface ConsumedChunk {
 	fileName: string | undefined;
 	module: null | Module;
 	name: string;
+	referenceId: string;
 	type: 'chunk';
 }
 
@@ -81,6 +83,7 @@ interface ConsumedAsset {
 	fileName: string | undefined;
 	name: string | undefined;
 	needsCodeReference: boolean;
+	referenceId: string;
 	source: string | Uint8Array | undefined;
 	type: 'asset';
 }
@@ -231,11 +234,11 @@ export class FileEmitter {
 		}
 		const source = getValidSource(requestedSource, consumedFile, referenceId);
 		if (this.output) {
-			this.finalizeAsset(consumedFile, source, referenceId, this.output);
+			this.finalizeAdditionalAsset(consumedFile, source, this.output);
 		} else {
 			consumedFile.source = source;
 			for (const emitter of this.outputFileEmitters) {
-				emitter.finalizeAsset(consumedFile, source, referenceId, emitter.output!);
+				emitter.finalizeAdditionalAsset(consumedFile, source, emitter.output!);
 			}
 		}
 	};
@@ -258,10 +261,19 @@ export class FileEmitter {
 				reserveFileNameInBundle(emittedFile.fileName, output, this.options.onwarn);
 			}
 		}
-		for (const [referenceId, consumedFile] of this.filesByReferenceId) {
+		const consumedAssetsByHash = new Map<string, ConsumedAsset[]>();
+		for (const consumedFile of this.filesByReferenceId.values()) {
 			if (consumedFile.type === 'asset' && consumedFile.source !== undefined) {
-				this.finalizeAsset(consumedFile, consumedFile.source, referenceId, output);
+				if (consumedFile.fileName) {
+					this.finalizeAdditionalAsset(consumedFile, consumedFile.source, output);
+				} else {
+					const sourceHash = getSourceHash(consumedFile.source);
+					getOrCreate(consumedAssetsByHash, sourceHash, () => []).push(consumedFile);
+				}
 			}
+		}
+		for (const [sourceHash, consumedFiles] of consumedAssetsByHash) {
+			this.finalizeAssetsWithSameSource(consumedFiles, sourceHash, output);
 		}
 	};
 
@@ -278,6 +290,7 @@ export class FileEmitter {
 			this.filesByReferenceId.has(referenceId) ||
 			this.outputFileEmitters.some(({ filesByReferenceId }) => filesByReferenceId.has(referenceId))
 		);
+		file.referenceId = referenceId;
 		this.filesByReferenceId.set(referenceId, file);
 		for (const { filesByReferenceId } of this.outputFileEmitters) {
 			filesByReferenceId.set(referenceId, file);
@@ -294,6 +307,7 @@ export class FileEmitter {
 			fileName: emittedAsset.fileName,
 			name: emittedAsset.name,
 			needsCodeReference: !!emittedAsset.needsCodeReference,
+			referenceId: '',
 			source,
 			type: 'asset'
 		};
@@ -302,10 +316,10 @@ export class FileEmitter {
 			emittedAsset.fileName || emittedAsset.name || String(this.nextIdBase++)
 		);
 		if (this.output) {
-			this.emitAssetWithReferenceId(consumedAsset, referenceId, this.output);
+			this.emitAssetWithReferenceId(consumedAsset, this.output);
 		} else {
 			for (const fileEmitter of this.outputFileEmitters) {
-				fileEmitter.emitAssetWithReferenceId(consumedAsset, referenceId, fileEmitter.output!);
+				fileEmitter.emitAssetWithReferenceId(consumedAsset, fileEmitter.output!);
 			}
 		}
 		return referenceId;
@@ -313,7 +327,6 @@ export class FileEmitter {
 
 	private emitAssetWithReferenceId(
 		consumedAsset: Readonly<ConsumedAsset>,
-		referenceId: string,
 		output: FileEmitterOutput
 	) {
 		const { fileName, source } = consumedAsset;
@@ -321,7 +334,7 @@ export class FileEmitter {
 			reserveFileNameInBundle(fileName, output, this.options.onwarn);
 		}
 		if (source !== undefined) {
-			this.finalizeAsset(consumedAsset, source, referenceId, output);
+			this.finalizeAdditionalAsset(consumedAsset, source, output);
 		}
 	}
 
@@ -340,6 +353,7 @@ export class FileEmitter {
 			fileName: emittedChunk.fileName,
 			module: null,
 			name: emittedChunk.name || emittedChunk.id,
+			referenceId: '',
 			type: 'chunk'
 		};
 		this.graph.moduleLoader
@@ -353,35 +367,25 @@ export class FileEmitter {
 		return this.assignReferenceId(consumedChunk, emittedChunk.id);
 	}
 
-	private finalizeAsset(
+	private finalizeAdditionalAsset(
 		consumedFile: Readonly<ConsumedAsset>,
 		source: string | Uint8Array,
-		referenceId: string,
 		{ bundle, fileNamesBySource, outputOptions }: FileEmitterOutput
 	): void {
-		let fileName = consumedFile.fileName;
+		let { fileName, needsCodeReference, referenceId } = consumedFile;
 
 		// Deduplicate assets if an explicit fileName is not provided
 		if (!fileName) {
 			const sourceHash = getSourceHash(source);
 			fileName = fileNamesBySource.get(sourceHash);
-			const newFileName = generateAssetFileName(
-				consumedFile.name,
-				source,
-				sourceHash,
-				outputOptions,
-				bundle
-			);
-			// make sure file name deterministic in parallel emits, always use the shorter and smaller file name
-			if (
-				!fileName ||
-				fileName.length > newFileName.length ||
-				(fileName.length === newFileName.length && fileName > newFileName)
-			) {
-				if (fileName) {
-					delete bundle[fileName];
-				}
-				fileName = newFileName;
+			if (!fileName) {
+				fileName = generateAssetFileName(
+					consumedFile.name,
+					source,
+					sourceHash,
+					outputOptions,
+					bundle
+				);
 				fileNamesBySource.set(sourceHash, fileName);
 			}
 		}
@@ -390,11 +394,55 @@ export class FileEmitter {
 		const assetWithFileName = { ...consumedFile, fileName, source };
 		this.filesByReferenceId.set(referenceId, assetWithFileName);
 
+		const existingAsset = bundle[fileName];
+		if (existingAsset?.type === 'asset') {
+			existingAsset.needsCodeReference &&= needsCodeReference;
+		} else {
+			bundle[fileName] = {
+				fileName,
+				name: consumedFile.name,
+				needsCodeReference,
+				source,
+				type: 'asset'
+			};
+		}
+	}
+
+	private finalizeAssetsWithSameSource(
+		consumedFiles: ReadonlyArray<ConsumedAsset>,
+		sourceHash: string,
+		{ bundle, fileNamesBySource, outputOptions }: FileEmitterOutput
+	): void {
+		let fileName = '';
+		let usedConsumedFile: ConsumedAsset;
+		let needsCodeReference = true;
+		for (const consumedFile of consumedFiles) {
+			needsCodeReference &&= consumedFile.needsCodeReference;
+			const assetFileName = generateAssetFileName(
+				consumedFile.name,
+				consumedFile.source!,
+				sourceHash,
+				outputOptions,
+				bundle
+			);
+			if (!fileName || assetFileName < fileName) {
+				fileName = assetFileName;
+				usedConsumedFile = consumedFile;
+			}
+		}
+		fileNamesBySource.set(sourceHash, fileName);
+
+		for (const consumedFile of consumedFiles) {
+			// We must not modify the original assets to avoid interaction between outputs
+			const assetWithFileName = { ...consumedFile, fileName };
+			this.filesByReferenceId.set(consumedFile.referenceId, assetWithFileName);
+		}
+
 		bundle[fileName] = {
 			fileName,
-			name: consumedFile.name,
-			needsCodeReference: consumedFile.needsCodeReference,
-			source,
+			name: usedConsumedFile!.name,
+			needsCodeReference,
+			source: usedConsumedFile!.source!,
 			type: 'asset'
 		};
 	}

--- a/test/chunking-form/samples/emit-file/deduplicate-assets/_config.js
+++ b/test/chunking-form/samples/emit-file/deduplicate-assets/_config.js
@@ -1,3 +1,14 @@
+const assert = require('node:assert');
+let string1Id,
+	string2Id,
+	stringSameSourceId,
+	stringSameAsBufferId,
+	otherStringId,
+	bufferId,
+	bufferSameSourceId,
+	sameBufferAsStringId,
+	otherBufferId;
+
 module.exports = {
 	description: 'deduplicates asset that have the same source',
 	options: {
@@ -5,36 +16,44 @@ module.exports = {
 		plugins: {
 			buildStart() {
 				// emit 'string' source in a random order
-				this.emitFile({ type: 'asset', name: 'stringSameSource.txt', source: 'string' });
-				this.emitFile({ type: 'asset', name: 'string2.txt', source: 'string' });
-				this.emitFile({ type: 'asset', name: 'string1.txt', source: 'string' });
-				this.emitFile({
+				stringSameSourceId = this.emitFile({
 					type: 'asset',
-					name: 'sameStringAsBuffer.txt',
+					name: 'stringSameSource.txt',
+					source: 'string'
+				});
+				string2Id = this.emitFile({ type: 'asset', name: 'string2.txt', source: 'string' });
+				string1Id = this.emitFile({ type: 'asset', name: 'string1.txt', source: 'string' });
+				stringSameAsBufferId = this.emitFile({
+					type: 'asset',
+					name: 'stringSameAsBuffer.txt',
 					source: Buffer.from('string') // Test cross Buffer/string deduplication
 				});
 
 				// Different string source
-				this.emitFile({ type: 'asset', name: 'otherString.txt', source: 'otherString' });
+				otherStringId = this.emitFile({
+					type: 'asset',
+					name: 'otherString.txt',
+					source: 'otherString'
+				});
 
 				const bufferSource = () => Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
-				this.emitFile({
+				bufferId = this.emitFile({
 					type: 'asset',
 					name: 'buffer.txt',
 					source: bufferSource()
 				});
-				this.emitFile({
+				bufferSameSourceId = this.emitFile({
 					type: 'asset',
 					name: 'bufferSameSource.txt',
 					source: bufferSource()
 				});
-				this.emitFile({
+				sameBufferAsStringId = this.emitFile({
 					type: 'asset',
 					name: 'sameBufferAsString.txt',
 					source: bufferSource().toString() // Test cross Buffer/string deduplication
 				});
 				// Different buffer source
-				this.emitFile({
+				otherBufferId = this.emitFile({
 					type: 'asset',
 					name: 'otherBuffer.txt',
 					source: Buffer.from('otherBuffer')
@@ -48,6 +67,41 @@ module.exports = {
 					source: bufferSource()
 				});
 				return null;
+			},
+			generateBundle() {
+				assert.strictEqual(this.getFileName(string1Id), 'assets/string1-473287f8.txt', 'string1');
+				assert.strictEqual(this.getFileName(string2Id), 'assets/string1-473287f8.txt', 'string2');
+				assert.strictEqual(
+					this.getFileName(stringSameSourceId),
+					'assets/string1-473287f8.txt',
+					'stringSameSource'
+				);
+				assert.strictEqual(
+					this.getFileName(stringSameAsBufferId),
+					'assets/string1-473287f8.txt',
+					'stringSameAsBuffer'
+				);
+				assert.strictEqual(
+					this.getFileName(otherStringId),
+					'assets/otherString-e296c1ca.txt',
+					'otherString'
+				);
+				assert.strictEqual(this.getFileName(bufferId), 'assets/buffer-d0ca8c2a.txt', 'buffer');
+				assert.strictEqual(
+					this.getFileName(bufferSameSourceId),
+					'assets/buffer-d0ca8c2a.txt',
+					'bufferSameSource'
+				);
+				assert.strictEqual(
+					this.getFileName(sameBufferAsStringId),
+					'assets/buffer-d0ca8c2a.txt',
+					'sameBufferAsString'
+				);
+				assert.strictEqual(
+					this.getFileName(otherBufferId),
+					'assets/otherBuffer-e8d9b528.txt',
+					'otherBuffer'
+				);
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4916 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The logic to guarantee deterministic names for emitted assets with the same source added in #4912 was unfortunately breaking `this.getFileName`. The new logic now only fixes the name when doing the first round of finalizations before `renderStart`, which should be good enough. Assets emitted at a later stage will still follow a "first assets determines the name" strategy. This guarantees, that `this.getFileName` will always return a correct and reliable name that does not change.