### PR TITLE
Handle pure annotations that are separated by a comment

### DIFF
--- a/rust/parse_ast/src/convert_ast/annotations.rs
+++ b/rust/parse_ast/src/convert_ast/annotations.rs
@@ -13,7 +13,7 @@ impl SequentialComments {
     if comment.text.starts_with('#') && comment.text.contains("sourceMappingURL=") {
       self.annotations.borrow_mut().push(AnnotationWithType {
         comment,
-        kind: AnnotationKind::SourceMappingUrl,
+        kind: CommentKind::Annotation(AnnotationKind::SourceMappingUrl),
       });
       return;
     }
@@ -33,14 +33,14 @@ impl SequentialComments {
           if annotation_slice.starts_with("__PURE__") {
             self.annotations.borrow_mut().push(AnnotationWithType {
               comment,
-              kind: AnnotationKind::Pure,
+              kind: CommentKind::Annotation(AnnotationKind::Pure),
             });
             return;
           }
           if annotation_slice.starts_with("__NO_SIDE_EFFECTS__") {
             self.annotations.borrow_mut().push(AnnotationWithType {
               comment,
-              kind: AnnotationKind::NoSideEffects,
+              kind: CommentKind::Annotation(AnnotationKind::NoSideEffects),
             });
             return;
           }
@@ -49,6 +49,10 @@ impl SequentialComments {
       }
       search_position += 2;
     }
+    self.annotations.borrow_mut().push(AnnotationWithType {
+      comment,
+      kind: CommentKind::Comment,
+    });
   }
 
   pub fn take_annotations(self) -> Vec<AnnotationWithType> {
@@ -122,9 +126,16 @@ impl Comments for SequentialComments {
   }
 }
 
+#[derive(Debug)]
 pub struct AnnotationWithType {
   pub comment: Comment,
-  pub kind: AnnotationKind,
+  pub kind: CommentKind,
+}
+
+#[derive(Clone, Debug)]
+pub enum CommentKind {
+  Annotation(AnnotationKind),
+  Comment,
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/test/form/samples/pure-comment-not-first/_config.js
+++ b/test/form/samples/pure-comment-not-first/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'recognizes pure comments when there are other comments in between'
+});

--- a/test/form/samples/pure-comment-not-first/_expected.js
+++ b/test/form/samples/pure-comment-not-first/_expected.js
@@ -1,0 +1,3 @@
+const five = /* #__PURE__ */ /* foo */ add(2, 3);
+
+export { five };

--- a/test/form/samples/pure-comment-not-first/main.js
+++ b/test/form/samples/pure-comment-not-first/main.js
@@ -1,0 +1,2 @@
+const four = /* #__PURE__ */ /* foo */ add(2, 2);
+export const five = /* #__PURE__ */ /* foo */ add(2, 3);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5324

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This extends the annotation logic to handle comments that separate annotations from the annotated code.