### PR TITLE
Fully deoptimize first level path when deoptimizing nested parameter paths

### DIFF
--- a/src/ast/variables/ParameterVariable.ts
+++ b/src/ast/variables/ParameterVariable.ts
@@ -109,7 +109,7 @@ export default class ParameterVariable extends LocalVariable {
 		for (const entity of this.entitiesToBeDeoptimized) {
 			// We do not need a recursion tracker here as we already track whether
 			// this field is deoptimized
-			entity.deoptimizePath(path);
+			entity.deoptimizePath([key]);
 		}
 		if (key === UnknownKey) {
 			// save some memory

--- a/test/function/samples/track-mutated-in-callback/_config.js
+++ b/test/function/samples/track-mutated-in-callback/_config.js
@@ -1,0 +1,8 @@
+module.exports = defineTest({
+	description: 'tracks mutations of variables in callbacks passed to globals',
+	context: {
+		globalFunction(callback) {
+			callback(true);
+		}
+	}
+});

--- a/test/function/samples/track-mutated-in-callback/main.js
+++ b/test/function/samples/track-mutated-in-callback/main.js
@@ -1,0 +1,10 @@
+const createCallback = box => newValue => {
+	box[0] = newValue;
+	return box[0];
+};
+
+const box = [null];
+const callback = createCallback(box);
+globalFunction(callback);
+
+assert.ok(box[0] ? true : false);


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Resolves #5152

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There was an asymmetry in the deoptimization logic that falsely marked parameter properties as "deoptimized" even though only their nested properties were deoptimized.