### PR TITLE
Do not fail if the location of a warning is outside the original source

### DIFF
--- a/src/utils/getCodeFrame.ts
+++ b/src/utils/getCodeFrame.ts
@@ -15,7 +15,7 @@ const ELLIPSIS = '...';
 export default function getCodeFrame(source: string, line: number, column: number): string {
 	let lines = source.split('\n');
 	// Needed if a plugin did not generate correct sourcemaps
-	if (line >= lines.length) return '';
+	if (line > lines.length) return '';
 	const maxLineLength = Math.max(
 		tabsToSpaces(lines[line - 1].slice(0, column)).length +
 			MIN_CHARACTERS_SHOWN_AFTER_LOCATION +

--- a/src/utils/getCodeFrame.ts
+++ b/src/utils/getCodeFrame.ts
@@ -14,6 +14,8 @@ const ELLIPSIS = '...';
 
 export default function getCodeFrame(source: string, line: number, column: number): string {
 	let lines = source.split('\n');
+	// Needed if a plugin did not generate correct sourcemaps
+	if (line >= lines.length) return '';
 	const maxLineLength = Math.max(
 		tabsToSpaces(lines[line - 1].slice(0, column)).length +
 			MIN_CHARACTERS_SHOWN_AFTER_LOCATION +

--- a/test/function/samples/warning-incorrect-sourcemap-location/_config.js
+++ b/test/function/samples/warning-incorrect-sourcemap-location/_config.js
@@ -1,0 +1,34 @@
+const { join } = require('node:path');
+const ID_MAIN = join(__dirname, 'main.js');
+const ID_CONSTANTS = join(__dirname, 'constants.js');
+
+module.exports = {
+	description: 'does not fail if a warning has an incorrect location due to missing sourcemaps',
+	options: {
+		plugins: [
+			{
+				name: 'test',
+				transform(code) {
+					return '/* injected */;\n\n\n\n\n\n\n\n' + code;
+				}
+			}
+		]
+	},
+	warnings: [
+		{
+			binding: 'NON_EXISTENT',
+			code: 'MISSING_EXPORT',
+			exporter: ID_CONSTANTS,
+			frame: '',
+			id: ID_MAIN,
+			loc: {
+				column: 15,
+				file: ID_MAIN,
+				line: 12
+			},
+			message: '"NON_EXISTENT" is not exported by "constants.js", imported by "main.js".',
+			pos: 111,
+			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module'
+		}
+	]
+};

--- a/test/function/samples/warning-incorrect-sourcemap-location/constants.js
+++ b/test/function/samples/warning-incorrect-sourcemap-location/constants.js
@@ -1,0 +1,1 @@
+export const q = 'Queue';

--- a/test/function/samples/warning-incorrect-sourcemap-location/main.js
+++ b/test/function/samples/warning-incorrect-sourcemap-location/main.js
@@ -1,0 +1,5 @@
+import * as CONSTANTS from './constants';
+
+export default class Sample {
+	x = CONSTANTS.NON_EXISTENT;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4920

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When a plugin transforms a file without generating a source map, it can be that the location when reporting a warning or error is outside the original source. This fix does not detect this case (locations will still be wrong), but ensures the warning or error is not covered by an out-of-bounds error.