### PR TITLE
Handle self-referencing namespaces

### DIFF
--- a/src/ast/variables/NamespaceVariable.ts
+++ b/src/ast/variables/NamespaceVariable.ts
@@ -135,15 +135,15 @@ export default class NamespaceVariable extends Variable {
 		const memberVariables = this.getMemberVariables();
 		const members: [key: string | null, value: string][] = Object.entries(memberVariables)
 			.filter(([_, variable]) => variable.included)
-			.map(([name, original]) => {
-				if (this.referencedEarly || original.isReassigned) {
+			.map(([name, variable]) => {
+				if (this.referencedEarly || variable.isReassigned || variable === this) {
 					return [
 						null,
-						`get ${name}${_}()${_}{${_}return ${original.getName(getPropertyAccess)}${s}${_}}`
+						`get ${name}${_}()${_}{${_}return ${variable.getName(getPropertyAccess)}${s}${_}}`
 					];
 				}
 
-				return [name, original.getName(getPropertyAccess)];
+				return [name, variable.getName(getPropertyAccess)];
 			});
 		members.unshift([null, `__proto__:${_}null`]);
 

--- a/test/function/samples/self-referencing-namespace/_config.js
+++ b/test/function/samples/self-referencing-namespace/_config.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert');
+const path = require('node:path');
+
+const ID_MAIN = path.join(__dirname, 'main.js');
+
+module.exports = defineTest({
+	description: 'supports dynamic namespaces that reference themselves',
+	options: {
+		output: { generatedCode: { constBindings: true } }
+	},
+	exports(exports) {
+		assert.strictEqual(exports.foo, 'foo');
+		assert.strictEqual(exports.ns.foo, 'foo');
+		assert.strictEqual(exports.ns.ns.foo, 'foo');
+	},
+	warnings: [
+		{
+			code: 'CIRCULAR_DEPENDENCY',
+			ids: [ID_MAIN, ID_MAIN],
+			message: 'Circular dependency: main.js -> main.js'
+		}
+	]
+});

--- a/test/function/samples/self-referencing-namespace/main.js
+++ b/test/function/samples/self-referencing-namespace/main.js
@@ -1,0 +1,2 @@
+export * as ns from './main.js';
+export const foo = 'foo';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4325

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This ensures that using "export * as variable" will use a getter for the namespace itself inside the namespace to avoid accessing the namespace variable before it is created.

https://rollup-8btvtg165-rollup-js.vercel.app/repl/?pr=4991&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyZXhwb3J0JTIwKiUyMGFzJTIwbnMlMjBmcm9tJTIwJy4lMkZtYWluLmpzJyUzQiU1Q25leHBvcnQlMjBkZWZhdWx0JTIwJ2ZvbyclM0IlMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlN0QlN0Q=