### PR TITLE
WIP: MSYS2 enviroment uses the gcc/clang free compilers, not the msvc ones, here the rust target is added for interoperability

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -100,7 +100,7 @@ jobs:
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             build: npm run build:napi -- --release --target aarch64-pc-windows-msvc
-          - host: windows-latest  # Add this for x86_64-pc-windows-gnu
+          - host: windows-latest  
             target: x86_64-pc-windows-gnu
             build: >-
               set -e &&

--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -100,6 +100,12 @@ jobs:
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             build: npm run build:napi -- --release --target aarch64-pc-windows-msvc
+          - host: windows-latest  # Add this for x86_64-pc-windows-gnu
+            target: x86_64-pc-windows-gnu
+            build: >-
+              set -e &&
+              rustup target add x86_64-pc-windows-gnu &&
+              npm run build:napi -- --release --target x86_64-pc-windows-gnu
 
           # MacOS
           - host: macos-latest

--- a/npm/win32-x64-gnu/README.md
+++ b/npm/win32-x64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@rollup/rollup-win32-x64-gnu`
+
+This is the **x86_64-pc-windows-gnu** binary for `rollup`

--- a/npm/win32-x64-gnu/package.json
+++ b/npm/win32-x64-gnu/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@rollup/rollup-win32-x64-gnu",
+  "version": "0.0.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "rollup.win32-x64-gnu.node"
+  ],
+  "description": "Native bindings for Rollup",
+  "author": "Lukas Taegert-Atkinson",
+  "homepage": "https://rollupjs.org/",
+  "license": "MIT",
+  "repository": "rollup/rollup",
+  "main": "./rollup.win32-x64-gnu.node"
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "riscv64gc-unknown-linux-gnu",
         "x86_64-apple-darwin",
         "x86_64-pc-windows-msvc",
+        "x86_64-pc-windows-gnu",
         "x86_64-unknown-linux-gnu",
         "x86_64-unknown-linux-musl"
       ]


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no
 
It can be tested but it will require to modify the workflow significantly, not sure if desirable.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
#5335 
#5439 
#5333 
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

I noticed the target is not added, but additional work is needed, for example for testing. And from upstream dependencies like wasm-pack

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
