### PR TITLE
[v4.0] Remove onwarn from normalized input options

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -15,8 +15,6 @@ export interface RollupError extends RollupLog {
 	watchFiles?: string[];
 }
 
-export type RollupWarning = RollupLog;
-
 export interface RollupLog {
 	binding?: string;
 	cause?: unknown;
@@ -598,7 +596,6 @@ export interface NormalizedInputOptions {
 	maxParallelFileOps: number;
 	moduleContext: (id: string) => string;
 	onLog: LogHandler;
-	onwarn: (warning: RollupLog) => void;
 	perf: boolean;
 	plugins: Plugin[];
 	preserveEntrySignatures: PreserveEntrySignaturesOption;

--- a/src/utils/options/mergeOptions.ts
+++ b/src/utils/options/mergeOptions.ts
@@ -53,7 +53,7 @@ export async function mergeOptions(
 	const logLevel = config.logLevel || LOGLEVEL_INFO;
 	const onLog = getOnLog(config, logLevel, printLog);
 	const log = getLogger(plugins, onLog, watchMode, logLevel);
-	const inputOptions = await mergeInputOptions(config, command, plugins, log, onLog);
+	const inputOptions = mergeInputOptions(config, command, plugins, log, onLog);
 	if (command.output) {
 		Object.assign(command, command.output);
 	}
@@ -75,14 +75,14 @@ export async function mergeOptions(
 			...Object.keys(commandAliases),
 			'bundleConfigAsCjs',
 			'config',
+			'configPlugin',
 			'environment',
+			'failAfterWarnings',
 			'filterLogs',
 			'plugin',
 			'silent',
-			'failAfterWarnings',
 			'stdin',
-			'waitForBundleInput',
-			'configPlugin'
+			'waitForBundleInput'
 		],
 		'CLI flags',
 		log,

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -8,7 +8,7 @@ import type {
 import { EMPTY_ARRAY } from '../blank';
 import { ensureArray } from '../ensureArray';
 import { getLogger } from '../logger';
-import { LOGLEVEL_INFO, LOGLEVEL_WARN } from '../logging';
+import { LOGLEVEL_INFO } from '../logging';
 import { error, logInvalidOption } from '../logs';
 import { resolve } from '../path';
 import { URL_TREESHAKE, URL_TREESHAKE_MODULESIDEEFFECTS } from '../urls';
@@ -55,7 +55,6 @@ export async function normalizeInputOptions(
 		maxParallelFileOps,
 		moduleContext: getModuleContext(config, context),
 		onLog,
-		onwarn: warning => onLog(LOGLEVEL_WARN, warning),
 		perf: config.perf || false,
 		plugins,
 		preserveEntrySignatures: config.preserveEntrySignatures ?? 'exports-only',
@@ -67,7 +66,7 @@ export async function normalizeInputOptions(
 
 	warnUnknownOptions(
 		config,
-		[...Object.keys(options), 'watch'],
+		[...Object.keys(options), 'onwarn', 'watch'],
 		'input options',
 		onLog,
 		/^(output)$/

--- a/test/function/samples/logging/log-from-plugin-options-onlog-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onlog-onwarn/_config.js
@@ -36,18 +36,7 @@ module.exports = defineTest({
 			['onLog', 'info', { message: 'infoLog' }],
 			['info', 'infoLog'],
 			['onLog', 'debug', { message: 'debugLog' }],
-			['debug', 'debugLog'],
-			['onLog', 'warn', { message: 'warnWarn' }],
-			['onwarn', { message: 'warnWarn' }],
-			['warn', 'warnWarn'],
-			['onLog', 'warn', { message: 'warnWarn=' }],
-			['onwarn', { message: 'warnWarn=' }],
-			['onLog', 'warn', { message: 'warnWarn+=' }],
-			['onwarn', { message: 'warnWarn+=' }],
-			['warn', 'log was replaced'],
-			['onLog', 'warn', { message: 'warnWarn-' }],
-			['onLog', 'warn', { message: 'warnWarn+-' }],
-			['info', 'log was replaced']
+			['debug', 'debugLog']
 		]);
 		assert.strictEqual(logs[0][2].toString(), 'warnLog');
 		assert.strictEqual(logs[1][1].toString(), 'warnLog');
@@ -88,11 +77,6 @@ module.exports = defineTest({
 					options.onLog('warn', { message: 'warnLog+-' });
 					options.onLog('info', { message: 'infoLog' });
 					options.onLog('debug', { message: 'debugLog' });
-					options.onwarn({ message: 'warnWarn' });
-					options.onwarn({ message: 'warnWarn=' });
-					options.onwarn({ message: 'warnWarn+=' });
-					options.onwarn({ message: 'warnWarn-' });
-					options.onwarn({ message: 'warnWarn+-' });
 				}
 			}
 		]

--- a/test/function/samples/logging/log-from-plugin-options-onlog/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onlog/_config.js
@@ -28,14 +28,7 @@ module.exports = defineTest({
 			['onLog', 'info', { message: 'infoLog' }],
 			['info', 'infoLog'],
 			['onLog', 'debug', { message: 'debugLog' }],
-			['debug', 'debugLog'],
-			['onLog', 'warn', { message: 'warnWarn' }],
-			['warn', 'warnWarn'],
-			['onLog', 'warn', { message: 'warnWarn-' }],
-			['onLog', 'warn', { message: 'warnWarn+-' }],
-			['debug', 'log was replaced'],
-			['onLog', 'warn', { message: 'warnWarn*-' }],
-			['info', 'log was replaced with string']
+			['debug', 'debugLog']
 		]);
 		assert.strictEqual(logs[0][2].toString(), 'warnLog');
 		assert.strictEqual(logs[2][2].toString(), '(fooPlugin plugin) fooFile (1:2) warnLog');
@@ -68,10 +61,6 @@ module.exports = defineTest({
 					options.onLog('warn', { message: 'warnLog*-' });
 					options.onLog('info', { message: 'infoLog' });
 					options.onLog('debug', { message: 'debugLog' });
-					options.onwarn({ message: 'warnWarn' });
-					options.onwarn({ message: 'warnWarn-' });
-					options.onwarn({ message: 'warnWarn+-' });
-					options.onwarn({ message: 'warnWarn*-' });
 				}
 			}
 		]

--- a/test/function/samples/logging/log-from-plugin-options-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onwarn/_config.js
@@ -25,14 +25,7 @@ module.exports = defineTest({
 			['onwarn', { message: 'warnLog*-' }],
 			['warn', 'log was replaced with string'],
 			['info', 'infoLog'],
-			['debug', 'debugLog'],
-			['onwarn', { message: 'warnWarn' }],
-			['warn', 'warnWarn'],
-			['onwarn', { message: 'warnWarn-' }],
-			['onwarn', { message: 'warnWarn+-' }],
-			['warn', 'log was replaced'],
-			['onwarn', { message: 'warnWarn*-' }],
-			['warn', 'log was replaced with string']
+			['debug', 'debugLog']
 		]);
 		assert.strictEqual(logs[0][1].toString(), 'warnLog');
 		assert.strictEqual(logs[2][1].toString(), '(fooPlugin plugin) fooFile (1:2) warnLog');
@@ -65,10 +58,6 @@ module.exports = defineTest({
 					options.onLog('warn', { message: 'warnLog*-' });
 					options.onLog('info', { message: 'infoLog' });
 					options.onLog('debug', { message: 'debugLog' });
-					options.onwarn({ message: 'warnWarn' });
-					options.onwarn({ message: 'warnWarn-' });
-					options.onwarn({ message: 'warnWarn+-' });
-					options.onwarn({ message: 'warnWarn*-' });
 				}
 			}
 		]

--- a/test/function/samples/logging/log-from-plugin-options-simple/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-simple/_config.js
@@ -15,14 +15,12 @@ module.exports = defineTest({
 		assert.deepStrictEqual(logs, [
 			['warn', 'warnLog'],
 			['info', 'infoLog'],
-			['debug', 'debugLog'],
-			['warn', 'warnWarn']
+			['debug', 'debugLog']
 		]);
 		assert.deepStrictEqual(pluginLogs, [
 			['warn', { message: 'warnLog' }],
 			['info', { message: 'infoLog' }],
-			['debug', { message: 'debugLog' }],
-			['warn', { message: 'warnWarn' }]
+			['debug', { message: 'debugLog' }]
 		]);
 	},
 	options: {
@@ -36,7 +34,6 @@ module.exports = defineTest({
 					options.onLog('warn', { message: 'warnLog' });
 					options.onLog('info', { message: 'infoLog' });
 					options.onLog('debug', { message: 'debugLog' });
-					options.onwarn({ message: 'warnWarn' });
 				},
 				onLog(level, log) {
 					pluginLogs.push([level, log]);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
As we have `onLog` now, there is no reason to expose and maintain `onwarn` as well on the normalized input options. Also removes the `RollupWarning` type.