### PR TITLE
fix: parameter variable infinite recursion error

### DIFF
--- a/src/ast/nodes/NewExpression.ts
+++ b/src/ast/nodes/NewExpression.ts
@@ -19,20 +19,17 @@ export default class NewExpression extends NodeBase {
 	declare annotationPure?: boolean;
 
 	hasEffects(context: HasEffectsContext): boolean {
-		try {
-			for (const argument of this.arguments) {
-				if (argument.hasEffects(context)) return true;
-			}
-			if (this.annotationPure) {
-				return false;
-			}
-			return (
-				this.callee.hasEffects(context) ||
-				this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
-			);
-		} finally {
-			if (!this.deoptimized) this.applyDeoptimizations();
+		if (!this.deoptimized) this.applyDeoptimizations();
+		for (const argument of this.arguments) {
+			if (argument.hasEffects(context)) return true;
 		}
+		if (this.annotationPure) {
+			return false;
+		}
+		return (
+			this.callee.hasEffects(context) ||
+			this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
+		);
 	}
 
 	hasEffectsOnInteractionAtPath(path: ObjectPath, { type }: NodeInteraction): boolean {

--- a/src/ast/nodes/TaggedTemplateExpression.ts
+++ b/src/ast/nodes/TaggedTemplateExpression.ts
@@ -34,17 +34,14 @@ export default class TaggedTemplateExpression extends CallExpressionBase {
 	}
 
 	hasEffects(context: HasEffectsContext): boolean {
-		try {
-			for (const argument of this.quasi.expressions) {
-				if (argument.hasEffects(context)) return true;
-			}
-			return (
-				this.tag.hasEffects(context) ||
-				this.tag.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
-			);
-		} finally {
-			if (!this.deoptimized) this.applyDeoptimizations();
+		if (!this.deoptimized) this.applyDeoptimizations();
+		for (const argument of this.quasi.expressions) {
+			if (argument.hasEffects(context)) return true;
 		}
+		return (
+			this.tag.hasEffects(context) ||
+			this.tag.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
+		);
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/test/function/samples/recursive-parameter-assignments/main.js
+++ b/test/function/samples/recursive-parameter-assignments/main.js
@@ -12,6 +12,7 @@ class Test {
 
 		this.name = name;
 		this.opts = opts;
+		// to make the function call not pure
 		created = true;
 	}
 }

--- a/test/function/samples/recursive-parameter-assignments/main.js
+++ b/test/function/samples/recursive-parameter-assignments/main.js
@@ -1,3 +1,5 @@
+let created = false;
+
 class Test {
 	constructor ( name, opts ) {
 		opts = opts || {};
@@ -10,7 +12,9 @@ class Test {
 
 		this.name = name;
 		this.opts = opts;
+		created = true;
 	}
 }
 
 new Test( 'a', {} );
+assert.equal( created, true );

--- a/test/function/samples/recursive-parameter-binding/_config.js
+++ b/test/function/samples/recursive-parameter-binding/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description:
+		'Avoid maximum call stack error, make sure parameter value is optimized before hasEffects (#5499).'
+});

--- a/test/function/samples/recursive-parameter-binding/main.js
+++ b/test/function/samples/recursive-parameter-binding/main.js
@@ -12,7 +12,7 @@ function Test(options) {
 
 function Test2(options) {
 	if (!this) {
-		return new Test(options);
+		return new Test2(options);
 	}
 	if (options.x) {
 		return 0;

--- a/test/function/samples/recursive-parameter-binding/main.js
+++ b/test/function/samples/recursive-parameter-binding/main.js
@@ -1,0 +1,26 @@
+let created = 0;
+
+function Test(options) {
+	if (!this) {
+		return new Test(options);
+	}
+	if (options.x) {
+		return 0;
+	}
+	created++;
+}
+
+function Test2(options) {
+	if (!this) {
+		return new Test(options);
+	}
+	if (options.x) {
+		return 0;
+	}
+	created++;
+}
+
+new Test({});
+Test2`{}`;
+
+assert.equal(created, 2);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

- resolves #5499

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The function parameter will only get a known value when it is the callee of a function call. It is also where the `hasEffects` of function body gets called (and the only place?), we need to make sure the known value is set first, then `hasEffects` of function body gets called for `NewExpression` and `TaggedTemplateExpression` too. In that case, we can get exactly a "call tree" instead of a "call graph", so the known value of a parameter is guaranteed to come from somewhere outside the function and is guaranteed to from a "analyzed" code/function.