### PR TITLE
fix: conditional/logical expression should request a new tree-shaking

### DIFF
--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -46,12 +46,23 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 	}
 
 	deoptimizeCache(): void {
-		this.isBranchResolutionAnalysed = false;
-		const { expressionsToBeDeoptimized } = this;
-		this.expressionsToBeDeoptimized = [];
-		for (const expression of expressionsToBeDeoptimized) {
-			expression.deoptimizeCache();
+		if (
+			this.usedBranch ||
+			this.isBranchResolutionAnalysed ||
+			this.expressionsToBeDeoptimized.length > 0
+		) {
+			const {
+				scope: { context },
+				expressionsToBeDeoptimized
+			} = this;
+			this.expressionsToBeDeoptimized = [];
+			for (const expression of expressionsToBeDeoptimized) {
+				expression.deoptimizeCache();
+			}
+			// Request another pass because we need to ensure "include" runs again if it is rendered
+			context.requestTreeshakingPass();
 		}
+		this.isBranchResolutionAnalysed = false;
 		if (this.usedBranch !== null) {
 			const unusedBranch = this.usedBranch === this.consequent ? this.alternate : this.consequent;
 			this.usedBranch = null;

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -51,16 +51,15 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 			this.isBranchResolutionAnalysed ||
 			this.expressionsToBeDeoptimized.length > 0
 		) {
-			const {
-				scope: { context },
-				expressionsToBeDeoptimized
-			} = this;
+			// Request another pass because we need to ensure "include" runs again if it is rendered
+			this.scope.context.requestTreeshakingPass();
+		}
+		const { expressionsToBeDeoptimized } = this;
+		if (expressionsToBeDeoptimized.length > 0) {
 			this.expressionsToBeDeoptimized = [];
 			for (const expression of expressionsToBeDeoptimized) {
 				expression.deoptimizeCache();
 			}
-			// Request another pass because we need to ensure "include" runs again if it is rendered
-			context.requestTreeshakingPass();
 		}
 		this.isBranchResolutionAnalysed = false;
 		if (this.usedBranch !== null) {

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -57,8 +57,11 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 	}
 
 	deoptimizeCache(): void {
-		this.isBranchResolutionAnalysed = false;
-		if (this.expressionsToBeDeoptimized.length > 0) {
+		if (
+			this.usedBranch ||
+			this.isBranchResolutionAnalysed ||
+			this.expressionsToBeDeoptimized.length > 0
+		) {
 			const {
 				scope: { context },
 				expressionsToBeDeoptimized
@@ -67,10 +70,10 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 			for (const expression of expressionsToBeDeoptimized) {
 				expression.deoptimizeCache();
 			}
-			// Request another pass because we need to ensure "include" runs again if
-			// it is rendered
+			// Request another pass because we need to ensure "include" runs again if it is rendered
 			context.requestTreeshakingPass();
 		}
+		this.isBranchResolutionAnalysed = false;
 		if (this.usedBranch) {
 			const unusedBranch = this.usedBranch === this.left ? this.right : this.left;
 			this.usedBranch = null;

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -62,16 +62,15 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 			this.isBranchResolutionAnalysed ||
 			this.expressionsToBeDeoptimized.length > 0
 		) {
-			const {
-				scope: { context },
-				expressionsToBeDeoptimized
-			} = this;
+			// Request another pass because we need to ensure "include" runs again if it is rendered
+			this.scope.context.requestTreeshakingPass();
+		}
+		const { expressionsToBeDeoptimized } = this;
+		if (expressionsToBeDeoptimized.length > 0) {
 			this.expressionsToBeDeoptimized = [];
 			for (const expression of expressionsToBeDeoptimized) {
 				expression.deoptimizeCache();
 			}
-			// Request another pass because we need to ensure "include" runs again if it is rendered
-			context.requestTreeshakingPass();
 		}
 		this.isBranchResolutionAnalysed = false;
 		if (this.usedBranch) {

--- a/test/form/samples/request-tree-shaking-before-render/_config.js
+++ b/test/form/samples/request-tree-shaking-before-render/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'a new tree-shaking is required so render will not fail'
+});

--- a/test/form/samples/request-tree-shaking-before-render/_expected.js
+++ b/test/form/samples/request-tree-shaking-before-render/_expected.js
@@ -1,0 +1,16 @@
+function s(t) {
+    t(x);
+}
+
+function f(b) {
+    return x.concat((b ? 1 : 0))
+}
+
+function w(b) {
+    f(b);
+}
+
+w(1);
+s(() => {
+  return w(0)
+});

--- a/test/form/samples/request-tree-shaking-before-render/main.js
+++ b/test/form/samples/request-tree-shaking-before-render/main.js
@@ -1,0 +1,16 @@
+function s(t) {
+    t(x)
+}
+
+function f(b) {
+    return x.concat((b ? 1 : 0))
+}
+
+function w(b) {
+    f(b)
+}
+
+w(1)
+s(() => {
+  return w(0)
+})


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- resolves #5480

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

While we should not request a tree-shaking in `ConditionalExpression` or `LogicalExpression` if nothing happens; we should request one if anything changes.

One way to validate this fix is to use example from #5480, see [repl](https://rollupjs.org/repl/?version=4.16.0&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMnVua25vd25fZ2xvYmFsJTVDbiU1Q25mdW5jdGlvbiUyMHModCklMjAlN0IlNUNuJTIwJTIwJTIwJTIwdCh1bmtub3duX2dsb2JhbCklNUNuJTdEJTNCJTVDbiU1Q25mdW5jdGlvbiUyMGYoYiklMjAlN0IlNUNuJTIwJTIwJTIwJTIwcmV0dXJuJTIwdW5rbm93bl9nbG9iYWwuY29uY2F0KChiJTIwJTNGJTIwMSUyMCUzQSUyMDApKSU1Q24lN0QlNUNuJTVDbmZ1bmN0aW9uJTIwdyhiKSUyMCU3QiU1Q24lMjAlMjAlMjAlMjBmKGIpJTVDbiU3RCU1Q24lNUNudygxKSU1Q25zKCgpJTIwJTNEJTNFJTIwJTdCJTVDbiUyMCUyMHJldHVybiUyMHcoMCklNUNuJTdEKSUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyb3V0cHV0JTIyJTNBJTdCJTIyZm9ybWF0JTIyJTNBJTIyZXMlMjIlN0QlMkMlMjJ0cmVlc2hha2UlMjIlM0F0cnVlJTdEJTdE), another one is to use [index.js](https://github.com/elchininet/shadow-dom-selector/releases/download/v4.1.2/index.js) from [https://github.com/elchininet/shadow-dom-selector](shadow-dom-selector)