### PR TITLE
fix: get right sideEffectModules

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1277,7 +1277,9 @@ export default class Module {
 	}
 
 	private includeVariable(variable: Variable): void {
-		if (!variable.included) {
+		if (variable.included) {
+			getAndExtendSideEffectModules(variable, this);
+		} else {
 			variable.include();
 			this.graph.needsTreeshakingPass = true;
 			const variableModule = variable.module;

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -1277,12 +1277,14 @@ export default class Module {
 	}
 
 	private includeVariable(variable: Variable): void {
+		const variableModule = variable.module;
 		if (variable.included) {
-			getAndExtendSideEffectModules(variable, this);
+			if (variableModule instanceof Module && variableModule !== this) {
+				getAndExtendSideEffectModules(variable, this);
+			}
 		} else {
 			variable.include();
 			this.graph.needsTreeshakingPass = true;
-			const variableModule = variable.module;
 			if (variableModule instanceof Module) {
 				if (!variableModule.isExecuted) {
 					markModuleAndImpureDependenciesAsExecuted(variableModule);

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_config.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_config.js
@@ -1,0 +1,22 @@
+const path = require('node:path');
+const commonjs = require('@rollup/plugin-commonjs');
+
+module.exports = defineTest({
+	description: 'the content of c.js is complete',
+	options: {
+		plugins: [
+			commonjs(),
+			{
+				resolveId(id) {
+					if (id === './c.js') {
+						return {
+							id: path.resolve('./c.js'),
+							moduleSideEffects: false
+						};
+					}
+				}
+			}
+		]
+	},
+	solo: true
+});

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_config.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_config.js
@@ -17,6 +17,5 @@ module.exports = defineTest({
 				}
 			}
 		]
-	},
-	solo: true
+	}
 });

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-a.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-a.js
@@ -1,0 +1,9 @@
+define(['exports', './generated-c'], (function (exports, c) { 'use strict';
+
+	function A() {
+		return { icon: c.c.faPrint };
+	}
+
+	exports.A = A;
+
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-b.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-b.js
@@ -1,0 +1,9 @@
+define(['exports', './generated-c'], (function (exports, c) { 'use strict';
+
+	function B() {
+		return { icon: c.c.faPrint };
+	}
+
+	exports.B = B;
+
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-c.js
@@ -1,0 +1,15 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var c = {};
+
+	(function (exports) {
+		exports.preFaPrint = {
+			foo: 1
+		};
+
+		exports.faPrint = exports.preFaPrint; 
+	} (c));
+
+	exports.c = c;
+
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/main.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/main.js
@@ -1,0 +1,8 @@
+define(['require'], (function (require) { 'use strict';
+
+	const importA = () => new Promise(function (resolve, reject) { require(['./generated-a'], resolve, reject); });
+	const importB = () => new Promise(function (resolve, reject) { require(['./generated-b'], resolve, reject); });
+
+	console.log(importA, importB);
+
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-a.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-a.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var c = require('./generated-c.js');
+
+function A() {
+	return { icon: c.c.faPrint };
+}
+
+exports.A = A;

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-b.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-b.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var c = require('./generated-c.js');
+
+function B() {
+	return { icon: c.c.faPrint };
+}
+
+exports.B = B;

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-c.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var c = {};
+
+(function (exports) {
+	exports.preFaPrint = {
+		foo: 1
+	};
+
+	exports.faPrint = exports.preFaPrint; 
+} (c));
+
+exports.c = c;

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/main.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/main.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const importA = () => Promise.resolve().then(function () { return require('./generated-a.js'); });
+const importB = () => Promise.resolve().then(function () { return require('./generated-b.js'); });
+
+console.log(importA, importB);

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-a.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-a.js
@@ -1,0 +1,7 @@
+import { c } from './generated-c.js';
+
+function A() {
+	return { icon: c.faPrint };
+}
+
+export { A };

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-b.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-b.js
@@ -1,0 +1,7 @@
+import { c } from './generated-c.js';
+
+function B() {
+	return { icon: c.faPrint };
+}
+
+export { B };

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-c.js
@@ -1,0 +1,11 @@
+var c = {};
+
+(function (exports) {
+	exports.preFaPrint = {
+		foo: 1
+	};
+
+	exports.faPrint = exports.preFaPrint; 
+} (c));
+
+export { c };

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/main.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/main.js
@@ -1,0 +1,4 @@
+const importA = () => import('./generated-a.js');
+const importB = () => import('./generated-b.js');
+
+console.log(importA, importB);

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-a.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-a.js
@@ -1,0 +1,18 @@
+System.register(['./generated-c.js'], (function (exports) {
+	'use strict';
+	var c;
+	return {
+		setters: [function (module) {
+			c = module.c;
+		}],
+		execute: (function () {
+
+			exports('A', A);
+
+			function A() {
+				return { icon: c.faPrint };
+			}
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-b.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-b.js
@@ -1,0 +1,18 @@
+System.register(['./generated-c.js'], (function (exports) {
+	'use strict';
+	var c;
+	return {
+		setters: [function (module) {
+			c = module.c;
+		}],
+		execute: (function () {
+
+			exports('B', B);
+
+			function B() {
+				return { icon: c.faPrint };
+			}
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-c.js
@@ -1,0 +1,18 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var c = exports('c', {});
+
+			(function (exports) {
+				exports.preFaPrint = {
+					foo: 1
+				};
+
+				exports.faPrint = exports.preFaPrint; 
+			} (c));
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/main.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/main.js
@@ -1,0 +1,13 @@
+System.register([], (function (exports, module) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const importA = () => module.import('./generated-a.js');
+			const importB = () => module.import('./generated-b.js');
+
+			console.log(importA, importB);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/a.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/a.js
@@ -1,0 +1,5 @@
+import { faPrint } from './c.js';
+
+export function A() {
+	return { icon: faPrint };
+}

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/b.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/b.js
@@ -1,0 +1,5 @@
+import { faPrint } from './c.js';
+
+export function B() {
+	return { icon: faPrint };
+}

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/c.js
@@ -1,0 +1,5 @@
+exports.preFaPrint = {
+	foo: 1
+};
+
+exports.faPrint = exports.preFaPrint;

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/main.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/main.js
@@ -1,0 +1,4 @@
+const importA = () => import('./a.js');
+const importB = () => import('./b.js');
+
+console.log(importA, importB);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #5025
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Maybe we should call the `getAndExtendSideEffectModules` function to get the correct `sideEffectModules` even though `variable` is included.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
