### PR TITLE
@rollup/browser: fix types export map entry

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -27,7 +27,7 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/rollup.d.ts",
+      "types": "./dist/rollup.browser.d.ts",
       "require": "./dist/rollup.browser.js",
       "import": "./dist/es/rollup.browser.js"
     },


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no


### Description

The package exports for `@rollup/browser` have `"types"` pointing to `"./dist/rollup.d.ts"`, however the actual location of the bundled dts is `"./dist/rollup.browser.d.ts"`.