### PR TITLE
Add locations to logs, warnings and error messages

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -195,22 +195,18 @@ const deferredHandlers: {
 	PLUGIN_WARNING(warnings) {
 		const nestedByPlugin = nest(warnings, 'plugin');
 
-		for (const { key: plugin, items } of nestedByPlugin) {
+		for (const { items } of nestedByPlugin) {
 			const nestedByMessage = nest(items, 'message');
 
 			let lastUrl = '';
 
 			for (const { key: message, items } of nestedByMessage) {
-				title(`Plugin ${plugin}: ${message}`);
+				title(message);
 				for (const warning of items) {
 					if (warning.url && warning.url !== lastUrl) info((lastUrl = warning.url));
 
-					const id = warning.id || warning.loc?.file;
-					if (id) {
-						let loc = relativeId(id);
-						if (warning.loc) {
-							loc += `: (${warning.loc.line}:${warning.loc.column})`;
-						}
+					const loc = formatLocation(warning);
+					if (loc) {
 						stderr(bold(loc));
 					}
 					if (warning.frame) info(warning.frame);
@@ -273,11 +269,9 @@ function defaultBody(log: RollupLog): void {
 		info(getRollupUrl(log.url));
 	}
 
-	const id = log.loc?.file || log.id;
-	if (id) {
-		const loc = log.loc ? `${relativeId(id)} (${log.loc.line}:${log.loc.column})` : relativeId(id);
-
-		stderr(bold(relativeId(loc)));
+	const loc = formatLocation(log);
+	if (loc) {
+		stderr(bold(loc));
 	}
 
 	if (log.frame) info(log.frame);
@@ -339,4 +333,10 @@ function generateLogFilter(command: Record<string, any>) {
 		filters.push(...process.env.ROLLUP_FILTER_LOGS.split(','));
 	}
 	return getLogFilter(filters);
+}
+
+function formatLocation(log: RollupLog): string | null {
+	const id = log.loc?.file || log.id;
+	if (!id) return null;
+	return log.loc ? `${id}:${log.loc.line}:${log.loc.column}` : id;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,7 +11,7 @@ import { getSortedValidatedPlugins } from './PluginDriver';
 import { EMPTY_SET } from './blank';
 import { doNothing } from './doNothing';
 import { LOGLEVEL_DEBUG, LOGLEVEL_INFO, LOGLEVEL_WARN, logLevelPriority } from './logging';
-import { error } from './logs';
+import { augmentLogMessage, error } from './logs';
 import { normalizeLog } from './options/options';
 
 export function getLogger(
@@ -23,6 +23,7 @@ export function getLogger(
 	plugins = getSortedValidatedPlugins('onLog', plugins);
 	const minimalPriority = logLevelPriority[logLevel];
 	const logger = (level: LogLevel, log: RollupLog, skipped: ReadonlySet<Plugin> = EMPTY_SET) => {
+		augmentLogMessage(log);
 		const logPriority = logLevelPriority[level];
 		if (logPriority < minimalPriority) {
 			return;

--- a/src/utils/options/options.ts
+++ b/src/utils/options/options.ts
@@ -19,7 +19,6 @@ import { EMPTY_ARRAY } from '../blank';
 import { LOGLEVEL_DEBUG, LOGLEVEL_ERROR, LOGLEVEL_WARN, logLevelPriority } from '../logging';
 import { error, logInvalidOption, logUnknownOption } from '../logs';
 import { printQuotedStringList } from '../printStringList';
-import relativeId from '../relativeId';
 
 export interface GenericConfigObject {
 	[key: string]: unknown;
@@ -60,7 +59,7 @@ const getDefaultOnLog = (printLog: LogHandler, onwarn?: WarningHandlerWithDefaul
 
 const addLogToString = (log: RollupLog): RollupLog => {
 	Object.defineProperty(log, 'toString', {
-		value: () => getExtendedLogMessage(log),
+		value: () => log.message,
 		writable: true
 	});
 	return log;
@@ -73,21 +72,7 @@ export const normalizeLog = (log: RollupLog | string | (() => RollupLog | string
 			? normalizeLog(log())
 			: log;
 
-const getExtendedLogMessage = (log: RollupLog): string => {
-	let prefix = '';
-
-	if (log.plugin) {
-		prefix += `(${log.plugin} plugin) `;
-	}
-	if (log.loc) {
-		prefix += `${relativeId(log.loc.file!)} (${log.loc.line}:${log.loc.column}) `;
-	}
-
-	return prefix + log.message;
-};
-
-const defaultPrintLog: LogHandler = (level, log) => {
-	const message = getExtendedLogMessage(log);
+const defaultPrintLog: LogHandler = (level, { message }) => {
 	switch (level) {
 		case LOGLEVEL_WARN: {
 			return console.warn(message);

--- a/test/cli/samples/filter-logs/_config.js
+++ b/test/cli/samples/filter-logs/_config.js
@@ -14,11 +14,11 @@ module.exports = defineTest({
 			stderr,
 			`
 main.js → stdout...
-first
-second
-third
-fourth
-fifth
+[plugin test] first
+[plugin test] second
+[plugin test] third
+[plugin test] fourth
+[plugin test] fifth
 `
 		);
 	}

--- a/test/cli/samples/handles-uncaught-errors-under-watch/_config.js
+++ b/test/cli/samples/handles-uncaught-errors-under-watch/_config.js
@@ -5,6 +5,6 @@ module.exports = defineTest({
 	command: 'rollup --config rollup.config.js -w',
 	error: () => true,
 	stderr(stderr) {
-		assertIncludes(stderr, 'Uncaught RollupError: LOL');
+		assertIncludes(stderr, 'Uncaught RollupError: [plugin test] LOL');
 	}
 });

--- a/test/cli/samples/log-side-effects/_config.js
+++ b/test/cli/samples/log-side-effects/_config.js
@@ -1,3 +1,4 @@
+const { sep } = require('node:path');
 const { assertIncludes } = require('../../../utils.js');
 
 module.exports = defineTest({
@@ -6,27 +7,27 @@ module.exports = defineTest({
 	env: { FORCE_COLOR: undefined, NO_COLOR: true },
 	stderr: stderr =>
 		assertIncludes(
-			stderr,
-			`First side effect in dep-mapped.js is at (2:26)
+			stderr.replaceAll(__dirname + sep, 'CWD/'),
+			`dep-mapped.js (1:0): First side effect in dep-mapped.js is at (2:26)
 1: const removed = true;
 2: const alsoRemoved = true; console.log('mapped effect');
                              ^
-dep-mapped.js (1:0)
+CWD/dep-mapped.js:1:0
 1: console.log('mapped effect');
    ^
-First side effect in dep-long-line.js is at (1:126)
+dep-long-line.js (1:126): First side effect in dep-long-line.js is at (1:126)
 1: /* This side effect is deeply hidden inside a very long line, beyond the 120-character limit that we impose for truncation */ console.lo...
                                                                                                                                  ^
-dep-long-line.js (1:126)
+CWD/dep-long-line.js:1:126
 1: /* This side effect is deeply hidden inside a very long line, beyond the 120-character limit that we impose for truncation */ console.lo...
                                                                                                                                  ^
-First side effect in main.js is at (3:0)
+main.js (3:0): First side effect in main.js is at (3:0)
 1: import './dep-mapped';
 2: import './dep-long-line';
 3: console.log('main effect');
    ^
 4: console.log('other effect');
-main.js (3:0)
+CWD/main.js:3:0
 1: import './dep-mapped';
 2: import './dep-long-line';
 3: console.log('main effect');

--- a/test/cli/samples/logs/_config.js
+++ b/test/cli/samples/logs/_config.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert');
+const { sep } = require('node:path');
 
 const BOLD = '\u001B[1m';
 const BLUE = '\u001B[34m';
@@ -14,23 +15,23 @@ module.exports = defineTest({
 	env: { FORCE_COLOR: '1', TERM: 'xterm' },
 	stderr(stderr) {
 		assert.strictEqual(
-			stderr,
+			stderr.replaceAll(__dirname + sep, 'CWD/'),
 			`${CYAN}
 ${BOLD}main.js${REGULAR} → ${BOLD}stdout${REGULAR}...${NOCOLOR}
-${BOLD}${CYAN}simple-info${NOCOLOR}${REGULAR}
-${BOLD}${CYAN}complex-info${NOCOLOR}${REGULAR}
+${BOLD}${CYAN}[plugin test] simple-info${NOCOLOR}${REGULAR}
+${BOLD}${CYAN}[plugin test] complex-info${NOCOLOR}${REGULAR}
 ${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
-${BOLD}${BLUE}simple-debug${NOCOLOR}${REGULAR}
-${BOLD}${BLUE}complex-debug${NOCOLOR}${REGULAR}
+${BOLD}${BLUE}[plugin test] simple-debug${NOCOLOR}${REGULAR}
+${BOLD}${BLUE}[plugin test] complex-debug${NOCOLOR}${REGULAR}
 ${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
-${BOLD}${CYAN}transform-info${NOCOLOR}${REGULAR}
+${BOLD}${CYAN}[plugin test] main.js (1:12): transform-info${NOCOLOR}${REGULAR}
 ${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
-${BOLD}main.js (1:12)${REGULAR}
+${BOLD}CWD/main.js:1:12${REGULAR}
 ${GRAY}1: assert.ok( true );
                ^${NOCOLOR}
-${BOLD}${BLUE}transform-debug${NOCOLOR}${REGULAR}
+${BOLD}${BLUE}[plugin test] main.js (1:13): transform-debug${NOCOLOR}${REGULAR}
 ${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
-${BOLD}main.js (1:13)${REGULAR}
+${BOLD}CWD/main.js:1:13${REGULAR}
 ${GRAY}1: assert.ok( true );
                 ^${NOCOLOR}
 `

--- a/test/cli/samples/validate/_config.js
+++ b/test/cli/samples/validate/_config.js
@@ -8,8 +8,8 @@ module.exports = defineTest({
 	stderr: stderr =>
 		assertIncludes(
 			stderr,
-			`(!) Chunk "out.js" is not valid JavaScript: Unterminated block comment.
-out.js (3:20)
+			`(!) out.js (3:20): Chunk "out.js" is not valid JavaScript: Unterminated block comment.
+out.js:3:20
 1: console.log(2 );
 2: 
 3: console.log("end"); /*

--- a/test/cli/samples/warn-multiple/_config.js
+++ b/test/cli/samples/warn-multiple/_config.js
@@ -1,3 +1,4 @@
+const { sep } = require('node:path');
 const { assertIncludes } = require('../../../utils.js');
 
 module.exports = defineTest({
@@ -31,10 +32,9 @@ module.exports = defineTest({
 				'8: export {url, assert, path};'
 		);
 		assertIncludes(
-			stderr,
-
-			'(!) Module level directives cause errors when bundled, "use stuff" in "main.js" was ignored.\n' +
-				'main.js (1:0)\n' +
+			stderr.replaceAll(__dirname + sep, 'CWD/'),
+			'(!) main.js (1:0): Module level directives cause errors when bundled, "use stuff" in "main.js" was ignored.\n' +
+				'CWD/main.js:1:0\n' +
 				"1: 'use stuff';\n" +
 				'   ^\n' +
 				'2: \n' +

--- a/test/cli/samples/warn-plugin-loc/_config.js
+++ b/test/cli/samples/warn-plugin-loc/_config.js
@@ -1,3 +1,4 @@
+const { sep } = require('node:path');
 const { assertIncludes } = require('../../../utils.js');
 
 module.exports = defineTest({
@@ -5,13 +6,13 @@ module.exports = defineTest({
 	command: 'rollup -c',
 	stderr: stderr => {
 		assertIncludes(
-			stderr,
-			'(!) Plugin test: Warning with file and id\n' +
-				'file1: (1:2)\n' +
-				'(!) Plugin test: Warning with file\n' +
-				'file2: (2:3)\n' +
-				'(!) Plugin test: Warning with id\n' +
-				'file-id3: (3:4)\n'
+			stderr.replaceAll(__dirname + sep, 'CWD/'),
+			'(!) [plugin test] file1 (1:2): Warning with file and id\n' +
+				'CWD/file1:1:2\n' +
+				'(!) [plugin test] file2 (2:3): Warning with file\n' +
+				'CWD/file2:2:3\n' +
+				'(!) [plugin test] file-id3 (3:4): Warning with id\n' +
+				'CWD/file-id3:3:4\n'
 		);
 	}
 });

--- a/test/cli/samples/warn-plugin/_config.js
+++ b/test/cli/samples/warn-plugin/_config.js
@@ -1,3 +1,4 @@
+const { sep } = require('node:path');
 const { assertIncludes } = require('../../../utils.js');
 
 module.exports = defineTest({
@@ -5,16 +6,19 @@ module.exports = defineTest({
 	command: 'rollup -c',
 	env: { FORCE_COLOR: undefined, NO_COLOR: true },
 	stderr: stderr => {
-		assertIncludes(stderr, 'Fifth\nother.js\n');
 		assertIncludes(
-			stderr,
-			'(!) Plugin test-plugin: First\n' +
-				'(!) Plugin test-plugin: Second\n' +
+			stderr.replaceAll(__dirname + sep, 'CWD/'),
+			'[plugin second-plugin] other.js: Fifth\n' + 'CWD/other.js\n'
+		);
+		assertIncludes(
+			stderr.replaceAll(__dirname + sep, 'CWD/'),
+			'(!) [plugin test-plugin] First\n' +
+				'(!) [plugin test-plugin] Second\n' +
 				'https://information\n' +
-				'(!) Plugin second-plugin: Third\n' +
-				'other.js\n' +
-				'(!) Plugin second-plugin: Fourth\n' +
-				'other.js: (1:2)\n' +
+				'(!) [plugin second-plugin] other.js: Third\n' +
+				'CWD/other.js\n' +
+				'(!) [plugin second-plugin] other.js (1:2): Fourth\n' +
+				'CWD/other.js:1:2\n' +
 				'custom frame'
 		);
 	}

--- a/test/cli/samples/watch/bundle-error/_config.js
+++ b/test/cli/samples/watch/bundle-error/_config.js
@@ -16,7 +16,7 @@ module.exports = defineTest({
 		setTimeout(() => unlinkSync(mainFile), 300);
 	},
 	abortOnStderr(data) {
-		if (data.includes('[!] RollupError: Expression expected')) {
+		if (data.includes('[!] RollupError: main.js (1:0): Expression expected')) {
 			setTimeout(() => atomicWriteFileSync(mainFile, 'export default 42;'), 500);
 			return false;
 		}

--- a/test/cli/samples/watch/filter-logs/_config.js
+++ b/test/cli/samples/watch/filter-logs/_config.js
@@ -19,11 +19,11 @@ module.exports = defineTest({
 			stderr,
 			`
 bundles main.js → _actual.js...
-first
-second
-third
-fourth
-fifth
+[plugin test] first
+[plugin test] second
+[plugin test] third
+[plugin test] fourth
+[plugin test] fifth
 created _actual.js`
 		);
 	}

--- a/test/form/samples/log-side-effects/_config.js
+++ b/test/form/samples/log-side-effects/_config.js
@@ -28,7 +28,7 @@ module.exports = defineTest({
 		{
 			level: 'info',
 			code: 'FIRST_SIDE_EFFECT',
-			message: `First side effect in dep-mapped.js is at (2:26)
+			message: `dep-mapped.js (1:0): First side effect in dep-mapped.js is at (2:26)
 1: const removed = true;
 2: const alsoRemoved = true; console.log('mapped effect');
                              ^`,
@@ -46,7 +46,7 @@ module.exports = defineTest({
 		{
 			level: 'info',
 			code: 'FIRST_SIDE_EFFECT',
-			message: `First side effect in main.js is at (2:0)
+			message: `main.js (2:0): First side effect in main.js is at (2:0)
 1: import './dep-mapped';
 2: console.log('main effect');
    ^

--- a/test/function/samples/adds-json-hint-for-missing-export-if-is-json-file/_config.js
+++ b/test/function/samples/adds-json-hint-for-missing-export-if-is-json-file/_config.js
@@ -23,6 +23,6 @@ module.exports = defineTest({
 		`,
 		watchFiles: [ID_ARRAY_JSON, ID_MAIN],
 		message:
-			'"default" is not exported by "array.json", imported by "main.js". (Note that you need @rollup/plugin-json to import JSON files)'
+			'main.js (1:7): "default" is not exported by "array.json", imported by "main.js". (Note that you need @rollup/plugin-json to import JSON files)'
 	}
 });

--- a/test/function/samples/ast-validations/double-default-export/_config.js
+++ b/test/function/samples/ast-validations/double-default-export/_config.js
@@ -6,7 +6,7 @@ module.exports = defineTest({
 	description: 'throws on double default exports',
 	error: {
 		code: 'DUPLICATE_EXPORT',
-		message: 'Duplicate export "default"',
+		message: 'foo.js (2:0): Duplicate export "default"',
 		id: ID_FOO,
 		pos: 18,
 		watchFiles: [ID_FOO, ID_MAIN],

--- a/test/function/samples/ast-validations/double-named-export/_config.js
+++ b/test/function/samples/ast-validations/double-named-export/_config.js
@@ -6,7 +6,7 @@ module.exports = defineTest({
 	description: 'throws on duplicate named exports',
 	error: {
 		code: 'DUPLICATE_EXPORT',
-		message: 'Duplicate export "foo"',
+		message: 'foo.js (3:9): Duplicate export "foo"',
 		id: ID_FOO,
 		pos: 38,
 		watchFiles: [ID_FOO, ID_MAIN],

--- a/test/function/samples/ast-validations/double-named-reexport/_config.js
+++ b/test/function/samples/ast-validations/double-named-reexport/_config.js
@@ -6,7 +6,7 @@ module.exports = defineTest({
 	description: 'throws on duplicate named exports',
 	error: {
 		code: 'DUPLICATE_EXPORT',
-		message: 'Duplicate export "foo"',
+		message: 'foo.js (3:9): Duplicate export "foo"',
 		id: ID_FOO,
 		pos: 38,
 		watchFiles: [ID_FOO, ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-function-export/_config.js
+++ b/test/function/samples/ast-validations/duplicate-function-export/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'throws on duplicate namespace exports',
 	error: {
 		code: 'DUPLICATE_EXPORT',
-		message: 'Duplicate export "foo"',
+		message: 'main.js (3:16): Duplicate export "foo"',
 		id: ID_MAIN,
 		pos: 54,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-import-fails/_config.js
+++ b/test/function/samples/ast-validations/duplicate-import-fails/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'disallows duplicate imports',
 	error: {
 		code: 'REDECLARATION_ERROR',
-		message: 'Identifier "a" has already been declared',
+		message: 'main.js (2:9): Identifier "a" has already been declared',
 		id: ID_MAIN,
 		pos: 36,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-import-specifier-fails/_config.js
+++ b/test/function/samples/ast-validations/duplicate-import-specifier-fails/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'disallows duplicate import specifiers',
 	error: {
 		code: 'REDECLARATION_ERROR',
-		message: 'Identifier "a" has already been declared',
+		message: 'main.js (1:12): Identifier "a" has already been declared',
 		id: ID_MAIN,
 		pos: 12,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-namespace-export/_config.js
+++ b/test/function/samples/ast-validations/duplicate-namespace-export/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'throws on duplicate namespace exports',
 	error: {
 		code: 'DUPLICATE_EXPORT',
-		message: 'Duplicate export "foo"',
+		message: 'main.js (3:12): Duplicate export "foo"',
 		id: ID_MAIN,
 		pos: 50,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-parameter-name/_config.js
+++ b/test/function/samples/ast-validations/duplicate-parameter-name/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'throws on duplicate parameter names as it would when running in strict mode',
 	error: {
 		code: 'DUPLICATE_ARGUMENT_NAME',
-		message: 'Duplicate argument name "a"',
+		message: 'main.js (1:15): Duplicate argument name "a"',
 		id: ID_MAIN,
 		pos: 15,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-var-export/_config.js
+++ b/test/function/samples/ast-validations/duplicate-var-export/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'throws on duplicate exports declared with "var"',
 	error: {
 		code: 'DUPLICATE_EXPORT',
-		message: 'Duplicate export "x"',
+		message: 'main.js (2:11): Duplicate export "x"',
 		id: ID_MAIN,
 		pos: 29,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/reassign-import-fails/_config.js
+++ b/test/function/samples/ast-validations/reassign-import-fails/_config.js
@@ -19,7 +19,7 @@ module.exports = defineTest({
 			8: x = 10;
 			   ^`,
 		watchFiles: [ID_FOO, ID_MAIN],
-		message: 'Illegal reassignment of import "x" in "main.js".'
+		message: 'main.js (8:0): Illegal reassignment of import "x" in "main.js".'
 	}
 });
 

--- a/test/function/samples/ast-validations/reassign-import-not-at-top-level-fails/_config.js
+++ b/test/function/samples/ast-validations/reassign-import-not-at-top-level-fails/_config.js
@@ -20,7 +20,7 @@ module.exports = defineTest({
 			     ^
 			8: }`,
 		watchFiles: [ID_FOO, ID_MAIN],
-		message: 'Illegal reassignment of import "x" in "main.js".'
+		message: 'main.js (7:2): Illegal reassignment of import "x" in "main.js".'
 	}
 });
 

--- a/test/function/samples/ast-validations/redeclare-block-function-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-block-function-function/_config.js
@@ -17,7 +17,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 3
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (3:10): Identifier "foo" has already been declared',
 		pos: 31,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-local-variable-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-local-variable-function/_config.js
@@ -17,7 +17,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 4
 		},
-		message: 'Identifier "error" has already been declared',
+		message: 'main.js (4:10): Identifier "error" has already been declared',
 		pos: 62,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-parameter-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-parameter-function/_config.js
@@ -17,7 +17,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 5
 		},
-		message: 'Identifier "a" has already been declared',
+		message: 'main.js (5:10): Identifier "a" has already been declared',
 		pos: 64,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-parameter-var-outside-conflict/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-parameter-var-outside-conflict/_config.js
@@ -18,7 +18,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 5
 		},
-		message: 'Identifier "error" has already been declared',
+		message: 'main.js (5:5): Identifier "error" has already been declared',
 		pos: 68,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-pattern-parameter-var/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-pattern-parameter-var/_config.js
@@ -17,7 +17,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 4
 		},
-		message: 'Identifier "message" has already been declared',
+		message: 'main.js (4:5): Identifier "message" has already been declared',
 		pos: 63,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-class-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-class-function/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 2
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (2:9): Identifier "foo" has already been declared',
 		pos: 22,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-const-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-const-function/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 2
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (2:9): Identifier "foo" has already been declared',
 		pos: 24,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-default-import-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-default-import-function/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'throws when redeclaring a default import with a function',
 	error: {
 		code: 'REDECLARATION_ERROR',
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (4:9): Identifier "foo" has already been declared',
 		id: ID_MAIN,
 		pos: 56,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/redeclare-import-var/_config.js
+++ b/test/function/samples/ast-validations/redeclare-import-var/_config.js
@@ -5,7 +5,7 @@ module.exports = defineTest({
 	description: 'throws when redeclaring an import with a var',
 	error: {
 		code: 'REDECLARATION_ERROR',
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (4:4): Identifier "foo" has already been declared',
 		id: ID_MAIN,
 		pos: 55,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/redeclare-let-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-let-function/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 2
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (2:9): Identifier "foo" has already been declared',
 		pos: 18,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-let-nested-var/_config.js
+++ b/test/function/samples/ast-validations/redeclare-let-nested-var/_config.js
@@ -18,7 +18,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 4
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (4:8): Identifier "foo" has already been declared',
 		pos: 34,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-nested-var-let/_config.js
+++ b/test/function/samples/ast-validations/redeclare-nested-var-let/_config.js
@@ -18,7 +18,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 5
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (5:6): Identifier "foo" has already been declared',
 		pos: 39,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-parameter-let/_config.js
+++ b/test/function/samples/ast-validations/redeclare-parameter-let/_config.js
@@ -16,7 +16,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 2
 		},
-		message: 'Identifier "x" has already been declared',
+		message: 'main.js (2:5): Identifier "x" has already been declared',
 		pos: 23,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-top-level-function-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-function-function/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 2
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (2:9): Identifier "foo" has already been declared',
 		pos: 27,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-top-level-var-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-var-function/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 2
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (2:9): Identifier "foo" has already been declared',
 		pos: 18,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-var-class/_config.js
+++ b/test/function/samples/ast-validations/redeclare-var-class/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 			file: ID_MAIN,
 			line: 2
 		},
-		message: 'Identifier "foo" has already been declared',
+		message: 'main.js (2:6): Identifier "foo" has already been declared',
 		pos: 15,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/update-expression-of-import-fails/_config.js
+++ b/test/function/samples/ast-validations/update-expression-of-import-fails/_config.js
@@ -19,7 +19,7 @@ module.exports = defineTest({
 			3: a++;
 			   ^`,
 		watchFiles: [ID_FOO, ID_MAIN],
-		message: 'Illegal reassignment of import "a" in "main.js".'
+		message: 'main.js (3:0): Illegal reassignment of import "a" in "main.js".'
 	}
 });
 

--- a/test/function/samples/cannot-call-external-namespace/_config.js
+++ b/test/function/samples/cannot-call-external-namespace/_config.js
@@ -7,8 +7,8 @@ module.exports = defineTest({
 	},
 	warnings(warnings) {
 		assert.deepStrictEqual(warnings.map(String), [
-			'main.js (4:1) Cannot call a namespace ("foo").',
-			'main.js (8:1) Cannot call a namespace ("foo").'
+			'main.js (4:1): Cannot call a namespace ("foo").',
+			'main.js (8:1): Cannot call a namespace ("foo").'
 		]);
 	}
 });

--- a/test/function/samples/cannot-call-internal-namespace/_config.js
+++ b/test/function/samples/cannot-call-internal-namespace/_config.js
@@ -4,8 +4,8 @@ module.exports = defineTest({
 	description: 'warns if code calls an internal namespace',
 	warnings(warnings) {
 		assert.deepStrictEqual(warnings.map(String), [
-			'main.js (4:1) Cannot call a namespace ("foo").',
-			'main.js (8:1) Cannot call a namespace ("foo").'
+			'main.js (4:1): Cannot call a namespace ("foo").',
+			'main.js (8:1): Cannot call a namespace ("foo").'
 		]);
 	}
 });

--- a/test/function/samples/cannot-resolve-sourcemap-warning/_config.js
+++ b/test/function/samples/cannot-resolve-sourcemap-warning/_config.js
@@ -26,7 +26,7 @@ module.exports = defineTest({
 				line: 1
 			},
 			message:
-				"Error when using sourcemap for reporting an error: Can't resolve original location of error.",
+				"main.js (1:15): Error when using sourcemap for reporting an error: Can't resolve original location of error.",
 			pos: 15
 		},
 		{
@@ -42,7 +42,7 @@ module.exports = defineTest({
 				line: 1
 			},
 			message:
-				"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+				"main.js (1:15): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 			pos: 15,
 			url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined'
 		}

--- a/test/function/samples/circular-missed-reexports/_config.js
+++ b/test/function/samples/circular-missed-reexports/_config.js
@@ -25,7 +25,8 @@ module.exports = defineTest({
 			binding: 'doesNotExist',
 			code: 'MISSING_EXPORT',
 			id: ID_MAIN,
-			message: '"doesNotExist" is not exported by "dep1.js", imported by "main.js".',
+			message:
+				'main.js (1:17): "doesNotExist" is not exported by "dep1.js", imported by "main.js".',
 			exporter: ID_DEP1,
 			pos: 17,
 			loc: {

--- a/test/function/samples/conflicting-reexports/named-import/_config.js
+++ b/test/function/samples/conflicting-reexports/named-import/_config.js
@@ -25,6 +25,6 @@ module.exports = defineTest({
 			2:
 			3: assert.strictEqual(foo, 1);`,
 		watchFiles: [ID_FIRST, ID_MAIN, ID_REEXPORT, ID_SECOND],
-		message: '"foo" is not exported by "reexport.js", imported by "main.js".'
+		message: 'main.js (1:9): "foo" is not exported by "reexport.js", imported by "main.js".'
 	}
 });

--- a/test/function/samples/conflicting-reexports/namespace-import/_config.js
+++ b/test/function/samples/conflicting-reexports/namespace-import/_config.js
@@ -20,7 +20,7 @@ module.exports = defineTest({
 			code: 'MISSING_EXPORT',
 			exporter: ID_REEXPORT,
 			id: ID_MAIN,
-			message: '"foo" is not exported by "reexport.js", imported by "main.js".',
+			message: 'main.js (4:22): "foo" is not exported by "reexport.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 125,
 			loc: {

--- a/test/function/samples/default-not-reexported/_config.js
+++ b/test/function/samples/default-not-reexported/_config.js
@@ -9,7 +9,7 @@ module.exports = defineTest({
 		binding: 'default',
 		code: 'MISSING_EXPORT',
 		exporter: ID_FOO,
-		message: '"default" is not exported by "foo.js", imported by "main.js".',
+		message: 'main.js (1:7): "default" is not exported by "foo.js", imported by "main.js".',
 		id: ID_MAIN,
 		pos: 7,
 		watchFiles: [ID_BAR, ID_FOO, ID_MAIN],

--- a/test/function/samples/emit-file/emit-from-output-options/_config.js
+++ b/test/function/samples/emit-file/emit-from-output-options/_config.js
@@ -17,7 +17,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		hook: 'outputOptions',
 		message:
-			'Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
+			'[plugin at position 1] Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
 		plugin: 'at position 1',
 		pluginCode: 'CANNOT_EMIT_FROM_OPTIONS_HOOK'
 	}

--- a/test/function/samples/emit-file/set-asset-source-transform/_config.js
+++ b/test/function/samples/emit-file/set-asset-source-transform/_config.js
@@ -19,7 +19,7 @@ module.exports = defineTest({
 		hook: 'transform',
 		id: path.join(__dirname, 'main.js'),
 		message:
-			'setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.',
+			'[plugin test-plugin] main.js: setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.',
 		plugin: 'test-plugin',
 		pluginCode: 'INVALID_SETASSETSOURCE',
 		watchFiles: [path.join(__dirname, 'main.js')]

--- a/test/function/samples/emit-file/set-source-in-output-options/_config.js
+++ b/test/function/samples/emit-file/set-source-in-output-options/_config.js
@@ -19,7 +19,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		hook: 'outputOptions',
 		message:
-			'Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
+			'[plugin at position 1] Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
 		plugin: 'at position 1',
 		pluginCode: 'CANNOT_EMIT_FROM_OPTIONS_HOOK'
 	}

--- a/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
+++ b/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
@@ -39,6 +39,6 @@ module.exports = defineTest({
 			3: Object.assign({}, a);
 		`,
 		watchFiles: [ID_EMPTY, ID_MAIN],
-		message: '"default" is not exported by "empty.js", imported by "main.js".'
+		message: 'main.js (1:7): "default" is not exported by "empty.js", imported by "main.js".'
 	}
 });

--- a/test/function/samples/error-const-reassign/_config.js
+++ b/test/function/samples/error-const-reassign/_config.js
@@ -14,7 +14,7 @@ module.exports = defineTest({
 			file: MAIN_ID,
 			line: 2
 		},
-		message: 'Cannot reassign a variable declared with `const`',
+		message: 'main.js (2:0): Cannot reassign a variable declared with `const`',
 		pos: 15,
 		watchFiles: [MAIN_ID]
 	}

--- a/test/function/samples/error-parse-json/_config.js
+++ b/test/function/samples/error-parse-json/_config.js
@@ -27,6 +27,6 @@ module.exports = defineTest({
 		`,
 		watchFiles: [ID_JSON, ID_MAIN],
 		message:
-			"Expected ';', '}' or <eof> (Note that you need @rollup/plugin-json to import JSON files)"
+			"file.json (2:8): Expected ';', '}' or <eof> (Note that you need @rollup/plugin-json to import JSON files)"
 	}
 });

--- a/test/function/samples/error-parse-unknown-extension/_config.js
+++ b/test/function/samples/error-parse-unknown-extension/_config.js
@@ -27,6 +27,6 @@ module.exports = defineTest({
 		`,
 		watchFiles: [ID_CSS, ID_MAIN],
 		message:
-			'Expression expected (Note that you need plugins to import files that are not JavaScript)'
+			'file.css (1:0): Expression expected (Note that you need plugins to import files that are not JavaScript)'
 	}
 });

--- a/test/function/samples/export-not-at-top-level-fails/_config.js
+++ b/test/function/samples/export-not-at-top-level-fails/_config.js
@@ -24,6 +24,6 @@ module.exports = defineTest({
 			3: }
 		`,
 		watchFiles: [ID_MAIN],
-		message: "'import', and 'export' cannot be used outside of module code"
+		message: "main.js (2:2): 'import', and 'export' cannot be used outside of module code"
 	}
 });

--- a/test/function/samples/import-assertions/warn-assertion-conflicts/_config.js
+++ b/test/function/samples/import-assertions/warn-assertion-conflicts/_config.js
@@ -23,7 +23,7 @@ module.exports = defineTest({
 				line: 3
 			},
 			message:
-				'Module "main.js" tried to import "external" with "type": "bar" attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
+				'main.js (3:0): Module "main.js" tried to import "external" with "type": "bar" attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
 			pos: 61
 		},
 		{
@@ -42,7 +42,7 @@ module.exports = defineTest({
 				line: 4
 			},
 			message:
-				'Module "main.js" tried to import "external" with no attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
+				'main.js (4:0): Module "main.js" tried to import "external" with no attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
 			pos: 101
 		},
 		{

--- a/test/function/samples/import-assertions/warn-unresolvable-assertions/_config.js
+++ b/test/function/samples/import-assertions/warn-unresolvable-assertions/_config.js
@@ -11,7 +11,7 @@ module.exports = defineTest({
 		{
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
-				'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
+				'main.js (1:0): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
 			id: ID_MAIN,
 			pos: 0,
 			loc: {
@@ -28,7 +28,7 @@ module.exports = defineTest({
 		{
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
-				'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
+				'main.js (2:0): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
 			id: ID_MAIN,
 			pos: 32,
 			loc: {
@@ -46,7 +46,7 @@ module.exports = defineTest({
 		{
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
-				'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
+				'main.js (4:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
 			id: ID_MAIN,
 			pos: 133,
 			loc: {
@@ -65,7 +65,7 @@ module.exports = defineTest({
 		{
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
-				'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
+				'main.js (5:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
 			id: ID_MAIN,
 			pos: 173,
 			loc: {
@@ -84,7 +84,7 @@ module.exports = defineTest({
 		{
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
-				'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
+				'main.js (6:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
 			id: ID_MAIN,
 			pos: 218,
 			loc: {
@@ -103,7 +103,7 @@ module.exports = defineTest({
 		{
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
-				'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
+				'main.js (7:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values. The attribute will be removed.',
 			id: ID_MAIN,
 			pos: 263,
 			loc: {
@@ -121,7 +121,7 @@ module.exports = defineTest({
 		{
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
-				'Rollup could not statically analyze the options argument of a dynamic import in "main.js". Dynamic import options need to be an object with a nested attributes object.',
+				'main.js (3:0): Rollup could not statically analyze the options argument of a dynamic import in "main.js". Dynamic import options need to be an object with a nested attributes object.',
 			id: ID_MAIN,
 			pos: 61,
 			loc: {

--- a/test/function/samples/import-not-at-top-level-fails/_config.js
+++ b/test/function/samples/import-not-at-top-level-fails/_config.js
@@ -24,6 +24,6 @@ module.exports = defineTest({
 			3: }
 		`,
 		watchFiles: [ID_MAIN],
-		message: "'import', and 'export' cannot be used outside of module code"
+		message: "main.js (2:2): 'import', and 'export' cannot be used outside of module code"
 	}
 });

--- a/test/function/samples/import-of-unexported-fails/_config.js
+++ b/test/function/samples/import-of-unexported-fails/_config.js
@@ -23,6 +23,6 @@ module.exports = defineTest({
 			3: a();
 		`,
 		watchFiles: [ID_EMPTY, ID_MAIN],
-		message: '"default" is not exported by "empty.js", imported by "main.js".'
+		message: 'main.js (1:7): "default" is not exported by "empty.js", imported by "main.js".'
 	}
 });

--- a/test/function/samples/invalid-addon-hook/_config.js
+++ b/test/function/samples/invalid-addon-hook/_config.js
@@ -6,6 +6,6 @@ module.exports = defineTest({
 	generateError: {
 		code: 'ADDON_ERROR',
 		message:
-			'Could not retrieve "intro". Check configuration of plugin "at position 1".\n\tError Message: Error running plugin hook "intro" for plugin "at position 1", expected a string, a function hook or an object with a "handler" string or function.'
+			'Could not retrieve "intro". Check configuration of plugin "at position 1".\n\tError Message: [plugin at position 1] Error running plugin hook "intro" for plugin "at position 1", expected a string, a function hook or an object with a "handler" string or function.'
 	}
 });

--- a/test/function/samples/load-module-error/buildEnd/_config.js
+++ b/test/function/samples/load-module-error/buildEnd/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
-	description: 'buildStart hooks can use this.error',
+	description: 'buildEnd hooks can use this.error',
 	options: {
 		plugins: [
 			{
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'buildEnd'
 	}
 });

--- a/test/function/samples/load-module-error/buildStart/_config.js
+++ b/test/function/samples/load-module-error/buildStart/_config.js
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'buildStart'
 	}
 });

--- a/test/function/samples/load-module-error/generateBundle/_config.js
+++ b/test/function/samples/load-module-error/generateBundle/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
-	description: 'buildStart hooks can use this.error',
+	description: 'generateBundle hooks can use this.error',
 	options: {
 		plugins: [
 			{
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'generateBundle'
 	}
 });

--- a/test/function/samples/load-module-error/renderChunk/_config.js
+++ b/test/function/samples/load-module-error/renderChunk/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
-	description: 'buildStart hooks can use this.error',
+	description: 'renderChunk hooks can use this.error',
 	options: {
 		plugins: [
 			{
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'renderChunk'
 	}
 });

--- a/test/function/samples/load-module-error/renderStart/_config.js
+++ b/test/function/samples/load-module-error/renderStart/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
-	description: 'buildStart hooks can use this.error',
+	description: 'renderStart hooks can use this.error',
 	options: {
 		plugins: [
 			{
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'renderStart'
 	}
 });

--- a/test/function/samples/load-module-error/resolveId/_config.js
+++ b/test/function/samples/load-module-error/resolveId/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
-	description: 'buildStart hooks can use this.error',
+	description: 'resolveId hooks can use this.error',
 	options: {
 		plugins: [
 			{
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'resolveId'
 	}
 });

--- a/test/function/samples/load-module-error/transform/_config.js
+++ b/test/function/samples/load-module-error/transform/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] main.js (1:22): nope',
 		hook: 'transform',
 		id: path.join(__dirname, 'main.js'),
 		watchFiles: [path.join(__dirname, 'main.js')],

--- a/test/function/samples/logging/handle-logs-in-plugins/_config.js
+++ b/test/function/samples/logging/handle-logs-in-plugins/_config.js
@@ -58,24 +58,16 @@ module.exports = defineTest({
 		]
 	},
 	after() {
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			[
 				'first',
 				'info',
-				{
-					message: 'passed to both plugins',
-					code: 'PLUGIN_LOG',
-					plugin: 'first'
-				}
+				{ message: '[plugin first] passed to both plugins', code: 'PLUGIN_LOG', plugin: 'first' }
 			],
 			[
 				'second',
 				'info',
-				{
-					message: 'passed to both plugins',
-					code: 'PLUGIN_LOG',
-					plugin: 'first'
-				}
+				{ message: '[plugin first] passed to both plugins', code: 'PLUGIN_LOG', plugin: 'first' }
 			],
 			[
 				'first',
@@ -83,7 +75,7 @@ module.exports = defineTest({
 				{
 					code: 'THIS_IS_UNDEFINED',
 					message:
-						"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+						"main.js (2:5): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 					url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined',
 					id: ID_MAIN,
 					pos: 24,
@@ -101,7 +93,7 @@ module.exports = defineTest({
 				{
 					code: 'THIS_IS_UNDEFINED',
 					message:
-						"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+						"main.js (2:5): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 					url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined',
 					id: ID_MAIN,
 					pos: 24,
@@ -156,7 +148,7 @@ module.exports = defineTest({
 					code: 'EVAL',
 					id: ID_MAIN,
 					message:
-						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+						'main.js (2:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 19,
 					loc: {
@@ -201,7 +193,7 @@ module.exports = defineTest({
 			level: 'warn',
 			code: 'THIS_IS_UNDEFINED',
 			message:
-				"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+				"main.js (2:5): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 			url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined',
 			id: ID_MAIN,
 			pos: 24,
@@ -215,6 +207,11 @@ module.exports = defineTest({
 				2: eval(this);
 				        ^`
 		},
-		{ level: 'info', message: 'passed to both plugins', code: 'PLUGIN_LOG', plugin: 'first' }
+		{
+			level: 'info',
+			message: '[plugin first] passed to both plugins',
+			code: 'PLUGIN_LOG',
+			plugin: 'first'
+		}
 	]
 });

--- a/test/function/samples/logging/log-from-options/_config.js
+++ b/test/function/samples/logging/log-from-options/_config.js
@@ -22,7 +22,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		hook: 'onLog',
-		message: 'error',
+		message: '[plugin test] error',
 		plugin: 'test'
 	}
 });

--- a/test/function/samples/logging/log-from-plugin-onlog-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-onlog-onwarn/_config.js
@@ -11,12 +11,12 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			[
 				'onLog',
 				'warn',
 				{
-					message: 'warnLog',
+					message: '[plugin test] warnLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					meta: { test: 'foo' },
@@ -27,39 +27,65 @@ module.exports = defineTest({
 			[
 				'onLog',
 				'warn',
-				{ message: 'warnLog', code: 'PLUGIN_WARNING', pluginCode: 'PLUGIN_CODE', plugin: 'test' }
+				{
+					message: '[plugin test] warnLog',
+					code: 'PLUGIN_WARNING',
+					pluginCode: 'PLUGIN_CODE',
+					plugin: 'test'
+				}
 			],
 			[
 				'onLog',
 				'warn',
-				{ message: 'warnLog', code: 'PLUGIN_WARNING', pluginCode: 'THE_CODE', plugin: 'test' }
+				{
+					message: '[plugin test] warnLog',
+					code: 'PLUGIN_WARNING',
+					pluginCode: 'THE_CODE',
+					plugin: 'test'
+				}
 			],
-			['onLog', 'warn', { message: 'warnLog', code: 'PLUGIN_WARNING', plugin: 'test' }],
-			['onLog', 'warn', { message: 'warnString', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			[
+				'onLog',
+				'warn',
+				{ message: '[plugin test] warnLog', code: 'PLUGIN_WARNING', plugin: 'test' }
+			],
+			[
+				'onLog',
+				'warn',
+				{ message: '[plugin test] warnString', code: 'PLUGIN_WARNING', plugin: 'test' }
+			],
 			[
 				'onLog',
 				'info',
 				{
-					message: 'infoLog',
+					message: '[plugin test] infoLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
 					plugin: 'test'
 				}
 			],
-			['onLog', 'info', { message: 'infoString', code: 'PLUGIN_LOG', plugin: 'test' }],
+			[
+				'onLog',
+				'info',
+				{ message: '[plugin test] infoString', code: 'PLUGIN_LOG', plugin: 'test' }
+			],
 			[
 				'onLog',
 				'debug',
 				{
-					message: 'debugLog',
+					message: '[plugin test] debugLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
 					plugin: 'test'
 				}
 			],
-			['onLog', 'debug', { message: 'debugString', code: 'PLUGIN_LOG', plugin: 'test' }]
+			[
+				'onLog',
+				'debug',
+				{ message: '[plugin test] debugString', code: 'PLUGIN_LOG', plugin: 'test' }
+			]
 		]);
 	},
 	options: {

--- a/test/function/samples/logging/log-from-plugin-onlog/_config.js
+++ b/test/function/samples/logging/log-from-plugin-onlog/_config.js
@@ -11,43 +11,55 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			[
 				'onLog',
 				'warn',
 				{
-					message: 'warnLog',
+					message: '[plugin test] warnLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_WARNING',
 					plugin: 'test'
 				}
 			],
-			['onLog', 'warn', { message: 'warnString', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			[
+				'onLog',
+				'warn',
+				{ message: '[plugin test] warnString', code: 'PLUGIN_WARNING', plugin: 'test' }
+			],
 			[
 				'onLog',
 				'info',
 				{
-					message: 'infoLog',
+					message: '[plugin test] infoLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
 					plugin: 'test'
 				}
 			],
-			['onLog', 'info', { message: 'infoString', code: 'PLUGIN_LOG', plugin: 'test' }],
+			[
+				'onLog',
+				'info',
+				{ message: '[plugin test] infoString', code: 'PLUGIN_LOG', plugin: 'test' }
+			],
 			[
 				'onLog',
 				'debug',
 				{
-					message: 'debugLog',
+					message: '[plugin test] debugLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
 					plugin: 'test'
 				}
 			],
-			['onLog', 'debug', { message: 'debugString', code: 'PLUGIN_LOG', plugin: 'test' }]
+			[
+				'onLog',
+				'debug',
+				{ message: '[plugin test] debugString', code: 'PLUGIN_LOG', plugin: 'test' }
+			]
 		]);
 	},
 	options: {

--- a/test/function/samples/logging/log-from-plugin-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-onwarn/_config.js
@@ -11,22 +11,22 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			[
 				'onwarn',
 				{
-					message: 'warnLog',
+					message: '[plugin test] warnLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_WARNING',
 					plugin: 'test'
 				}
 			],
-			['onwarn', { message: 'warnString', code: 'PLUGIN_WARNING', plugin: 'test' }],
-			['info', '(test plugin) infoLog'],
-			['info', '(test plugin) infoString'],
-			['debug', '(test plugin) debugLog'],
-			['debug', '(test plugin) debugString']
+			['onwarn', { message: '[plugin test] warnString', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			['info', '[plugin test] infoLog'],
+			['info', '[plugin test] infoString'],
+			['debug', '[plugin test] debugLog'],
+			['debug', '[plugin test] debugString']
 		]);
 	},
 	options: {

--- a/test/function/samples/logging/log-from-plugin-options-onlog-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onlog-onwarn/_config.js
@@ -11,20 +11,28 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			['onLog', 'warn', { message: 'warnLog' }],
 			['onwarn', { message: 'warnLog' }],
 			['warn', 'warnLog'],
 			[
 				'onLog',
 				'warn',
-				{ message: 'warnLog', plugin: 'fooPlugin', loc: { file: 'fooFile', line: 1, column: 2 } }
+				{
+					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					plugin: 'fooPlugin',
+					loc: { file: 'fooFile', line: 1, column: 2 }
+				}
 			],
 			[
 				'onwarn',
-				{ message: 'warnLog', plugin: 'fooPlugin', loc: { file: 'fooFile', line: 1, column: 2 } }
+				{
+					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					plugin: 'fooPlugin',
+					loc: { file: 'fooFile', line: 1, column: 2 }
+				}
 			],
-			['warn', '(fooPlugin plugin) fooFile (1:2) warnLog'],
+			['warn', '[plugin fooPlugin] fooFile (1:2): warnLog'],
 			['onLog', 'warn', { message: 'warnLog=' }],
 			['onwarn', { message: 'warnLog=' }],
 			['onLog', 'warn', { message: 'warnLog+=' }],
@@ -40,8 +48,8 @@ module.exports = defineTest({
 		]);
 		assert.strictEqual(logs[0][2].toString(), 'warnLog');
 		assert.strictEqual(logs[1][1].toString(), 'warnLog');
-		assert.strictEqual(logs[3][2].toString(), '(fooPlugin plugin) fooFile (1:2) warnLog');
-		assert.strictEqual(logs[4][1].toString(), '(fooPlugin plugin) fooFile (1:2) warnLog');
+		assert.strictEqual(logs[3][2].toString(), '[plugin fooPlugin] fooFile (1:2): warnLog');
+		assert.strictEqual(logs[4][1].toString(), '[plugin fooPlugin] fooFile (1:2): warnLog');
 	},
 	options: {
 		logLevel: 'debug',

--- a/test/function/samples/logging/log-from-plugin-options-onlog/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onlog/_config.js
@@ -11,15 +11,19 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			['onLog', 'warn', { message: 'warnLog' }],
 			['warn', 'warnLog'],
 			[
 				'onLog',
 				'warn',
-				{ message: 'warnLog', plugin: 'fooPlugin', loc: { file: 'fooFile', line: 1, column: 2 } }
+				{
+					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					plugin: 'fooPlugin',
+					loc: { file: 'fooFile', line: 1, column: 2 }
+				}
 			],
-			['warn', '(fooPlugin plugin) fooFile (1:2) warnLog'],
+			['warn', '[plugin fooPlugin] fooFile (1:2): warnLog'],
 			['onLog', 'warn', { message: 'warnLog-' }],
 			['onLog', 'warn', { message: 'warnLog+-' }],
 			['debug', 'log was replaced'],
@@ -31,7 +35,7 @@ module.exports = defineTest({
 			['debug', 'debugLog']
 		]);
 		assert.strictEqual(logs[0][2].toString(), 'warnLog');
-		assert.strictEqual(logs[2][2].toString(), '(fooPlugin plugin) fooFile (1:2) warnLog');
+		assert.strictEqual(logs[2][2].toString(), '[plugin fooPlugin] fooFile (1:2): warnLog');
 	},
 	options: {
 		logLevel: 'debug',

--- a/test/function/samples/logging/log-from-plugin-options-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onwarn/_config.js
@@ -11,14 +11,18 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			['onwarn', { message: 'warnLog' }],
 			['warn', 'warnLog'],
 			[
 				'onwarn',
-				{ message: 'warnLog', plugin: 'fooPlugin', loc: { file: 'fooFile', line: 1, column: 2 } }
+				{
+					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					plugin: 'fooPlugin',
+					loc: { file: 'fooFile', line: 1, column: 2 }
+				}
 			],
-			['warn', '(fooPlugin plugin) fooFile (1:2) warnLog'],
+			['warn', '[plugin fooPlugin] fooFile (1:2): warnLog'],
 			['onwarn', { message: 'warnLog-' }],
 			['onwarn', { message: 'warnLog+-' }],
 			['warn', 'log was replaced'],
@@ -28,7 +32,7 @@ module.exports = defineTest({
 			['debug', 'debugLog']
 		]);
 		assert.strictEqual(logs[0][1].toString(), 'warnLog');
-		assert.strictEqual(logs[2][1].toString(), '(fooPlugin plugin) fooFile (1:2) warnLog');
+		assert.strictEqual(logs[2][1].toString(), '[plugin fooPlugin] fooFile (1:2): warnLog');
 	},
 	options: {
 		logLevel: 'debug',

--- a/test/function/samples/logging/log-from-plugin-options-simple/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-simple/_config.js
@@ -12,12 +12,12 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			['warn', 'warnLog'],
 			['info', 'infoLog'],
 			['debug', 'debugLog']
 		]);
-		assert.deepStrictEqual(pluginLogs, [
+		assert.deepEqual(pluginLogs, [
 			['warn', { message: 'warnLog' }],
 			['info', { message: 'infoLog' }],
 			['debug', { message: 'debugLog' }]

--- a/test/function/samples/logging/log-from-plugin-simple/_config.js
+++ b/test/function/samples/logging/log-from-plugin-simple/_config.js
@@ -11,13 +11,13 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
-			['warn', '(test plugin) warnLog'],
-			['warn', '(test plugin) warnString'],
-			['info', '(test plugin) infoLog'],
-			['info', '(test plugin) infoString'],
-			['debug', '(test plugin) debugLog'],
-			['debug', '(test plugin) debugString']
+		assert.deepEqual(logs, [
+			['warn', '[plugin test] warnLog'],
+			['warn', '[plugin test] warnString'],
+			['info', '[plugin test] infoLog'],
+			['info', '[plugin test] infoString'],
+			['debug', '[plugin test] debugLog'],
+			['debug', '[plugin test] debugString']
 		]);
 	},
 	options: {

--- a/test/function/samples/logging/loglevel-debug/_config.js
+++ b/test/function/samples/logging/loglevel-debug/_config.js
@@ -16,26 +16,29 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			['debug', { message: 'onLog-debug' }],
 			['console-debug', 'onLogOption-debug'],
 			['console-info', 'onLogOption-info'],
 			['console-warn', 'onLogOption-warn'],
 			['info', { message: 'onLog-info' }],
 			['warn', { message: 'onLog-warn' }],
-			['debug', { message: 'options-debug', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['info', { message: 'options-info', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['warn', { message: 'options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
-			['debug', { message: 'buildStart-debug', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['info', { message: 'buildStart-info', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['warn', { message: 'buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			['debug', { message: '[plugin test] options-debug', code: 'PLUGIN_LOG', plugin: 'test' }],
+			['info', { message: '[plugin test] options-info', code: 'PLUGIN_LOG', plugin: 'test' }],
+			['warn', { message: '[plugin test] options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			['debug', { message: '[plugin test] buildStart-debug', code: 'PLUGIN_LOG', plugin: 'test' }],
+			['info', { message: '[plugin test] buildStart-info', code: 'PLUGIN_LOG', plugin: 'test' }],
+			[
+				'warn',
+				{ message: '[plugin test] buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }
+			],
 			['debug', { message: 'buildStart-options-debug' }],
 			['info', { message: 'buildStart-options-info' }],
 			['warn', { message: 'buildStart-options-warn' }],
 			[
 				'debug',
 				{
-					message: 'transform-debug',
+					message: '[plugin test] main.js: transform-debug',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_LOG',
@@ -45,7 +48,7 @@ module.exports = defineTest({
 			[
 				'info',
 				{
-					message: 'transform-info',
+					message: '[plugin test] main.js: transform-info',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_LOG',
@@ -55,7 +58,7 @@ module.exports = defineTest({
 			[
 				'warn',
 				{
-					message: 'transform-warn',
+					message: '[plugin test] main.js: transform-warn',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_WARNING',
@@ -68,7 +71,7 @@ module.exports = defineTest({
 					code: 'EVAL',
 					id: ID_MAIN,
 					message:
-						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+						'main.js (1:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 0,
 					loc: {

--- a/test/function/samples/logging/loglevel-info/_config.js
+++ b/test/function/samples/logging/loglevel-info/_config.js
@@ -16,21 +16,24 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			['info', { message: 'onLog-info' }],
 			['console-info', 'onLogOption-info'],
 			['console-warn', 'onLogOption-warn'],
 			['warn', { message: 'onLog-warn' }],
-			['info', { message: 'options-info', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['warn', { message: 'options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
-			['info', { message: 'buildStart-info', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['warn', { message: 'buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			['info', { message: '[plugin test] options-info', code: 'PLUGIN_LOG', plugin: 'test' }],
+			['warn', { message: '[plugin test] options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			['info', { message: '[plugin test] buildStart-info', code: 'PLUGIN_LOG', plugin: 'test' }],
+			[
+				'warn',
+				{ message: '[plugin test] buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }
+			],
 			['info', { message: 'buildStart-options-info' }],
 			['warn', { message: 'buildStart-options-warn' }],
 			[
 				'info',
 				{
-					message: 'transform-info',
+					message: '[plugin test] main.js: transform-info',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_LOG',
@@ -40,7 +43,7 @@ module.exports = defineTest({
 			[
 				'warn',
 				{
-					message: 'transform-warn',
+					message: '[plugin test] main.js: transform-warn',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_WARNING',
@@ -53,7 +56,7 @@ module.exports = defineTest({
 					code: 'EVAL',
 					id: ID_MAIN,
 					message:
-						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+						'main.js (1:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 0,
 					loc: {

--- a/test/function/samples/logging/loglevel-silent/_config.js
+++ b/test/function/samples/logging/loglevel-silent/_config.js
@@ -14,7 +14,7 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, []);
+		assert.deepEqual(logs, []);
 	},
 	options: {
 		logLevel: 'silent',

--- a/test/function/samples/logging/loglevel-warn/_config.js
+++ b/test/function/samples/logging/loglevel-warn/_config.js
@@ -16,16 +16,19 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, [
+		assert.deepEqual(logs, [
 			['warn', { message: 'onLog-warn' }],
 			['console-warn', 'onLogOption-warn'],
-			['warn', { message: 'options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
-			['warn', { message: 'buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			['warn', { message: '[plugin test] options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			[
+				'warn',
+				{ message: '[plugin test] buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }
+			],
 			['warn', { message: 'buildStart-options-warn' }],
 			[
 				'warn',
 				{
-					message: 'transform-warn',
+					message: '[plugin test] main.js: transform-warn',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_WARNING',
@@ -38,7 +41,7 @@ module.exports = defineTest({
 					code: 'EVAL',
 					id: ID_MAIN,
 					message:
-						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+						'main.js (1:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 0,
 					loc: {

--- a/test/function/samples/logging/no-log-with-position/_config.js
+++ b/test/function/samples/logging/no-log-with-position/_config.js
@@ -54,11 +54,21 @@ module.exports = defineTest({
 			message:
 				'Plugin "test" tried to add a file position to a log or warning. This is only supported in the "transform" hook at the moment and will be ignored.'
 		},
-		{ level: 'warn', message: 'log-message1', code: 'PLUGIN_WARNING', plugin: 'test' },
-		{ level: 'warn', message: 'log-message1', code: 'PLUGIN_WARNING', plugin: 'test' },
-		{ level: 'info', message: 'log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
-		{ level: 'info', message: 'log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
-		{ level: 'debug', message: 'log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
-		{ level: 'debug', message: 'log-message1', code: 'PLUGIN_LOG', plugin: 'test' }
+		{
+			level: 'warn',
+			message: '[plugin test] log-message1',
+			code: 'PLUGIN_WARNING',
+			plugin: 'test'
+		},
+		{
+			level: 'warn',
+			message: '[plugin test] log-message1',
+			code: 'PLUGIN_WARNING',
+			plugin: 'test'
+		},
+		{ level: 'info', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
+		{ level: 'info', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
+		{ level: 'debug', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
+		{ level: 'debug', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' }
 	]
 });

--- a/test/function/samples/logging/plugin-order/_config.js
+++ b/test/function/samples/logging/plugin-order/_config.js
@@ -16,7 +16,7 @@ module.exports = defineTest({
 				},
 				onLog(level, log) {
 					logs.push(['first', level, log]);
-					if (log.message === 'first') {
+					if (log.message.endsWith('first')) {
 						return false;
 					}
 				}
@@ -27,7 +27,7 @@ module.exports = defineTest({
 					order: 'pre',
 					handler(level, log) {
 						logs.push(['second', level, log]);
-						if (log.message === 'second') {
+						if (log.message.endsWith('second')) {
 							return false;
 						}
 					}
@@ -39,7 +39,7 @@ module.exports = defineTest({
 					order: 'post',
 					handler(level, log) {
 						logs.push(['third', level, log]);
-						if (log.message === 'third') {
+						if (log.message.endsWith('third')) {
 							return false;
 						}
 					}
@@ -48,13 +48,13 @@ module.exports = defineTest({
 		]
 	},
 	after() {
-		assert.deepStrictEqual(logs, [
-			['second', 'info', { message: 'first', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['first', 'info', { message: 'first', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['second', 'info', { message: 'second', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['second', 'info', { message: 'third', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['first', 'info', { message: 'third', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['third', 'info', { message: 'third', code: 'PLUGIN_LOG', plugin: 'first' }]
+		assert.deepEqual(logs, [
+			['second', 'info', { message: '[plugin first] first', code: 'PLUGIN_LOG', plugin: 'first' }],
+			['first', 'info', { message: '[plugin first] first', code: 'PLUGIN_LOG', plugin: 'first' }],
+			['second', 'info', { message: '[plugin first] second', code: 'PLUGIN_LOG', plugin: 'first' }],
+			['second', 'info', { message: '[plugin first] third', code: 'PLUGIN_LOG', plugin: 'first' }],
+			['first', 'info', { message: '[plugin first] third', code: 'PLUGIN_LOG', plugin: 'first' }],
+			['third', 'info', { message: '[plugin first] third', code: 'PLUGIN_LOG', plugin: 'first' }]
 		]);
 	},
 	logs: []

--- a/test/function/samples/logging/promote-log-to-error/_config.js
+++ b/test/function/samples/logging/promote-log-to-error/_config.js
@@ -11,7 +11,7 @@ module.exports = defineTest({
 	},
 	after() {
 		Object.assign(console, { debug, info, warn });
-		assert.deepStrictEqual(logs, []);
+		assert.deepEqual(logs, []);
 	},
 	options: {
 		onwarn: null,
@@ -31,7 +31,7 @@ module.exports = defineTest({
 		binding: 'foo',
 		code: 'PLUGIN_ERROR',
 		hook: 'buildStart',
-		message: 'info becomes error',
+		message: '[plugin test] info becomes error',
 		plugin: 'test',
 		pluginCode: 'EXTRA_CODE'
 	}

--- a/test/function/samples/logging/this-error-onlog/_config.js
+++ b/test/function/samples/logging/this-error-onlog/_config.js
@@ -16,7 +16,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		hook: 'buildStart',
-		message: 'test log',
+		message: '[plugin test] test log',
 		plugin: 'test',
 		pluginCode: 'THE_CODE'
 	}

--- a/test/function/samples/logging/transform-log-with-position/_config.js
+++ b/test/function/samples/logging/transform-log-with-position/_config.js
@@ -25,7 +25,7 @@ module.exports = defineTest({
 	logs: [
 		{
 			level: 'warn',
-			message: 'warn-message1',
+			message: '[plugin test] main.js (2:3): warn-message1',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -44,7 +44,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'info',
-			message: 'info-message1',
+			message: '[plugin test] main.js (2:3): info-message1',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -63,7 +63,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'debug',
-			message: 'debug-message1',
+			message: '[plugin test] main.js (2:3): debug-message1',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -82,7 +82,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'warn',
-			message: 'warn-message2',
+			message: '[plugin test] main.js (2:1): warn-message2',
 			loc: {
 				column: 1,
 				file: ID_MAIN,
@@ -100,7 +100,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'info',
-			message: 'info-message2',
+			message: '[plugin test] main.js (2:1): info-message2',
 			loc: {
 				column: 1,
 				file: ID_MAIN,
@@ -118,7 +118,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'debug',
-			message: 'debug-message2',
+			message: '[plugin test] main.js (2:1): debug-message2',
 			loc: {
 				column: 1,
 				file: ID_MAIN,
@@ -136,7 +136,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'warn',
-			message: 'warn-message3',
+			message: '[plugin test] main.js (2:3): warn-message3',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -155,7 +155,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'info',
-			message: 'info-message3',
+			message: '[plugin test] main.js (2:3): info-message3',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -174,7 +174,7 @@ module.exports = defineTest({
 		},
 		{
 			level: 'debug',
-			message: 'debug-message3',
+			message: '[plugin test] main.js (2:3): debug-message3',
 			pos: 20,
 			loc: {
 				column: 3,

--- a/test/function/samples/module-level-directive/_config.js
+++ b/test/function/samples/module-level-directive/_config.js
@@ -8,7 +8,7 @@ module.exports = defineTest({
 			code: 'MODULE_LEVEL_DIRECTIVE',
 			id: ID_MAIN,
 			message:
-				'Module level directives cause errors when bundled, "use asm" in "main.js" was ignored.',
+				'main.js (1:0): Module level directives cause errors when bundled, "use asm" in "main.js" was ignored.',
 			pos: 0,
 			loc: {
 				column: 0,

--- a/test/function/samples/namespace-missing-export/_config.js
+++ b/test/function/samples/namespace-missing-export/_config.js
@@ -10,7 +10,7 @@ module.exports = defineTest({
 			code: 'MISSING_EXPORT',
 			exporter: ID_EMPTY,
 			id: ID_MAIN,
-			message: '"foo" is not exported by "empty.js", imported by "main.js".',
+			message: 'main.js (3:25): "foo" is not exported by "empty.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 61,
 			loc: {

--- a/test/function/samples/namespace-reassign-import-fails/_config.js
+++ b/test/function/samples/namespace-reassign-import-fails/_config.js
@@ -16,7 +16,7 @@ module.exports = defineTest({
 			code: 'MISSING_EXPORT',
 			exporter: ID_FOO,
 			id: ID_MAIN,
-			message: '"bar" is not exported by "foo.js", imported by "main.js".',
+			message: 'main.js (4:4): "bar" is not exported by "foo.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 48,
 			loc: {
@@ -32,7 +32,7 @@ module.exports = defineTest({
 		},
 		{
 			code: 'ILLEGAL_REASSIGNMENT',
-			message: 'Illegal reassignment of import "exp" in "main.js".',
+			message: 'main.js (3:0): Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 31,
 			loc: {
@@ -49,7 +49,7 @@ module.exports = defineTest({
 		},
 		{
 			code: 'ILLEGAL_REASSIGNMENT',
-			message: 'Illegal reassignment of import "exp" in "main.js".',
+			message: 'main.js (4:0): Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 44,
 			loc: {

--- a/test/function/samples/namespace-update-import-fails/_config.js
+++ b/test/function/samples/namespace-update-import-fails/_config.js
@@ -11,7 +11,7 @@ module.exports = defineTest({
 	warnings: [
 		{
 			code: 'ILLEGAL_REASSIGNMENT',
-			message: 'Illegal reassignment of import "exp" in "main.js".',
+			message: 'main.js (3:0): Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 31,
 			loc: {

--- a/test/function/samples/non-function-hook-async/_config.js
+++ b/test/function/samples/non-function-hook-async/_config.js
@@ -7,7 +7,7 @@ module.exports = defineTest({
 		code: 'INVALID_PLUGIN_HOOK',
 		hook: 'resolveId',
 		message:
-			'Error running plugin hook "resolveId" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
+			'[plugin at position 1] Error running plugin hook "resolveId" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
 		plugin: 'at position 1'
 	}
 });

--- a/test/function/samples/non-function-hook-sync/_config.js
+++ b/test/function/samples/non-function-hook-sync/_config.js
@@ -11,7 +11,7 @@ module.exports = defineTest({
 		code: 'INVALID_PLUGIN_HOOK',
 		hook: 'outputOptions',
 		message:
-			'Error running plugin hook "outputOptions" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
+			'[plugin at position 1] Error running plugin hook "outputOptions" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
 		plugin: 'at position 1'
 	}
 });

--- a/test/function/samples/plugin-error-loc-instead-pos/_config.js
+++ b/test/function/samples/plugin-error-loc-instead-pos/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] main.js (1:22): nope',
 		hook: 'transform',
 		id: path.join(__dirname, 'main.js'),
 		watchFiles: [path.join(__dirname, 'main.js')],

--- a/test/function/samples/plugin-error/buildEnd/_config.js
+++ b/test/function/samples/plugin-error/buildEnd/_config.js
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'buildEnd'
 	}
 });

--- a/test/function/samples/plugin-error/buildStart/_config.js
+++ b/test/function/samples/plugin-error/buildStart/_config.js
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'buildStart'
 	}
 });

--- a/test/function/samples/plugin-error/generateBundle/_config.js
+++ b/test/function/samples/plugin-error/generateBundle/_config.js
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'generateBundle'
 	}
 });

--- a/test/function/samples/plugin-error/load/_config.js
+++ b/test/function/samples/plugin-error/load/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: `Could not load ${path.join(__dirname, 'main.js')}: nope`,
+		message: `Could not load ${path.join(__dirname, 'main.js')}: [plugin test] nope`,
 		hook: 'load'
 	}
 });

--- a/test/function/samples/plugin-error/renderChunk/_config.js
+++ b/test/function/samples/plugin-error/renderChunk/_config.js
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'renderChunk'
 	}
 });

--- a/test/function/samples/plugin-error/renderStart/_config.js
+++ b/test/function/samples/plugin-error/renderStart/_config.js
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	generateError: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'renderStart'
 	}
 });

--- a/test/function/samples/plugin-error/resolveId/_config.js
+++ b/test/function/samples/plugin-error/resolveId/_config.js
@@ -13,7 +13,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] nope',
 		hook: 'resolveId'
 	}
 });

--- a/test/function/samples/plugin-error/transform/_config.js
+++ b/test/function/samples/plugin-error/transform/_config.js
@@ -15,7 +15,7 @@ module.exports = defineTest({
 	error: {
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
-		message: 'nope',
+		message: '[plugin test] main.js (1:22): nope',
 		hook: 'transform',
 		id: path.join(__dirname, 'main.js'),
 		watchFiles: [path.join(__dirname, 'main.js')],

--- a/test/function/samples/plugin-warn-loc-instead-pos/_config.js
+++ b/test/function/samples/plugin-warn-loc-instead-pos/_config.js
@@ -19,7 +19,7 @@ module.exports = defineTest({
 			id: path.join(__dirname, 'main.js'),
 			plugin: 'test',
 			hook: 'transform',
-			message: 'foo',
+			message: '[plugin test] main.js (1:22): foo',
 			loc: {
 				file: path.join(__dirname, 'main.js'),
 				line: 1,

--- a/test/function/samples/plugin-warn/_config.js
+++ b/test/function/samples/plugin-warn/_config.js
@@ -20,7 +20,7 @@ module.exports = defineTest({
 			id: path.join(__dirname, 'main.js'),
 			hook: 'transform',
 			plugin: 'test',
-			message: 'foo',
+			message: '[plugin test] main.js: foo',
 			pluginCode: 'CODE'
 		},
 		{
@@ -28,7 +28,7 @@ module.exports = defineTest({
 			id: path.join(__dirname, 'main.js'),
 			plugin: 'test',
 			hook: 'transform',
-			message: 'bar',
+			message: '[plugin test] main.js (1:22): bar',
 			pos: 22,
 			loc: {
 				file: path.join(__dirname, 'main.js'),

--- a/test/function/samples/reexport-missing-error/_config.js
+++ b/test/function/samples/reexport-missing-error/_config.js
@@ -20,6 +20,6 @@ module.exports = defineTest({
 			1: export { foo as bar } from './empty.js';
 			            ^`,
 		watchFiles: [ID_EMPTY, ID_MAIN],
-		message: '"foo" is not exported by "empty.js", imported by "main.js".'
+		message: 'main.js (1:9): "foo" is not exported by "empty.js", imported by "main.js".'
 	}
 });

--- a/test/function/samples/transform-without-sourcemap-render-chunk/_config.js
+++ b/test/function/samples/transform-without-sourcemap-render-chunk/_config.js
@@ -24,7 +24,7 @@ module.exports = defineTest({
 		{
 			code: `SOURCEMAP_BROKEN`,
 			plugin: 'fake plugin 1',
-			message: `Sourcemap is likely to be incorrect: a plugin (fake plugin 1) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
+			message: `[plugin fake plugin 1] Sourcemap is likely to be incorrect: a plugin (fake plugin 1) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
 			url: `https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect`
 		}
 	]

--- a/test/function/samples/validate-output/_config.js
+++ b/test/function/samples/validate-output/_config.js
@@ -11,7 +11,7 @@ module.exports = defineTest({
 	},
 	generateError: {
 		code: 'CHUNK_INVALID',
-		message: 'Chunk "main.js" is not valid JavaScript: Unterminated block comment.',
+		message: 'main.js (5:0): Chunk "main.js" is not valid JavaScript: Unterminated block comment.',
 		frame: `
 3: throw new Error('Not executed');
 4:

--- a/test/function/samples/warn-misplaced-annotations/_config.js
+++ b/test/function/samples/warn-misplaced-annotations/_config.js
@@ -8,7 +8,7 @@ module.exports = defineTest({
 			code: 'INVALID_ANNOTATION',
 			id: ID_MAIN,
 			message:
-				'A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+				'main.js (2:0): A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
 			url: 'https://rollupjs.org/configuration-options/#no-side-effects',
 			pos: 45,
 			loc: {
@@ -27,7 +27,7 @@ module.exports = defineTest({
 			code: 'INVALID_ANNOTATION',
 			id: ID_MAIN,
 			message:
-				'A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+				'main.js (4:0): A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
 			url: 'https://rollupjs.org/configuration-options/#no-side-effects',
 			pos: 113,
 			loc: {
@@ -45,7 +45,7 @@ module.exports = defineTest({
 			code: 'INVALID_ANNOTATION',
 			id: ID_MAIN,
 			message:
-				'A comment\n\n"/*@__PURE__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+				'main.js (1:0): A comment\n\n"/*@__PURE__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
 			url: 'https://rollupjs.org/configuration-options/#pure',
 			pos: 0,
 			loc: {

--- a/test/function/samples/warn-on-eval/_config.js
+++ b/test/function/samples/warn-on-eval/_config.js
@@ -8,7 +8,7 @@ module.exports = defineTest({
 			code: 'EVAL',
 			id: ID_MAIN,
 			message:
-				'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+				'main.js (1:13): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 			url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 			pos: 13,
 			loc: {

--- a/test/function/samples/warn-on-top-level-this/_config.js
+++ b/test/function/samples/warn-on-top-level-this/_config.js
@@ -7,7 +7,7 @@ module.exports = defineTest({
 		{
 			code: 'THIS_IS_UNDEFINED',
 			id: path.join(__dirname, 'main.js'),
-			message: `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`,
+			message: `main.js (3:0): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`,
 			pos: 81,
 			loc: {
 				file: path.join(__dirname, 'main.js'),

--- a/test/function/samples/warn-on-unused-missing-imports/_config.js
+++ b/test/function/samples/warn-on-unused-missing-imports/_config.js
@@ -10,7 +10,7 @@ module.exports = defineTest({
 			code: 'MISSING_EXPORT',
 			exporter: ID_FOO,
 			id: ID_MAIN,
-			message: '"b" is not exported by "foo.js", imported by "main.js".',
+			message: 'main.js (1:12): "b" is not exported by "foo.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 12,
 			loc: {

--- a/test/function/samples/warning-incorrect-sourcemap-location/_config.js
+++ b/test/function/samples/warning-incorrect-sourcemap-location/_config.js
@@ -26,7 +26,8 @@ module.exports = defineTest({
 				file: ID_MAIN,
 				line: 12
 			},
-			message: '"NON_EXISTENT" is not exported by "constants.js", imported by "main.js".',
+			message:
+				'main.js (12:15): "NON_EXISTENT" is not exported by "constants.js", imported by "main.js".',
 			pos: 111,
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module'
 		}

--- a/test/function/samples/warning-low-resolution-location/_config.js
+++ b/test/function/samples/warning-low-resolution-location/_config.js
@@ -34,7 +34,7 @@ module.exports = defineTest({
 				line: 1
 			},
 			message:
-				"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+				"main.js (1:0): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 			pos: 15,
 			url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined'
 		}

--- a/test/function/samples/warnings-to-string/_config.js
+++ b/test/function/samples/warnings-to-string/_config.js
@@ -14,7 +14,7 @@ module.exports = defineTest({
 	},
 	warnings(warnings) {
 		assert.deepStrictEqual(warnings.map(String), [
-			'(test-plugin plugin) main.js (1:6) This might be removed',
+			'[plugin test-plugin] main.js (1:6): This might be removed',
 			'Generated an empty chunk: "main".'
 		]);
 	}

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { outputFile, readdir, remove } = require('fs-extra');
 /**
- * @type {import('../../src/rollup/types')} Rollup
+ * @type {import("../../src/rollup/types")} Rollup
  */
 const rollup = require('../../dist/rollup.js');
 const { loader, wait } = require('../utils.js');
@@ -96,10 +96,10 @@ describe('hooks', () => {
 				input: 'input',
 				onwarn(warning) {
 					if (callCnt === 0) {
-						assert.strictEqual(warning.message, 'build start');
+						assert.strictEqual(warning.message, '[plugin at position 2] build start');
 						callCnt++;
 					} else if (callCnt === 1) {
-						assert.strictEqual(warning.message, 'build end');
+						assert.strictEqual(warning.message, '[plugin at position 2] build end');
 						callCnt++;
 					}
 				},
@@ -132,7 +132,7 @@ describe('hooks', () => {
 							this.error('build start error');
 						},
 						buildEnd(error) {
-							assert.strictEqual(error.message, 'build start error');
+							assert.strictEqual(error.message, '[plugin at position 2] build start error');
 							handledError = true;
 						}
 					}
@@ -140,7 +140,7 @@ describe('hooks', () => {
 			})
 			.catch(error => {
 				assert.ok(handledError);
-				assert.strictEqual(error.message, 'build start error');
+				assert.strictEqual(error.message, '[plugin at position 2] build start error');
 			})
 			.then(() => {
 				assert.ok(handledError);
@@ -1024,7 +1024,7 @@ describe('hooks', () => {
 			})
 			.then(bundle => bundle.close())
 			.catch(error => {
-				assert.strictEqual(error.message, 'close bundle error');
+				assert.strictEqual(error.message, '[plugin at position 2] close bundle error');
 				handledError = true;
 			})
 			.then(() => {
@@ -1080,6 +1080,7 @@ describe('hooks', () => {
 		addPlugin('post');
 		addPlugin('pre');
 		addPlugin();
+
 		function addPlugin(order) {
 			const name = `${order}-${plugins.length}`;
 			const plugin = { name };

--- a/test/misc/sanity-checks.js
+++ b/test/misc/sanity-checks.js
@@ -33,7 +33,7 @@ describe('sanity checks', () => {
 		assert.equal(parameters[0].code, 'EVAL');
 		assert.equal(
 			parameters[0].message,
-			'Use of eval in "x" is strongly discouraged as it poses security risks and may cause issues with minification.'
+			'x (1:0): Use of eval in "x" is strongly discouraged as it poses security risks and may cause issues with minification.'
 		);
 		assert.equal(typeof parameters[1], 'function');
 	});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5246

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

As we keep getting issues that Rollup does not tell you the location of warnings and errors when run through tools like Vite, this PR will automatically extend all error, warning and log messages that have a location and/or a plugin to also mention this in their error message, e.g.

```
[plugin test] main.js (1:0): Some error occurred
```

instead of just

```
Some error occurred
```