### PR TITLE
Handle special characters before double underscores

### DIFF
--- a/test/form/samples/handles-special-comments/_config.js
+++ b/test/form/samples/handles-special-comments/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'does not fail on certain comments (#5174)'
+});

--- a/test/form/samples/handles-special-comments/_expected.js
+++ b/test/form/samples/handles-special-comments/_expected.js
@@ -1,0 +1,2 @@
+// “__
+console.log('main');

--- a/test/form/samples/handles-special-comments/main.js
+++ b/test/form/samples/handles-special-comments/main.js
@@ -1,0 +1,2 @@
+// “__
+console.log('main');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5174

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The logic to efficiently detect pure comments was assuming that the character preceding a double underscore always had a by length of 1, which is fixed here.