### PR TITLE
Allow to redeclare parameters multiple times in nested scopes

### DIFF
--- a/src/ast/scopes/BlockScope.ts
+++ b/src/ast/scopes/BlockScope.ts
@@ -22,7 +22,10 @@ export default class BlockScope extends ChildScope {
 			const existingVariable =
 				this.hoistedVariables?.get(name) || (this.variables.get(name) as LocalVariable | undefined);
 			if (existingVariable) {
-				if (existingVariable.kind === VariableKind.var) {
+				if (
+					existingVariable.kind === VariableKind.var ||
+					(kind === VariableKind.var && existingVariable.kind === VariableKind.parameter)
+				) {
 					existingVariable.addDeclaration(identifier, init);
 					return existingVariable;
 				}

--- a/test/function/samples/ast-validations/redeclare-var-parameter-nested/_config.js
+++ b/test/function/samples/ast-validations/redeclare-var-parameter-nested/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'allows to redeclare parameters with multiple nested vars'
+});

--- a/test/function/samples/ast-validations/redeclare-var-parameter-nested/main.js
+++ b/test/function/samples/ast-validations/redeclare-var-parameter-nested/main.js
@@ -1,0 +1,21 @@
+export function f(val) {
+	{
+		var val = 1;
+		var val = 2;
+	}
+	assert.equal(val, 2);
+}
+f(0);
+
+export function g(val) {
+	{
+		{
+			var val = 1;
+		}
+		{
+			var val = 2;
+		}
+	}
+	assert.equal(val, 2);
+}
+g(0);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5274 

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When a parameter is redeclared as a `var` several times in the same nested scope (or in several child scopes of the same nested scope), then this caused a conflict due to some aspects of the var-conflict detection logic. This is fixed here by adding an exception when a var redeclares a parameter.
