### PR TITLE
Allow functions to redeclare vars and functions in function scopes

### DIFF
--- a/src/ast/scopes/CatchBodyScope.ts
+++ b/src/ast/scopes/CatchBodyScope.ts
@@ -70,13 +70,6 @@ export default class CatchBodyScope extends ChildScope {
 			this.addHoistedVariable(name, declaredVariable);
 			return declaredVariable;
 		}
-		// Functions can never re-declare catch parameters
-		if (kind === VariableKind.function) {
-			const name = identifier.name;
-			if (this.hoistedVariables?.get(name)) {
-				context.error(logRedeclarationError(name), identifier.start);
-			}
-		}
 		return super.addDeclaration(identifier, context, init, kind);
 	}
 }

--- a/src/ast/scopes/FunctionBodyScope.ts
+++ b/src/ast/scopes/FunctionBodyScope.ts
@@ -1,0 +1,46 @@
+import type { AstContext } from '../../Module';
+import { logRedeclarationError } from '../../utils/logs';
+import type Identifier from '../nodes/Identifier';
+import type { ExpressionEntity } from '../nodes/shared/Expression';
+import { VariableKind } from '../nodes/shared/VariableKinds';
+import LocalVariable from '../variables/LocalVariable';
+import ChildScope from './ChildScope';
+import type ParameterScope from './ParameterScope';
+
+export default class FunctionBodyScope extends ChildScope {
+	constructor(
+		readonly parent: ParameterScope,
+		readonly context: AstContext
+	) {
+		super(parent, context);
+	}
+
+	// There is stuff that is only allowed in function scopes, i.e. functions can
+	// be redeclared, functions and var can redeclare each other
+	addDeclaration(
+		identifier: Identifier,
+		context: AstContext,
+		init: ExpressionEntity,
+		kind: VariableKind
+	): LocalVariable {
+		const name = identifier.name;
+		const existingVariable =
+			this.hoistedVariables?.get(name) || (this.variables.get(name) as LocalVariable);
+		if (existingVariable) {
+			const existingKind = existingVariable.kind;
+			if (
+				(kind === VariableKind.var || kind === VariableKind.function) &&
+				(existingKind === VariableKind.var ||
+					existingKind === VariableKind.function ||
+					existingKind === VariableKind.parameter)
+			) {
+				existingVariable.addDeclaration(identifier, init);
+				return existingVariable;
+			}
+			context.error(logRedeclarationError(name), identifier.start);
+		}
+		const newVariable = new LocalVariable(identifier.name, identifier, init, context, kind);
+		this.variables.set(name, newVariable);
+		return newVariable;
+	}
+}

--- a/src/ast/scopes/ParameterScope.ts
+++ b/src/ast/scopes/ParameterScope.ts
@@ -7,6 +7,7 @@ import type { ExpressionEntity } from '../nodes/shared/Expression';
 import ParameterVariable from '../variables/ParameterVariable';
 import CatchBodyScope from './CatchBodyScope';
 import ChildScope from './ChildScope';
+import FunctionBodyScope from './FunctionBodyScope';
 import type Scope from './Scope';
 
 export default class ParameterScope extends ChildScope {
@@ -19,7 +20,7 @@ export default class ParameterScope extends ChildScope {
 		super(parent, context);
 		this.bodyScope = isCatchScope
 			? new CatchBodyScope(this, context)
-			: new ChildScope(this, context);
+			: new FunctionBodyScope(this, context);
 	}
 
 	/**

--- a/src/ast/scopes/Scope.ts
+++ b/src/ast/scopes/Scope.ts
@@ -15,6 +15,7 @@ export default class Scope {
 	/*
 	Redeclaration rules:
 	- var can redeclare var
+	- in function scopes, function and var can redeclare function and var
 	- var is hoisted across scopes, function remains in the scope it is declared
 	- var and function can redeclare function parameters, but parameters cannot redeclare parameters
 	- function cannot redeclare catch scope parameters
@@ -34,11 +35,7 @@ export default class Scope {
 			this.hoistedVariables?.get(name) || (this.variables.get(name) as LocalVariable);
 		if (existingVariable) {
 			const existingKind = existingVariable.kind;
-			if (
-				(kind === VariableKind.var &&
-					(existingKind === VariableKind.var || existingKind === VariableKind.parameter)) ||
-				(kind === VariableKind.function && existingKind === VariableKind.parameter)
-			) {
+			if (kind === VariableKind.var && existingKind === VariableKind.var) {
 				existingVariable.addDeclaration(identifier, init);
 				return existingVariable;
 			}

--- a/test/function/samples/ast-validations/redeclare-block-function-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-block-function-function/_config.js
@@ -1,0 +1,24 @@
+const path = require('node:path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
+module.exports = defineTest({
+	description: 'throws when redeclaring a function binding as a function in a block scope',
+	error: {
+		code: 'REDECLARATION_ERROR',
+		frame: `
+			1: {
+			2:   function foo() {}
+			3:   function foo() {}
+			              ^
+			4: }`,
+		id: ID_MAIN,
+		loc: {
+			column: 10,
+			file: ID_MAIN,
+			line: 3
+		},
+		message: 'Identifier "foo" has already been declared',
+		pos: 31,
+		watchFiles: [ID_MAIN]
+	}
+});

--- a/test/function/samples/ast-validations/redeclare-block-function-function/main.js
+++ b/test/function/samples/ast-validations/redeclare-block-function-function/main.js
@@ -1,0 +1,4 @@
+{
+	function foo() {}
+	function foo() {}
+}

--- a/test/function/samples/ast-validations/redeclare-top-level-function-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-function-function/_config.js
@@ -1,0 +1,22 @@
+const path = require('node:path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
+module.exports = defineTest({
+	description: 'throws when redeclaring a top-level function binding as a function',
+	error: {
+		code: 'REDECLARATION_ERROR',
+		frame: `
+			1: function foo() {}
+			2: function foo() {}
+			            ^`,
+		id: ID_MAIN,
+		loc: {
+			column: 9,
+			file: ID_MAIN,
+			line: 2
+		},
+		message: 'Identifier "foo" has already been declared',
+		pos: 27,
+		watchFiles: [ID_MAIN]
+	}
+});

--- a/test/function/samples/ast-validations/redeclare-top-level-function-function/main.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-function-function/main.js
@@ -1,0 +1,2 @@
+function foo() {}
+function foo() {}

--- a/test/function/samples/ast-validations/redeclare-top-level-var-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-var-function/_config.js
@@ -1,0 +1,22 @@
+const path = require('node:path');
+const ID_MAIN = path.join(__dirname, 'main.js');
+
+module.exports = defineTest({
+	description: 'throws when redeclaring a top-level var binding as a function',
+	error: {
+		code: 'REDECLARATION_ERROR',
+		frame: `
+			1: var foo;
+			2: function foo() {}
+			            ^`,
+		id: ID_MAIN,
+		loc: {
+			column: 9,
+			file: ID_MAIN,
+			line: 2
+		},
+		message: 'Identifier "foo" has already been declared',
+		pos: 18,
+		watchFiles: [ID_MAIN]
+	}
+});

--- a/test/function/samples/ast-validations/redeclare-top-level-var-function/main.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-var-function/main.js
@@ -1,0 +1,2 @@
+var foo;
+function foo() {}

--- a/test/function/samples/ast-validations/redeclare-var-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-var-function/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'allows to redeclare vars and functions as vars and functions in function scopes'
+});

--- a/test/function/samples/ast-validations/redeclare-var-function/main.js
+++ b/test/function/samples/ast-validations/redeclare-var-function/main.js
@@ -1,0 +1,10 @@
+function foo() {
+	var fn = 1;
+	function fn() {}
+	function fn() {}
+	var fn = 2;
+
+	assert.equal(fn, 2);
+}
+
+foo();


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5247 

<!--
If this PR resolves any issues, list them as

  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Apparently, the semantics for duplicate function names differ between function scopes and other scopes: In function scopes, `function` can redeclare `function` and `var` while in other scopes it is forbidden