### PR TITLE
build: static link msvc runtime on Windows x64 platform

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -85,7 +85,7 @@ jobs:
 
           # Windows
           - host: windows-latest
-            build: npm run build:napi -- --release
+            build: RUSTFLAGS="-C target-feature=+crt-static" npm run build:napi -- --release
             target: x86_64-pc-windows-msvc
           - host: windows-latest
             build: >-


### PR DESCRIPTION
Ref: https://github.com/vercel/next.js/pull/55505

Reported issues:
  - https://discord.com/channels/874290842444111882/874290843262021705/1193789627828543559
  - Close https://github.com/rollup/rollup/issues/5333
  - Close https://github.com/rollup/rollup/issues/5325