### PR TITLE
perf(sourcemap): lazy compute decoded mappings

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -48,6 +48,7 @@ import type {
 } from './rollup/types';
 import { EMPTY_OBJECT } from './utils/blank';
 import { BuildPhase } from './utils/buildPhase';
+import { decodedSourcemap, resetSourcemapCache } from './utils/decodedSourcemap';
 import { getId } from './utils/getId';
 import { getNewSet, getOrCreate } from './utils/getOrCreate';
 import { getOriginalLocation } from './utils/getOriginalLocation';
@@ -817,8 +818,18 @@ export default class Module {
 
 		this.info.code = code;
 		this.originalCode = originalCode;
-		this.originalSourcemap = originalSourcemap;
-		this.sourcemapChain = sourcemapChain;
+
+		// We need to call decodedSourcemap on the input in case they were hydrated from json in the cache and don't
+		// have the lazy evaluation cache configured. Right now this isn't enforced by the type system because the
+		// RollupCache stores `ExistingDecodedSourcemap` instead of `ExistingRawSourcemap`
+		this.originalSourcemap = decodedSourcemap(originalSourcemap);
+		this.sourcemapChain = sourcemapChain.map(mapOrMissing =>
+			mapOrMissing.missing ? mapOrMissing : decodedSourcemap(mapOrMissing)
+		);
+
+		// If coming from cache and this value is already fully decoded, we want to re-encode here to save memory.
+		resetSourcemapCache(this.originalSourcemap, this.sourcemapChain);
+
 		if (transformFiles) {
 			this.transformFiles = transformFiles;
 		}

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -74,11 +74,10 @@ export interface ExistingRawSourceMap {
 
 export type DecodedSourceMapOrMissing =
 	| {
-			mappings?: never;
 			missing: true;
 			plugin: string;
 	  }
-	| ExistingDecodedSourceMap;
+	| (ExistingDecodedSourceMap & { missing?: false });
 
 export interface SourceMap {
 	file: string;

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -52,7 +52,7 @@ export type SourceMapSegment =
 
 export interface ExistingDecodedSourceMap {
 	file?: string;
-	mappings: SourceMapSegment[][];
+	readonly mappings: SourceMapSegment[][];
 	names: string[];
 	sourceRoot?: string;
 	sources: string[];

--- a/src/utils/decodedSourcemap.ts
+++ b/src/utils/decodedSourcemap.ts
@@ -90,10 +90,6 @@ export function decodedSourcemap(map: Input): ExistingDecodedSourceMap | null {
 			cache.decodedMappings = decode(cache.encodedMappings!);
 			cache.encodedMappings = undefined;
 			return cache.decodedMappings;
-		},
-		set mappings(value) {
-			cache.decodedMappings = value;
-			cache.encodedMappings = undefined;
 		}
 	};
 

--- a/src/utils/decodedSourcemap.ts
+++ b/src/utils/decodedSourcemap.ts
@@ -1,5 +1,6 @@
-import { decode } from '@jridgewell/sourcemap-codec';
+import { decode, encode } from '@jridgewell/sourcemap-codec';
 import type {
+	DecodedSourceMapOrMissing,
 	ExistingDecodedSourceMap,
 	ExistingRawSourceMap,
 	SourceMapInput
@@ -7,6 +8,50 @@ import type {
 
 type Input = SourceMapInput | ExistingDecodedSourceMap | undefined;
 
+interface CachedSourcemapData {
+	encodedMappings: string | undefined;
+	decodedMappings: ExistingDecodedSourceMap['mappings'] | undefined;
+}
+
+const sourceMapCache = new WeakMap<ExistingDecodedSourceMap, CachedSourcemapData>();
+
+/**
+ * This clears the decoded array and falls back to the encoded string form.
+ * Sourcemap mappings arrays can be very large and holding on to them for longer
+ * than is necessary leads to poor heap utilization.
+ */
+function resetCacheToEncoded(cache: CachedSourcemapData) {
+	if (cache.encodedMappings === undefined && cache.decodedMappings) {
+		cache.encodedMappings = encode(cache.decodedMappings);
+	}
+	cache.decodedMappings = undefined;
+}
+
+export function resetSourcemapCache(
+	map: ExistingDecodedSourceMap | null,
+	sourcemapChain?: DecodedSourceMapOrMissing[]
+) {
+	if (map) {
+		const cache = sourceMapCache.get(map);
+		if (cache) {
+			resetCacheToEncoded(cache);
+		}
+	}
+
+	if (!sourcemapChain) {
+		return;
+	}
+
+	for (const map of sourcemapChain) {
+		if (map.missing) continue;
+
+		resetSourcemapCache(map);
+	}
+}
+
+export function decodedSourcemap(map: null | undefined): null;
+export function decodedSourcemap(map: Exclude<Input, null | undefined>): ExistingDecodedSourceMap;
+export function decodedSourcemap(map: Input): ExistingDecodedSourceMap | null;
 export function decodedSourcemap(map: Input): ExistingDecodedSourceMap | null {
 	if (!map) return null;
 
@@ -23,22 +68,36 @@ export function decodedSourcemap(map: Input): ExistingDecodedSourceMap | null {
 	}
 
 	const originalMappings = map.mappings;
-	let memoizedMappings: ExistingDecodedSourceMap['mappings'] | undefined;
-	return {
+	const isAlreadyDecoded = typeof originalMappings !== 'string';
+	const cache = {
+		decodedMappings: isAlreadyDecoded ? originalMappings : undefined,
+		encodedMappings: isAlreadyDecoded ? undefined : originalMappings
+	};
+
+	const decodedMap = {
 		...(map as ExistingRawSourceMap | ExistingDecodedSourceMap),
 		// By moving mappings behind an accessor, we can avoid unneeded computation for cases
 		// where the mappings field is never actually accessed. This appears to greatly reduce
 		// the overhead of sourcemap decoding in terms of both compute time and memory usage.
 		get mappings() {
-			if (memoizedMappings) {
-				return memoizedMappings;
+			if (cache.decodedMappings) {
+				return cache.decodedMappings;
 			}
-			memoizedMappings =
-				typeof originalMappings === 'string' ? decode(originalMappings) : originalMappings;
-			return memoizedMappings;
+			// If decodedMappings doesn't exist then encodedMappings should.
+			// The only scenario where cache.encodedMappings should be undefined is if the map
+			// this was constructed from was already decoded, or if mappings was set to a new
+			// decoded string. In either case, this line shouldn't get hit.
+			cache.decodedMappings = decode(cache.encodedMappings!);
+			cache.encodedMappings = undefined;
+			return cache.decodedMappings;
 		},
 		set mappings(value) {
-			memoizedMappings = value;
+			cache.decodedMappings = value;
+			cache.encodedMappings = undefined;
 		}
 	};
+
+	sourceMapCache.set(decodedMap, cache);
+
+	return decodedMap;
 }

--- a/src/utils/getOriginalLocation.ts
+++ b/src/utils/getOriginalLocation.ts
@@ -5,7 +5,7 @@ export function getOriginalLocation(
 	location: { column: number; line: number }
 ): { column: number; line: number } {
 	const filteredSourcemapChain = sourcemapChain.filter(
-		(sourcemap): sourcemap is ExistingDecodedSourceMap => !!sourcemap.mappings
+		(sourcemap): sourcemap is ExistingDecodedSourceMap => !sourcemap.missing
 	);
 	traceSourcemap: while (filteredSourcemapChain.length > 0) {
 		const sourcemap = filteredSourcemapChain.pop()!;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

By deferring the decoding of the sourcemap mappings field, we can avoid extra computation and garbage generation, both of which appear to save a significant amount of time.

In my test application (using vite), I saw a reduction in total vite build time of about **28.4%** _(8.76s)_, and a reduction in peak heap size of **19.6%** _(706 MB)_. [Update] The latest commit reduces the peak heap size by 36.6% in total (1,300 MB) for projects that deal with large sourcemaps. While the first commit reduces allocations, the second commit technically allocates more, but frees up more data to be garbage collected which has a net positive effect. The stats below reflect only the first commit, a summary of the two commits combined can be found in this comment: https://github.com/rollup/rollup/pull/5075#issuecomment-1656918949

Project Info:
* Node: v18.17.0
* Vite v4.4.7
* Rollup v3.26.3
* Module Count: 5490 modules transformed
* Chunk Count: 54 chunks rendered

Before:
* Average vite build time (5 runs): 30.89 seconds
* Average peak heap size (5 runs): 3,594.83 MB
* Time spent in GC: ~13.7 seconds
* Time spent in `decode()`: ~3.11 seconds

After:
* Average vite build time (5 runs): 22.13 seconds
* Average peak heap size (5 runs): 2,888.2 MB
* Time spent in GC: ~5.9 seconds
* Time spent in `decode()`: ~1.70 seconds

I'm happy to try to write tests for this if it is needed, but as I'm still getting my feet wet in this project that might take me a little while to figure out exactly how to go about it.

I'm also a little curious if there is a higher-level optimization to be applied that would make this no longer necessary. For example, what are the cases where we are calling `decodedSourcemap`, but then abandoning the result without ever actually accessing the mappings value? 

Are we able to avoid call to `decodedSourcemap` at all and/or any json parsing until we know we will need it to be decoded? 

Are there cases where we decode the sourcemap only to pass it back into the SourceMap constructor which then re-encodes it to a string? 

While I think those are all good questions to ask, the current solution provides enough benefit and seems relatively low risk, so IMO its worth pursuing on its own.

Allocations Before:
<img width="315" alt="image" src="https://github.com/rollup/rollup/assets/17907922/df3b4960-b7e3-4d4a-89b0-f7a55e1a3597">

Allocations After:
<img width="419" alt="image" src="https://github.com/rollup/rollup/assets/17907922/8fca4313-dcbd-4a6f-bf55-522291a22c19">
