### PR TITLE
Prevent exit before stdout is drained

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -21,6 +21,8 @@ if (command.help || (process.argv.length <= 2 && process.stdin.isTTY)) {
 	} catch {
 		// do nothing
 	}
-
-	run(command).then(() => process.exit(0));
+	run(command).then(() => {
+		process.stdout.on('finish', () => process.exit(0));
+		process.stdout.end();
+	});
 }

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -58,88 +58,76 @@ async function runTest(config, command) {
 				killSignal: 'SIGKILL'
 			},
 			async (error, code, stderr) => {
-				if (config.after) {
-					await config.after(error, code, stderr);
-				}
-				if (error && !error.killed) {
-					if (config.error) {
-						if (!config.error(error)) {
-							return resolve();
-						}
-					} else {
-						return reject(error);
+				try {
+					if (config.after) {
+						await config.after(error, code, stderr);
 					}
-				}
-				if (childProcess.signalCode === 'SIGKILL') {
-					return reject(new Error('Test aborted due to timeout.'));
-				}
-
-				if ('stderr' in config) {
-					const shouldContinue = config.stderr(stderr);
-					if (!shouldContinue) return resolve();
-				} else if (stderr) {
-					console.error(stderr);
-				}
-
-				let unintendedError;
-
-				if (config.execute) {
-					try {
-						const function_ = new Function('require', 'module', 'exports', 'assert', code);
-						const module = {
-							exports: {}
-						};
-						function_(require, module, module.exports, assert);
-
+					if (error && !error.killed) {
 						if (config.error) {
-							unintendedError = new Error('Expected an error while executing output');
-						}
-
-						if (config.exports) {
-							await config.exports(module.exports);
-						}
-					} catch (error) {
-						if (config.error) {
-							config.error(error);
+							if (!config.error(error)) {
+								return resolve();
+							}
 						} else {
-							unintendedError = error;
+							return reject(error);
 						}
 					}
-
-					if (config.show || unintendedError) {
-						console.log(code + '\n\n\n');
+					if (childProcess.signalCode === 'SIGKILL') {
+						return reject(new Error('Test aborted due to timeout.'));
 					}
 
-					if (config.solo) console.groupEnd();
+					if ('stderr' in config) {
+						const shouldContinue = config.stderr(stderr);
+						if (!shouldContinue) return resolve();
+					} else if (stderr) {
+						console.error(stderr);
+					}
 
-					return unintendedError ? reject(unintendedError) : resolve();
-				}
-				if (config.result) {
-					try {
+					let unintendedError;
+
+					if (config.execute) {
+						try {
+							const function_ = new Function('require', 'module', 'exports', 'assert', code);
+							const module = {
+								exports: {}
+							};
+							function_(require, module, module.exports, assert);
+
+							if (config.error) {
+								unintendedError = new Error('Expected an error while executing output');
+							}
+
+							if (config.exports) {
+								config.exports(module.exports);
+							}
+						} catch (error) {
+							if (config.error) {
+								config.error(error);
+							} else {
+								unintendedError = error;
+							}
+						}
+
+						if (config.show || unintendedError) {
+							console.log(code + '\n\n\n');
+						}
+
+						if (config.solo) console.groupEnd();
+
+						return unintendedError ? reject(unintendedError) : resolve();
+					}
+					if (config.result) {
 						config.result(code);
 						return resolve();
-					} catch (error) {
-						return reject(error);
 					}
-				}
-				if (config.test) {
-					try {
+					if (config.test) {
 						config.test();
 						return resolve();
-					} catch (error) {
-						return reject(error);
 					}
-				}
-				if (existsSync('_expected') && statSync('_expected').isDirectory()) {
-					try {
+					if (existsSync('_expected') && statSync('_expected').isDirectory()) {
 						assertDirectoriesAreEqual('_actual', '_expected');
 						return resolve();
-					} catch (error) {
-						return reject(error);
 					}
-				}
-				const expected = readFileSync('_expected.js', 'utf8');
-				try {
+					const expected = readFileSync('_expected.js', 'utf8');
 					assert.equal(normaliseOutput(code), normaliseOutput(expected));
 					return resolve();
 				} catch (error) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4982

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This will ensure that stdout is closed and drained before manually exiting Rollup. Unfortunately, I am not sure if it is possible to test this properly.