### PR TITLE
Allow shouldTransformCachedModule to return null

### DIFF
--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -564,14 +564,14 @@ type ShouldTransformCachedModuleHook = (options: {
 	meta: { [plugin: string]: any };
 	moduleSideEffects: boolean | 'no-treeshake';
 	syntheticNamedExports: boolean | string;
-}) => boolean;
+}) => boolean | NullValue;
 ```
 
 If the Rollup cache is used (e.g. in watch mode or explicitly via the JavaScript API), Rollup will skip the [`transform`](#transform) hook of a module if after the [`load`](#transform) hook, the loaded `code` is identical to the code of the cached copy. To prevent this, discard the cached copy and instead transform a module, plugins can implement this hook and return `true`.
 
 This hook can also be used to find out which modules were cached and access their cached meta information.
 
-If a plugin does not return `true`, Rollup will trigger this hook for other plugins, otherwise all remaining plugins will be skipped.
+If a plugin does not return a boolean, Rollup will trigger this hook for other plugins, otherwise all remaining plugins will be skipped.
 
 ### transform
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -254,7 +254,7 @@ export type ShouldTransformCachedModuleHook = (
 		resolvedSources: ResolvedIdMap;
 		syntheticNamedExports: boolean | string;
 	}
-) => boolean;
+) => boolean | NullValue;
 
 export type IsExternal = (
 	source: string,


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Allow `shouldTransformCachedModule` to return null. The hook uses the `hookFirst` approach, which only delegates other plugins if the return value is null.

https://github.com/rollup/rollup/blob/0bcf0a672ac087ff2eb88fbba45ec62389a4f45f/src/utils/PluginDriver.ts#L141-L154

Since the types only restricts returning a `boolean`, it makes it that the first plugin that implements this will take precedence over everything. Allowing to return null should fix this.

Perhaps there could be discussion if this was intentional.
