### PR TITLE
[v4.0] Handle empty exports

### DIFF
--- a/rust/parse_ast/src/convert_ast/converter.rs
+++ b/rust/parse_ast/src/convert_ast/converter.rs
@@ -674,14 +674,15 @@ impl<'a> AstConverter<'a> {
   }
 
   fn convert_export_named_declaration(&mut self, export_named_declaration: &NamedExport) {
-    match export_named_declaration.specifiers.first().unwrap() {
-      ExportSpecifier::Namespace(export_namespace_specifier) => self.store_export_all_declaration(
-        &export_named_declaration.span,
-        export_named_declaration.src.as_ref().unwrap(),
-        &export_named_declaration.with,
-        Some(&export_namespace_specifier.name),
-      ),
-      ExportSpecifier::Named(_) => self.store_export_named_declaration(
+    match export_named_declaration.specifiers.first() {
+      Some(ExportSpecifier::Namespace(export_namespace_specifier)) => self
+        .store_export_all_declaration(
+          &export_named_declaration.span,
+          export_named_declaration.src.as_ref().unwrap(),
+          &export_named_declaration.with,
+          Some(&export_namespace_specifier.name),
+        ),
+      None | Some(ExportSpecifier::Named(_)) => self.store_export_named_declaration(
         &export_named_declaration.span,
         &export_named_declaration.specifiers,
         export_named_declaration
@@ -691,7 +692,7 @@ impl<'a> AstConverter<'a> {
         None,
         &export_named_declaration.with,
       ),
-      ExportSpecifier::Default(_) => panic!("Unexpected default export specifier"),
+      Some(ExportSpecifier::Default(_)) => panic!("Unexpected default export specifier"),
     }
   }
 

--- a/test/form/samples/empty-export/_config.js
+++ b/test/form/samples/empty-export/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'handles empty exports'
+});

--- a/test/form/samples/empty-export/_expected/amd.js
+++ b/test/form/samples/empty-export/_expected/amd.js
@@ -1,0 +1,5 @@
+define((function () { 'use strict';
+
+	console.log('main');
+
+}));

--- a/test/form/samples/empty-export/_expected/cjs.js
+++ b/test/form/samples/empty-export/_expected/cjs.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('main');

--- a/test/form/samples/empty-export/_expected/es.js
+++ b/test/form/samples/empty-export/_expected/es.js
@@ -1,0 +1,1 @@
+console.log('main');

--- a/test/form/samples/empty-export/_expected/iife.js
+++ b/test/form/samples/empty-export/_expected/iife.js
@@ -1,0 +1,6 @@
+(function () {
+	'use strict';
+
+	console.log('main');
+
+})();

--- a/test/form/samples/empty-export/_expected/system.js
+++ b/test/form/samples/empty-export/_expected/system.js
@@ -1,0 +1,10 @@
+System.register([], (function () {
+	'use strict';
+	return {
+		execute: (function () {
+
+			console.log('main');
+
+		})
+	};
+}));

--- a/test/form/samples/empty-export/_expected/umd.js
+++ b/test/form/samples/empty-export/_expected/umd.js
@@ -1,0 +1,8 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+})((function () { 'use strict';
+
+	console.log('main');
+
+}));

--- a/test/form/samples/empty-export/main.js
+++ b/test/form/samples/empty-export/main.js
@@ -1,0 +1,2 @@
+console.log('main');
+export {};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There was a small bug in the code that prevented parsing of the empty export `export {}`.