### PR TITLE
Deoptimize custom event detail

### DIFF
--- a/src/ast/nodes/shared/knownGlobals.ts
+++ b/src/ast/nodes/shared/knownGlobals.ts
@@ -478,7 +478,17 @@ const knownGlobals: GlobalDescription = {
 	CSSSupportsRule: C,
 	CustomElementRegistry: C,
 	customElements: O,
-	CustomEvent: C,
+	CustomEvent: {
+		__proto__: null,
+		[ValueProperties]: {
+			deoptimizeArgumentsOnCall({ args }: NodeInteractionCalled) {
+				args[2]?.deoptimizePath(['detail']);
+			},
+			getLiteralValue: getTruthyLiteralValue,
+			hasEffectsWhenCalled: returnFalse
+		},
+		prototype: O
+	},
 	DataTransfer: C,
 	DataTransferItem: C,
 	DataTransferItemList: C,

--- a/test/form/samples/custom-event-detail/_config.js
+++ b/test/form/samples/custom-event-detail/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'observes side effects for custom event payloads'
+});

--- a/test/form/samples/custom-event-detail/_expected.js
+++ b/test/form/samples/custom-event-detail/_expected.js
@@ -1,0 +1,5 @@
+const detail = { value: null };
+const event = new CustomEvent('test', { detail });
+event.detail.value = true;
+if (detail.value) console.log('ok');
+else console.log('failed');

--- a/test/form/samples/custom-event-detail/main.js
+++ b/test/form/samples/custom-event-detail/main.js
@@ -1,0 +1,5 @@
+const detail = { value: null };
+const event = new CustomEvent('test', { detail });
+event.detail.value = true;
+if (detail.value) console.log('ok');
+else console.log('failed');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5122

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This deoptimizes the `detail` property of custom events as that can be mutated later.
