### PR TITLE
Remove rollup-plugin-thatworks from devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
         "rollup": "^4.8.0",
         "rollup-plugin-license": "^3.2.0",
         "rollup-plugin-string": "^3.0.0",
-        "rollup-plugin-thatworks": "^1.0.4",
         "semver": "^7.5.4",
         "shx": "^0.3.4",
         "signal-exit": "^4.1.0",
@@ -9555,15 +9554,6 @@
       "dev": true,
       "dependencies": {
         "rollup-pluginutils": "^2.4.1"
-      }
-    },
-    "node_modules/rollup-plugin-thatworks": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-thatworks/-/rollup-plugin-thatworks-1.0.4.tgz",
-      "integrity": "sha512-RxlYx/oolwXW7akleFzRmJ8gQrWUK4NSZw8E+LHJTWHiA1mhseIMurz8IkyDAG4fwensXHocNYvKUHivhN9EXw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -170,7 +170,6 @@
     "rollup": "^4.8.0",
     "rollup-plugin-license": "^3.2.0",
     "rollup-plugin-string": "^3.0.0",
-    "rollup-plugin-thatworks": "^1.0.4",
     "semver": "^7.5.4",
     "shx": "^0.3.4",
     "signal-exit": "^4.1.0",

--- a/test/cli/samples/config-mjs-plugins/nested/plugin.mjs
+++ b/test/cli/samples/config-mjs-plugins/nested/plugin.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url';
 
 export default () => ({
 	transform(code) {
-		return `console.log('${relative(process.cwd(), fileURLToPath(import.meta.url)).replace(
+		return `#!/usr/bin/env node\nconsole.log('${relative(process.cwd(), fileURLToPath(import.meta.url)).replace(
 			'\\',
 			'/'
 		)}');\n${code}`;

--- a/test/cli/samples/config-mjs-plugins/rollup.config.mjs
+++ b/test/cli/samples/config-mjs-plugins/rollup.config.mjs
@@ -1,10 +1,9 @@
 import replace from '@rollup/plugin-replace';
-import { shebang } from 'rollup-plugin-thatworks';
 import nestedPlugin from './nested/plugin.mjs';
 import plugin from './plugin.mjs';
 
 export default {
 	input: 'main.js',
 	output: { format: 'cjs', exports: 'auto' },
-	plugins: [shebang(), replace({ preventAssignment: true, ANSWER: 42 }), plugin(), nestedPlugin()]
+	plugins: [replace({ preventAssignment: true, ANSWER: 42 }), plugin(), nestedPlugin()]
 };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Because Rollup V4 preserves the shebang, I believe we no longer need this plugin.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
