### PR TITLE
Fix race condition when emitting implicitly dependent entries

### DIFF
--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry/_config.js
@@ -194,6 +194,12 @@ module.exports = defineTest({
 				assert.strictEqual(dep.isEntry, true, 'dep.isEntry');
 				assert.strictEqual(dep.isDynamicEntry, false, 'dep.isDynamicEntry');
 				assert.strictEqual(dep.isImplicitEntry, false, 'dep.isImplicitEntry');
+			},
+			async transform(code, id) {
+				if (id.endsWith('main.js')) {
+					// This delay used to cause a race condition
+					await new Promise(resolve => setTimeout(resolve, 200));
+				}
 			}
 		}
 	}

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_config.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_config.js
@@ -1,0 +1,200 @@
+const assert = require('node:assert');
+const path = require('node:path');
+
+const ID_MAIN = path.join(__dirname, 'main.js');
+const ID_LIB = path.join(__dirname, 'lib.js');
+const ID_DEP = path.join(__dirname, 'dep.js');
+
+module.exports = defineTest({
+	description: 'makes sure emitted entry points are never implicit dependencies',
+	options: {
+		preserveEntrySignatures: 'allow-extension',
+		plugins: {
+			name: 'test-plugin',
+			async buildStart() {
+				this.emitFile({
+					type: 'chunk',
+					id: 'dep.js',
+					implicitlyLoadedAfterOneOf: [ID_MAIN]
+				});
+				await new Promise(resolve => setTimeout(resolve, 200));
+				this.emitFile({
+					type: 'chunk',
+					id: 'dep.js'
+				});
+			},
+			buildEnd() {
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_MAIN))), {
+					id: ID_MAIN,
+					attributes: {},
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								source: { type: 'Literal', start: 22, end: 29, raw: "'./lib'", value: './lib' },
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								attributes: []
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										computed: false,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										optional: false,
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' }
+									},
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
+					dynamicallyImportedIdResolutions: [],
+					dynamicallyImportedIds: [],
+					dynamicImporters: [],
+					exportedBindings: {
+						'.': []
+					},
+					exports: [],
+					hasDefaultExport: false,
+					moduleSideEffects: true,
+					implicitlyLoadedAfterOneOf: [],
+					implicitlyLoadedBefore: [],
+					importedIdResolutions: [
+						{
+							attributes: {},
+							external: false,
+							id: ID_LIB,
+							meta: {},
+							moduleSideEffects: true,
+							resolvedBy: 'rollup',
+							syntheticNamedExports: false
+						}
+					],
+					importedIds: [ID_LIB],
+					importers: [],
+					isEntry: true,
+					isExternal: false,
+					isIncluded: true,
+					meta: {},
+					syntheticNamedExports: false
+				});
+				assert.deepStrictEqual(JSON.parse(JSON.stringify(this.getModuleInfo(ID_DEP))), {
+					id: ID_DEP,
+					attributes: {},
+					ast: {
+						type: 'Program',
+						start: 0,
+						end: 51,
+						body: [
+							{
+								type: 'ImportDeclaration',
+								start: 0,
+								end: 30,
+								source: { type: 'Literal', start: 22, end: 29, raw: "'./lib'", value: './lib' },
+								specifiers: [
+									{
+										type: 'ImportSpecifier',
+										start: 9,
+										end: 14,
+										imported: { type: 'Identifier', start: 9, end: 14, name: 'value' },
+										local: { type: 'Identifier', start: 9, end: 14, name: 'value' }
+									}
+								],
+								attributes: []
+							},
+							{
+								type: 'ExpressionStatement',
+								start: 31,
+								end: 50,
+								expression: {
+									type: 'CallExpression',
+									start: 31,
+									end: 49,
+									arguments: [{ type: 'Identifier', start: 43, end: 48, name: 'value' }],
+									callee: {
+										type: 'MemberExpression',
+										start: 31,
+										end: 42,
+										computed: false,
+										object: { type: 'Identifier', start: 31, end: 38, name: 'console' },
+										optional: false,
+										property: { type: 'Identifier', start: 39, end: 42, name: 'log' }
+									},
+									optional: false
+								}
+							}
+						],
+						sourceType: 'module'
+					},
+					code: "import { value } from './lib';\nconsole.log(value);\n",
+					dynamicallyImportedIdResolutions: [],
+					dynamicallyImportedIds: [],
+					dynamicImporters: [],
+					exportedBindings: {
+						'.': []
+					},
+					exports: [],
+					hasDefaultExport: false,
+					moduleSideEffects: true,
+					implicitlyLoadedAfterOneOf: [],
+					implicitlyLoadedBefore: [],
+					importedIdResolutions: [
+						{
+							attributes: {},
+							external: false,
+							id: ID_LIB,
+							meta: {},
+							moduleSideEffects: true,
+							resolvedBy: 'rollup',
+							syntheticNamedExports: false
+						}
+					],
+					importedIds: [ID_LIB],
+					importers: [],
+					isEntry: true,
+					isExternal: false,
+					isIncluded: true,
+					meta: {},
+					syntheticNamedExports: false
+				});
+			},
+			generateBundle(options, bundle) {
+				const main = bundle['main.js'];
+				assert.deepStrictEqual(main.implicitlyLoadedBefore, [], 'main.implicitlyLoadedBefore');
+				assert.strictEqual(main.isEntry, true, 'main.isEntry');
+				assert.strictEqual(main.isDynamicEntry, false, 'main.isDynamicEntry');
+				assert.strictEqual(main.isImplicitEntry, false, 'main.isImplicitEntry');
+				const dep = bundle['generated-dep.js'];
+				assert.deepStrictEqual(dep.implicitlyLoadedBefore, [], 'dep.implicitlyLoadedBefore');
+				assert.strictEqual(dep.isEntry, true, 'dep.isEntry');
+				assert.strictEqual(dep.isDynamicEntry, false, 'dep.isDynamicEntry');
+				assert.strictEqual(dep.isImplicitEntry, false, 'dep.isImplicitEntry');
+			}
+		}
+	}
+});

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/amd/generated-dep.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/amd/generated-dep.js
@@ -1,0 +1,5 @@
+define(['./generated-lib'], (function (lib) { 'use strict';
+
+	console.log(lib.value);
+
+}));

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/amd/generated-lib.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/amd/generated-lib.js
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	const value = 42;
+
+	exports.value = value;
+
+}));

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/amd/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(['./generated-lib'], (function (lib) { 'use strict';
+
+	console.log(lib.value);
+
+}));

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/cjs/generated-dep.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/cjs/generated-dep.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var lib = require('./generated-lib.js');
+
+console.log(lib.value);

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/cjs/generated-lib.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/cjs/generated-lib.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const value = 42;
+
+exports.value = value;

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/cjs/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/cjs/main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var lib = require('./generated-lib.js');
+
+console.log(lib.value);

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/es/generated-dep.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/es/generated-dep.js
@@ -1,0 +1,3 @@
+import { v as value } from './generated-lib.js';
+
+console.log(value);

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/es/generated-lib.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/es/generated-lib.js
@@ -1,0 +1,3 @@
+const value = 42;
+
+export { value as v };

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/es/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/es/main.js
@@ -1,0 +1,3 @@
+import { v as value } from './generated-lib.js';
+
+console.log(value);

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/system/generated-dep.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/system/generated-dep.js
@@ -1,0 +1,14 @@
+System.register(['./generated-lib.js'], (function () {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log(value);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/system/generated-lib.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/system/generated-lib.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const value = exports('v', 42);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/system/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register(['./generated-lib.js'], (function () {
+	'use strict';
+	var value;
+	return {
+		setters: [function (module) {
+			value = module.v;
+		}],
+		execute: (function () {
+
+			console.log(value);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/dep.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/dep.js
@@ -1,0 +1,2 @@
+import { value } from './lib';
+console.log(value);

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/lib.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/lib.js
@@ -1,0 +1,1 @@
+export const value = 42;

--- a/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/main.js
+++ b/test/chunking-form/samples/implicit-dependencies/implicitly-dependent-emitted-entry2/main.js
@@ -1,0 +1,2 @@
+import { value } from './lib';
+console.log(value);

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,6 @@
 require('source-map-support').install();
 
-describe('rollup', function () {
-	this.timeout(30_000);
+describe('rollup', () => {
 	require('./misc/index.js');
 	require('./function/index.js');
 	require('./form/index.js');
@@ -13,4 +12,4 @@ describe('rollup', function () {
 	require('./load-config-file/index.js');
 	require('./cli/index.js');
 	require('./watch/index.js');
-});
+}).timeout(30_000);

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 require('source-map-support').install();
 
-describe('rollup', () => {
+describe('rollup', function () {
+	this.timeout(30_000);
 	require('./misc/index.js');
 	require('./function/index.js');
 	require('./form/index.js');
@@ -12,4 +13,4 @@ describe('rollup', () => {
 	require('./load-config-file/index.js');
 	require('./cli/index.js');
 	require('./watch/index.js');
-}).timeout(30_000);
+});

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -1302,7 +1302,7 @@ describe('rollup.watch', () => {
 			],
 			0
 		);
-	});
+	}).retries(1);
 
 	it('observes configured build delays', async () => {
 		await copy('test/watch/samples/basic', 'test/_tmp/input');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When working on async parsing, I found that there is a race condition where when a file is emitted both as an actual entry and an implicitly dependent entry, then it could be that it would still be emitted only as an implicitly dependent entry and not as an independent entry.
