### PR TITLE
fix: reassigned (and maybe more treeshake parameter error here...)

### DIFF
--- a/src/ast/variables/ParameterVariable.ts
+++ b/src/ast/variables/ParameterVariable.ts
@@ -161,11 +161,11 @@ export default class ParameterVariable extends LocalVariable {
 	}
 
 	deoptimizePath(path: ObjectPath): void {
-		if (this.deoptimizedFields.has(UnknownKey)) {
-			return;
-		}
 		if (path.length === 0) {
 			this.markReassigned();
+			return;
+		}
+		if (this.deoptimizedFields.has(UnknownKey)) {
 			return;
 		}
 		const key = path[0];

--- a/test/function/samples/reassigned-parameter/main.js
+++ b/test/function/samples/reassigned-parameter/main.js
@@ -1,7 +1,21 @@
 function f(a) {
-  assert.equal(a ? 'OK' : 'FAIL', 'OK');
-  a = false;
-  assert.equal(a ? 'FAIL' : 'OK', 'OK');
+	assert.equal(a ? 'OK' : 'FAIL', 'OK');
+	a = false;
+	assert.equal(a ? 'FAIL' : 'OK', 'OK');
 }
 
-f(true)
+f(true);
+
+function g(array) {
+	if (array === null) {
+		array = [];
+	}
+
+	if (array) {
+		return 'OK';
+	}
+	return array;
+}
+
+assert.equal(g(null), 'OK');
+


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- https://github.com/remix-run/react-router/issues/11480
- https://github.com/rollup/rollup/pull/5443

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

[REPL](https://rollupjs.org/repl/?version=4.16.1&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMmZ1bmN0aW9uJTIwZm9vKGFyciklMjAlN0IlNUNuJTIwJTIwaWYlMjAoYXJyJTIwJTNEJTNEJTNEJTIwbnVsbCklMjAlN0IlNUNuJTIwJTIwJTIwJTIwYXJyJTIwJTNEJTIwJTVCJTVEJTVDbiUyMCUyMCU3RCU1Q24lMjAlMjAlNUNuJTIwJTIwaWYlMjAoYXJyKSUyMCU3QiU1Q24lMjAlMjAlMjAlMjBjb25zb2xlLmxvZygwKSU1Q24lMjAlMjAlN0QlNUNuJTIwJTIwcmV0dXJuJTIwYXJyJTVDbiU3RCU1Q24lNUNuY29uc29sZS5sb2coZm9vKG51bGwpKSUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlNUQlMkMlMjJvcHRpb25zJTIyJTNBJTdCJTIyb3V0cHV0JTIyJTNBJTdCJTIyZm9ybWF0JTIyJTNBJTIyZXMlMjIlN0QlMkMlMjJ0cmVlc2hha2UlMjIlM0F0cnVlJTdEJTdE)

`markReassigned` caused by reassignment in `ParameterVariable` should not be shadowed by `UnknownKey`.

Also I am checking other issues related to 4.16.1, maybe we revert it or fix it here.

Currently known other issues:

- https://github.com/rollup/rollup/issues/5480 (https://github.com/vaadin/flow/issues/19216)