### PR TITLE
fix: exports `TreeshakingPreset`

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -503,7 +503,7 @@ export interface Plugin<A = any> extends OutputPlugin, Partial<PluginHooks> {
 	api?: A;
 }
 
-type TreeshakingPreset = 'smallest' | 'safest' | 'recommended';
+export type TreeshakingPreset = 'smallest' | 'safest' | 'recommended';
 
 export interface NormalizedTreeshakingOptions {
 	annotations: boolean;


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

Closes: #5128

### Description

Exports `TreeshakingPreset` to fix `tsup` `--dts-resolve` flag.