### PR TITLE
Use correct scope in switch statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,9 +143,6 @@
     "weak-napi": "^2.0.2",
     "yargs-parser": "^21.1.1"
   },
-  "overrides": {
-    "d3": "7.8.0"
-  },
   "files": [
     "dist/**/*.js",
     "dist/*.d.ts",

--- a/src/ast/nodes/SwitchStatement.ts
+++ b/src/ast/nodes/SwitchStatement.ts
@@ -6,10 +6,12 @@ import {
 	type InclusionContext
 } from '../ExecutionContext';
 import BlockScope from '../scopes/BlockScope';
+import type ChildScope from '../scopes/ChildScope';
 import type Scope from '../scopes/Scope';
 import type * as NodeType from './NodeType';
 import type SwitchCase from './SwitchCase';
-import { type ExpressionNode, type IncludeChildren, StatementBase } from './shared/Node';
+import type { ExpressionNode, GenericEsTreeNode, IncludeChildren } from './shared/Node';
+import { StatementBase } from './shared/Node';
 
 export default class SwitchStatement extends StatementBase {
 	declare cases: readonly SwitchCase[];
@@ -17,8 +19,10 @@ export default class SwitchStatement extends StatementBase {
 	declare type: NodeType.tSwitchStatement;
 
 	private declare defaultCase: number | null;
+	private declare parentScope: ChildScope;
 
 	createScope(parentScope: Scope): void {
+		this.parentScope = parentScope as ChildScope;
 		this.scope = new BlockScope(parentScope);
 	}
 
@@ -87,6 +91,15 @@ export default class SwitchStatement extends StatementBase {
 			}
 		}
 		this.defaultCase = null;
+	}
+
+	parseNode(esTreeNode: GenericEsTreeNode) {
+		this.discriminant = new (this.context.getNodeConstructor(esTreeNode.discriminant.type))(
+			esTreeNode.discriminant,
+			this,
+			this.parentScope
+		);
+		super.parseNode(esTreeNode);
 	}
 
 	render(code: MagicString, options: RenderOptions): void {

--- a/test/function/samples/switch-scope/_config.js
+++ b/test/function/samples/switch-scope/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'uses correct scopes for switch statements'
+});

--- a/test/function/samples/switch-scope/main.js
+++ b/test/function/samples/switch-scope/main.js
@@ -1,0 +1,10 @@
+const foo = 1;
+let triggered = false;
+
+switch (foo) {
+	case 1:
+		const foo = 2;
+		triggered = true;
+}
+
+assert.ok(triggered);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4976 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Rollup wrongly used the inner "switch case" scope for the switch statement discriminant while it should have used the outer scope. This lead to wrong variable associations and invalid code, see the linked issue.