### PR TITLE
Add JSDoc types to internal scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@rollup/plugin-typescript": "11.1.5",
         "@rollup/pluginutils": "^5.1.0",
         "@types/estree": "1.0.5",
+        "@types/inquirer": "^9.0.7",
         "@types/mocha": "^10.0.6",
         "@types/node": "18.0.0",
         "@types/yargs-parser": "^21.0.3",
@@ -2109,6 +2110,16 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/inquirer": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.7.tgz",
+      "integrity": "sha512-Q0zyBupO6NxGRZut/JdmqYKOnN95Eg5V8Csg3PGKkP+FnvsUZx1jAyK7fztIszxxMuoBA6E3KXWvdZVXIpx60g==",
+      "dev": true,
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2197,6 +2208,15 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
+      "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@rollup/plugin-typescript": "11.1.5",
     "@rollup/pluginutils": "^5.1.0",
     "@types/estree": "1.0.5",
+    "@types/inquirer": "^9.0.7",
     "@types/mocha": "^10.0.6",
     "@types/node": "18.0.0",
     "@types/yargs-parser": "^21.0.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test:package": "node scripts/test-package.js",
     "test:options": "node scripts/test-options.js",
     "test:only": "mocha test/test.js",
-    "test:typescript": "shx rm -rf test/typescript/dist && shx cp -r dist test/typescript/ && tsc --noEmit -p test/typescript && tsc --noEmit",
+    "test:typescript": "shx rm -rf test/typescript/dist && shx cp -r dist test/typescript/ && tsc --noEmit -p test/typescript && tsc --noEmit && tsc --noEmit -p scripts",
     "test:browser": "mocha test/browser/index.js",
     "watch": "rollup --config rollup.config.ts --configPlugin typescript --watch"
   },

--- a/scripts/declarations.d.ts
+++ b/scripts/declarations.d.ts
@@ -1,0 +1,23 @@
+declare module 'github-api' {
+	export interface Repo {
+		listPullRequests({ state: string }): Promise<{
+			data: { number: number; title: string; head: { sha: string } }[];
+		}>;
+
+		getPullRequest(pr: number): Promise<{ data: { body: string; user: { login: string } } }>;
+
+		createRelease(release: { body: string; name: string; tag_name: string }): Promise<void>;
+	}
+
+	export interface Issues {
+		createIssueComment(issueNumber: number, text: string): Promise<void>;
+	}
+
+	export default class GitHub {
+		constructor({ token: string });
+
+		getRepo(organization: string, repository: string): Repo;
+
+		getIssues(organization: string, repository: string): Issues;
+	}
+}

--- a/scripts/find-config.js
+++ b/scripts/find-config.js
@@ -1,6 +1,10 @@
 import { readdir } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+/**
+ * @param {string} targetDirectory
+ * @return {Promise<string>}
+ */
 export async function findConfigFileName(targetDirectory) {
 	const filesInWorkingDirectory = new Set(await readdir(targetDirectory));
 	for (const extension of ['mjs', 'cjs', 'ts', 'js']) {

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -5,24 +5,32 @@ import { blue, bold, cyan, green, magenta, red, yellow } from './colors.js';
 const colors = [cyan, yellow, blue, red, green, magenta];
 let nextColorIndex = 0;
 
+/**
+ * @param {string} command
+ * @param {string[]} parameters
+ * @param {Parameters<typeof spawn>[2]=} options
+ * @return {Promise<void>}
+ */
 export function runWithEcho(command, parameters, options) {
 	const color = colors[nextColorIndex];
 	nextColorIndex = (nextColorIndex + 1) % colors.length;
-	return new Promise((resolve, reject) => {
-		const cmdString = formatCommand(command, parameters);
-		console.error(bold(`\n${color('Run>')} ${cmdString}`));
+	return /** @type {Promise<void>} */ (
+		new Promise((resolve, reject) => {
+			const cmdString = formatCommand(command, parameters);
+			console.error(bold(`\n${color('Run>')} ${cmdString}`));
 
-		const childProcess = spawn(command, parameters, { stdio: 'inherit', ...options });
+			const childProcess = spawn(command, parameters, { stdio: 'inherit', ...options });
 
-		childProcess.on('close', code => {
-			if (code) {
-				reject(new Error(`"${cmdString}" exited with code ${code}.`));
-			} else {
-				console.error(bold(`${color('Finished>')} ${cmdString}\n`));
-				resolve();
-			}
-		});
-	});
+			childProcess.on('close', code => {
+				if (code) {
+					reject(new Error(`"${cmdString}" exited with code ${code}.`));
+				} else {
+					console.error(bold(`${color('Finished>')} ${cmdString}\n`));
+					resolve();
+				}
+			});
+		})
+	);
 }
 
 /**
@@ -48,6 +56,11 @@ export function runAndGetStdout(command, parameters) {
 	});
 }
 
+/**
+ * @param {string} command
+ * @param {string[]} parameters
+ * @return {string}
+ */
 function formatCommand(command, parameters) {
 	return [command, ...parameters].join(' ');
 }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -10,7 +10,7 @@ export function runWithEcho(command, parameters, options) {
 	nextColorIndex = (nextColorIndex + 1) % colors.length;
 	return new Promise((resolve, reject) => {
 		const cmdString = formatCommand(command, parameters);
-		console.error(bold(`\n${color`Run>`} ${cmdString}`));
+		console.error(bold(`\n${color('Run>')} ${cmdString}`));
 
 		const childProcess = spawn(command, parameters, { stdio: 'inherit', ...options });
 
@@ -18,7 +18,7 @@ export function runWithEcho(command, parameters, options) {
 			if (code) {
 				reject(new Error(`"${cmdString}" exited with code ${code}.`));
 			} else {
-				console.error(bold(`${color`Finished>`} ${cmdString}\n`));
+				console.error(bold(`${color('Finished>')} ${cmdString}\n`));
 				resolve();
 			}
 		});

--- a/scripts/perf-init.js
+++ b/scripts/perf-init.js
@@ -24,9 +24,13 @@ rmSync(TARGET_DIR, {
 	recursive: true
 });
 
-const [, repo, , branch] = VALID_REPO.exec(repoWithBranch);
+const repoWithBranchMatch = VALID_REPO.exec(repoWithBranch);
+if (!repoWithBranchMatch) {
+	throw new Error('Could not match repository and branch.');
+}
+const [, repo, , branch] = repoWithBranchMatch;
 
-const gitArguments = ['clone', '--depth', 1, '--progress'];
+const gitArguments = ['clone', '--depth', '1', '--progress'];
 if (branch) {
 	console.error(`Cloning branch "${branch}" of "${repo}"...`);
 	gitArguments.push('--branch', branch);

--- a/scripts/perf.js
+++ b/scripts/perf.js
@@ -83,9 +83,13 @@ function getAverage(accumulatedMeasurements, runs, discarded) {
 }
 
 async function calculatePrintAndPersistTimings(config, existingTimings) {
-	const timings = await buildAndGetTimings(config);
+	const serializedTimings = await buildAndGetTimings(config);
+	/**
+	 * @type {Record<string, [number, number, number][]>}
+	 */
+	const timings = {};
 	for (const label of Object.keys(timings)) {
-		timings[label] = [timings[label]];
+		timings[label] = [serializedTimings[label]];
 	}
 	for (let currentRun = 1; currentRun < numberOfRunsToAverage; currentRun++) {
 		const numberOfLinesToClear = printMeasurements(
@@ -109,6 +113,9 @@ async function calculatePrintAndPersistTimings(config, existingTimings) {
 	if (Object.keys(existingTimings).length === 0) persistTimings(averageTimings);
 }
 
+/**
+ * @return {Promise<import('rollup').SerializedTimings>}
+ */
 async function buildAndGetTimings(config) {
 	config.perf = true;
 	if (Array.isArray(config.output)) {

--- a/scripts/perf.js
+++ b/scripts/perf.js
@@ -11,6 +11,14 @@ import { loadConfigFile } from '../dist/loadConfigFile.js';
 import { rollup } from '../dist/rollup.js';
 import { findConfigFileName } from './find-config.js';
 
+/**
+ * @typedef {Record<string,{memory:number,time:number}>} PersistedTimings
+ */
+
+/**
+ * @typedef {Record<string, [number, number, number][]>} AccumulatedTimings
+ */
+
 const initialDirectory = cwd();
 const targetDirectory = fileURLToPath(new URL('../perf', import.meta.url).href);
 const perfFile = fileURLToPath(new URL('../perf/rollup.perf.json', import.meta.url).href);
@@ -51,6 +59,12 @@ console.info(
 
 await calculatePrintAndPersistTimings(configs.options[0], await getExistingTimings());
 
+/**
+ * @param {number[]} times
+ * @param {number} runs
+ * @param {number} discarded
+ * @return {number}
+ */
 function getSingleAverage(times, runs, discarded) {
 	const actualDiscarded = Math.min(discarded, runs - 1);
 	return (
@@ -63,7 +77,16 @@ function getSingleAverage(times, runs, discarded) {
 	);
 }
 
+/**
+ * @param {AccumulatedTimings} accumulatedMeasurements
+ * @param {number} runs
+ * @param {number} discarded
+ * @return {PersistedTimings}
+ */
 function getAverage(accumulatedMeasurements, runs, discarded) {
+	/**
+	 * @type {PersistedTimings}
+	 */
 	const average = {};
 	for (const label of Object.keys(accumulatedMeasurements)) {
 		average[label] = {
@@ -82,57 +105,80 @@ function getAverage(accumulatedMeasurements, runs, discarded) {
 	return average;
 }
 
+/**
+ * @param {import('rollup').MergedRollupOptions} config
+ * @param {PersistedTimings} existingTimings
+ * @return {Promise<void>}
+ */
 async function calculatePrintAndPersistTimings(config, existingTimings) {
 	const serializedTimings = await buildAndGetTimings(config);
 	/**
 	 * @type {Record<string, [number, number, number][]>}
 	 */
-	const timings = {};
-	for (const label of Object.keys(timings)) {
-		timings[label] = [serializedTimings[label]];
+	const accumulatedTimings = {};
+	for (const label of Object.keys(serializedTimings)) {
+		accumulatedTimings[label] = [serializedTimings[label]];
 	}
 	for (let currentRun = 1; currentRun < numberOfRunsToAverage; currentRun++) {
 		const numberOfLinesToClear = printMeasurements(
-			getAverage(timings, currentRun, numberOfDiscardedResults),
+			getAverage(accumulatedTimings, currentRun, numberOfDiscardedResults),
 			existingTimings,
 			/^#/
 		);
 		console.info(`Completed run ${currentRun}.`);
 		const currentTimings = await buildAndGetTimings(config);
 		clearLines(numberOfLinesToClear);
-		for (const label of Object.keys(timings)) {
+		for (const label of Object.keys(accumulatedTimings)) {
 			if (currentTimings.hasOwnProperty(label)) {
-				timings[label].push(currentTimings[label]);
+				accumulatedTimings[label].push(currentTimings[label]);
 			} else {
-				delete timings[label];
+				delete accumulatedTimings[label];
 			}
 		}
 	}
-	const averageTimings = getAverage(timings, numberOfRunsToAverage, numberOfDiscardedResults);
+	const averageTimings = getAverage(
+		accumulatedTimings,
+		numberOfRunsToAverage,
+		numberOfDiscardedResults
+	);
 	printMeasurements(averageTimings, existingTimings);
-	if (Object.keys(existingTimings).length === 0) persistTimings(averageTimings);
+	if (Object.keys(existingTimings).length === 0) {
+		persistTimings(averageTimings);
+	}
 }
 
 /**
+ * @param {import('rollup').MergedRollupOptions} config
  * @return {Promise<import('rollup').SerializedTimings>}
  */
 async function buildAndGetTimings(config) {
 	config.perf = true;
-	if (Array.isArray(config.output)) {
-		config.output = config.output[0];
-	}
+	const output = Array.isArray(config.output) ? config.output[0] : config.output;
+	// @ts-expect-error garbage collection may not be enabled
 	gc();
 	chdir(targetDirectory);
 	const bundle = await rollup(config);
 	chdir(initialDirectory);
-	await bundle.generate(config.output);
+	await bundle.generate(output);
+	if (!bundle.getTimings) {
+		throw new Error('Timings not found in the bundle.');
+	}
 	return bundle.getTimings();
 }
 
+/**
+ * @param {PersistedTimings} average
+ * @param {PersistedTimings} existingAverage
+ * @param {RegExp} filter
+ * @return {number}
+ */
 function printMeasurements(average, existingAverage, filter = /.*/) {
 	const printedLabels = Object.keys(average).filter(label => filter.test(label));
 	console.info('');
 	for (const label of printedLabels) {
+		/**
+		 * @type {function(string): string}
+		 */
 		let color = identity;
 		if (label[0] === '#') {
 			color = bold;
@@ -155,10 +201,16 @@ function printMeasurements(average, existingAverage, filter = /.*/) {
 	return printedLabels.length + 2;
 }
 
+/**
+ * @param {number} numberOfLines
+ */
 function clearLines(numberOfLines) {
 	console.info('\u001B[A' + '\u001B[2K\u001B[A'.repeat(numberOfLines));
 }
 
+/**
+ * @return {PersistedTimings}
+ */
 function getExistingTimings() {
 	try {
 		const timings = JSON.parse(readFileSync(perfFile, 'utf8'));
@@ -171,6 +223,9 @@ function getExistingTimings() {
 	}
 }
 
+/**
+ * @param {PersistedTimings} timings
+ */
 function persistTimings(timings) {
 	try {
 		writeFileSync(perfFile, JSON.stringify(timings, null, 2), 'utf8');
@@ -181,7 +236,15 @@ function persistTimings(timings) {
 	}
 }
 
+/**
+ * @param {number} currentTime
+ * @param {number} persistedTime
+ * @return {string}
+ */
 function getFormattedTime(currentTime, persistedTime = currentTime) {
+	/**
+	 * @type {function(string): string}
+	 */
 	let color = identity,
 		formattedTime = `${currentTime.toFixed(0)}ms`;
 	const absoluteDeviation = Math.abs(currentTime - persistedTime);
@@ -198,7 +261,15 @@ function getFormattedTime(currentTime, persistedTime = currentTime) {
 	return color(formattedTime);
 }
 
+/**
+ * @param {number} currentMemory
+ * @param {number} persistedMemory
+ * @return {string}
+ */
 function getFormattedMemory(currentMemory, persistedMemory = currentMemory) {
+	/**
+	 * @type {function(string): string}
+	 */
 	let color = identity,
 		formattedMemory = prettyBytes(currentMemory);
 	const absoluteDeviation = Math.abs(currentMemory - persistedMemory);
@@ -211,6 +282,11 @@ function getFormattedMemory(currentMemory, persistedMemory = currentMemory) {
 	return color(formattedMemory);
 }
 
+/**
+ * @template T
+ * @param {T} x
+ * @returns {T}
+ */
 function identity(x) {
 	return x;
 }

--- a/scripts/postpublish.js
+++ b/scripts/postpublish.js
@@ -62,6 +62,11 @@ if (!isPreRelease) {
 	await runWithEcho('git', ['push', '--force', 'origin', DOCUMENTATION_BRANCH]);
 }
 
+/**
+ * @param {string} changelog
+ * @param {string} tag
+ * @return {Promise<void>}
+ */
 function createReleaseNotes(changelog, tag) {
 	return repo.createRelease({
 		body: changelog,
@@ -70,12 +75,24 @@ function createReleaseNotes(changelog, tag) {
 	});
 }
 
+/**
+ * @param {import('./release-helpers.js').IncludedPR[]} includedPRs
+ * @param {import('github-api').Issues} issues
+ * @param {string} version
+ * @return {Promise<void>}
+ */
 async function postReleaseComments(includedPRs, issues, version) {
 	const installNote = semverPreRelease(version)
 		? `Note that this is a pre-release, so to test it, you need to install Rollup via \`npm install rollup@${version}\` or \`npm install rollup@beta\`. It will likely become part of a regular release later.`
 		: 'You can test it via `npm install rollup`.';
 
 	let caughtError = null;
+
+	/**
+	 * @param {number} issueNumber
+	 * @param {string} comment
+	 * @return {Promise<unknown>}
+	 */
 	const addComment = (issueNumber, comment) =>
 		// Add a small timeout to avoid rate limiting issues
 		new Promise(resolve => setTimeout(resolve, 500)).then(() =>

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -79,6 +79,9 @@ await pushChanges(gitTag);
 
 async function getNewVersion(mainPackage, isMainBranch) {
 	const { version } = mainPackage;
+	/**
+	 * @type {import('semver').ReleaseType[]}
+	 */
 	const availableIncrements = isMainBranch
 		? ['patch', 'minor']
 		: semverPreRelease(version)

--- a/scripts/publish-wasm-node-package.js
+++ b/scripts/publish-wasm-node-package.js
@@ -11,8 +11,12 @@ const WASM_NODE_PACKAGE_INFO = {
 const COPIED_FILES_OR_DIRS = ['LICENSE.md', 'dist'];
 const PACKAGE_DIR = fileURLToPath(new URL('../wasm-node-package', import.meta.url));
 
-function getOutputPath(...arguments_) {
-	return resolve(PACKAGE_DIR, ...arguments_);
+/**
+ * @param {string[]} pathSegments
+ * @return {string}
+ */
+function getOutputPath(...pathSegments) {
+	return resolve(PACKAGE_DIR, ...pathSegments);
 }
 
 export default async function publishWasmNodePackage() {

--- a/scripts/test-options.js
+++ b/scripts/test-options.js
@@ -78,10 +78,14 @@ const helpOptionLines = splitHelpText.filter(line => line.startsWith('-'));
 const cliFlagsText = commandReferenceText
 	.split('\n## ')
 	.find(text => text.startsWith('Command line flags'));
-const optionListLines = cliFlagsText
-	.match(/```\n([\S\s]*?)\n```/)[1]
-	.split('\n')
-	.filter(line => line.startsWith('-'));
+if (!cliFlagsText) {
+	throw new Error('Could not find "Command line flags" section.');
+}
+const cliMarkdownSection = cliFlagsText.match(/```\n([\S\s]*?)\n```/);
+if (!cliMarkdownSection) {
+	throw new Error('Could not find markdown section in "Command line flags" section.');
+}
+const optionListLines = cliMarkdownSection[1].split('\n').filter(line => line.startsWith('-'));
 
 for (const [index, line] of helpOptionLines.entries()) {
 	const optionListLine = optionListLines[index];

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"checkJs": true,
+		"allowJs": true,
+		"target": "esnext",
+		"module": "esnext",
+		"noEmit": true,
+		"lib": ["esnext"],
+		"esModuleInterop": true,
+		"moduleResolution": "node",
+		"skipLibCheck": true
+	},
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -2,12 +2,15 @@
 	"compilerOptions": {
 		"checkJs": true,
 		"allowJs": true,
-		"target": "esnext",
-		"module": "esnext",
+		"forceConsistentCasingInFileNames": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"noEmit": true,
-		"lib": ["esnext"],
+		"noUnusedParameters": true,
+		"lib": ["ESNext"],
 		"esModuleInterop": true,
-		"moduleResolution": "node",
-		"skipLibCheck": true
-	},
+		"skipLibCheck": true,
+		"strict": true,
+		"target": "ESNext"
+	}
 }

--- a/typings/declarations.d.ts
+++ b/typings/declarations.d.ts
@@ -23,7 +23,7 @@ declare module 'is-reference' {
 		parent: NodeWithFieldDefinition
 	): boolean;
 
-	export type Node =
+	type EstreeNode =
 		| estree.ArrayExpression
 		| estree.ArrayPattern
 		| estree.ArrowFunctionExpression
@@ -96,10 +96,10 @@ declare module 'is-reference' {
 		| estree.YieldExpression;
 
 	export type NodeWithFieldDefinition =
-		| Node
+		| EstreeNode
 		| {
 				computed: boolean;
 				type: 'FieldDefinition';
-				value: Node;
+				value: EstreeNode;
 		  };
 }

--- a/typings/fsevents.d.ts
+++ b/typings/fsevents.d.ts
@@ -2,5 +2,6 @@
 // and not installed on linux/windows. this will provide (bogus) type information for
 // linux/windows, and overwrite (replace) the types coming with the 'fsevents' module on macOS
 declare module 'fsevents' {
-	export default {};
+	const fsevents: object;
+	export default fsevents;
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This adds (strict) JSDocs types to all scripts in the `scripts` folder. This will hopefully help as I want to add some scripts to generate AST transformation code to ensure that encoders and decoders are always synced.
