### PR TITLE
docs(tutorial): change the .js extension to .mjs

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -94,10 +94,10 @@ So far, so good, but as we start adding more options it becomes a bit of a nuisa
 
 To save repeating ourselves, we can create a config file containing all the options we need. A config file is written in JavaScript and is more flexible than the raw CLI.
 
-Create a file in the project root called `rollup.config.js`, and add the following code:
+Create a file in the project root called `rollup.config.mjs`, and add the following code:
 
 ```js
-// rollup.config.js
+// rollup.config.mjs
 export default {
 	input: 'src/main.js',
 	output: {
@@ -124,11 +124,11 @@ rollup -c -o bundle-2.js # `-o` is equivalent to `--file` (formerly "output")
 
 _Note: Rollup itself processes the config file, which is why we're able to use `export default` syntax – the code isn't being transpiled with Babel or anything similar, so you can only use ES2015 features that are supported in the version of Node.js that you're running._
 
-You can, if you like, specify a different config file from the default `rollup.config.js`:
+You can, if you like, specify a different config file from the default `rollup.config.mjs`:
 
 ```shell
-rollup --config rollup.config.dev.js
-rollup --config rollup.config.prod.js
+rollup --config rollup.config.dev.mjs
+rollup --config rollup.config.prod.mjs
 ```
 
 ## Installing Rollup locally
@@ -210,10 +210,10 @@ export default function () {
 }
 ```
 
-Edit your `rollup.config.js` file to include the JSON plugin:
+Edit your `rollup.config.mjs` file to include the JSON plugin:
 
 ```js
-// rollup.config.js
+// rollup.config.mjs
 import json from '@rollup/plugin-json';
 
 export default {
@@ -252,10 +252,10 @@ Let us extend the previous example to provide a minified build together with the
 npm install --save-dev @rollup/plugin-terser
 ```
 
-Edit your `rollup.config.js` file to add a second minified output. As format, we choose `iife`. This format wraps the code so that it can be consumed via a `script` tag in the browser while avoiding unwanted interactions with other code. As we have an export, we need to provide the name of a global variable that will be created by our bundle so that other code can access our export via this variable.
+Edit your `rollup.config.mjs` file to add a second minified output. As format, we choose `iife`. This format wraps the code so that it can be consumed via a `script` tag in the browser while avoiding unwanted interactions with other code. As we have an export, we need to provide the name of a global variable that will be created by our bundle so that other code can access our export via this variable.
 
 ```js
-// rollup.config.js
+// rollup.config.mjs
 import json from '@rollup/plugin-json';
 import terser from '@rollup/plugin-terser';
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

resolves #5060 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Currently, If users study Rollup with the tutorial docs, they will encounter an error that described in issue #5060. This PR changes `.js` extension of the config file to `.mjs`, It can fix this issue.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
