### PR TITLE
feature(fix): function parameter tracking

### DIFF
--- a/src/ast/nodes/ArrowFunctionExpression.ts
+++ b/src/ast/nodes/ArrowFunctionExpression.ts
@@ -5,8 +5,9 @@ import type ChildScope from '../scopes/ChildScope';
 import ReturnValueScope from '../scopes/ReturnValueScope';
 import { type ObjectPath } from '../utils/PathTracker';
 import type BlockStatement from './BlockStatement';
+import type CallExpression from './CallExpression';
 import Identifier from './Identifier';
-import type * as NodeType from './NodeType';
+import * as NodeType from './NodeType';
 import { Flag, isFlagSet, setFlag } from './shared/BitFlags';
 import FunctionBase from './shared/FunctionBase';
 import type { ExpressionNode, IncludeChildren } from './shared/Node';
@@ -65,6 +66,13 @@ export default class ArrowFunctionExpression extends FunctionBase {
 			context.brokenFlow = brokenFlow;
 		}
 		return false;
+	}
+
+	protected onlyFunctionCallUsed(): boolean {
+		const isIIFE =
+			this.parent.type === NodeType.CallExpression &&
+			(this.parent as CallExpression).callee === this;
+		return isIIFE || super.onlyFunctionCallUsed();
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -63,20 +63,17 @@ export default class CallExpression
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {
-		try {
-			for (const argument of this.arguments) {
-				if (argument.hasEffects(context)) return true;
-			}
-			if (this.annotationPure) {
-				return false;
-			}
-			return (
-				this.callee.hasEffects(context) ||
-				this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
-			);
-		} finally {
-			if (!this.deoptimized) this.applyDeoptimizations();
+		if (!this.deoptimized) this.applyDeoptimizations();
+		for (const argument of this.arguments) {
+			if (argument.hasEffects(context)) return true;
 		}
+		if (this.annotationPure) {
+			return false;
+		}
+		return (
+			this.callee.hasEffects(context) ||
+			this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
+		);
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/ConditionalExpression.ts
+++ b/src/ast/nodes/ConditionalExpression.ts
@@ -1,5 +1,5 @@
 import type MagicString from 'magic-string';
-import { BLANK } from '../../utils/blank';
+import { BLANK, EMPTY_ARRAY } from '../../utils/blank';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import {
 	findFirstOccurrenceOutsideComment,
@@ -46,26 +46,15 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 	}
 
 	deoptimizeCache(): void {
-		if (
-			this.usedBranch ||
-			this.isBranchResolutionAnalysed ||
-			this.expressionsToBeDeoptimized.length > 0
-		) {
-			// Request another pass because we need to ensure "include" runs again if it is rendered
-			this.scope.context.requestTreeshakingPass();
-		}
-		const { expressionsToBeDeoptimized } = this;
-		if (expressionsToBeDeoptimized.length > 0) {
-			this.expressionsToBeDeoptimized = [];
-			for (const expression of expressionsToBeDeoptimized) {
-				expression.deoptimizeCache();
-			}
-		}
-		this.isBranchResolutionAnalysed = false;
 		if (this.usedBranch !== null) {
 			const unusedBranch = this.usedBranch === this.consequent ? this.alternate : this.consequent;
 			this.usedBranch = null;
 			unusedBranch.deoptimizePath(UNKNOWN_PATH);
+			const { expressionsToBeDeoptimized } = this;
+			this.expressionsToBeDeoptimized = EMPTY_ARRAY as unknown as DeoptimizableEntity[];
+			for (const expression of expressionsToBeDeoptimized) {
+				expression.deoptimizeCache();
+			}
 		}
 	}
 
@@ -84,9 +73,9 @@ export default class ConditionalExpression extends NodeBase implements Deoptimiz
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown {
-		this.expressionsToBeDeoptimized.push(origin);
 		const usedBranch = this.getUsedBranch();
 		if (!usedBranch) return UnknownValue;
+		this.expressionsToBeDeoptimized.push(origin);
 		return usedBranch.getLiteralValueAtPath(path, recursionTracker, origin);
 	}
 

--- a/src/ast/nodes/FunctionDeclaration.ts
+++ b/src/ast/nodes/FunctionDeclaration.ts
@@ -14,6 +14,11 @@ export default class FunctionDeclaration extends FunctionNode {
 		}
 	}
 
+	protected onlyFunctionCallUsed(): boolean {
+		// call super.onlyFunctionCallUsed for export default anonymous function
+		return this.id?.variable.getOnlyFunctionCallUsed() ?? super.onlyFunctionCallUsed();
+	}
+
 	parseNode(esTreeNode: GenericEsTreeNode): this {
 		if (esTreeNode.id !== null) {
 			this.id = new Identifier(this, this.scope.parent as ChildScope).parseNode(

--- a/src/ast/nodes/FunctionExpression.ts
+++ b/src/ast/nodes/FunctionExpression.ts
@@ -2,6 +2,7 @@ import type MagicString from 'magic-string';
 import { BLANK } from '../../utils/blank';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import ChildScope from '../scopes/ChildScope';
+import type CallExpression from './CallExpression';
 import type { IdentifierWithVariable } from './Identifier';
 import Identifier from './Identifier';
 import * as NodeType from './NodeType';
@@ -23,6 +24,14 @@ export default class FunctionExpression extends FunctionNode {
 			) as IdentifierWithVariable;
 		}
 		return super.parseNode(esTreeNode);
+	}
+
+	protected onlyFunctionCallUsed(): boolean {
+		const isIIFE =
+			this.parent.type === NodeType.CallExpression &&
+			(this.parent as CallExpression).callee === this &&
+			(this.id === null || this.id.variable.getOnlyFunctionCallUsed());
+		return isIIFE || super.onlyFunctionCallUsed();
 	}
 
 	render(

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -60,10 +60,12 @@ export default class Identifier extends NodeBase implements PatternNode {
 		}
 	}
 
+	private isReferenceVariable = false;
 	bind(): void {
 		if (!this.variable && isReference(this, this.parent as NodeWithFieldDefinition)) {
 			this.variable = this.scope.findVariable(this.name);
 			this.variable.addReference(this);
+			this.isReferenceVariable = true;
 		}
 	}
 
@@ -294,6 +296,9 @@ export default class Identifier extends NodeBase implements PatternNode {
 		if (this.variable instanceof LocalVariable) {
 			this.variable.consolidateInitializers();
 			this.scope.context.requestTreeshakingPass();
+		}
+		if (this.isReferenceVariable) {
+			this.variable!.addUsedPlace(this);
 		}
 	}
 

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -299,6 +299,7 @@ export default class Identifier extends NodeBase implements PatternNode {
 		}
 		if (this.isReferenceVariable) {
 			this.variable!.addUsedPlace(this);
+			this.scope.context.requestTreeshakingPass();
 		}
 	}
 

--- a/src/ast/nodes/IfStatement.ts
+++ b/src/ast/nodes/IfStatement.ts
@@ -7,7 +7,7 @@ import { EMPTY_PATH, SHARED_RECURSION_TRACKER } from '../utils/PathTracker';
 import BlockStatement from './BlockStatement';
 import type Identifier from './Identifier';
 import * as NodeType from './NodeType';
-import { type LiteralValueOrUnknown, UnknownValue } from './shared/Expression';
+import { type LiteralValueOrUnknown } from './shared/Expression';
 import {
 	type ExpressionNode,
 	type GenericEsTreeNode,
@@ -29,7 +29,7 @@ export default class IfStatement extends StatementBase implements DeoptimizableE
 	private testValue: LiteralValueOrUnknown | typeof unset = unset;
 
 	deoptimizeCache(): void {
-		this.testValue = UnknownValue;
+		this.testValue = unset;
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {

--- a/src/ast/nodes/IfStatement.ts
+++ b/src/ast/nodes/IfStatement.ts
@@ -7,7 +7,7 @@ import { EMPTY_PATH, SHARED_RECURSION_TRACKER } from '../utils/PathTracker';
 import BlockStatement from './BlockStatement';
 import type Identifier from './Identifier';
 import * as NodeType from './NodeType';
-import { type LiteralValueOrUnknown } from './shared/Expression';
+import { type LiteralValueOrUnknown, UnknownValue } from './shared/Expression';
 import {
 	type ExpressionNode,
 	type GenericEsTreeNode,
@@ -29,7 +29,7 @@ export default class IfStatement extends StatementBase implements DeoptimizableE
 	private testValue: LiteralValueOrUnknown | typeof unset = unset;
 
 	deoptimizeCache(): void {
-		this.testValue = unset;
+		this.testValue = UnknownValue;
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {

--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -1,5 +1,5 @@
 import type MagicString from 'magic-string';
-import { BLANK } from '../../utils/blank';
+import { BLANK, EMPTY_ARRAY } from '../../utils/blank';
 import {
 	findFirstOccurrenceOutsideComment,
 	findNonWhiteSpace,
@@ -57,26 +57,21 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 	}
 
 	deoptimizeCache(): void {
-		if (
-			this.usedBranch ||
-			this.isBranchResolutionAnalysed ||
-			this.expressionsToBeDeoptimized.length > 0
-		) {
-			// Request another pass because we need to ensure "include" runs again if it is rendered
-			this.scope.context.requestTreeshakingPass();
-		}
-		const { expressionsToBeDeoptimized } = this;
-		if (expressionsToBeDeoptimized.length > 0) {
-			this.expressionsToBeDeoptimized = [];
-			for (const expression of expressionsToBeDeoptimized) {
-				expression.deoptimizeCache();
-			}
-		}
-		this.isBranchResolutionAnalysed = false;
 		if (this.usedBranch) {
 			const unusedBranch = this.usedBranch === this.left ? this.right : this.left;
 			this.usedBranch = null;
 			unusedBranch.deoptimizePath(UNKNOWN_PATH);
+			const {
+				scope: { context },
+				expressionsToBeDeoptimized
+			} = this;
+			this.expressionsToBeDeoptimized = EMPTY_ARRAY as unknown as DeoptimizableEntity[];
+			for (const expression of expressionsToBeDeoptimized) {
+				expression.deoptimizeCache();
+			}
+			// Request another pass because we need to ensure "include" runs again if
+			// it is rendered
+			context.requestTreeshakingPass();
 		}
 	}
 
@@ -95,9 +90,9 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown {
-		this.expressionsToBeDeoptimized.push(origin);
 		const usedBranch = this.getUsedBranch();
 		if (!usedBranch) return UnknownValue;
+		this.expressionsToBeDeoptimized.push(origin);
 		return usedBranch.getLiteralValueAtPath(path, recursionTracker, origin);
 	}
 

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -1,7 +1,7 @@
 import type MagicString from 'magic-string';
 import type { AstContext } from '../../Module';
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
-import { BLANK, EMPTY_ARRAY } from '../../utils/blank';
+import { BLANK } from '../../utils/blank';
 import { LOGLEVEL_WARN } from '../../utils/logging';
 import { logIllegalImportReassignment, logMissingExport } from '../../utils/logs';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
@@ -185,7 +185,7 @@ export default class MemberExpression
 
 	deoptimizeCache(): void {
 		const { expressionsToBeDeoptimized, object } = this;
-		this.expressionsToBeDeoptimized = EMPTY_ARRAY as unknown as DeoptimizableEntity[];
+		this.expressionsToBeDeoptimized = [];
 		this.propertyKey = UnknownKey;
 		object.deoptimizePath(UNKNOWN_PATH);
 		for (const expression of expressionsToBeDeoptimized) {
@@ -395,6 +395,9 @@ export default class MemberExpression
 				SHARED_RECURSION_TRACKER
 			);
 			this.scope.context.requestTreeshakingPass();
+		}
+		if (this.variable) {
+			this.variable.addUsedPlace(this);
 		}
 	}
 

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -398,6 +398,7 @@ export default class MemberExpression
 		}
 		if (this.variable) {
 			this.variable.addUsedPlace(this);
+			this.scope.context.requestTreeshakingPass();
 		}
 	}
 

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -1,7 +1,7 @@
 import type MagicString from 'magic-string';
 import type { AstContext } from '../../Module';
 import type { NormalizedTreeshakingOptions } from '../../rollup/types';
-import { BLANK } from '../../utils/blank';
+import { BLANK, EMPTY_ARRAY } from '../../utils/blank';
 import { LOGLEVEL_WARN } from '../../utils/logging';
 import { logIllegalImportReassignment, logMissingExport } from '../../utils/logs';
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
@@ -185,7 +185,7 @@ export default class MemberExpression
 
 	deoptimizeCache(): void {
 		const { expressionsToBeDeoptimized, object } = this;
-		this.expressionsToBeDeoptimized = [];
+		this.expressionsToBeDeoptimized = EMPTY_ARRAY as unknown as DeoptimizableEntity[];
 		this.propertyKey = UnknownKey;
 		object.deoptimizePath(UNKNOWN_PATH);
 		for (const expression of expressionsToBeDeoptimized) {

--- a/src/ast/nodes/UpdateExpression.ts
+++ b/src/ast/nodes/UpdateExpression.ts
@@ -87,7 +87,7 @@ export default class UpdateExpression extends NodeBase {
 		this.argument.deoptimizePath(EMPTY_PATH);
 		if (this.argument instanceof Identifier) {
 			const variable = this.scope.findVariable(this.argument.name);
-			variable.isReassigned = true;
+			variable.markReassigned();
 		}
 		this.scope.context.requestTreeshakingPass();
 	}

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -9,12 +9,22 @@ import {
 } from '../../NodeInteractions';
 import type ReturnValueScope from '../../scopes/ReturnValueScope';
 import type { ObjectPath, PathTracker } from '../../utils/PathTracker';
-import { UNKNOWN_PATH, UnknownKey } from '../../utils/PathTracker';
+import {
+	EMPTY_PATH,
+	SHARED_RECURSION_TRACKER,
+	UNKNOWN_PATH,
+	UnknownKey
+} from '../../utils/PathTracker';
+import { UNDEFINED_EXPRESSION } from '../../values';
 import type ParameterVariable from '../../variables/ParameterVariable';
+import type Variable from '../../variables/Variable';
 import BlockStatement from '../BlockStatement';
+import type ExportDefaultDeclaration from '../ExportDefaultDeclaration';
 import Identifier from '../Identifier';
+import * as NodeType from '../NodeType';
 import RestElement from '../RestElement';
 import type SpreadElement from '../SpreadElement';
+import type VariableDeclarator from '../VariableDeclarator';
 import { Flag, isFlagSet, setFlag } from './BitFlags';
 import type { ExpressionEntity, LiteralValueOrUnknown } from './Expression';
 import { UNKNOWN_EXPRESSION, UNKNOWN_RETURN_EXPRESSION } from './Expression';
@@ -26,6 +36,13 @@ import {
 } from './Node';
 import type { ObjectEntity } from './ObjectEntity';
 import type { PatternNode } from './Pattern';
+
+type InteractionCalledArguments = NodeInteractionCalled['args'];
+
+// This handler does nothing.
+// Since we always re-evaluate argument values in a new tree-shaking pass,
+// we don't need to get notified if it is deoptimized.
+const EMPTY_DEOPTIMIZABLE_HANDLER = { deoptimizeCache() {} };
 
 export default abstract class FunctionBase extends NodeBase {
 	declare body: BlockStatement | ExpressionNode;
@@ -57,6 +74,107 @@ export default abstract class FunctionBase extends NodeBase {
 		this.flags = setFlag(this.flags, Flag.generator, value);
 	}
 
+	private knownParameterValues: (ExpressionEntity | undefined)[] = [];
+	private allArguments: InteractionCalledArguments[] = [];
+	/**
+	 * update knownParameterValues when a call is made to this function
+	 * @param newArguments arguments of the call
+	 */
+	private updateKnownParameterValues(newArguments: InteractionCalledArguments): void {
+		for (let position = 0; position < this.params.length; position++) {
+			// only the "this" argument newArguments[0] can be null
+			// it's possible that some arguments are empty, so the value is undefined
+			const argument = newArguments[position + 1] ?? UNDEFINED_EXPRESSION;
+			const parameter = this.params[position];
+			// RestElement can be, and can only be, the last parameter
+			if (parameter instanceof RestElement) {
+				return;
+			}
+
+			const knownParameterValue = this.knownParameterValues[position];
+			if (knownParameterValue === undefined) {
+				this.knownParameterValues[position] = argument;
+				continue;
+			}
+			if (
+				knownParameterValue === UNKNOWN_EXPRESSION ||
+				knownParameterValue === argument ||
+				(knownParameterValue instanceof Identifier &&
+					argument instanceof Identifier &&
+					knownParameterValue.variable === argument.variable)
+			) {
+				continue;
+			}
+
+			const oldValue = knownParameterValue.getLiteralValueAtPath(
+				EMPTY_PATH,
+				SHARED_RECURSION_TRACKER,
+				EMPTY_DEOPTIMIZABLE_HANDLER
+			);
+			const newValue = argument.getLiteralValueAtPath(
+				EMPTY_PATH,
+				SHARED_RECURSION_TRACKER,
+				EMPTY_DEOPTIMIZABLE_HANDLER
+			);
+			if (oldValue !== newValue || typeof oldValue === 'symbol') {
+				this.knownParameterValues[position] = UNKNOWN_EXPRESSION;
+			} // else both are the same literal, no need to update
+		}
+	}
+
+	private forwardArgumentsForFunctionCalledOnce(newArguments: InteractionCalledArguments): void {
+		for (let position = 0; position < this.params.length; position++) {
+			const parameter = this.params[position];
+			if (parameter instanceof Identifier) {
+				const ParameterVariable = parameter.variable as ParameterVariable | null;
+				const argument = newArguments[position + 1] ?? UNDEFINED_EXPRESSION;
+				ParameterVariable?.setKnownValue(argument);
+			}
+		}
+	}
+
+	/**
+	 * each time tree-shake starts, this method should be called to reoptimize the parameters
+	 * a parameter's state will change at most twice:
+	 *   `undefined` (no call is made) -> an expression -> `UnknownArgument`
+	 * we are sure it will converge, and can use state from last iteration
+	 */
+	private applyFunctionParameterOptimization() {
+		if (this.allArguments.length === 0) {
+			return;
+		}
+
+		if (this.allArguments.length === 1) {
+			// we are sure what knownParameterValues will be, so skip it and do setKnownValue
+			this.forwardArgumentsForFunctionCalledOnce(this.allArguments[0]);
+			return;
+		}
+
+		// reoptimize all arguments, that's why we save them
+		for (const argumentsList of this.allArguments) {
+			this.updateKnownParameterValues(argumentsList);
+		}
+		for (let position = 0; position < this.params.length; position++) {
+			const parameter = this.params[position];
+			// Parameters without default values
+			if (parameter instanceof Identifier) {
+				const parameterVariable = parameter.variable as ParameterVariable | null;
+				// Only the RestElement may be undefined
+				const knownParameterValue = this.knownParameterValues[position]!;
+				parameterVariable?.setKnownValue(knownParameterValue);
+			}
+		}
+	}
+
+	private deoptimizeFunctionParameters() {
+		for (const parameter of this.params) {
+			if (parameter instanceof Identifier) {
+				const parameterVariable = parameter.variable as ParameterVariable | null;
+				parameterVariable?.markReassigned();
+			}
+		}
+	}
+
 	protected objectEntity: ObjectEntity | null = null;
 
 	deoptimizeArgumentsOnInteractionAtPath(
@@ -84,6 +202,7 @@ export default abstract class FunctionBase extends NodeBase {
 					this.addArgumentToBeDeoptimized(argument);
 				}
 			}
+			this.allArguments.push(args);
 		} else {
 			this.getObjectEntity().deoptimizeArgumentsOnInteractionAtPath(
 				interaction,
@@ -102,6 +221,7 @@ export default abstract class FunctionBase extends NodeBase {
 			for (const parameterList of this.scope.parameters) {
 				for (const parameter of parameterList) {
 					parameter.deoptimizePath(UNKNOWN_PATH);
+					parameter.markReassigned();
 				}
 			}
 		}
@@ -180,7 +300,30 @@ export default abstract class FunctionBase extends NodeBase {
 		return false;
 	}
 
+	/**
+	 * If the function (expression or declaration) is only used as function calls
+	 */
+	protected onlyFunctionCallUsed(): boolean {
+		let variable: Variable | null = null;
+		if (this.parent.type === NodeType.VariableDeclarator) {
+			variable = (this.parent as VariableDeclarator).id.variable ?? null;
+		}
+		if (this.parent.type === NodeType.ExportDefaultDeclaration) {
+			variable = (this.parent as ExportDefaultDeclaration).variable;
+		}
+		return variable?.getOnlyFunctionCallUsed() ?? false;
+	}
+
+	private functionParametersOptimized = false;
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {
+		const shouldOptimizeFunctionParameters = this.onlyFunctionCallUsed();
+		if (shouldOptimizeFunctionParameters) {
+			this.applyFunctionParameterOptimization();
+		} else if (this.functionParametersOptimized) {
+			this.deoptimizeFunctionParameters();
+		}
+		this.functionParametersOptimized = shouldOptimizeFunctionParameters;
+
 		if (!this.deoptimized) this.applyDeoptimizations();
 		this.included = true;
 		const { brokenFlow } = context;

--- a/src/ast/variables/ExportDefaultVariable.ts
+++ b/src/ast/variables/ExportDefaultVariable.ts
@@ -3,6 +3,7 @@ import ClassDeclaration from '../nodes/ClassDeclaration';
 import type ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import FunctionDeclaration from '../nodes/FunctionDeclaration';
 import Identifier, { type IdentifierWithVariable } from '../nodes/Identifier';
+import type { NodeBase } from '../nodes/shared/Node';
 import LocalVariable from './LocalVariable';
 import UndefinedVariable from './UndefinedVariable';
 import type Variable from './Variable';
@@ -34,6 +35,15 @@ export default class ExportDefaultVariable extends LocalVariable {
 	addReference(identifier: Identifier): void {
 		if (!this.hasId) {
 			this.name = identifier.name;
+		}
+	}
+
+	addUsedPlace(usedPlace: NodeBase): void {
+		const original = this.getOriginalVariable();
+		if (original === this) {
+			super.addUsedPlace(usedPlace);
+		} else {
+			original.addUsedPlace(usedPlace);
 		}
 	}
 

--- a/src/ast/variables/GlobalVariable.ts
+++ b/src/ast/variables/GlobalVariable.ts
@@ -13,9 +13,12 @@ import type { ObjectPath, PathTracker } from '../utils/PathTracker';
 import Variable from './Variable';
 
 export default class GlobalVariable extends Variable {
-	// Ensure we use live-bindings for globals as we do not know if they have
-	// been reassigned
-	isReassigned = true;
+	constructor(name: string) {
+		super(name);
+		// Ensure we use live-bindings for globals as we do not know if they have
+		// been reassigned
+		this.markReassigned();
+	}
 
 	deoptimizeArgumentsOnInteractionAtPath(
 		interaction: NodeInteraction,

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -91,7 +91,7 @@ export default class LocalVariable extends Variable {
 			return;
 		}
 		if (path.length === 0) {
-			this.isReassigned = true;
+			this.markReassigned();
 			const expressionsToBeDeoptimized = this.expressionsToBeDeoptimized;
 			this.expressionsToBeDeoptimized = EMPTY_ARRAY as unknown as DeoptimizableEntity[];
 			for (const expression of expressionsToBeDeoptimized) {
@@ -222,7 +222,7 @@ export default class LocalVariable extends Variable {
 		if (this.additionalInitializers === null) {
 			this.additionalInitializers = [this.init];
 			this.init = UNKNOWN_EXPRESSION;
-			this.isReassigned = true;
+			this.markReassigned();
 		}
 		return this.additionalInitializers;
 	}

--- a/src/ast/variables/ParameterVariable.ts
+++ b/src/ast/variables/ParameterVariable.ts
@@ -1,14 +1,17 @@
 import type { AstContext } from '../../Module';
 import { EMPTY_ARRAY } from '../../utils/blank';
+import type { DeoptimizableEntity } from '../DeoptimizableEntity';
+import type { HasEffectsContext } from '../ExecutionContext';
 import type { NodeInteraction } from '../NodeInteractions';
-import { INTERACTION_CALLED } from '../NodeInteractions';
+import { INTERACTION_ASSIGNED, INTERACTION_CALLED } from '../NodeInteractions';
 import type ExportDefaultDeclaration from '../nodes/ExportDefaultDeclaration';
 import type Identifier from '../nodes/Identifier';
-import type { ExpressionEntity } from '../nodes/shared/Expression';
+import type { ExpressionEntity, LiteralValueOrUnknown } from '../nodes/shared/Expression';
 import {
 	deoptimizeInteraction,
 	UNKNOWN_EXPRESSION,
-	UNKNOWN_RETURN_EXPRESSION
+	UNKNOWN_RETURN_EXPRESSION,
+	UnknownValue
 } from '../nodes/shared/Expression';
 import type { ObjectPath, ObjectPathKey } from '../utils/PathTracker';
 import {
@@ -35,6 +38,7 @@ export default class ParameterVariable extends LocalVariable {
 	private deoptimizations = new PathTracker();
 	private deoptimizedFields = new Set<ObjectPathKey>();
 	private entitiesToBeDeoptimized = new Set<ExpressionEntity>();
+	private knownExpressionsToBeDeoptimized: DeoptimizableEntity[] = [];
 
 	constructor(
 		name: string,
@@ -71,6 +75,65 @@ export default class ParameterVariable extends LocalVariable {
 		}
 	}
 
+	markReassigned(): void {
+		if (this.isReassigned) {
+			return;
+		}
+		super.markReassigned();
+		for (const expression of this.knownExpressionsToBeDeoptimized) {
+			expression.deoptimizeCache();
+		}
+		this.knownExpressionsToBeDeoptimized = [];
+	}
+
+	private knownValue: ExpressionEntity = UNKNOWN_EXPRESSION;
+	/**
+	 * If we are sure about the value of this parameter, we can set it here.
+	 * It can be a literal or the only possible value of the parameter.
+	 * an undefined value means that the parameter is not known.
+	 * @param value The known value of the parameter to be set.
+	 */
+	setKnownValue(value: ExpressionEntity): void {
+		if (this.isReassigned) {
+			return;
+		}
+		if (this.knownValue !== value) {
+			for (const expression of this.knownExpressionsToBeDeoptimized) {
+				expression.deoptimizeCache();
+			}
+			this.knownExpressionsToBeDeoptimized = [];
+		}
+		this.knownValue = value;
+	}
+
+	getLiteralValueAtPath(
+		path: ObjectPath,
+		recursionTracker: PathTracker,
+		origin: DeoptimizableEntity
+	): LiteralValueOrUnknown {
+		if (this.isReassigned) {
+			return UnknownValue;
+		}
+		this.knownExpressionsToBeDeoptimized.push(origin);
+		return recursionTracker.withTrackedEntityAtPath(
+			path,
+			this.knownValue,
+			() => this.knownValue!.getLiteralValueAtPath(path, recursionTracker, origin),
+			UnknownValue
+		);
+	}
+
+	hasEffectsOnInteractionAtPath(
+		path: ObjectPath,
+		interaction: NodeInteraction,
+		context: HasEffectsContext
+	): boolean {
+		// assigned is a bit different, since the value has a new name (the parameter)
+		return interaction.type === INTERACTION_ASSIGNED
+			? super.hasEffectsOnInteractionAtPath(path, interaction, context)
+			: this.knownValue.hasEffectsOnInteractionAtPath(path, interaction, context);
+	}
+
 	deoptimizeArgumentsOnInteractionAtPath(interaction: NodeInteraction, path: ObjectPath): void {
 		// For performance reasons, we fully deoptimize all deeper interactions
 		if (
@@ -98,7 +161,11 @@ export default class ParameterVariable extends LocalVariable {
 	}
 
 	deoptimizePath(path: ObjectPath): void {
-		if (path.length === 0 || this.deoptimizedFields.has(UnknownKey)) {
+		if (path.length === 0) {
+			this.markReassigned();
+			return;
+		}
+		if (this.deoptimizedFields.has(UnknownKey)) {
 			return;
 		}
 		const key = path[0];

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -44,7 +44,6 @@ export default class Variable extends ExpressionEntity {
 	private onlyFunctionCallUsed = true;
 	/**
 	 * Check if the identifier variable is only used as function call
-	 * Forward the check to the export default variable if it is only used once
 	 * @returns true if the variable is only used as function call
 	 */
 	getOnlyFunctionCallUsed(): boolean {

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/amd/dep1.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/amd/dep1.js
@@ -5,12 +5,13 @@ define(['exports'], (function (exports) { 'use strict';
 	console.log('This is the output when a missing export is used internally but not reexported');
 
 	function almostUseUnused(useIt) {
-		if (useIt) {
+		{
+			console.log(useIt);
 			console.log(_missingExportShim);
 		}
 	}
 
-	almostUseUnused(false);
+	almostUseUnused(true);
 
 	exports.missing1 = _missingExportShim;
 

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/cjs/dep1.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/cjs/dep1.js
@@ -5,11 +5,12 @@ var _missingExportShim = void 0;
 console.log('This is the output when a missing export is used internally but not reexported');
 
 function almostUseUnused(useIt) {
-	if (useIt) {
+	{
+		console.log(useIt);
 		console.log(_missingExportShim);
 	}
 }
 
-almostUseUnused(false);
+almostUseUnused(true);
 
 exports.missing1 = _missingExportShim;

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/es/dep1.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/es/dep1.js
@@ -3,11 +3,12 @@ var _missingExportShim = void 0;
 console.log('This is the output when a missing export is used internally but not reexported');
 
 function almostUseUnused(useIt) {
-	if (useIt) {
+	{
+		console.log(useIt);
 		console.log(_missingExportShim);
 	}
 }
 
-almostUseUnused(false);
+almostUseUnused(true);
 
 export { _missingExportShim as missing1 };

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/system/dep1.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/_expected/system/dep1.js
@@ -8,12 +8,13 @@ System.register([], (function (exports) {
 			console.log('This is the output when a missing export is used internally but not reexported');
 
 			function almostUseUnused(useIt) {
-				if (useIt) {
+				{
+					console.log(useIt);
 					console.log(_missingExportShim);
 				}
 			}
 
-			almostUseUnused(false);
+			almostUseUnused(true);
 
 			exports("missing1", _missingExportShim);
 

--- a/test/chunking-form/samples/missing-export-reused-deconflicting/dep1.js
+++ b/test/chunking-form/samples/missing-export-reused-deconflicting/dep1.js
@@ -2,8 +2,9 @@ console.log('This is the output when a missing export is used internally but not
 
 function almostUseUnused(useIt) {
 	if (useIt) {
+		console.log(useIt);
 		console.log(_missingExportShim);
 	}
 }
 
-almostUseUnused(false);
+almostUseUnused(true);

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/_virtual/_commonjsHelpers.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/amd/_virtual/_commonjsHelpers.js
@@ -1,7 +1,7 @@
 define(['exports'], (function (exports) { 'use strict';
 
 	function getDefaultExportFromCjs (x) {
-		return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+		return x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 	}
 
 	exports.getDefaultExportFromCjs = getDefaultExportFromCjs;

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/_virtual/_commonjsHelpers.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/cjs/_virtual/_commonjsHelpers.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function getDefaultExportFromCjs (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+	return x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 }
 
 exports.getDefaultExportFromCjs = getDefaultExportFromCjs;

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/_virtual/_commonjsHelpers.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/es/_virtual/_commonjsHelpers.js
@@ -1,5 +1,5 @@
 function getDefaultExportFromCjs (x) {
-	return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+	return x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 }
 
 export { getDefaultExportFromCjs };

--- a/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/_virtual/_commonjsHelpers.js
+++ b/test/chunking-form/samples/preserve-modules-commonjs/_expected/system/_virtual/_commonjsHelpers.js
@@ -6,7 +6,7 @@ System.register([], (function (exports) {
 			exports("getDefaultExportFromCjs", getDefaultExportFromCjs);
 
 			function getDefaultExportFromCjs (x) {
-				return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+				return x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
 			}
 
 		})

--- a/test/form/samples/deopt-string-concatenation/_expected.js
+++ b/test/form/samples/deopt-string-concatenation/_expected.js
@@ -9,3 +9,4 @@ function parseInt(str, radix) {
 }
 
 console.log(parseInt('1'));
+console.log(parseInt(Symbol('1')));

--- a/test/form/samples/deopt-string-concatenation/main.js
+++ b/test/form/samples/deopt-string-concatenation/main.js
@@ -9,3 +9,4 @@ function parseInt(str, radix) {
 }
 
 console.log(parseInt('1'));
+console.log(parseInt(Symbol('1')));

--- a/test/form/samples/request-tree-shaking-before-render/_config.js
+++ b/test/form/samples/request-tree-shaking-before-render/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'a new tree-shaking is required so render will not fail'
+});

--- a/test/form/samples/request-tree-shaking-before-render/_expected.js
+++ b/test/form/samples/request-tree-shaking-before-render/_expected.js
@@ -1,0 +1,16 @@
+function s(t) {
+    t(x);
+}
+
+function f(b) {
+    return x.concat((b ? 1 : 0))
+}
+
+function w(b) {
+    f(b);
+}
+
+w(1);
+s(() => {
+  return w(0)
+});

--- a/test/form/samples/request-tree-shaking-before-render/main.js
+++ b/test/form/samples/request-tree-shaking-before-render/main.js
@@ -1,0 +1,16 @@
+function s(t) {
+    t(x)
+}
+
+function f(b) {
+    return x.concat((b ? 1 : 0))
+}
+
+function w(b) {
+    f(b)
+}
+
+w(1)
+s(() => {
+  return w(0)
+})

--- a/test/form/samples/side-effect-h/_expected/amd.js
+++ b/test/form/samples/side-effect-h/_expected/amd.js
@@ -7,6 +7,7 @@ define((function () { 'use strict';
 	}
 
 	foo();
+	foo(true);
 
 	var main = 42;
 

--- a/test/form/samples/side-effect-h/_expected/cjs.js
+++ b/test/form/samples/side-effect-h/_expected/cjs.js
@@ -7,6 +7,7 @@ function foo ( ok ) {
 }
 
 foo();
+foo(true);
 
 var main = 42;
 

--- a/test/form/samples/side-effect-h/_expected/es.js
+++ b/test/form/samples/side-effect-h/_expected/es.js
@@ -5,6 +5,7 @@ function foo ( ok ) {
 }
 
 foo();
+foo(true);
 
 var main = 42;
 

--- a/test/form/samples/side-effect-h/_expected/iife.js
+++ b/test/form/samples/side-effect-h/_expected/iife.js
@@ -8,6 +8,7 @@ var myBundle = (function () {
 	}
 
 	foo();
+	foo(true);
 
 	var main = 42;
 

--- a/test/form/samples/side-effect-h/_expected/system.js
+++ b/test/form/samples/side-effect-h/_expected/system.js
@@ -10,6 +10,7 @@ System.register('myBundle', [], (function (exports) {
 			}
 
 			foo();
+			foo(true);
 
 			var main = exports("default", 42);
 

--- a/test/form/samples/side-effect-h/_expected/umd.js
+++ b/test/form/samples/side-effect-h/_expected/umd.js
@@ -11,6 +11,7 @@
 	}
 
 	foo();
+	foo(true);
 
 	var main = 42;
 

--- a/test/form/samples/side-effect-h/main.js
+++ b/test/form/samples/side-effect-h/main.js
@@ -5,5 +5,6 @@ function foo ( ok ) {
 }
 
 foo();
+foo(true);
 
 export default 42;

--- a/test/form/samples/side-effects-return-statements/_expected/amd.js
+++ b/test/form/samples/side-effects-return-statements/_expected/amd.js
@@ -8,5 +8,6 @@ define((function () { 'use strict';
 	}
 
 	assert.equal( isUsed( true ), 2 );
+	assert.equal( isUsed( false ), 1 );
 
 }));

--- a/test/form/samples/side-effects-return-statements/_expected/cjs.js
+++ b/test/form/samples/side-effects-return-statements/_expected/cjs.js
@@ -8,3 +8,4 @@ function isUsed ( x ) {
 }
 
 assert.equal( isUsed( true ), 2 );
+assert.equal( isUsed( false ), 1 );

--- a/test/form/samples/side-effects-return-statements/_expected/es.js
+++ b/test/form/samples/side-effects-return-statements/_expected/es.js
@@ -6,3 +6,4 @@ function isUsed ( x ) {
 }
 
 assert.equal( isUsed( true ), 2 );
+assert.equal( isUsed( false ), 1 );

--- a/test/form/samples/side-effects-return-statements/_expected/iife.js
+++ b/test/form/samples/side-effects-return-statements/_expected/iife.js
@@ -9,5 +9,6 @@
 	}
 
 	assert.equal( isUsed( true ), 2 );
+	assert.equal( isUsed( false ), 1 );
 
 })();

--- a/test/form/samples/side-effects-return-statements/_expected/system.js
+++ b/test/form/samples/side-effects-return-statements/_expected/system.js
@@ -11,6 +11,7 @@ System.register('myBundle', [], (function () {
 			}
 
 			assert.equal( isUsed( true ), 2 );
+			assert.equal( isUsed( false ), 1 );
 
 		})
 	};

--- a/test/form/samples/side-effects-return-statements/_expected/umd.js
+++ b/test/form/samples/side-effects-return-statements/_expected/umd.js
@@ -11,5 +11,6 @@
 	}
 
 	assert.equal( isUsed( true ), 2 );
+	assert.equal( isUsed( false ), 1 );
 
 }));

--- a/test/form/samples/side-effects-return-statements/main.js
+++ b/test/form/samples/side-effects-return-statements/main.js
@@ -15,3 +15,4 @@ function isUsed ( x ) {
 }
 
 assert.equal( isUsed( true ), 2 );
+assert.equal( isUsed( false ), 1 );

--- a/test/form/samples/supports-es5-shim/_expected.js
+++ b/test/form/samples/supports-es5-shim/_expected.js
@@ -2202,7 +2202,6 @@ var es5Shim = {exports: {}};
 	        // eslint-disable-next-line no-global-assign, no-implicit-globals
 	        parseInt = (function (origParseInt) {
 	            return function parseInt(str, radix) {
-	                if (this instanceof parseInt) { new origParseInt(); } // eslint-disable-line new-cap, no-new, max-statements-per-line
 	                var string = trim(String(str));
 	                var defaultedRadix = $Number(radix) || (hexRegex.test(string) ? 16 : 10);
 	                return origParseInt(string, defaultedRadix);
@@ -2233,7 +2232,6 @@ var es5Shim = {exports: {}};
 	        // eslint-disable-next-line no-global-assign, no-implicit-globals
 	        parseInt = (function (origParseInt) {
 	            return function parseInt(str, radix) {
-	                if (this instanceof parseInt) { new origParseInt(); } // eslint-disable-line new-cap, no-new, max-statements-per-line
 	                var isSym = typeof str === 'symbol';
 	                if (!isSym && str && typeof str === 'object') {
 	                    try {

--- a/test/form/samples/supports-es6-shim/_expected.js
+++ b/test/form/samples/supports-es6-shim/_expected.js
@@ -2057,7 +2057,7 @@ var es6Shim = {exports: {}};
 	  };
 
 	  var withinULPDistance = function withinULPDistance(result, expected, distance) {
-	    return _abs(1 - (result / expected)) / Number.EPSILON < (distance || 8);
+	    return _abs(1 - (result / expected)) / Number.EPSILON < (8);
 	  };
 
 	  defineProperties(Math, MathShims);

--- a/test/form/samples/tree-shake-literal-parameter/argument-assignment/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/argument-assignment/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'argument assignment side-effect'
+});

--- a/test/form/samples/tree-shake-literal-parameter/argument-assignment/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/argument-assignment/_expected.js
@@ -1,0 +1,15 @@
+function add(a, b) {
+	let sum = 0;
+	for (let i = a; i < b; i++) {
+		sum += i;
+	}
+	return sum;
+}
+
+function foo(a) {
+	// don't optimize to '0;'
+	a = 0;
+	console.log(a);
+}
+
+console.log(foo(add(0, 100)));

--- a/test/form/samples/tree-shake-literal-parameter/argument-assignment/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/argument-assignment/main.js
@@ -1,0 +1,15 @@
+function add(a, b) {
+	let sum = 0;
+	for (let i = a; i < b; i++) {
+		sum += i;
+	}
+	return sum;
+}
+
+function foo(a) {
+	// don't optimize to '0;'
+	a = 0;
+	console.log(a)
+}
+
+console.log(foo(add(0, 100)))

--- a/test/form/samples/tree-shake-literal-parameter/do-not-optimize/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/do-not-optimize/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'do not tree-shake literal parameter cases'
+});

--- a/test/form/samples/tree-shake-literal-parameter/do-not-optimize/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/do-not-optimize/_expected.js
@@ -1,0 +1,18 @@
+function foo(enable) {
+	console.log(enable ? 1 : 0);
+}
+
+foo(1);
+
+function bar(f = foo) {
+	f(0);
+}
+
+// global variable
+g = function (enable) {
+	console.log(enable ? 1: 0);
+};
+
+g(1);
+
+export { bar };

--- a/test/form/samples/tree-shake-literal-parameter/do-not-optimize/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/do-not-optimize/main.js
@@ -1,0 +1,16 @@
+function foo(enable) {
+	console.log(enable ? 1 : 0);
+}
+
+foo(1);
+
+export function bar(f = foo) {
+	f(0);
+}
+
+// global variable
+g = function (enable) {
+	console.log(enable ? 1: 0);
+};
+
+g(1);

--- a/test/form/samples/tree-shake-literal-parameter/expression-cache/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/expression-cache/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'should update cache of logical and conditional expressions'
+});

--- a/test/form/samples/tree-shake-literal-parameter/expression-cache/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/expression-cache/_expected.js
@@ -1,0 +1,14 @@
+function add1(a, b, enable) {
+	{
+		return a + b;
+	}
+}
+
+function add2(a, b, enable) {
+	{
+		return a + b;
+	}
+}
+
+console.log(add1(1, 2));
+console.log(add2(1, 2));

--- a/test/form/samples/tree-shake-literal-parameter/expression-cache/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/expression-cache/main.js
@@ -1,0 +1,16 @@
+function add1(a, b, enable) {
+	if (enable? true: false) {
+		return a + b;
+	}
+	return a - b;
+}
+
+function add2(a, b, enable) {
+	if (enable && 1) {
+		return a + b;
+	}
+	return a - b;
+}
+
+console.log(add1(1, 2, true));
+console.log(add2(1, 2, true));

--- a/test/form/samples/tree-shake-literal-parameter/iife/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/iife/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'tree-shake literal parameter for IIFE'
+});

--- a/test/form/samples/tree-shake-literal-parameter/iife/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/iife/_expected.js
@@ -1,0 +1,32 @@
+const result1 = ((enable) => {
+	{
+		return 'enabled';
+	}
+})();
+
+const result2 = (function (enable) {
+	{
+		return 'enabled';
+	}
+})();
+
+const result3 = (function foo (enable) {
+	{
+		return 'enabled';
+	}
+})();
+
+// lose track of iife
+const result4 = (function foo (enable) {
+	if (enable) {
+		unknown_global_function(foo);
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+})(true);
+
+console.log(result1);
+console.log(result2);
+console.log(result3);
+console.log(result4);

--- a/test/form/samples/tree-shake-literal-parameter/iife/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/iife/main.js
@@ -1,0 +1,38 @@
+const result1 = ((enable) => {
+	if (enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+})(true);
+
+const result2 = (function (enable) {
+	if (enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+})(true);
+
+const result3 = (function foo (enable) {
+	if (enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+})(true);
+
+// lose track of iife
+const result4 = (function foo (enable) {
+	if (enable) {
+		unknown_global_function(foo);
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+})(true);
+
+console.log(result1);
+console.log(result2);
+console.log(result3);
+console.log(result4);

--- a/test/form/samples/tree-shake-literal-parameter/import-function/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/import-function/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'set parameters to literal if all calls are literal'
+});

--- a/test/form/samples/tree-shake-literal-parameter/import-function/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/import-function/_expected.js
@@ -1,0 +1,70 @@
+// export default
+function add (a, b, enable) {
+	{
+		return a + b;
+	}
+}
+
+function add1(a, b, enable) {
+	return a - b;
+}
+
+function add2(a, b, enable) {
+	return a - b;
+}
+
+// keep it
+function add3(a, b, enable) {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+// conditional expression
+function add4(a, b, enable) {
+	{
+		return a + b;
+	}
+}
+
+// export default
+var arrowAdd = (a, b, enable) => {
+	{
+		return a + b;
+	}
+};
+
+const arrowAdd1 = (a, b, enable) => {
+	return a - b;
+};
+
+// keep it
+const arrowAdd2 = (a, b, enable) => {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+};
+
+// conditional expression
+const arrowAdd3 = (a, b, enable) => {
+	{
+		return a + b;
+	}
+};
+
+function foo(bar) {
+	console.log(bar());
+}
+
+console.log(add(1, 2));
+console.log(add1(1, 2));
+console.log(add2(1, 2)); // unused argument should be treated as undefined
+console.log(foo(add3));
+console.log(add4(1, 2));
+
+console.log(arrowAdd(1, 2));
+console.log(arrowAdd1(1, 2));
+console.log(foo(arrowAdd2));
+console.log(arrowAdd3(1, 2));

--- a/test/form/samples/tree-shake-literal-parameter/import-function/arrow_lib.js
+++ b/test/form/samples/tree-shake-literal-parameter/import-function/arrow_lib.js
@@ -1,0 +1,30 @@
+// export default
+export default (a, b, enable) => {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+export const arrowAdd1 = (a, b, enable) => {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+// keep it
+export const arrowAdd2 = (a, b, enable) => {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+// conditional expression
+export const arrowAdd3 = (a, b, enable) => {
+	if (enable? true: false) {
+		return a + b;
+	}
+	return a - b;
+}

--- a/test/form/samples/tree-shake-literal-parameter/import-function/lib.js
+++ b/test/form/samples/tree-shake-literal-parameter/import-function/lib.js
@@ -1,0 +1,37 @@
+// export default
+export default function (a, b, enable) {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+export function add1(a, b, enable) {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+export function add2(a, b, enable) {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+// keep it
+export function add3(a, b, enable) {
+	if (enable) {
+		return a + b;
+	}
+	return a - b;
+}
+
+// conditional expression
+export function add4(a, b, enable) {
+	if (enable? true: false) {
+		return a + b;
+	}
+	return a - b;
+}

--- a/test/form/samples/tree-shake-literal-parameter/import-function/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/import-function/main.js
@@ -1,0 +1,17 @@
+import add, { add1, add2, add3, add4 } from './lib.js'
+import arrowAdd, { arrowAdd1, arrowAdd2, arrowAdd3 } from './arrow_lib.js'
+
+function foo(bar) {
+	console.log(bar());
+}
+
+console.log(add(1, 2, true));
+console.log(add1(1, 2, false));
+console.log(add2(1, 2)); // unused argument should be treated as undefined
+console.log(foo(add3))
+console.log(add4(1, 2, true));
+
+console.log(arrowAdd(1, 2, true));
+console.log(arrowAdd1(1, 2, false));
+console.log(foo(arrowAdd2));
+console.log(arrowAdd3(1, 2, true));

--- a/test/form/samples/tree-shake-literal-parameter/indirect-import-function/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/indirect-import-function/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'parameters of indirect function import should also be tree-shaken'
+});

--- a/test/form/samples/tree-shake-literal-parameter/indirect-import-function/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/indirect-import-function/_expected.js
@@ -1,0 +1,14 @@
+function importThenExportSub(enable) {
+	{
+		return 'importThenExportSub';
+	}
+}
+
+function defineAndExportDefault(enable) {
+	{
+		return 'defineAndExportDefault';
+	}
+}
+
+console.log(importThenExportSub());
+console.log(defineAndExportDefault());

--- a/test/form/samples/tree-shake-literal-parameter/indirect-import-function/define_and_export_default.js
+++ b/test/form/samples/tree-shake-literal-parameter/indirect-import-function/define_and_export_default.js
@@ -1,0 +1,7 @@
+function defineAndExportDefault(enable) {
+	if (enable) {
+		return 'defineAndExportDefault';
+	}
+}
+
+export default defineAndExportDefault;

--- a/test/form/samples/tree-shake-literal-parameter/indirect-import-function/import_then_export.js
+++ b/test/form/samples/tree-shake-literal-parameter/indirect-import-function/import_then_export.js
@@ -1,0 +1,3 @@
+import { importThenExportSub } from './import_then_export_sub.js'
+
+export { importThenExportSub }

--- a/test/form/samples/tree-shake-literal-parameter/indirect-import-function/import_then_export_sub.js
+++ b/test/form/samples/tree-shake-literal-parameter/indirect-import-function/import_then_export_sub.js
@@ -1,0 +1,5 @@
+export function importThenExportSub(enable) {
+	if (enable) {
+		return 'importThenExportSub';
+	}
+}

--- a/test/form/samples/tree-shake-literal-parameter/indirect-import-function/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/indirect-import-function/main.js
@@ -1,0 +1,5 @@
+import { importThenExportSub } from './import_then_export.js'
+import defineAndExportDefault from './define_and_export_default.js'
+
+console.log(importThenExportSub(true))
+console.log(defineAndExportDefault(true))

--- a/test/form/samples/tree-shake-literal-parameter/recursion-literal-object/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/recursion-literal-object/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'function parameters tree-shaken should be recursive if literal'
+});

--- a/test/form/samples/tree-shake-literal-parameter/recursion-literal-object/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/recursion-literal-object/_expected.js
@@ -1,0 +1,22 @@
+function fun1(options) {
+	{
+		return 'fun1';
+	}
+}
+
+function fun2(options) {
+	{
+		return fun1();
+	}
+}
+
+function fun4(options) {
+	{
+		console.log('func4');
+	}
+}
+
+console.log(
+	fun2(),
+	fun4()
+);

--- a/test/form/samples/tree-shake-literal-parameter/recursion-literal-object/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/recursion-literal-object/main.js
@@ -1,0 +1,40 @@
+function fun1(options) {
+	if (options.enable) {
+		return 'fun1';
+	} else {
+		console.log('func1');
+	}
+}
+
+function fun2(options) {
+	if (options.enable) {
+		return fun1(options);
+	} else {
+		console.log('func2');
+	}
+}
+
+function fun3(options) {
+	if (options.enable) {
+		return 'fun3';
+	} else {
+		console.log('func3');
+	}
+}
+
+function fun4(options) {
+	if (options.enable) {
+		return fun3(options);
+	} else {
+		console.log('func4');
+	}
+}
+
+console.log(
+	fun2({
+		enable: true
+	}),
+	fun4({
+		enable: false
+	})
+);

--- a/test/form/samples/tree-shake-literal-parameter/recursion-literal/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/recursion-literal/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'function parameters tree-shaken should be recursive if literal'
+});

--- a/test/form/samples/tree-shake-literal-parameter/recursion-literal/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/recursion-literal/_expected.js
@@ -1,0 +1,13 @@
+function fun1(enable) {
+	{
+		return 'fun1';
+	}
+}
+
+function fun2(enable) {
+	{
+		return fun1();
+	}
+}
+
+console.log(fun2());

--- a/test/form/samples/tree-shake-literal-parameter/recursion-literal/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/recursion-literal/main.js
@@ -1,0 +1,13 @@
+function fun1(enable) {
+	if (enable) {
+		return 'fun1';
+	}
+}
+
+function fun2(enable) {
+	if (enable) {
+		return fun1(enable);
+	}
+}
+
+console.log(fun2(true));

--- a/test/form/samples/tree-shake-literal-parameter/reexport-function/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/reexport-function/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'function parameters tree-shaken should support reexport'
+});

--- a/test/form/samples/tree-shake-literal-parameter/reexport-function/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/reexport-function/_expected.js
@@ -1,0 +1,7 @@
+function module2 (enable) {
+	{
+		return 'module2'
+	}
+}
+
+console.log(module2());

--- a/test/form/samples/tree-shake-literal-parameter/reexport-function/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/reexport-function/main.js
@@ -1,0 +1,3 @@
+import { module2 } from './module1.js'
+
+console.log(module2(true))

--- a/test/form/samples/tree-shake-literal-parameter/reexport-function/module1.js
+++ b/test/form/samples/tree-shake-literal-parameter/reexport-function/module1.js
@@ -1,0 +1,1 @@
+export * from './module2.js';

--- a/test/form/samples/tree-shake-literal-parameter/reexport-function/module2.js
+++ b/test/form/samples/tree-shake-literal-parameter/reexport-function/module2.js
@@ -1,0 +1,5 @@
+export function module2 (enable) {
+	if (enable) {
+		return 'module2'
+	}
+}

--- a/test/form/samples/tree-shake-literal-parameter/side-effect/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/side-effect/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'test tree-shake-literal-parameter with side-effect'
+});

--- a/test/form/samples/tree-shake-literal-parameter/side-effect/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/side-effect/_expected.js
@@ -1,0 +1,63 @@
+function foo1() {
+	return 1;
+}
+
+function bar1(foo) {
+	console.log(foo());
+}
+
+function bar2(foo) {
+}
+
+// not pure, preserve
+function foo3() {
+	console.log(1);
+}
+
+function bar3(foo) {
+	foo();
+}
+
+console.log(bar1(foo1), bar2(), bar3(foo3));
+
+const options = {
+	enable: 1
+};
+
+const options2 = {
+	enable: 1
+};
+
+function calledWithSameVariable(options) {
+	{
+		return 'enabled';
+	}
+}
+
+function calledWithDifferentVariable(options) {
+	if (options.enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+}
+
+// forward hasEffects to `options`
+console.log(calledWithSameVariable(), calledWithSameVariable());
+// no optimization
+console.log(calledWithDifferentVariable(options), calledWithDifferentVariable(options2));
+
+const optionsBeModified = {
+	enable: 1
+};
+
+function calledWithModifiedVariable(options) {
+	if (options.enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+}
+
+console.log(calledWithModifiedVariable(optionsBeModified));
+optionsBeModified.enable = 0;

--- a/test/form/samples/tree-shake-literal-parameter/side-effect/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/side-effect/main.js
@@ -1,0 +1,71 @@
+function foo1() {
+	return 1;
+}
+
+function bar1(foo) {
+	console.log(foo())
+}
+
+// pure, can be tree-shaken
+function foo2() {
+	return 1;
+}
+
+function bar2(foo) {
+	foo()
+}
+
+// not pure, preserve
+function foo3() {
+	console.log(1);
+}
+
+function bar3(foo) {
+	foo()
+}
+
+console.log(bar1(foo1), bar2(foo2), bar3(foo3))
+
+const options = {
+	enable: 1
+}
+
+const options2 = {
+	enable: 1
+}
+
+function calledWithSameVariable(options) {
+	if (options.enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+}
+
+function calledWithDifferentVariable(options) {
+	if (options.enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+}
+
+// forward hasEffects to `options`
+console.log(calledWithSameVariable(options), calledWithSameVariable(options))
+// no optimization
+console.log(calledWithDifferentVariable(options), calledWithDifferentVariable(options2))
+
+const optionsBeModified = {
+	enable: 1
+}
+
+function calledWithModifiedVariable(options) {
+	if (options.enable) {
+		return 'enabled';
+	} else {
+		return 'disabled';
+	}
+}
+
+console.log(calledWithModifiedVariable(optionsBeModified))
+optionsBeModified.enable = 0;

--- a/test/form/samples/tree-shake-literal-parameter/top-level/_config.js
+++ b/test/form/samples/tree-shake-literal-parameter/top-level/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'Top level exports and global variables should not be optimized'
+});

--- a/test/form/samples/tree-shake-literal-parameter/top-level/_expected.js
+++ b/test/form/samples/tree-shake-literal-parameter/top-level/_expected.js
@@ -1,0 +1,23 @@
+function foo(x) {
+	// The exported function might also be called with "false"
+	if (x) console.log('true');
+	else console.log('false');
+}
+
+// global variable should not be optimized
+foo2 = (x) => {
+	if (x) console.log('true');
+	else console.log('false');
+};
+
+// export default should not be optimized
+var main = foo3 = (x) => {
+	if (x) console.log('true');
+	else console.log('false');
+};
+
+foo(true);
+foo2(true);
+foo3(true);
+
+export { main as default, foo };

--- a/test/form/samples/tree-shake-literal-parameter/top-level/main.js
+++ b/test/form/samples/tree-shake-literal-parameter/top-level/main.js
@@ -1,0 +1,23 @@
+function foo(x) {
+	// The exported function might also be called with "false"
+	if (x) console.log('true');
+	else console.log('false');
+}
+
+// global variable should not be optimized
+foo2 = (x) => {
+	if (x) console.log('true');
+	else console.log('false');
+}
+
+// export default should not be optimized
+export default foo3 = (x) => {
+	if (x) console.log('true');
+	else console.log('false');
+}
+
+foo(true);
+foo2(true);
+foo3(true);
+
+export { foo };

--- a/test/form/samples/try-statement-deoptimization/deactivate-via-option/_expected.js
+++ b/test/form/samples/try-statement-deoptimization/deactivate-via-option/_expected.js
@@ -6,13 +6,11 @@ const mutated = {};
 
 function test(callback) {
 	try {
-		callback();
 		mutate(mutated);
 	} catch {}
 }
 
-test(() => {
-});
+test();
 
 try {} finally {
 	console.log('retained');

--- a/test/function/samples/acorn-walk/_config.js
+++ b/test/function/samples/acorn-walk/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'in acorn walk, immediate function lose track so we do not optimize parameter'
+});

--- a/test/function/samples/acorn-walk/main.js
+++ b/test/function/samples/acorn-walk/main.js
@@ -1,0 +1,26 @@
+let found = false;
+
+const base = {
+	ExpressionStatement(node, c) {
+		c(node.value, "Expression");
+	},
+	Expression() { },
+	Identifier() { }
+};
+
+function simple(node, visitors, baseVisitor) {
+	if (!baseVisitor) baseVisitor = base
+		; (function c(node, override) {
+			let type = override || node.type
+			baseVisitor[type](node, c)
+			if (visitors[type]) visitors[type](node)
+		})(node)
+}
+
+simple({ type: "ExpressionStatement", value: { type: "Identifier" } }, {
+	Expression(node) {
+		found = true;
+	}
+});
+
+assert.equal(found, true);

--- a/test/function/samples/reassigned-parameter-side-effect/_config.js
+++ b/test/function/samples/reassigned-parameter-side-effect/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'when a parameter is reassigned, hasEffectsOnInteractionAtPath returns true'
+});

--- a/test/function/samples/reassigned-parameter-side-effect/main.js
+++ b/test/function/samples/reassigned-parameter-side-effect/main.js
@@ -1,0 +1,14 @@
+function foo(a) {
+	a.x;
+}
+let sideEffect = false
+foo({
+	x: 1
+});
+foo({
+	get x() {
+		sideEffect = true
+	},
+});
+
+assert.equal(sideEffect, true)

--- a/test/function/samples/reassigned-parameter/_config.js
+++ b/test/function/samples/reassigned-parameter/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'parameters reassigned/updated should be detected'
+});

--- a/test/function/samples/reassigned-parameter/main.js
+++ b/test/function/samples/reassigned-parameter/main.js
@@ -1,0 +1,21 @@
+function f(a) {
+	assert.equal(a ? 'OK' : 'FAIL', 'OK');
+	a = false;
+	assert.equal(a ? 'FAIL' : 'OK', 'OK');
+}
+
+f(true);
+
+function g(array) {
+	if (array === null) {
+		array = [];
+	}
+
+	if (array) {
+		return 'OK';
+	}
+	return array;
+}
+
+assert.equal(g(null), 'OK');
+


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- resolves #5480 

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

This PR is to point out a problem with 4.16, and discuss if we should revert it first if the work to do is heavy.

Unused node should not be included, otherwise:

```
logicalExpression1 -- logicalExpression2 -- LogicalExpression3
                                         -- LogicalExpression4
                   -- logicalExpression5 -- LogicalExpression6
                                         -- LogicalExpression7
```

In the first visit, assuming no optimization info for node1, so node2 and node5 will both get included. and node6 may get not included.

However, if in the second visit, node5 is excluded, becaused it is still mark `included`, in render stage renderer will try to render node5 and find node6 or node 7 error.

This PR can fix #5480. (no tests because the condition is a bit harsh and I have not reproduced a smaller one)

While it is fixable, It actually reveals: we need a way to revert `include`. This can be done in two ways to make sure no problems:

1. explicitly set `included=false` in every `include` function that may only include some children (or `deoptimizePath` like in the PR, it actually makes no difference because `deoptimizeCache` will request one `include`, but place it in `include` may be better because there may be other functions causing children included change (in the future?) and request a `include`) 
2. in render function, we don't use `included` to check, but only uses `usedBranch` or other stuffs like that. I guess it's not how it is designed.

This PR only achives a part of the first way. I'll be off for next 12 or more hours, so if it's too heavy to do, maybe we should revert version 4.16 ...