### PR TITLE
Cache module info getters before output generation

### DIFF
--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -1,6 +1,7 @@
 import ExternalVariable from './ast/variables/ExternalVariable';
 import type { CustomPluginOptions, ModuleInfo, NormalizedInputOptions } from './rollup/types';
 import { EMPTY_ARRAY } from './utils/blank';
+import { cacheObjectGetters } from './utils/getter';
 import { makeLegal } from './utils/identifierHelpers';
 import { LOGLEVEL_WARN } from './utils/logging';
 import { logUnusedExternalImports } from './utils/logs';
@@ -30,6 +31,7 @@ export default class ExternalModule {
 		this.suggestedVariableName = makeLegal(id.split(/[/\\]/).pop()!);
 
 		const { importers, dynamicImporters } = this;
+		// NOTE: any getter props should also be defined in cacheInfoGetters
 		this.info = {
 			ast: null,
 			attributes,
@@ -57,6 +59,10 @@ export default class ExternalModule {
 			moduleSideEffects,
 			syntheticNamedExports: false
 		};
+	}
+
+	cacheInfoGetters(): void {
+		cacheObjectGetters(this.info, ['dynamicImporters', 'importers']);
 	}
 
 	getVariableForExportName(name: string): [variable: ExternalVariable] {

--- a/src/ExternalModule.ts
+++ b/src/ExternalModule.ts
@@ -31,7 +31,6 @@ export default class ExternalModule {
 		this.suggestedVariableName = makeLegal(id.split(/[/\\]/).pop()!);
 
 		const { importers, dynamicImporters } = this;
-		// NOTE: any getter props should also be defined in cacheInfoGetters
 		this.info = {
 			ast: null,
 			attributes,

--- a/src/Graph.ts
+++ b/src/Graph.ts
@@ -151,6 +151,7 @@ export default class Graph {
 			throw new Error('You must supply options.input to rollup');
 		}
 		for (const module of this.modulesById.values()) {
+			module.cacheInfoGetters();
 			if (module instanceof Module) {
 				this.modules.push(module);
 			} else {

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -55,6 +55,7 @@ import { decodedSourcemap, resetSourcemapCache } from './utils/decodedSourcemap'
 import { getId } from './utils/getId';
 import { getNewSet, getOrCreate } from './utils/getOrCreate';
 import { getOriginalLocation } from './utils/getOriginalLocation';
+import { cacheObjectGetters } from './utils/getter';
 import { makeLegal } from './utils/identifierHelpers';
 import { LOGLEVEL_WARN } from './utils/logging';
 import {
@@ -293,6 +294,7 @@ export default class Module {
 			sourcesWithAttributes
 		} = this;
 
+		// NOTE: any getter props should also be defined in cacheInfoGetters
 		this.info = {
 			ast: null,
 			attributes,
@@ -388,6 +390,23 @@ export default class Module {
 
 	bindReferences(): void {
 		this.ast!.bind();
+	}
+
+	cacheInfoGetters(): void {
+		cacheObjectGetters(this.info, [
+			'dynamicallyImportedIdResolutions',
+			'dynamicallyImportedIds',
+			'dynamicImporters',
+			'exportedBindings',
+			'exports',
+			'hasDefaultExport',
+			'implicitlyLoadedAfterOneOf',
+			'implicitlyLoadedBefore',
+			'importedIdResolutions',
+			'importedIds',
+			'importers',
+			'isIncluded'
+		]);
 	}
 
 	error(properties: RollupError, pos: number | undefined): never {

--- a/src/Module.ts
+++ b/src/Module.ts
@@ -294,7 +294,6 @@ export default class Module {
 			sourcesWithAttributes
 		} = this;
 
-		// NOTE: any getter props should also be defined in cacheInfoGetters
 		this.info = {
 			ast: null,
 			attributes,
@@ -404,8 +403,7 @@ export default class Module {
 			'implicitlyLoadedBefore',
 			'importedIdResolutions',
 			'importedIds',
-			'importers',
-			'isIncluded'
+			'importers'
 		]);
 	}
 

--- a/src/utils/getter.ts
+++ b/src/utils/getter.ts
@@ -3,16 +3,14 @@ export function cacheObjectGetters<T, K extends PropertyKey = keyof T>(
 	getterProperties: K[]
 ) {
 	for (const property of getterProperties) {
-		const propertyGetter = Object.getOwnPropertyDescriptor(object, property)?.get;
-		if (propertyGetter) {
-			Object.defineProperty(object, property, {
-				get: () => {
-					const value = propertyGetter.call(object);
-					// This replaces the getter with a fixed value for subsequent calls
-					Object.defineProperty(object, property, { value });
-					return value;
-				}
-			});
-		}
+		const propertyGetter = Object.getOwnPropertyDescriptor(object, property)!.get!;
+		Object.defineProperty(object, property, {
+			get() {
+				const value = propertyGetter.call(object);
+				// This replaces the getter with a fixed value for subsequent calls
+				Object.defineProperty(object, property, { value });
+				return value;
+			}
+		});
 	}
 }

--- a/src/utils/getter.ts
+++ b/src/utils/getter.ts
@@ -5,13 +5,12 @@ export function cacheObjectGetters<T, K extends PropertyKey = keyof T>(
 	for (const property of getterProperties) {
 		const propertyGetter = Object.getOwnPropertyDescriptor(object, property)?.get;
 		if (propertyGetter) {
-			let cached: unknown;
 			Object.defineProperty(object, property, {
 				get: () => {
-					if (cached === undefined) {
-						cached = propertyGetter.call(object);
-					}
-					return cached;
+					const value = propertyGetter.call(object);
+					// This replaces the getter with a fixed value for subsequent calls
+					Object.defineProperty(object, property, { value });
+					return value;
 				}
 			});
 		}

--- a/src/utils/getter.ts
+++ b/src/utils/getter.ts
@@ -1,0 +1,19 @@
+export function cacheObjectGetters<T, K extends PropertyKey = keyof T>(
+	object: T,
+	getterProperties: K[]
+) {
+	for (const property of getterProperties) {
+		const propertyGetter = Object.getOwnPropertyDescriptor(object, property)?.get;
+		if (propertyGetter) {
+			let cached: unknown;
+			Object.defineProperty(object, property, {
+				get: () => {
+					if (cached === undefined) {
+						cached = propertyGetter.call(object);
+					}
+					return cached;
+				}
+			});
+		}
+	}
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no



### Description

According to [`this.getModuleInfo`](https://rollupjs.org/plugin-development/#this-getmoduleinfo):

> During the build, this object represents currently available information about the module which may be inaccurate before the [buildEnd](https://rollupjs.org/#buildend) hook

After that, during the output generation phase, the props will no longer change and are stable. However, the internal implementation still keeps them as getters, so there's a cost later even if they don't change.

This PR implements caching for the getters after the build ends (or specifically at the start of output generation). This way accessing the module info will be fast.

---

Usage in the wild:
1. Vite reads the module graph to [analyze ineffective dynamic imports](https://github.com/vitejs/vite/blob/d44342859a45a295b9497775f8716de83ca1c03d/packages/vite/src/node/plugins/reporter.ts#L118-L147) (This could actually be nice if supported natively in Rollup)
2. Astro walks the module graph for [CSS and scripts analysis](https://github.com/withastro/astro/blob/fdceed58894f34c81db46b104da662daf0807cb4/packages/astro/src/core/build/graph.ts#L5-L40).

I was measuring the perf for https://github.com/withastro/docs, and with this PR, the Rollup build time dropped from 3m30s to 3m.

---

I'm not sure how to write a test for cache effectiveness, but I tested manually that the caching works. Existing tests should also pass.
