### PR TITLE
Ensure arguments are deoptimized when arguments variable is used

### DIFF
--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -54,8 +54,11 @@ export default abstract class FunctionBase extends NodeBase {
 					argument.deoptimizePath(UNKNOWN_PATH);
 				} else if (parameter instanceof Identifier) {
 					parameters[position][0].addEntityToBeDeoptimized(argument);
+					this.addArgumentToBeDeoptimized(argument);
 				} else if (parameter) {
 					argument.deoptimizePath(UNKNOWN_PATH);
+				} else {
+					this.addArgumentToBeDeoptimized(argument);
 				}
 			}
 		} else {
@@ -180,6 +183,8 @@ export default abstract class FunctionBase extends NodeBase {
 		}
 		super.parseNode(esTreeNode);
 	}
+
+	protected addArgumentToBeDeoptimized(_argument: ExpressionEntity) {}
 
 	protected applyDeoptimizations() {}
 

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -5,6 +5,7 @@ import FunctionScope from '../../scopes/FunctionScope';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
 import type BlockStatement from '../BlockStatement';
 import Identifier, { type IdentifierWithVariable } from '../Identifier';
+import type { ExpressionEntity } from './Expression';
 import { UNKNOWN_EXPRESSION } from './Expression';
 import FunctionBase from './FunctionBase';
 import { type IncludeChildren } from './Node';
@@ -93,6 +94,10 @@ export default class FunctionNode extends FunctionBase {
 	initialise(): void {
 		super.initialise();
 		this.id?.declare('function', this);
+	}
+
+	protected addArgumentToBeDeoptimized(argument: ExpressionEntity) {
+		this.scope.argumentsVariable.addArgumentToBeDeoptimized(argument);
 	}
 
 	protected getObjectEntity(): ObjectEntity {

--- a/src/ast/variables/ArgumentsVariable.ts
+++ b/src/ast/variables/ArgumentsVariable.ts
@@ -1,16 +1,36 @@
 import type { AstContext } from '../../Module';
 import type { NodeInteraction } from '../NodeInteractions';
 import { INTERACTION_ACCESSED } from '../NodeInteractions';
+import type { ExpressionEntity } from '../nodes/shared/Expression';
 import { UNKNOWN_EXPRESSION } from '../nodes/shared/Expression';
 import type { ObjectPath } from '../utils/PathTracker';
+import { UNKNOWN_PATH } from '../utils/PathTracker';
 import LocalVariable from './LocalVariable';
 
 export default class ArgumentsVariable extends LocalVariable {
+	private deoptimizedArguments: ExpressionEntity[] = [];
+
 	constructor(context: AstContext) {
 		super('arguments', null, UNKNOWN_EXPRESSION, context);
 	}
 
+	addArgumentToBeDeoptimized(argument: ExpressionEntity): void {
+		if (this.included) {
+			argument.deoptimizePath(UNKNOWN_PATH);
+		} else {
+			this.deoptimizedArguments.push(argument);
+		}
+	}
+
 	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {
 		return type !== INTERACTION_ACCESSED || path.length > 1;
+	}
+
+	include() {
+		super.include();
+		for (const argument of this.deoptimizedArguments) {
+			argument.deoptimizePath(UNKNOWN_PATH);
+		}
+		this.deoptimizedArguments.length = 0;
 	}
 }

--- a/test/function/samples/deoptimize-via-arguments/_config.js
+++ b/test/function/samples/deoptimize-via-arguments/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'deoptimize call parameters when arguments variable is used'
+};

--- a/test/function/samples/deoptimize-via-arguments/main.js
+++ b/test/function/samples/deoptimize-via-arguments/main.js
@@ -1,0 +1,17 @@
+function mutate(a) {
+	arguments[0].x = true;
+	arguments[1].x = true;
+}
+
+var obj1 = {
+	x: false
+};
+
+var obj2 = {
+	x: false
+};
+
+mutate(obj1, obj2);
+
+assert.ok(obj1.x ? true : false);
+assert.ok(obj2.x ? true : false);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4960

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The new selective call argument deoptimization logic did not take usages of "arguments" into account, which is fixed here.