### PR TITLE
Do not handle declarations in modules without side effects as TDZ

### DIFF
--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -243,7 +243,9 @@ export default class Identifier extends NodeBase implements PatternNode {
 			return (this.isTDZAccess = true);
 		}
 
-		if (!this.variable.initReached) {
+		// We ignore the case where the module is not yet executed because
+		// moduleSideEffects are false.
+		if (!this.variable.initReached && this.scope.context.module.isExecuted) {
 			// Either a const/let TDZ violation or
 			// var use before declaration was encountered.
 			return (this.isTDZAccess = true);

--- a/test/form/samples/tree-shake-nested-call-no-module-side-effects/_config.js
+++ b/test/form/samples/tree-shake-nested-call-no-module-side-effects/_config.js
@@ -1,0 +1,8 @@
+module.exports = defineTest({
+	description: 'properly tree-shakes nested function calls when moduleSideEffects are disabled',
+	options: {
+		treeshake: {
+			moduleSideEffects: false
+		}
+	}
+});

--- a/test/form/samples/tree-shake-nested-call-no-module-side-effects/_expected.js
+++ b/test/form/samples/tree-shake-nested-call-no-module-side-effects/_expected.js
@@ -1,0 +1,4 @@
+const main = () => {
+};
+
+export { main };

--- a/test/form/samples/tree-shake-nested-call-no-module-side-effects/alpha.js
+++ b/test/form/samples/tree-shake-nested-call-no-module-side-effects/alpha.js
@@ -1,0 +1,7 @@
+const doNothing = () => {};
+
+const alpha = () => {
+	doNothing();
+};
+
+export { alpha };

--- a/test/form/samples/tree-shake-nested-call-no-module-side-effects/main.js
+++ b/test/form/samples/tree-shake-nested-call-no-module-side-effects/main.js
@@ -1,0 +1,7 @@
+import { alpha } from "./alpha";
+
+const main = () => {
+	alpha();
+};
+
+export { main };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5317 

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This ignores the TDZ detection logic when the variable is inside a module with moduleSideEffects=false as the logic would otgherwise detect false positives.