### PR TITLE
docs: fix code example for `onLog`

### DIFF
--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -492,7 +492,7 @@ export default {
 		if (level === 'warn') {
 			handler('error', log); // turn other warnings into errors
 		} else {
-			handler(level, info); // otherwise, just print the log
+			handler(level, log); // otherwise, just print the log
 		}
 	}
 };


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

I think `log` is meant to be passed through? There is no `info` variable.