### PR TITLE
[v4.0] warn for invalid annotations

### DIFF
--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -2082,8 +2082,12 @@ class Impure {
 	}
 }
 
-/*@__PURE__*/ new Impure();
+/*@__PURE__ There may be additional text in the comment */ new Impure();
 ```
+
+Such an annotation is considered _valid_ if it directly precedes a function call or constructor invocation and is only separated from the callee by white-space or comments. The only exception are parentheses that wrap a call or invocation.
+
+Invalid annotations are removed and Rollup emits a warning. Valid annotations remain in the code unless their function call or constructor invocation is removed as well.
 
 ##### `@__NO_SIDE_EFFECTS__`
 
@@ -2103,6 +2107,10 @@ const impureArrowFn = () => {
 impure(); // <-- call will be considered as side effect free
 impureArrowFn(); // <-- call will be considered as side effect free
 ```
+
+Such an annotation is considered _valid_ if it directly precedes a function declaration or a constant variable declaration where the first declared variable is a function and is only separated from the declaration by white-space or comments.
+
+Invalid annotations are removed and Rollup emits a warning. Valid annotations remain in the code unless their declaration is removed as well
 
 #### treeshake.correctVarValueBeforeDeclaration
 

--- a/src/ast/nodes/VariableDeclaration.ts
+++ b/src/ast/nodes/VariableDeclaration.ts
@@ -179,6 +179,7 @@ export default class VariableDeclaration extends NodeBase {
 		for (const { node, start, separator, contentEnd, end } of separatedNodes) {
 			if (!node.included) {
 				code.remove(start, end);
+				node.removeAnnotations(code);
 				continue;
 			}
 			node.render(code, options);

--- a/src/utils/convert-ast.ts
+++ b/src/utils/convert-ast.ts
@@ -1234,7 +1234,7 @@ interface ImportExpression extends estree.ImportExpression {
 export const ANNOTATION_KEY = '_rollupAnnotations';
 export const INVALID_ANNOTATION_KEY = '_rollupRemoved';
 
-type AnnotationType = 'pure' | 'noSideEffects';
+export type AnnotationType = 'pure' | 'noSideEffects';
 
 export interface RollupAnnotation {
 	start: number;

--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -6,6 +6,7 @@ import type {
 	NormalizedInputOptions,
 	RollupLog
 } from '../rollup/types';
+import type { AnnotationType } from './convert-ast';
 import getCodeFrame from './getCodeFrame';
 import { LOGLEVEL_WARN } from './logging';
 import { extname } from './path';
@@ -26,7 +27,9 @@ import {
 	URL_OUTPUT_NAME,
 	URL_SOURCEMAP_IS_LIKELY_TO_BE_INCORRECT,
 	URL_THIS_IS_UNDEFINED,
-	URL_TREATING_MODULE_AS_EXTERNAL_DEPENDENCY
+	URL_TREATING_MODULE_AS_EXTERNAL_DEPENDENCY,
+	URL_TREESHAKE_NOSIDEEFFECTS,
+	URL_TREESHAKE_PURE
 } from './urls';
 
 export function error(base: Error | RollupLog): never {
@@ -97,6 +100,7 @@ const ADDON_ERROR = 'ADDON_ERROR',
 	ILLEGAL_IDENTIFIER_AS_NAME = 'ILLEGAL_IDENTIFIER_AS_NAME',
 	ILLEGAL_REASSIGNMENT = 'ILLEGAL_REASSIGNMENT',
 	INCONSISTENT_IMPORT_ATTRIBUTES = 'INCONSISTENT_IMPORT_ATTRIBUTES',
+	INVALID_ANNOTATION = 'INVALID_ANNOTATION',
 	INPUT_HOOK_IN_OUTPUT_PLUGIN = 'INPUT_HOOK_IN_OUTPUT_PLUGIN',
 	INVALID_CHUNK = 'INVALID_CHUNK',
 	INVALID_CONFIG_MODULE_FORMAT = 'INVALID_CONFIG_MODULE_FORMAT',
@@ -422,6 +426,17 @@ const formatAttributes = (attributes: Record<string, string>): string => {
 	if (entries.length === 0) return 'no';
 	return entries.map(([key, value]) => `"${key}": "${value}"`).join(', ');
 };
+
+export function logInvalidAnnotation(comment: string, id: string, type: AnnotationType): RollupLog {
+	return {
+		code: INVALID_ANNOTATION,
+		id,
+		message: `A comment\n\n"${comment}"\n\nin "${relativeId(
+			id
+		)}" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.`,
+		url: getRollupUrl(type === 'noSideEffects' ? URL_TREESHAKE_NOSIDEEFFECTS : URL_TREESHAKE_PURE)
+	};
+}
 
 export function logInputHookInOutputPlugin(pluginName: string, hookName: string): RollupLog {
 	return {

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -30,6 +30,8 @@ export const URL_OUTPUT_SOURCEMAPBASEURL = 'configuration-options/#output-source
 export const URL_OUTPUT_SOURCEMAPFILE = 'configuration-options/#output-sourcemapfile';
 export const URL_PRESERVEENTRYSIGNATURES = 'configuration-options/#preserveentrysignatures';
 export const URL_TREESHAKE = 'configuration-options/#treeshake';
+export const URL_TREESHAKE_PURE = 'configuration-options/#pure';
+export const URL_TREESHAKE_NOSIDEEFFECTS = 'configuration-options/#no-side-effects';
 export const URL_TREESHAKE_MODULESIDEEFFECTS = 'configuration-options/#treeshake-modulesideeffects';
 export const URL_WATCH = 'configuration-options/#watch';
 

--- a/test/form/samples/nested-pure-comments/_config.js
+++ b/test/form/samples/nested-pure-comments/_config.js
@@ -1,3 +1,4 @@
 module.exports = defineTest({
-	description: 'correctly associates pure comments before sequence expressions etc.'
+	description: 'correctly associates pure comments before sequence expressions etc.',
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/form/samples/no-side-effects-function-declaration-preserve/_config.js
+++ b/test/form/samples/no-side-effects-function-declaration-preserve/_config.js
@@ -1,3 +1,4 @@
 module.exports = defineTest({
-	description: 'preserve __NO_SIDE_EFFECTS__ annotations for function declarations'
+	description: 'preserve __NO_SIDE_EFFECTS__ annotations for function declarations',
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/form/samples/pure-comment-line-break/_config.js
+++ b/test/form/samples/pure-comment-line-break/_config.js
@@ -1,3 +1,4 @@
 module.exports = defineTest({
-	description: 'adjust line-break handling when dealing with pure annotations'
+	description: 'adjust line-break handling when dealing with pure annotations',
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/form/samples/pure-comment-scenarios-complex/_config.js
+++ b/test/form/samples/pure-comment-scenarios-complex/_config.js
@@ -1,5 +1,6 @@
 // tests compiled from https://github.com/mishoo/UglifyJS2/blob/bcebacbb9e7ddac7d9c0e4ca2c7e0faf0e0bca7c/test/compress/issue-1261.js
 
 module.exports = defineTest({
-	description: 'correctly handles various advanced pure comment scenarios'
+	description: 'correctly handles various advanced pure comment scenarios',
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/form/samples/pure-comment-scenarios-simple/_config.js
+++ b/test/form/samples/pure-comment-scenarios-simple/_config.js
@@ -1,5 +1,6 @@
 // tests compiled from https://github.com/mishoo/UglifyJS2/blob/88c8f4e363e0d585b33ea29df560243d3dc74ce1/test/compress/pure_funcs.js
 
 module.exports = defineTest({
-	description: 'correctly handles various pure comment scenarios'
+	description: 'correctly handles various pure comment scenarios',
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/form/samples/pure-comments-disabled/_config.js
+++ b/test/form/samples/pure-comments-disabled/_config.js
@@ -4,5 +4,6 @@ module.exports = defineTest({
 		treeshake: {
 			annotations: false
 		}
-	}
+	},
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/form/samples/remove-invalid-pure-comments/_config.js
+++ b/test/form/samples/remove-invalid-pure-comments/_config.js
@@ -1,3 +1,4 @@
 module.exports = defineTest({
-	description: 'removes invalidly placed pure annotations'
+	description: 'removes invalidly placed pure annotations',
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/form/samples/remove-no-side-effects-variable/_config.js
+++ b/test/form/samples/remove-no-side-effects-variable/_config.js
@@ -1,5 +1,4 @@
 module.exports = defineTest({
-	solo: true,
 	description:
 		'removes __NO_SIDE_EFFECTS__ annotation if the variable declaration is only removed partially'
 });

--- a/test/form/samples/remove-no-side-effects-variable/_config.js
+++ b/test/form/samples/remove-no-side-effects-variable/_config.js
@@ -1,0 +1,5 @@
+module.exports = defineTest({
+	solo: true,
+	description:
+		'removes __NO_SIDE_EFFECTS__ annotation if the variable declaration is only removed partially'
+});

--- a/test/form/samples/remove-no-side-effects-variable/_expected.js
+++ b/test/form/samples/remove-no-side-effects-variable/_expected.js
@@ -1,0 +1,5 @@
+const bar = () => console.log();
+
+// should be retained, but the annotation needs to be removed, otherwise it
+// will appear to be side effect free for downstream consumers.
+bar();

--- a/test/form/samples/remove-no-side-effects-variable/main.js
+++ b/test/form/samples/remove-no-side-effects-variable/main.js
@@ -1,0 +1,9 @@
+/*@__NO_SIDE_EFFECTS__*/
+const foo = () => console.log(), bar = () => console.log();
+
+// should be removed
+foo();
+
+// should be retained, but the annotation needs to be removed, otherwise it
+// will appear to be side effect free for downstream consumers.
+bar();

--- a/test/form/samples/remove-tree-shaken-pure-comments/_config.js
+++ b/test/form/samples/remove-tree-shaken-pure-comments/_config.js
@@ -1,3 +1,4 @@
 module.exports = defineTest({
-	description: 'removes pure comments of tree-shaken nodes'
+	description: 'removes pure comments of tree-shaken nodes',
+	expectedWarnings: ['INVALID_ANNOTATION']
 });

--- a/test/function/samples/warn-misplaced-annotations/_config.js
+++ b/test/function/samples/warn-misplaced-annotations/_config.js
@@ -1,0 +1,63 @@
+const { join } = require('node:path');
+const ID_MAIN = join(__dirname, 'main.js');
+
+module.exports = defineTest({
+	description: 'warns for misplaced annotations',
+	warnings: [
+		{
+			code: 'INVALID_ANNOTATION',
+			id: ID_MAIN,
+			message:
+				'A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+			url: 'https://rollupjs.org/configuration-options/#no-side-effects',
+			pos: 45,
+			loc: {
+				column: 0,
+				file: ID_MAIN,
+				line: 2
+			},
+			frame: `
+				1: /*@__PURE__*/ const x = () => console.log();
+				2: /*@__NO_SIDE_EFFECTS__*/ const foo = 1,
+				   ^
+				3:   bar = () => console.log();
+				4: /*@__NO_SIDE_EFFECTS__*/ assert.ok(true);`
+		},
+		{
+			code: 'INVALID_ANNOTATION',
+			id: ID_MAIN,
+			message:
+				'A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+			url: 'https://rollupjs.org/configuration-options/#no-side-effects',
+			pos: 113,
+			loc: {
+				column: 0,
+				file: ID_MAIN,
+				line: 4
+			},
+			frame: `
+				2: /*@__NO_SIDE_EFFECTS__*/ const foo = 1,
+				3:   bar = () => console.log();
+				4: /*@__NO_SIDE_EFFECTS__*/ assert.ok(true);
+				   ^`
+		},
+		{
+			code: 'INVALID_ANNOTATION',
+			id: ID_MAIN,
+			message:
+				'A comment\n\n"/*@__PURE__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+			url: 'https://rollupjs.org/configuration-options/#pure',
+			pos: 0,
+			loc: {
+				column: 0,
+				file: ID_MAIN,
+				line: 1
+			},
+			frame: `
+				1: /*@__PURE__*/ const x = () => console.log();
+				   ^
+				2: /*@__NO_SIDE_EFFECTS__*/ const foo = 1,
+				3:   bar = () => console.log();`
+		}
+	]
+});

--- a/test/function/samples/warn-misplaced-annotations/main.js
+++ b/test/function/samples/warn-misplaced-annotations/main.js
@@ -1,0 +1,4 @@
+/*@__PURE__*/ const x = () => console.log();
+/*@__NO_SIDE_EFFECTS__*/ const foo = 1,
+	bar = () => console.log();
+/*@__NO_SIDE_EFFECTS__*/ assert.ok(true);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This adds a warning when Rollup encounters a `@__PURE__` or `@__NO_SIDE_EFFECTS__` annotations in an invalid position. The warning contains a link to the documentation to educate users how to place annotations.
The warning looks like this:

```
(!) A comment

"/*@__NO_SIDE_EFFECTS__*/"

in "src/main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.
https://rollupjs.org/https://rollupjs.org/configuration-options/#no-side-effects
src/main.js (4:0)
2: /*@__NO_SIDE_EFFECTS__*/ const foo = 1,
3:   bar = () => console.log();
4: /*@__NO_SIDE_EFFECTS__*/ assert.ok(true);
   ^
```