### PR TITLE
Disable puppeteer sandbox to fix Vercel deployment

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -129,7 +129,6 @@ export default defineConfig({
 	title: 'Rollup',
 	transformPageData,
 	vite: {
-		optimizeDeps: { include: ['moment-mini', '@braintree/sanitize-url'] },
 		plugins: [
 			renderMermaidGraphsPlugin(),
 			{

--- a/docs/.vitepress/mermaid.ts
+++ b/docs/.vitepress/mermaid.ts
@@ -14,6 +14,7 @@ const mermaidRegExp = /^```mermaid\n([\S\s]*?)\n```/gm;
 const greaterThanRegExp = /&gt;/g;
 const styleTagRegExp = /<style>[\S\s]*?<\/style>/gm;
 const configFileURL = new URL('mermaid.config.json', import.meta.url);
+const puppeteerConfigFileURL = new URL('puppeteer-config.json', import.meta.url);
 
 export function renderMermaidGraphsPlugin(): Plugin {
 	const existingGraphFileNamesPromise = mkdir(graphsDirectory, { recursive: true })
@@ -28,7 +29,9 @@ export function renderMermaidGraphsPlugin(): Plugin {
 			const inFileURL = new URL(`${outFile}.mmd`, graphsDirectory);
 			await writeFile(inFileURL, codeBlock);
 			const { stdout, stderr } = await execPromise(
-				`npx mmdc --configFile ${fileURLToPath(configFileURL)} --input ${fileURLToPath(
+				`npx mmdc --configFile ${fileURLToPath(
+					configFileURL
+				)} --puppeteerConfigFile ${fileURLToPath(puppeteerConfigFileURL)} --input ${fileURLToPath(
 					inFileURL
 				)} --output ${fileURLToPath(outFileURL)}`
 			);

--- a/docs/.vitepress/puppeteer-config.json
+++ b/docs/.vitepress/puppeteer-config.json
@@ -1,0 +1,3 @@
+{
+	"args": ["--no-sandbox"]
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Apparently, Vercel loves to run their deployment containers as root, which puppeteer does not like...