### PR TITLE
Do not assume setTimeout return type

### DIFF
--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -35,7 +35,7 @@ export class Watcher {
 	readonly emitter: RollupWatcher;
 
 	private buildDelay = 0;
-	private buildTimeout: NodeJS.Timer | null = null;
+	private buildTimeout: ReturnType<typeof setTimeout> | null = null;
 	private closed = false;
 	private readonly invalidatedIds = new Map<string, ChangeEvent>();
 	private rerun = false;


### PR DESCRIPTION
It typically changed between Node 18.13 and 18.19

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no
