### PR TITLE
perf: use mimalloc for bindings_napi

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
 name = "bindings_napi"
 version = "0.0.0"
 dependencies = [
+ "mimalloc-rust",
  "napi",
  "napi-build",
  "napi-derive",
@@ -332,6 +333,12 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "dashmap"
@@ -679,6 +686,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "mimalloc-rust"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb726c8298efb4010b2c46d8050e4be36cf807b9d9e98cb112f830914fc9bbe"
+dependencies = [
+ "cty",
+ "mimalloc-rust-sys",
+]
+
+[[package]]
+name = "mimalloc-rust-sys"
+version = "1.7.9-source"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6413e13241a9809f291568133eca6694572cf528c1a6175502d090adce5dd5db"
+dependencies = [
+ "cc",
+ "cty",
 ]
 
 [[package]]

--- a/rust/bindings_napi/Cargo.toml
+++ b/rust/bindings_napi/Cargo.toml
@@ -15,5 +15,11 @@ napi-derive = "2.13.0"
 parse_ast = { path = "../parse_ast" }
 xxhash = { path = "../xxhash" }
 
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+mimalloc-rust = { version = "0.2" }
+
+[target.'cfg(all(target_os = "linux", not(all(target_env = "musl", target_arch = "aarch64"))))'.dependencies]
+mimalloc-rust = { version = "0.2", features = ["local-dynamic-tls"] }
+
 [build-dependencies]
 napi-build = "2.0.1"

--- a/rust/bindings_napi/src/lib.rs
+++ b/rust/bindings_napi/src/lib.rs
@@ -2,6 +2,13 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use parse_ast::parse_ast;
 
+#[cfg(all(
+  not(all(target_os = "linux", target_env = "musl", target_arch = "aarch64")),
+  not(debug_assertions)
+))]
+#[global_allocator]
+static ALLOC: mimalloc_rust::GlobalMiMalloc = mimalloc_rust::GlobalMiMalloc;
+
 #[napi]
 pub fn parse(code: String, allow_return_outside_function: bool) -> Buffer {
   parse_ast(code, allow_return_outside_function).into()


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR swaps the memory allocator with [mimalloc](https://github.com/microsoft/mimalloc).
This allocator seems to be common in napi-rs world ([swc](https://github.com/swc-project/swc/blob/1c67df55f52f229beeed487066b577b2c3fb40e5/crates/swc_node_base/src/lib.rs), [@napi-rs/fast-escape](https://github.com/napi-rs/fast-escape/blob/03191e7628a44c856275f21bc10745c0d24ff4d6/src/lib.rs#L10-L15), [parcel](https://github.com/parcel-bundler/parcel/blob/b521cfbdaace01674b7919d41201bb523cc14e41/crates/node-bindings/src/lib.rs#L4-L10), [@resvg/resvg-js](https://github.com/yisibl/resvg-js/blob/4e689705eb1416d0aa25a058cc7074e3b3a9a642/src/lib.rs#L38-L45)).
Some projects uses jemallocator on some OS/architectures and ideally we should check which allocator performs better on each of them. But I'll leave this investigation for now.

Running the benchmark in https://github.com/rollup/rollup/issues/5182 (actually I used the esbuild repo instead), I got ~200ms / ~3% improvement on my laptop.

<details>
<summary>Benchmark results</summary>

#### rollup 3.29.4
```
# BUILD: 6079ms, 934 MB / 944 MB
## initialize: 1ms, 3.55 kB / 9.85 MB
## generate module graph: 2891ms, 765 MB / 775 MB
- plugin 0 (stdin) - resolveId: 16ms, -3.18 MB / 773 MB
- plugin 0 (stdin) - load: 7ms, 883 kB / 774 MB
generate ast: 632ms, 159 MB / 774 MB
analyze ast: 1382ms, 829 MB / 774 MB
## sort and bind modules: 253ms, 38.4 MB / 813 MB
## mark included statements: 2934ms, 131 MB / 944 MB
treeshaking pass 1: 1013ms, 102 MB / 917 MB
treeshaking pass 2: 457ms, 24 MB / 941 MB
treeshaking pass 3: 184ms, -5.31 MB / 936 MB
treeshaking pass 4: 178ms, 6.55 MB / 942 MB
treeshaking pass 5: 198ms, -115 kB / 942 MB
treeshaking pass 6: 169ms, 14.5 MB / 957 MB
treeshaking pass 7: 164ms, -5.48 MB / 951 MB
treeshaking pass 8: 152ms, 3.51 MB / 955 MB
treeshaking pass 9: 137ms, 1.66 MB / 956 MB
treeshaking pass 10: 137ms, 2.53 MB / 959 MB
treeshaking pass 11: 139ms, -15.3 MB / 944 MB
# GENERATE: 553ms, 107 MB / 1.05 GB
## initialize render: 0ms, 3.46 kB / 946 MB
## generate chunks: 47ms, 4.11 MB / 950 MB
optimize chunks: 1ms, 394 kB / 950 MB
## render chunks: 487ms, 83.1 MB / 1.03 GB
## transform chunks: 19ms, 19.7 MB / 1.05 GB
## generate bundle: 0ms, 11.7 kB / 1.05 GB
# WRITE: 31ms, 19.7 MB / 1.07 GB
```

#### rollup 4.0.2
```
# BUILD: 6656ms, 917 MB / 926 MB
## initialize: 0ms, 3.55 kB / 9.06 MB
## generate module graph: 3437ms, 747 MB / 756 MB
- plugin 0 (stdin) - resolveId: 13ms, 3.18 MB / 755 MB
- plugin 0 (stdin) - load: 8ms, 882 kB / 756 MB
generate ast: 1177ms, 137 MB / 756 MB
analyze ast: 1419ms, 721 MB / 756 MB
## sort and bind modules: 245ms, 38.3 MB / 794 MB
## mark included statements: 2973ms, 132 MB / 926 MB
treeshaking pass 1: 1123ms, 103 MB / 899 MB
treeshaking pass 2: 464ms, 24.5 MB / 924 MB
treeshaking pass 3: 175ms, -5.22 MB / 918 MB
treeshaking pass 4: 173ms, 6.72 MB / 925 MB
treeshaking pass 5: 196ms, -284 kB / 925 MB
treeshaking pass 6: 161ms, 14.4 MB / 939 MB
treeshaking pass 7: 150ms, -5.39 MB / 934 MB
treeshaking pass 8: 136ms, 3.57 MB / 937 MB
treeshaking pass 9: 119ms, 1.7 MB / 939 MB
treeshaking pass 10: 124ms, 2.52 MB / 942 MB
treeshaking pass 11: 147ms, -15.3 MB / 926 MB
# GENERATE: 573ms, 107 MB / 1.04 GB
## initialize render: 0ms, 3.46 kB / 928 MB
## generate chunks: 50ms, 3.55 MB / 932 MB
optimize chunks: 1ms, 428 kB / 933 MB
## render chunks: 503ms, 82.5 MB / 1.01 GB
## transform chunks: 19ms, 20.8 MB / 1.04 GB
## generate bundle: 0ms, 1.74 kB / 1.04 GB
# WRITE: 33ms, 19.5 MB / 1.05 GB
```

#### rollup 4.1.0
```
# BUILD: 6597ms, 847 MB / 855 MB
## initialize: 0ms, 3.55 kB / 8.51 MB
## generate module graph: 3451ms, 667 MB / 676 MB
- plugin 0 (stdin) - resolveId: 16ms, -6.69 MB / 677 MB
- plugin 0 (stdin) - load: 8ms, 882 kB / 677 MB
generate ast: 1208ms, 168 MB / 677 MB
analyze ast: 1404ms, 650 MB / 677 MB
## sort and bind modules: 246ms, 37.3 MB / 713 MB
## mark included statements: 2900ms, 142 MB / 855 MB
treeshaking pass 1: 1086ms, 100 MB / 815 MB
treeshaking pass 2: 474ms, 22.1 MB / 837 MB
treeshaking pass 3: 183ms, 10.3 MB / 847 MB
treeshaking pass 4: 171ms, 6.99 MB / 854 MB
treeshaking pass 5: 194ms, -688 kB / 853 MB
treeshaking pass 6: 160ms, -1.58 MB / 852 MB
treeshaking pass 7: 140ms, -5.54 MB / 846 MB
treeshaking pass 8: 137ms, 3.62 MB / 850 MB
treeshaking pass 9: 116ms, 1.5 MB / 851 MB
treeshaking pass 10: 119ms, 2.55 MB / 854 MB
treeshaking pass 11: 110ms, 1.15 MB / 855 MB
# GENERATE: 569ms, 101 MB / 958 MB
## initialize render: 0ms, 3.46 kB / 857 MB
## generate chunks: 49ms, 1.97 MB / 859 MB
optimize chunks: 1ms, 380 kB / 860 MB
## render chunks: 503ms, 72.7 MB / 932 MB
## transform chunks: 16ms, 26.2 MB / 958 MB
## generate bundle: 0ms, 1.74 kB / 958 MB
# WRITE: 33ms, 17.5 MB / 975 MB
```

#### using mimalloc (~200ms / ~3% improvement)
```
# BUILD: 6345ms, 853 MB / 862 MB
## initialize: 0ms, 3.55 kB / 9.11 MB
## generate module graph: 3204ms, 671 MB / 680 MB
- plugin 0 (stdin) - resolveId: 13ms, 1.27 MB / 679 MB
- plugin 0 (stdin) - load: 9ms, 882 kB / 680 MB
generate ast: 996ms, 163 MB / 680 MB
analyze ast: 1392ms, 722 MB / 680 MB
## sort and bind modules: 220ms, 37.7 MB / 718 MB
## mark included statements: 2920ms, 144 MB / 862 MB
treeshaking pass 1: 1039ms, 101 MB / 820 MB
treeshaking pass 2: 480ms, 23.6 MB / 844 MB
treeshaking pass 3: 189ms, 10.3 MB / 854 MB
treeshaking pass 4: 171ms, -9.57 MB / 845 MB
treeshaking pass 5: 209ms, -27.3 kB / 844 MB
treeshaking pass 6: 161ms, 14.2 MB / 859 MB
treeshaking pass 7: 143ms, -5.51 MB / 853 MB
treeshaking pass 8: 146ms, 3.66 MB / 857 MB
treeshaking pass 9: 120ms, 1.59 MB / 858 MB
treeshaking pass 10: 130ms, 2.51 MB / 861 MB
treeshaking pass 11: 124ms, 1.18 MB / 862 MB
# GENERATE: 578ms, 113 MB / 961 MB
## initialize render: 0ms, 3.46 kB / 848 MB
## generate chunks: 51ms, 3.72 MB / 852 MB
optimize chunks: 1ms, 481 kB / 853 MB
## render chunks: 510ms, 82.8 MB / 935 MB
## transform chunks: 17ms, 26.2 MB / 961 MB
## generate bundle: 0ms, 1.74 kB / 961 MB
# WRITE: 35ms, 15.4 MB / 976 MB
```

</details>

<details>
<summary>Specs of my laptop</summary>

- CPU: Intel Core-i7 1360P
- Memory: DDR5-4800 32GB
- OS: Windows 11

</details>

This change increases the binary size by 0.07MB (3.25MB -> 3.32MB).
