### PR TITLE
Keep leading comments on consecutive lines

### DIFF
--- a/src/ast/nodes/Program.ts
+++ b/src/ast/nodes/Program.ts
@@ -3,7 +3,11 @@ import type MagicString from 'magic-string';
 import getCodeFrame from '../../utils/getCodeFrame';
 import { getOriginalLocation } from '../../utils/getOriginalLocation';
 import relativeId from '../../utils/relativeId';
-import { type RenderOptions, renderStatementList } from '../../utils/renderHelpers';
+import {
+	findFirstLineBreakOutsideComment,
+	type RenderOptions,
+	renderStatementList
+} from '../../utils/renderHelpers';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import { createHasEffectsContext } from '../ExecutionContext';
 import type * as NodeType from './NodeType';
@@ -79,6 +83,16 @@ export default class Program extends NodeBase {
 			code.remove(0, start);
 		}
 		if (this.body.length > 0) {
+			// Keep all consecutive lines that start with a comment
+			while (code.original[start] === '/' && /[*/]/.test(code.original[start + 1])) {
+				const firstLineBreak = findFirstLineBreakOutsideComment(
+					code.original.slice(start, this.body[0].start)
+				);
+				if (firstLineBreak[0] === -1) {
+					break;
+				}
+				start += firstLineBreak[1];
+			}
 			renderStatementList(this.body, code, start, this.end, options);
 		} else {
 			super.render(code, options);

--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -70,7 +70,7 @@ export function findNonWhiteSpace(code: string, index: number): number {
 
 // This assumes "code" only contains white-space and comments
 // Returns position of line-comment if applicable
-function findFirstLineBreakOutsideComment(code: string): [number, number] {
+export function findFirstLineBreakOutsideComment(code: string): [number, number] {
 	let lineBreakPos,
 		charCodeAfterSlash,
 		start = 0;

--- a/test/form/samples/leading-comments/_config.js
+++ b/test/form/samples/leading-comments/_config.js
@@ -1,0 +1,6 @@
+module.exports = defineTest({
+	description: 'keeps leading comments on consecutive lines',
+	options: {
+		external: ['external']
+	}
+});

--- a/test/form/samples/leading-comments/_expected.js
+++ b/test/form/samples/leading-comments/_expected.js
@@ -1,0 +1,13 @@
+import 'external';
+
+// comment dep 1/3
+/* comment
+*/ // comment dep 2/3
+// comment dep 3/3
+
+console.log('dep');
+
+// comment main 1/2
+// comment main 2/2
+
+console.log('main');

--- a/test/form/samples/leading-comments/dep.js
+++ b/test/form/samples/leading-comments/dep.js
@@ -1,0 +1,7 @@
+// comment dep 1/3
+/* comment
+*/ // comment dep 2/3
+// comment dep 3/3
+/* import comment */ import 'external';
+
+console.log('dep');

--- a/test/form/samples/leading-comments/main.js
+++ b/test/form/samples/leading-comments/main.js
@@ -1,0 +1,6 @@
+#! /usr/bin/env node
+// comment main 1/2
+// comment main 2/2
+import './dep.js';
+
+console.log('main');

--- a/test/form/samples/pure-comment-scenarios-complex/_expected.js
+++ b/test/form/samples/pure-comment-scenarios-complex/_expected.js
@@ -1,5 +1,6 @@
 // pure top-level IIFE will be dropped
 
+
 // pure top-level IIFE assigned to unreferenced var will not be dropped
 global.iife1 = /*@__PURE__*/(function() {
 	console.log("iife1");

--- a/test/form/samples/remove-treeshaken-banners/_expected.js
+++ b/test/form/samples/remove-treeshaken-banners/_expected.js
@@ -1,4 +1,5 @@
 // dep included banner: included
+
 console.log('dep included');
 
 // dep included footer: included

--- a/test/form/samples/render-removed-statements/_expected.js
+++ b/test/form/samples/render-removed-statements/_expected.js
@@ -1,4 +1,5 @@
 /* header retained */
+
  /* lead
 retained */ console.log(2); // trail retained
 console.log(2); // trail retained


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4953

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Previously, only comments on the first line of a module were guaranteed to be included while subsequent comments were only retained if the first statement remained part of the bundle. This was a problem when leadings comments were written as a series of line comments instead of a block comment, or there was more than one comment.
This PR changes the logic so that all leadings comments are retained provided that
- there are no empty lines in between
- each line that is not already part of a comment starts with a comment