### PR TITLE
fix: `__NO_SIDE_EFFECTS__` annotation for async function

### DIFF
--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -36,12 +36,15 @@ export default class ArrowFunctionExpression extends FunctionBase {
 		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) return true;
-		if (interaction.type === INTERACTION_CALLED) {
-			if (this.annotationNoSideEffects) {
-				return false;
-			}
+		if (this.annotationNoSideEffects) {
+			return false;
+		}
 
+		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) {
+			return true;
+		}
+
+		if (interaction.type === INTERACTION_CALLED) {
 			const { ignore, brokenFlow } = context;
 			context.ignore = {
 				breaks: false,

--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -36,12 +36,12 @@ export default class ArrowFunctionExpression extends FunctionBase {
 		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (this.annotationNoSideEffects) {
-			return false;
-		}
-
 		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) {
 			return true;
+		}
+
+		if (this.annotationNoSideEffects) {
+			return false;
 		}
 
 		if (interaction.type === INTERACTION_CALLED) {

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -121,6 +121,9 @@ export default abstract class FunctionBase extends NodeBase {
 			return this.getObjectEntity().hasEffectsOnInteractionAtPath(path, interaction, context);
 		}
 		if (this.async) {
+			if (this.annotationNoSideEffects) {
+				return false;
+			}
 			const { propertyReadSideEffects } = this.context.options
 				.treeshake as NormalizedTreeshakingOptions;
 			const returnExpression = this.scope.getReturnExpression();

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -120,10 +120,12 @@ export default abstract class FunctionBase extends NodeBase {
 		if (path.length > 0 || interaction.type !== INTERACTION_CALLED) {
 			return this.getObjectEntity().hasEffectsOnInteractionAtPath(path, interaction, context);
 		}
+
+		if (this.annotationNoSideEffects) {
+			return false;
+		}
+
 		if (this.async) {
-			if (this.annotationNoSideEffects) {
-				return false;
-			}
 			const { propertyReadSideEffects } = this.context.options
 				.treeshake as NormalizedTreeshakingOptions;
 			const returnExpression = this.scope.getReturnExpression();

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -58,11 +58,11 @@ export default class FunctionNode extends FunctionBase {
 		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
+		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) return true;
+
 		if (this.annotationNoSideEffects) {
 			return false;
 		}
-
-		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) return true;
 
 		if (interaction.type === INTERACTION_CALLED) {
 			const thisInit = context.replacedVariableInits.get(this.scope.thisVariable);

--- a/src/ast/nodes/shared/FunctionNode.ts
+++ b/src/ast/nodes/shared/FunctionNode.ts
@@ -58,11 +58,11 @@ export default class FunctionNode extends FunctionBase {
 		interaction: NodeInteraction,
 		context: HasEffectsContext
 	): boolean {
-		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) return true;
-
 		if (this.annotationNoSideEffects) {
 			return false;
 		}
+
+		if (super.hasEffectsOnInteractionAtPath(path, interaction, context)) return true;
 
 		if (interaction.type === INTERACTION_CALLED) {
 			const thisInit = context.replacedVariableInits.get(this.scope.thisVariable);

--- a/test/form/samples/no-side-effects-function-declaration/functions.js
+++ b/test/form/samples/no-side-effects-function-declaration/functions.js
@@ -51,6 +51,42 @@ export const fnF = (args) => {
   return args
 }
 
+// #__NO_SIDE_EFFECTS__
+export async function fnG(args) {
+  console.log(args)
+  return args
+}
+
+/**
+ * #__NO_SIDE_EFFECTS__
+ */ 
+export const fnH = async (args) => {
+  console.log(args)
+  return args
+}
+
+export const fnI = /*#__NO_SIDE_EFFECTS__*/ async (args) => {
+  console.log(args)
+  return args
+}
+
+
+/**
+ * #__NO_SIDE_EFFECTS__
+ */ 
+export function * fnJ(args) {
+  console.log(args)
+  return args
+}
+
+/**
+ * #__NO_SIDE_EFFECTS__
+ */ 
+export async function * fnK(args) {
+  console.log(args)
+  return args
+}
+
 /*#__NO_SIDE_EFFECTS__*/ 
 export default function fnDefault(args) {
   console.log(args)

--- a/test/form/samples/no-side-effects-function-declaration/main.js
+++ b/test/form/samples/no-side-effects-function-declaration/main.js
@@ -1,4 +1,4 @@
-import fnDefault, { fnPure, fnEffects, fnA, fnB, fnC, fnD, fnE, fnF, fnAlias, fnFromSub } from './functions'
+import fnDefault, { fnPure, fnEffects, fnA, fnB, fnC, fnD, fnE, fnF, fnI, fnG, fnJ, fnK, fnAlias, fnFromSub } from './functions'
 
 const pure = fnPure(1)
 const effects = fnEffects(2)
@@ -9,6 +9,10 @@ const c = fnC(3)
 const d = fnD(4)
 const e = fnE(5)
 const f = fnF(6)
+const g = fnG(7)
+const i = fnI(8)
+const j = fnJ(9)
+const k = fnK(10)
 
 const defaults = fnDefault(3)
 const alias = fnAlias(6)


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Thanks to @evanw for his finding: https://github.com/evanw/esbuild/issues/3149#issuecomment-1585820844. I missed async functions and generators in the initial PR. I think `__NO_SIDE_EFFECTS__` should take higher priority than `super.hasEffectsOnInteractionAtPath`.