### PR TITLE
Handle shimming missing exports when preserving modules

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -747,7 +747,11 @@ export default class Module {
 		// Modules where this.ast is missing have been loaded via this.load and are
 		// not yet fully processed, hence they cannot be included.
 		return (
-			this.ast && (this.ast.included || this.namespace.included || this.importedFromNotTreeshaken)
+			this.ast &&
+			(this.ast.included ||
+				this.namespace.included ||
+				this.importedFromNotTreeshaken ||
+				this.exportShimVariable.included)
 		);
 	}
 

--- a/test/function/samples/missing-export-preserve-modules/_config.js
+++ b/test/function/samples/missing-export-preserve-modules/_config.js
@@ -1,0 +1,19 @@
+const path = require('node:path');
+
+module.exports = defineTest({
+	description: 'supports shimming missing exports when preserving modules',
+	options: {
+		shimMissingExports: true,
+		output: {
+			preserveModules: true
+		}
+	},
+	warnings: [
+		{
+			binding: 'bar',
+			code: 'SHIMMED_EXPORT',
+			exporter: path.join(__dirname, 'foo.js'),
+			message: 'Missing export "bar" has been shimmed in module "foo.js".'
+		}
+	]
+});

--- a/test/function/samples/missing-export-preserve-modules/foo.js
+++ b/test/function/samples/missing-export-preserve-modules/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/test/function/samples/missing-export-preserve-modules/main.js
+++ b/test/function/samples/missing-export-preserve-modules/main.js
@@ -1,0 +1,2 @@
+import { bar } from './foo';
+assert.strictEqual(bar, undefined);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4884

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This ensures that modules with shimmed missing exports always get a chunk created when preserving modules