### PR TITLE
Properly quit on uncaught exceptions

### DIFF
--- a/cli/run/watch-cli.ts
+++ b/cli/run/watch-cli.ts
@@ -29,7 +29,7 @@ export async function watch(command: Record<string, any>): Promise<void> {
 	const runWatchHook = createWatchHooks(command);
 
 	onExit(close);
-	process.on('uncaughtException', close);
+	process.on('uncaughtException', closeWithError);
 	if (!process.stdin.isTTY) {
 		process.stdin.on('end', close);
 		process.stdin.resume();
@@ -147,7 +147,7 @@ export async function watch(command: Record<string, any>): Promise<void> {
 	}
 
 	async function close(code: number | null | undefined): Promise<void> {
-		process.removeListener('uncaughtException', close);
+		process.removeListener('uncaughtException', closeWithError);
 		// removing a non-existent listener is a no-op
 		process.stdin.removeListener('end', close);
 
@@ -159,4 +159,9 @@ export async function watch(command: Record<string, any>): Promise<void> {
 
 	// return a promise that never resolves to keep the process running
 	return new Promise(() => {});
+}
+
+function closeWithError(error: Error): void {
+	error.name = `Uncaught ${error.name}`;
+	handleError(error);
 }

--- a/test/cli/samples/handles-uncaught-errors/_config.js
+++ b/test/cli/samples/handles-uncaught-errors/_config.js
@@ -1,0 +1,10 @@
+const { assertIncludes } = require('../../../utils.js');
+
+module.exports = defineTest({
+	description: 'handles uncaught errors',
+	command: 'rollup --config rollup.config.js',
+	error: () => true,
+	stderr(stderr) {
+		assertIncludes(stderr, 'TypeError: foo');
+	}
+});

--- a/test/cli/samples/handles-uncaught-errors/main.js
+++ b/test/cli/samples/handles-uncaught-errors/main.js
@@ -1,0 +1,1 @@
+assert.equal( 42, 42 );

--- a/test/cli/samples/handles-uncaught-errors/rollup.config.js
+++ b/test/cli/samples/handles-uncaught-errors/rollup.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+	input: 'main.js',
+	output: {
+		format: 'cjs'
+	},
+	plugins: [
+		{
+			name: 'test',
+			buildStart() {
+				Promise.resolve().then(() => {
+					throw new TypeError('foo');
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- #4986

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There was a bug in the uncaughtException handler in that it accidentally passed the error as exit code, swallowing the actual error. This is fixed here.