### PR TITLE
Do not force quit Rollup or close stdout

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -21,8 +21,6 @@ if (command.help || (process.argv.length <= 2 && process.stdin.isTTY)) {
 	} catch {
 		// do nothing
 	}
-	run(command).then(() => {
-		process.stdout.on('finish', () => process.exit(0));
-		process.stdout.end();
-	});
+
+	run(command);
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -137,7 +137,16 @@ export default async function (
 			terser({ module: true, output: { comments: 'some' } }),
 			collectLicensesBrowser(),
 			writeLicenseBrowser(),
-			cleanBeforeWrite('browser/dist')
+			cleanBeforeWrite('browser/dist'),
+			{
+				closeBundle() {
+					// On CI, macOS runs sometimes do not close properly. This is a hack
+					// to fix this until the problem is understood.
+					console.log('Force quit.');
+					setTimeout(() => process.exit(0));
+				},
+				name: 'force-close'
+			}
 		],
 		strictDeprecations: true,
 		treeshake

--- a/src/utils/hookActions.ts
+++ b/src/utils/hookActions.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import process from 'node:process';
 import type { HookAction, PluginDriver } from './PluginDriver';
 
@@ -25,33 +24,40 @@ function formatAction([pluginName, hookName, parameters]: HookAction): string {
 	return action;
 }
 
-// We do not directly listen on process to avoid max listeners warnings for
-// complicated build processes
-const beforeExitEvent = 'beforeExit';
-// eslint-disable-next-line unicorn/prefer-event-target
-const beforeExitEmitter = new EventEmitter();
-beforeExitEmitter.setMaxListeners(0);
-process.on(beforeExitEvent, () => beforeExitEmitter.emit(beforeExitEvent));
+let handleBeforeExit: null | (() => void) = null;
+const rejectByPluginDriver = new Map<PluginDriver, (reason: Error) => void>();
 
 export async function catchUnfinishedHookActions<T>(
 	pluginDriver: PluginDriver,
 	callback: () => Promise<T>
 ): Promise<T> {
-	let handleEmptyEventLoop: () => void;
 	const emptyEventLoopPromise = new Promise<T>((_, reject) => {
-		handleEmptyEventLoop = () => {
-			const unfulfilledActions = pluginDriver.getUnfulfilledHookActions();
-			reject(
-				new Error(
-					`Unexpected early exit. This happens when Promises returned by plugins cannot resolve. Unfinished hook action(s) on exit:\n` +
-						[...unfulfilledActions].map(formatAction).join('\n')
-				)
-			);
-		};
-		beforeExitEmitter.once(beforeExitEvent, handleEmptyEventLoop);
+		rejectByPluginDriver.set(pluginDriver, reject);
+		if (!handleBeforeExit) {
+			// We only ever create a single event listener to avoid max listener and
+			// other issues
+			handleBeforeExit = () => {
+				for (const [pluginDriver, reject] of rejectByPluginDriver) {
+					const unfulfilledActions = pluginDriver.getUnfulfilledHookActions();
+					reject(
+						new Error(
+							`Unexpected early exit. This happens when Promises returned by plugins cannot resolve. Unfinished hook action(s) on exit:\n` +
+								[...unfulfilledActions].map(formatAction).join('\n')
+						)
+					);
+				}
+			};
+			process.once('beforeExit', handleBeforeExit);
+		}
 	});
 
-	const result = await Promise.race([callback(), emptyEventLoopPromise]);
-	beforeExitEmitter.off(beforeExitEvent, handleEmptyEventLoop!);
-	return result;
+	try {
+		return await Promise.race([callback(), emptyEventLoopPromise]);
+	} finally {
+		rejectByPluginDriver.delete(pluginDriver);
+		if (rejectByPluginDriver.size === 0) {
+			process.off('beforeExit', handleBeforeExit!);
+			handleBeforeExit = null;
+		}
+	}
 }


### PR DESCRIPTION
reverts #4969, #4983

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4998 
- resolves #4995 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This basically reverts #4969 and #4983 as calling `process.exit()` or `process.stdout.end()` seems to break various workflows. Instead, we should find out what keeps Rollup from quitting in the first place, maybe some plugins?