### PR TITLE
fix: ignores empty statements in class body that is returned by SWC parser

### DIFF
--- a/rust/parse_ast/src/convert_ast/converter.rs
+++ b/rust/parse_ast/src/convert_ast/converter.rs
@@ -556,10 +556,10 @@ impl<'a> AstConverter<'a> {
       ClassMember::PrivateMethod(private_method) => self.convert_private_method(private_method),
       ClassMember::PrivateProp(private_property) => self.convert_private_property(private_property),
       ClassMember::StaticBlock(static_block) => self.convert_static_block(static_block),
+      ClassMember::Empty(empty_stmt) => self.convert_empty_statement(empty_stmt),
       ClassMember::TsIndexSignature(_) => {
         unimplemented!("Cannot convert ClassMember::TsIndexSignature")
       }
-      ClassMember::Empty(_) => unimplemented!("Cannot convert ClassMember::Empty"),
       ClassMember::AutoAccessor(_) => unimplemented!("Cannot convert ClassMember::AutoAccessor"),
     }
   }

--- a/rust/parse_ast/src/convert_ast/converter.rs
+++ b/rust/parse_ast/src/convert_ast/converter.rs
@@ -556,11 +556,11 @@ impl<'a> AstConverter<'a> {
       ClassMember::PrivateMethod(private_method) => self.convert_private_method(private_method),
       ClassMember::PrivateProp(private_property) => self.convert_private_property(private_property),
       ClassMember::StaticBlock(static_block) => self.convert_static_block(static_block),
-      ClassMember::Empty(empty_stmt) => self.convert_empty_statement(empty_stmt),
       ClassMember::TsIndexSignature(_) => {
         unimplemented!("Cannot convert ClassMember::TsIndexSignature")
       }
       ClassMember::AutoAccessor(_) => unimplemented!("Cannot convert ClassMember::AutoAccessor"),
+      ClassMember::Empty(_) => {}
     }
   }
 
@@ -1543,8 +1543,15 @@ impl<'a> AstConverter<'a> {
 
   fn convert_class_body(&mut self, class_members: &Vec<ClassMember>, start: u32, end: u32) {
     let end_position = self.add_type_and_explicit_start(&TYPE_CLASS_BODY, start);
+    let class_members_filtered: Vec<&ClassMember> = class_members
+      .iter()
+      .filter(|class_member| match class_member {
+        ClassMember::Empty(_) => false,
+        _ => true,
+      })
+      .collect();
     // body
-    self.convert_item_list(class_members, |ast_converter, class_member| {
+    self.convert_item_list(&class_members_filtered, |ast_converter, class_member| {
       ast_converter.convert_class_member(class_member);
       true
     });

--- a/src/ast/nodes/EmptyStatement.ts
+++ b/src/ast/nodes/EmptyStatement.ts
@@ -1,4 +1,3 @@
-import type MagicString from 'magic-string';
 import type * as NodeType from './NodeType';
 import { StatementBase } from './shared/Node';
 
@@ -7,8 +6,5 @@ export default class EmptyStatement extends StatementBase {
 
 	hasEffects(): boolean {
 		return false;
-	}
-	render(code: MagicString) {
-		code.remove(this.start, this.end);
 	}
 }

--- a/src/ast/nodes/EmptyStatement.ts
+++ b/src/ast/nodes/EmptyStatement.ts
@@ -1,3 +1,4 @@
+import type MagicString from 'magic-string';
 import type * as NodeType from './NodeType';
 import { StatementBase } from './shared/Node';
 
@@ -6,5 +7,8 @@ export default class EmptyStatement extends StatementBase {
 
 	hasEffects(): boolean {
 		return false;
+	}
+	render(code: MagicString) {
+		code.remove(this.start, this.end);
 	}
 }

--- a/test/form/samples/empty-statament-class-member/_config.js
+++ b/test/form/samples/empty-statament-class-member/_config.js
@@ -1,4 +1,3 @@
 module.exports = defineTest({
-	description: 'remove empty statement from class member',
-	verifyAst: false
+	description: 'Do not crash if class body has empty statements'
 });

--- a/test/form/samples/empty-statament-class-member/_config.js
+++ b/test/form/samples/empty-statament-class-member/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description: 'remove empty statement from class member',
+	verifyAst: false
+});

--- a/test/form/samples/empty-statament-class-member/_expected/amd.js
+++ b/test/form/samples/empty-statament-class-member/_expected/amd.js
@@ -1,0 +1,11 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	class Foo {
+		foo() {
+			console.log(3);
+		}
+	}
+
+	exports.Foo = Foo;
+
+}));

--- a/test/form/samples/empty-statament-class-member/_expected/amd.js
+++ b/test/form/samples/empty-statament-class-member/_expected/amd.js
@@ -1,11 +1,11 @@
-define(['exports'], (function (exports) { 'use strict';
+define((function () { 'use strict';
 
 	class Foo {
 		foo() {
-			console.log(3);
-		}
+			console.log('foo');
+		};
 	}
 
-	exports.Foo = Foo;
+	console.log(Foo);
 
 }));

--- a/test/form/samples/empty-statament-class-member/_expected/cjs.js
+++ b/test/form/samples/empty-statament-class-member/_expected/cjs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+class Foo {
+	foo() {
+		console.log(3);
+	}
+}
+
+exports.Foo = Foo;

--- a/test/form/samples/empty-statament-class-member/_expected/cjs.js
+++ b/test/form/samples/empty-statament-class-member/_expected/cjs.js
@@ -2,8 +2,8 @@
 
 class Foo {
 	foo() {
-		console.log(3);
-	}
+		console.log('foo');
+	};
 }
 
-exports.Foo = Foo;
+console.log(Foo);

--- a/test/form/samples/empty-statament-class-member/_expected/es.js
+++ b/test/form/samples/empty-statament-class-member/_expected/es.js
@@ -1,7 +1,7 @@
 class Foo {
 	foo() {
-		console.log(3);
-	}
+		console.log('foo');
+	};
 }
 
-export { Foo };
+console.log(Foo);

--- a/test/form/samples/empty-statament-class-member/_expected/es.js
+++ b/test/form/samples/empty-statament-class-member/_expected/es.js
@@ -1,0 +1,7 @@
+class Foo {
+	foo() {
+		console.log(3);
+	}
+}
+
+export { Foo };

--- a/test/form/samples/empty-statament-class-member/_expected/iife.js
+++ b/test/form/samples/empty-statament-class-member/_expected/iife.js
@@ -1,14 +1,12 @@
-(function (exports) {
+(function () {
 	'use strict';
 
 	class Foo {
 		foo() {
-			console.log(3);
-		}
+			console.log('foo');
+		};
 	}
 
-	exports.Foo = Foo;
+	console.log(Foo);
 
-	return exports;
-
-})({});
+})();

--- a/test/form/samples/empty-statament-class-member/_expected/iife.js
+++ b/test/form/samples/empty-statament-class-member/_expected/iife.js
@@ -1,0 +1,14 @@
+(function (exports) {
+	'use strict';
+
+	class Foo {
+		foo() {
+			console.log(3);
+		}
+	}
+
+	exports.Foo = Foo;
+
+	return exports;
+
+})({});

--- a/test/form/samples/empty-statament-class-member/_expected/system.js
+++ b/test/form/samples/empty-statament-class-member/_expected/system.js
@@ -1,0 +1,14 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			class Foo {
+				foo() {
+					console.log(3);
+				}
+			} exports('Foo', Foo);
+
+		})
+	};
+}));

--- a/test/form/samples/empty-statament-class-member/_expected/system.js
+++ b/test/form/samples/empty-statament-class-member/_expected/system.js
@@ -1,13 +1,15 @@
-System.register([], (function (exports) {
+System.register([], (function () {
 	'use strict';
 	return {
 		execute: (function () {
 
 			class Foo {
 				foo() {
-					console.log(3);
-				}
-			} exports('Foo', Foo);
+					console.log('foo');
+				};
+			}
+
+			console.log(Foo);
 
 		})
 	};

--- a/test/form/samples/empty-statament-class-member/_expected/umd.js
+++ b/test/form/samples/empty-statament-class-member/_expected/umd.js
@@ -1,0 +1,14 @@
+(function (factory) {
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory();
+})((function () { 'use strict';
+
+	class Foo {
+		foo() {
+			console.log('foo');
+		};
+	}
+
+	console.log(Foo);
+
+}));

--- a/test/form/samples/empty-statament-class-member/main.js
+++ b/test/form/samples/empty-statament-class-member/main.js
@@ -1,5 +1,7 @@
-export class Foo {
+class Foo {
 	foo() {
-		console.log(3);
+		console.log('foo');
 	};
 }
+
+console.log(Foo);

--- a/test/form/samples/empty-statament-class-member/main.js
+++ b/test/form/samples/empty-statament-class-member/main.js
@@ -1,0 +1,5 @@
+export class Foo {
+	foo() {
+		console.log(3);
+	};
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #5171 
<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
~~This PR also defines the default rendering of the `EmptyStatement` node~~
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
