### PR TITLE
Render emtpy block comments after tree-shaken statements

### DIFF
--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -82,7 +82,7 @@ export function findFirstLineBreakOutsideComment(code: string): [number, number]
 		// With our assumption, '/' always starts a comment. Determine comment type:
 		charCodeAfterSlash = code.charCodeAt(start + 1);
 		if (charCodeAfterSlash === 47 /*"/"*/) return [start, lineBreakPos + 1];
-		start = code.indexOf('*/', start + 3) + 2;
+		start = code.indexOf('*/', start + 2) + 2;
 		if (start > lineBreakPos) {
 			lineBreakPos = code.indexOf('\n', start);
 		}

--- a/test/form/samples/empty-block-comment/_config.js
+++ b/test/form/samples/empty-block-comment/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'renders empty block comments after tree-shaken statements (#5230)'
+});

--- a/test/form/samples/empty-block-comment/_expected.js
+++ b/test/form/samples/empty-block-comment/_expected.js
@@ -1,0 +1,4 @@
+function instance() {
+}
+
+export { instance };

--- a/test/form/samples/empty-block-comment/main.js
+++ b/test/form/samples/empty-block-comment/main.js
@@ -1,0 +1,3 @@
+export function instance() {
+		const b = 2; /**/
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5230

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There was a subtle bug in the statement list tree-shaking logic that has been there for years but strangely did not yet come up, basically an off-by-one error.