### PR TITLE
Deoptimize all parameters when losing track of a function

### DIFF
--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -74,8 +74,13 @@ export default abstract class FunctionBase extends NodeBase {
 		this.getObjectEntity().deoptimizePath(path);
 		if (path.length === 1 && path[0] === UnknownKey) {
 			// A reassignment of UNKNOWN_PATH is considered equivalent to having lost track
-			// which means the return expression needs to be reassigned
+			// which means the return expression and parameters need to be reassigned
 			this.scope.getReturnExpression().deoptimizePath(UNKNOWN_PATH);
+			for (const parameterList of this.scope.parameters) {
+				for (const parameter of parameterList) {
+					parameter.deoptimizePath(UNKNOWN_PATH);
+				}
+			}
 		}
 	}
 

--- a/test/function/samples/mutate-via-parameter/_config.js
+++ b/test/function/samples/mutate-via-parameter/_config.js
@@ -1,0 +1,9 @@
+const assert = require('node:assert');
+
+module.exports = defineTest({
+	description:
+		'respects variable mutations via unknown parameter values if we lose track of a function',
+	exports({ test }) {
+		assert.ok(test(state => (state.modified = true)));
+	}
+});

--- a/test/function/samples/mutate-via-parameter/main.js
+++ b/test/function/samples/mutate-via-parameter/main.js
@@ -1,0 +1,8 @@
+export function test(callback) {
+	const state = {
+		modified: false
+	};
+	callback(state);
+	if (state.modified) return true;
+	return false;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5156

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
I wonder why this did not turn up earlier. Basically we need to assume a function can be called with arbitrary values when we lose track of it e.g. because it is exported.