### PR TITLE
fix: add a trailing slash automatically for sourcemapBaseUrl

### DIFF
--- a/src/utils/options/normalizeOutputOptions.ts
+++ b/src/utils/options/normalizeOutputOptions.ts
@@ -14,7 +14,7 @@ import {
 } from '../error';
 import { resolve } from '../path';
 import { sanitizeFileName as defaultSanitizeFileName } from '../sanitizeFileName';
-import { isValidUrl } from '../url';
+import { addTrailingSlashIfMissed, isValidUrl } from '../url';
 import {
 	URL_OUTPUT_AMD_BASEPATH,
 	URL_OUTPUT_AMD_ID,
@@ -537,7 +537,7 @@ const getSourcemapBaseUrl = (
 	const { sourcemapBaseUrl } = config;
 	if (sourcemapBaseUrl) {
 		if (isValidUrl(sourcemapBaseUrl)) {
-			return sourcemapBaseUrl;
+			return addTrailingSlashIfMissed(sourcemapBaseUrl);
 		}
 		return error(
 			errorInvalidOption(

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -10,3 +10,10 @@ export function isValidUrl(url: string): boolean {
 export function getRollupUrl(snippet: string) {
 	return `https://rollupjs.org/${snippet}`;
 }
+
+export function addTrailingSlashIfMissed(url: string) {
+	if (!url.endsWith('/')) {
+		return url + '/';
+	}
+	return url;
+}

--- a/test/sourcemaps/samples/sourcemap-base-url-without-trailing-slash/_config.js
+++ b/test/sourcemaps/samples/sourcemap-base-url-without-trailing-slash/_config.js
@@ -1,16 +1,15 @@
 const assert = require('node:assert');
 
 module.exports = defineTest({
-	description: 'adds a sourcemap base url',
+	description: 'add a trailing slash automatically if it is missing',
 	options: {
 		output: {
-			sourcemapBaseUrl: 'https://example.com/a/'
+			sourcemapBaseUrl: 'https://example.com/a'
 		}
 	},
 	test: (code, map, { format }) => {
-		assert.equal(map.file, `bundle.${format}.js`);
 		const sourceMappingURL = code.split('\n').slice(-2)[0];
-		assert.equal(
+		assert.strictEqual(
 			sourceMappingURL,
 			`//# sourceMappingURL=https://example.com/a/bundle.${format}.js.map`
 		);

--- a/test/sourcemaps/samples/sourcemap-base-url-without-trailing-slash/main.js
+++ b/test/sourcemaps/samples/sourcemap-base-url-without-trailing-slash/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #5020 
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
