### PR TITLE
Automatically force close Rollup when done

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -22,5 +22,6 @@ if (command.help || (process.argv.length <= 2 && process.stdin.isTTY)) {
 		// do nothing
 	}
 
-	run(command);
+	// eslint-disable-next-line unicorn/no-process-exit
+	run(command).then(() => process.exit(0));
 }

--- a/cli/run/index.ts
+++ b/cli/run/index.ts
@@ -55,7 +55,7 @@ export default async function runRollup(command: Record<string, any>): Promise<v
 	if (isWatchEnabled(command.watch)) {
 		await loadFsEvents();
 		const { watch } = await import('./watch-cli');
-		watch(command);
+		await watch(command);
 	} else {
 		try {
 			const { options, warnings } = await getConfigs(command);

--- a/cli/run/watch-cli.ts
+++ b/cli/run/watch-cli.ts
@@ -154,9 +154,10 @@ export async function watch(command: Record<string, any>): Promise<void> {
 		if (watcher) await watcher.close();
 		if (configWatcher) configWatcher.close();
 
-		if (code) {
-			// eslint-disable-next-line unicorn/no-process-exit
-			process.exit(code);
-		}
+		// eslint-disable-next-line unicorn/no-process-exit
+		process.exit(code || 0);
 	}
+
+	// return a promise that never resolves to keep the process running
+	return new Promise(() => {});
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,3 @@
-import { exit } from 'node:process';
 import { fileURLToPath } from 'node:url';
 import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
@@ -138,16 +137,7 @@ export default async function (
 			terser({ module: true, output: { comments: 'some' } }),
 			collectLicensesBrowser(),
 			writeLicenseBrowser(),
-			cleanBeforeWrite('browser/dist'),
-			{
-				closeBundle() {
-					// On CI, MacOS runs sometimes do not close properly. This is a hack
-					// to fix this until the problem is understood.
-					console.log('Force quit.');
-					setTimeout(() => exit(0));
-				},
-				name: 'force-close'
-			}
+			cleanBeforeWrite('browser/dist')
 		],
 		strictDeprecations: true,
 		treeshake


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4213

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
As many people were reporting issues, this implements the proposed force quite via `process.exit` that some proposed.