### PR TITLE
Roll back vitepress as 1.0.0-rc.40 breaks the development build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "tslib": "^2.6.2",
         "typescript": "^5.3.3",
         "vite": "^5.0.12",
-        "vitepress": "^1.0.0-rc.40",
+        "vitepress": "1.0.0-rc.39",
         "vue": "^3.4.15",
         "wasm-pack": "^0.12.1",
         "weak-napi": "^2.0.2",
@@ -2107,21 +2107,6 @@
         "win32"
       ]
     },
-    "node_modules/@shikijs/core": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.0.0-beta.3.tgz",
-      "integrity": "sha512-SCwPom2Wn8XxNlEeqdzycU93SKgzYeVsedjqDsgZaz4XiiPpZUzlHt2NAEQTwTnPcHNZapZ6vbkwJ8P11ggL3Q==",
-      "dev": true
-    },
-    "node_modules/@shikijs/transformers": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.0.0-beta.3.tgz",
-      "integrity": "sha512-ASQQQqxW4dANxMGw4yGkTjtMSsUaRhImv/lzJEdfJ3/eP8TVlVYnohOFQVgpLjBBYGy9P0l0oKrlbjiGosTJ/Q==",
-      "dev": true,
-      "dependencies": {
-        "shiki": "1.0.0-beta.3"
-      }
-    },
     "node_modules/@types/buble": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@types/buble/-/buble-0.19.2.tgz",
@@ -2568,41 +2553,6 @@
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
       "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==",
       "dev": true
-    },
-    "node_modules/@vue/devtools-kit": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.0.14.tgz",
-      "integrity": "sha512-wAAJazr4hI0aVRpgWOCVPw+NzMQdthhnprHHIg4njp1MkKrpCNGQ7MtQbZF1AltAA7xpMCGyyt+0kYH0FqTiPg==",
-      "dev": true,
-      "dependencies": {
-        "@vue/devtools-schema": "^7.0.14",
-        "@vue/devtools-shared": "^7.0.14",
-        "hookable": "^5.5.3",
-        "mitt": "^3.0.1",
-        "perfect-debounce": "^1.0.0",
-        "speakingurl": "^14.0.1"
-      }
-    },
-    "node_modules/@vue/devtools-kit/node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
-    },
-    "node_modules/@vue/devtools-schema": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-schema/-/devtools-schema-7.0.14.tgz",
-      "integrity": "sha512-tpUeCLVrdHX+KzWMLTAwx/vAPFbo6jAUi7sr6Q+0mBIqIVSSIxNr5wEhegiFvYva+OtDeM2OrT+f7/X/5bvZNg==",
-      "dev": true
-    },
-    "node_modules/@vue/devtools-shared": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.0.14.tgz",
-      "integrity": "sha512-79RP1NDakBVWou9rDpVnT1WMjTbL1lJKm6YEOodjQ0dq5ehf0wsRbeYDhgAlnjehWRzTq5GAYFBFUPYBs0/QpA==",
-      "dev": true,
-      "dependencies": {
-        "rfdc": "^1.3.1"
-      }
     },
     "node_modules/@vue/eslint-config-prettier": {
       "version": "9.0.0",
@@ -5814,12 +5764,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/hookable": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-      "dev": true
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -8246,12 +8190,6 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
-    "node_modules/perfect-debounce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -9504,13 +9442,28 @@
         "node": "*"
       }
     },
-    "node_modules/shiki": {
-      "version": "1.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.0.0-beta.3.tgz",
-      "integrity": "sha512-z7cHTNSSvwGx2DfeLwjSNLo+HcVxifgNIzLm6Ye52eXcIwNHXT0wHbhy7FDOKSKveuEHBwt9opfj3Hoc8LE1Yg==",
+    "node_modules/shikiji": {
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.19.tgz",
+      "integrity": "sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==",
       "dev": true,
       "dependencies": {
-        "@shikijs/core": "1.0.0-beta.3"
+        "shikiji-core": "0.9.19"
+      }
+    },
+    "node_modules/shikiji-core": {
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.19.tgz",
+      "integrity": "sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw==",
+      "dev": true
+    },
+    "node_modules/shikiji-transformers": {
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.19.tgz",
+      "integrity": "sha512-lGLI7Z8frQrIBbhZ74/eiJtxMoCQRbpaHEB+gcfvdIy+ZFaAtXncJGnc52932/UET+Y4GyKtwwC/vjWUCp+c/Q==",
+      "dev": true,
+      "dependencies": {
+        "shikiji": "0.9.19"
       }
     },
     "node_modules/shx": {
@@ -9729,15 +9682,6 @@
         "spdx-compare": "^1.0.0",
         "spdx-expression-parse": "^3.0.0",
         "spdx-ranges": "^2.0.0"
-      }
-    },
-    "node_modules/speakingurl": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -10542,26 +10486,26 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.0-rc.41",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.41.tgz",
-      "integrity": "sha512-PAEoIIc9J//k/Wg39C6k86hZpXPmLZjRiTBwieDNeYGdevD7xr5Ve8o1W/w+e9dtyQMkuvzgianEamXDX3aj7g==",
+      "version": "1.0.0-rc.39",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.39.tgz",
+      "integrity": "sha512-EcgoRlAAp37WOxUOYv45oxyhLrcy3Upey+mKpqW3ldsg6Ol4trPndRBk2GO0QiSvEKlb9BMerk49D/bFICN6kg==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.5.2",
         "@docsearch/js": "^3.5.2",
-        "@shikijs/core": "^1.0.0-beta.3",
-        "@shikijs/transformers": "^1.0.0-beta.3",
         "@types/markdown-it": "^13.0.7",
         "@vitejs/plugin-vue": "^5.0.3",
-        "@vue/devtools-api": "^7.0.14",
+        "@vue/devtools-api": "^6.5.1",
         "@vueuse/core": "^10.7.2",
         "@vueuse/integrations": "^10.7.2",
         "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
         "minisearch": "^6.3.0",
-        "shiki": "^1.0.0-beta.3",
-        "vite": "^5.0.12",
-        "vue": "^3.4.15"
+        "shikiji": "^0.9.19",
+        "shikiji-core": "^0.9.19",
+        "shikiji-transformers": "^0.9.19",
+        "vite": "^5.0.11",
+        "vue": "^3.4.14"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
@@ -10577,15 +10521,6 @@
         "postcss": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitepress/node_modules/@vue/devtools-api": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.0.14.tgz",
-      "integrity": "sha512-TluWR9qZ6aO11bwtYK8+fzXxBqLfsE0mWZz1q/EQBmO9k82Cm6deieLwNNXjNFJz7xutazoia5Qa+zTYkPPOfw==",
-      "dev": true,
-      "dependencies": {
-        "@vue/devtools-kit": "^7.0.14"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "@types/estree": "1.0.5"
   },
   "devDependenciesComments": {
-    "@types/node": "Version 18.19.0 breaks chokidar and vite types"
+    "@types/node": "Version 18.19.0 breaks chokidar and vite types",
+    "vitepress": "Version 1.0.0-rc.40 breaks npm run dev"
   },
   "devDependencies": {
     "@codemirror/commands": "^6.3.3",
@@ -184,7 +185,7 @@
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",
-    "vitepress": "^1.0.0-rc.40",
+    "vitepress": "1.0.0-rc.39",
     "vue": "^3.4.15",
     "wasm-pack": "^0.12.1",
     "weak-napi": "^2.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
 			"platformAutomerge": true
 		},
 		{
-			"matchPackageNames": ["node", "npm", "fsevents"],
+			"matchPackageNames": ["node", "npm", "fsevents", "vitepress"],
 			"enabled": false
 		},
 		{


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
`npm run dev` was breaking with JavaScript errors that pointed to issues with the vite server.