### PR TITLE
Resolve import.meta.{filename,dirname} in files imported from config

### DIFF
--- a/cli/run/loadConfigFile.ts
+++ b/cli/run/loadConfigFile.ts
@@ -118,8 +118,14 @@ async function loadTranspiledConfigFile(
 					if (property === 'url') {
 						return `'${pathToFileURL(moduleId).href}'`;
 					}
+					if (property == 'filename') {
+						return `'${moduleId}'`;
+					}
+					if (property == 'dirname') {
+						return `'${path.dirname(moduleId)}'`;
+					}
 					if (property == null) {
-						return `{url:'${pathToFileURL(moduleId).href}'}`;
+						return `{url:'${pathToFileURL(moduleId).href}', filename: '${moduleId}', dirname: '${path.dirname(moduleId)}'}`;
 					}
 				}
 			}

--- a/test/cli/samples/config-import-meta/_config.js
+++ b/test/cli/samples/config-import-meta/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
-	description: 'uses correct import.meta.url in config files',
+	description: 'uses correct import.meta.{url,filename,dirname} in config files',
 	command: 'rollup -c --bundleConfigAsCjs'
 });

--- a/test/cli/samples/config-import-meta/plugin/plugin.js
+++ b/test/cli/samples/config-import-meta/plugin/plugin.js
@@ -9,6 +9,8 @@ const fileName = `test.txt`;
 
 function validateImportMeta(importMeta) {
 	assert.strictEqual(importMeta.url, import.meta.url);
+	assert.strictEqual(importMeta.filename, import.meta.filename);
+	assert.strictEqual(importMeta.dirname, import.meta.dirname);
 }
 
 validateImportMeta(import.meta);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: N/A

### Description

Back in #4005, rollup was taught how to resolve `import.meta.url` in files imported into the rollup config using a relative path - making `import.meta.url` refer the file it's used in, rather than the config file.

[node 20.11.0](https://nodejs.org/en/blog/release/v20.11.0) introduced two new import meta fields - `import.meta.filename` and `import.meta.dirname` - that act the same as __filename and __dirname in commonjs.

This PR teaches rollup config transpilation how to transform `import.meta.filename` and `import.meta.dirname` so they behave as expected inside plugins that are imported via relative paths. Previously, import.meta.filename and import.meta.dirname would be the file/directory of the config file.
