### PR TITLE
Use Spanned trait to simplify logic

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -122,7 +122,7 @@ Repository: micromatch/braces
 
 > The MIT License (MIT)
 > 
-> Copyright (c) 2014-2018, Jon Schlinkert.
+> Copyright (c) 2014-present, Jon Schlinkert.
 > 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/rust/parse_ast/src/ast_nodes/method_definition.rs
+++ b/rust/parse_ast/src/ast_nodes/method_definition.rs
@@ -1,4 +1,4 @@
-use swc_common::Span;
+use swc_common::{Span, Spanned};
 use swc_ecma_ast::{
   ClassMethod, Constructor, Function, MethodKind, ParamOrTsParamProp, Pat, PrivateMethod,
   PrivateName, PropName,
@@ -10,10 +10,10 @@ use crate::convert_ast::converter::ast_constants::{
   METHOD_DEFINITION_KIND_OFFSET, METHOD_DEFINITION_RESERVED_BYTES, METHOD_DEFINITION_STATIC_FLAG,
   METHOD_DEFINITION_VALUE_OFFSET, TYPE_FUNCTION_EXPRESSION, TYPE_METHOD_DEFINITION,
 };
+use crate::convert_ast::converter::AstConverter;
 use crate::convert_ast::converter::string_constants::{
   STRING_CONSTRUCTOR, STRING_GET, STRING_METHOD, STRING_SET,
 };
-use crate::convert_ast::converter::AstConverter;
 
 impl<'a> AstConverter<'a> {
   pub fn store_method_definition(
@@ -53,7 +53,7 @@ impl<'a> AstConverter<'a> {
     let key_end = match key {
       PropOrPrivateName::PropName(prop_name) => {
         self.convert_property_name(prop_name);
-        self.get_property_name_span(prop_name).hi.0 - 1
+        prop_name.span().hi.0 - 1
       }
       PropOrPrivateName::PrivateName(private_name) => {
         self.store_private_identifier(private_name);
@@ -99,7 +99,7 @@ impl<'a> AstConverter<'a> {
     match &constructor.body {
       Some(block_statement) => {
         self.update_reference_position(end_position + METHOD_DEFINITION_VALUE_OFFSET);
-        let key_end = self.get_property_name_span(&constructor.key).hi.0 - 1;
+        let key_end = constructor.key.span().hi.0 - 1;
         let function_start = find_first_occurrence_outside_comment(self.code, b'(', key_end);
         let parameters: Vec<&Pat> = constructor
           .params

--- a/rust/parse_ast/src/ast_nodes/method_definition.rs
+++ b/rust/parse_ast/src/ast_nodes/method_definition.rs
@@ -10,10 +10,10 @@ use crate::convert_ast::converter::ast_constants::{
   METHOD_DEFINITION_KIND_OFFSET, METHOD_DEFINITION_RESERVED_BYTES, METHOD_DEFINITION_STATIC_FLAG,
   METHOD_DEFINITION_VALUE_OFFSET, TYPE_FUNCTION_EXPRESSION, TYPE_METHOD_DEFINITION,
 };
-use crate::convert_ast::converter::AstConverter;
 use crate::convert_ast::converter::string_constants::{
   STRING_CONSTRUCTOR, STRING_GET, STRING_METHOD, STRING_SET,
 };
+use crate::convert_ast::converter::AstConverter;
 
 impl<'a> AstConverter<'a> {
   pub fn store_method_definition(

--- a/rust/parse_ast/src/ast_nodes/property.rs
+++ b/rust/parse_ast/src/ast_nodes/property.rs
@@ -1,4 +1,4 @@
-use swc_common::Span;
+use swc_common::{Span, Spanned};
 use swc_ecma_ast::{
   AssignPatProp, BlockStmt, Expr, GetterProp, Ident, KeyValuePatProp, KeyValueProp, MethodProp,
   Pat, Prop, PropName, SetterProp,
@@ -11,8 +11,8 @@ use crate::convert_ast::converter::ast_constants::{
   PROPERTY_METHOD_FLAG, PROPERTY_RESERVED_BYTES, PROPERTY_SHORTHAND_FLAG, PROPERTY_VALUE_OFFSET,
   TYPE_FUNCTION_EXPRESSION, TYPE_PROPERTY,
 };
-use crate::convert_ast::converter::string_constants::{STRING_GET, STRING_INIT, STRING_SET};
 use crate::convert_ast::converter::AstConverter;
+use crate::convert_ast::converter::string_constants::{STRING_GET, STRING_INIT, STRING_SET};
 
 impl<'a> AstConverter<'a> {
   pub fn convert_property(&mut self, property: &Prop) {
@@ -50,7 +50,7 @@ impl<'a> AstConverter<'a> {
   fn store_key_value_property(&mut self, property_name: &PropName, value: PatternOrExpression) {
     let end_position = self.add_type_and_explicit_start(
       &TYPE_PROPERTY,
-      self.get_property_name_span(property_name).lo.0 - 1,
+      &property_name.span().lo.0 - 1,
       PROPERTY_RESERVED_BYTES,
     );
     // key
@@ -100,7 +100,7 @@ impl<'a> AstConverter<'a> {
     // key
     self.update_reference_position(end_position + PROPERTY_KEY_OFFSET);
     self.convert_property_name(key);
-    let key_end = self.get_property_name_span(key).hi.0 - 1;
+    let key_end = key.span().hi.0 - 1;
     // flags, method and shorthand are always false
     let mut flags = 0u32;
     if matches!(key, PropName::Computed(_)) {
@@ -143,7 +143,7 @@ impl<'a> AstConverter<'a> {
     // key
     self.update_reference_position(end_position + PROPERTY_KEY_OFFSET);
     self.convert_property_name(&method_property.key);
-    let key_end = self.get_property_name_span(&method_property.key).hi.0 - 1;
+    let key_end = &method_property.key.span().hi.0 - 1;
     let function_start = find_first_occurrence_outside_comment(self.code, b'(', key_end);
     // flags, shorthand is always false
     let mut flags = PROPERTY_METHOD_FLAG;

--- a/rust/parse_ast/src/ast_nodes/property.rs
+++ b/rust/parse_ast/src/ast_nodes/property.rs
@@ -11,8 +11,8 @@ use crate::convert_ast::converter::ast_constants::{
   PROPERTY_METHOD_FLAG, PROPERTY_RESERVED_BYTES, PROPERTY_SHORTHAND_FLAG, PROPERTY_VALUE_OFFSET,
   TYPE_FUNCTION_EXPRESSION, TYPE_PROPERTY,
 };
-use crate::convert_ast::converter::AstConverter;
 use crate::convert_ast::converter::string_constants::{STRING_GET, STRING_INIT, STRING_SET};
+use crate::convert_ast::converter::AstConverter;
 
 impl<'a> AstConverter<'a> {
   pub fn convert_property(&mut self, property: &Prop) {

--- a/rust/parse_ast/src/ast_nodes/property.rs
+++ b/rust/parse_ast/src/ast_nodes/property.rs
@@ -48,10 +48,11 @@ impl<'a> AstConverter<'a> {
   }
 
   fn store_key_value_property(&mut self, property_name: &PropName, value: PatternOrExpression) {
-    let end_position = self.add_type_and_explicit_start(
+    let end_position = self.add_type_and_start(
       &TYPE_PROPERTY,
-      &property_name.span().lo.0 - 1,
+      &property_name.span(),
       PROPERTY_RESERVED_BYTES,
+      false,
     );
     // key
     self.update_reference_position(end_position + PROPERTY_KEY_OFFSET);
@@ -68,23 +69,12 @@ impl<'a> AstConverter<'a> {
     self.buffer[kind_position..kind_position + 4].copy_from_slice(&STRING_INIT);
     // value
     self.update_reference_position(end_position + PROPERTY_VALUE_OFFSET);
-    let value_position = self.buffer.len();
-    let value_boundaries = match value {
+    match value {
       PatternOrExpression::Pattern(pattern) => self.convert_pattern(pattern),
       PatternOrExpression::Expression(expression) => self.convert_expression(expression),
     };
     // end
-    let end_bytes: [u8; 4] = match value_boundaries {
-      Some((_, end)) => end.to_ne_bytes(),
-      None => {
-        let value_end: [u8; 4] = self.buffer[value_position + 8..value_position + 12]
-          .try_into()
-          .unwrap();
-        value_end
-      }
-    };
-    // TODO SWC avoid copying positions around but use span getters instead
-    self.buffer[end_position..end_position + 4].copy_from_slice(&end_bytes);
+    self.add_end(end_position, &value.span());
   }
 
   fn store_getter_setter_property(
@@ -244,6 +234,7 @@ impl<'a> AstConverter<'a> {
   }
 }
 
+#[derive(Spanned)]
 pub enum PatternOrExpression<'a> {
   Pattern(&'a Pat),
   Expression(&'a Expr),

--- a/rust/parse_ast/src/ast_nodes/rest_element.rs
+++ b/rust/parse_ast/src/ast_nodes/rest_element.rs
@@ -7,15 +7,16 @@ use crate::convert_ast::converter::AstConverter;
 
 impl<'a> AstConverter<'a> {
   pub fn store_rest_element(&mut self, rest_pattern: &RestPat) {
-    let end_position = self.add_type_and_explicit_start(
+    let end_position = self.add_type_and_start(
       &TYPE_REST_ELEMENT,
-      rest_pattern.dot3_token.lo.0 - 1,
+      &rest_pattern.dot3_token,
       REST_ELEMENT_RESERVED_BYTES,
+      false,
     );
     // argument
     self.update_reference_position(end_position + REST_ELEMENT_ARGUMENT_OFFSET);
     self.convert_pattern(&rest_pattern.arg);
     // end
-    self.add_explicit_end(end_position, rest_pattern.span.hi.0 - 1);
+    self.add_end(end_position, &rest_pattern.span);
   }
 }

--- a/rust/parse_ast/src/ast_nodes/return_statement.rs
+++ b/rust/parse_ast/src/ast_nodes/return_statement.rs
@@ -14,10 +14,10 @@ impl<'a> AstConverter<'a> {
       false,
     );
     // argument
-    return_statement.arg.as_ref().map(|argument| {
+    if let Some(argument) = return_statement.arg.as_ref() {
       self.update_reference_position(end_position + RETURN_STATEMENT_ARGUMENT_OFFSET);
       self.convert_expression(argument)
-    });
+    }
     // end
     self.add_end(end_position, &return_statement.span);
   }

--- a/rust/parse_ast/src/ast_nodes/shared/class_node.rs
+++ b/rust/parse_ast/src/ast_nodes/shared/class_node.rs
@@ -1,3 +1,4 @@
+use swc_common::Spanned;
 use swc_ecma_ast::{Class, Ident};
 
 use crate::convert_ast::converter::analyze_code::find_first_occurrence_outside_comment;
@@ -31,7 +32,7 @@ impl<'a> AstConverter<'a> {
     if let Some(super_class) = class.super_class.as_ref() {
       self.update_reference_position(end_position + CLASS_DECLARATION_SUPER_CLASS_OFFSET);
       self.convert_expression(super_class);
-      body_start_search = self.get_expression_span(super_class).hi.0 - 1;
+      body_start_search = super_class.span().hi.0 - 1;
     }
     // body
     self.update_reference_position(end_position + CLASS_DECLARATION_BODY_OFFSET);

--- a/rust/parse_ast/src/ast_nodes/spread_element.rs
+++ b/rust/parse_ast/src/ast_nodes/spread_element.rs
@@ -1,4 +1,4 @@
-use swc_common::Span;
+use swc_common::{Span, Spanned};
 use swc_ecma_ast::{Expr, SpreadElement};
 
 use crate::convert_ast::converter::ast_constants::{
@@ -14,15 +14,11 @@ impl<'a> AstConverter<'a> {
       SPREAD_ELEMENT_RESERVED_BYTES,
       false,
     );
-    // we need to set the end position to that of the expression
-    let argument_position = self.buffer.len();
     // argument
     self.update_reference_position(end_position + SPREAD_ELEMENT_ARGUMENT_OFFSET);
     self.convert_expression(argument);
-    let expression_end: [u8; 4] = self.buffer[argument_position + 8..argument_position + 12]
-      .try_into()
-      .unwrap();
-    self.buffer[end_position..end_position + 4].copy_from_slice(&expression_end);
+    // end
+    self.add_end(end_position, &argument.span());
   }
 
   pub fn convert_spread_element(&mut self, spread_element: &SpreadElement) {

--- a/rust/parse_ast/src/ast_nodes/switch_case.rs
+++ b/rust/parse_ast/src/ast_nodes/switch_case.rs
@@ -15,10 +15,10 @@ impl<'a> AstConverter<'a> {
       false,
     );
     // test
-    switch_case.test.as_ref().map(|expression| {
+    if let Some(expression) = switch_case.test.as_ref() {
       self.update_reference_position(end_position + SWITCH_CASE_TEST_OFFSET);
       self.convert_expression(expression)
-    });
+    }
     // consequent
     self.convert_item_list(
       &switch_case.cons,

--- a/rust/parse_ast/src/ast_nodes/yield_expression.rs
+++ b/rust/parse_ast/src/ast_nodes/yield_expression.rs
@@ -22,10 +22,10 @@ impl<'a> AstConverter<'a> {
     let flags_position = end_position + YIELD_EXPRESSION_FLAGS_OFFSET;
     self.buffer[flags_position..flags_position + 4].copy_from_slice(&flags.to_ne_bytes());
     // argument
-    yield_expression.arg.as_ref().map(|expression| {
+    if let Some(expression) = yield_expression.arg.as_ref() {
       self.update_reference_position(end_position + YIELD_EXPRESSION_ARGUMENT_OFFSET);
       self.convert_expression(expression)
-    });
+    }
     // end
     self.add_end(end_position, &yield_expression.span);
   }

--- a/rust/parse_ast/src/convert_ast/converter.rs
+++ b/rust/parse_ast/src/convert_ast/converter.rs
@@ -1,6 +1,6 @@
 use swc_common::Span;
 use swc_ecma_ast::{
-  AssignTarget, AssignTargetPat, CallExpr, Callee, ClassMember, Decl, ExportSpecifier, Expr,
+  AssignTarget, AssignTargetPat, Callee, CallExpr, ClassMember, Decl, ExportSpecifier, Expr,
   ExprOrSpread, ForHead, ImportSpecifier, Lit, ModuleDecl, ModuleExportName, ModuleItem,
   NamedExport, ObjectPatProp, OptChainBase, ParenExpr, Pat, Program, PropName, PropOrSpread,
   SimpleAssignTarget, Stmt, VarDeclOrExpr,
@@ -407,55 +407,6 @@ impl<'a> AstConverter<'a> {
     }
   }
 
-  pub(crate) fn get_expression_span(&mut self, expression: &Expr) -> Span {
-    match expression {
-      Expr::Array(array_literal) => array_literal.span,
-      Expr::Arrow(arrow_expression) => arrow_expression.span,
-      Expr::Assign(assignment_expression) => assignment_expression.span,
-      Expr::Await(await_expression) => await_expression.span,
-      Expr::Bin(binary_expression) => binary_expression.span,
-      Expr::Call(call_expression) => call_expression.span,
-      Expr::Class(class_expression) => class_expression.class.span,
-      Expr::Cond(conditional_expression) => conditional_expression.span,
-      Expr::Fn(function_expression) => function_expression.function.span,
-      Expr::Ident(identifier) => identifier.span,
-      Expr::Lit(Lit::Str(literal)) => literal.span,
-      Expr::Lit(Lit::Bool(literal)) => literal.span,
-      Expr::Lit(Lit::Null(literal)) => literal.span,
-      Expr::Lit(Lit::Num(literal)) => literal.span,
-      Expr::Lit(Lit::BigInt(literal)) => literal.span,
-      Expr::Lit(Lit::Regex(literal)) => literal.span,
-      Expr::Member(member_expression) => member_expression.span,
-      Expr::MetaProp(meta_property) => meta_property.span,
-      Expr::New(new_expression) => new_expression.span,
-      Expr::Object(object_literal) => object_literal.span,
-      Expr::OptChain(optional_chain_expression) => optional_chain_expression.span,
-      Expr::Paren(parenthesized_expression) => parenthesized_expression.span,
-      Expr::PrivateName(private_name) => private_name.span,
-      Expr::Seq(sequence_expression) => sequence_expression.span,
-      Expr::SuperProp(super_property) => super_property.span,
-      Expr::TaggedTpl(tagged_template_expression) => tagged_template_expression.span,
-      Expr::This(this_expression) => this_expression.span,
-      Expr::Tpl(template_literal) => template_literal.span,
-      Expr::Unary(unary_expression) => unary_expression.span,
-      Expr::Update(update_expression) => update_expression.span,
-      Expr::Yield(yield_expression) => yield_expression.span,
-      Expr::JSXMember(_) => unimplemented!("Cannot convert Expr::JSXMember"),
-      Expr::JSXNamespacedName(_) => unimplemented!("Cannot convert Expr::JSXNamespacedName"),
-      Expr::JSXEmpty(_) => unimplemented!("Cannot convert Expr::JSXEmpty"),
-      Expr::JSXElement(_) => unimplemented!("Cannot convert Expr::JSXElement"),
-      Expr::JSXFragment(_) => unimplemented!("Cannot convert Expr::JSXFragment"),
-      Expr::TsTypeAssertion(_) => unimplemented!("Cannot convert Expr::TsTypeAssertion"),
-      Expr::TsConstAssertion(_) => unimplemented!("Cannot convert Expr::TsConstAssertion"),
-      Expr::TsNonNull(_) => unimplemented!("Cannot convert Expr::TsNonNull"),
-      Expr::TsAs(_) => unimplemented!("Cannot convert Expr::TsAs"),
-      Expr::TsInstantiation(_) => unimplemented!("Cannot convert Expr::TsInstantiation"),
-      Expr::TsSatisfies(_) => unimplemented!("Cannot convert Expr::TsSatisfies"),
-      Expr::Invalid(_) => unimplemented!("Cannot convert Expr::Invalid"),
-      Expr::Lit(Lit::JSXText(_)) => unimplemented!("Cannot convert Lit::JSXText"),
-    }
-  }
-
   pub(crate) fn convert_for_head(&mut self, for_head: &ForHead) {
     match for_head {
       ForHead::VarDecl(variable_declaration) => {
@@ -695,16 +646,6 @@ impl<'a> AstConverter<'a> {
         self.store_literal_bigint(bigint);
         None
       }
-    }
-  }
-
-  pub(crate) fn get_property_name_span(&self, property_name: &PropName) -> Span {
-    match property_name {
-      PropName::Computed(computed_property_name) => computed_property_name.span,
-      PropName::Ident(ident) => ident.span,
-      PropName::Str(string) => string.span,
-      PropName::Num(number) => number.span,
-      PropName::BigInt(bigint) => bigint.span,
     }
   }
 

--- a/rust/parse_ast/src/convert_ast/converter.rs
+++ b/rust/parse_ast/src/convert_ast/converter.rs
@@ -274,39 +274,31 @@ impl<'a> AstConverter<'a> {
     }
   }
 
-  pub fn convert_expression(&mut self, expression: &Expr) -> Option<(u32, u32)> {
+  pub fn convert_expression(&mut self, expression: &Expr) {
     match expression {
       Expr::Array(array_literal) => {
         self.store_array_expression(array_literal);
-        None
       }
       Expr::Arrow(arrow_expression) => {
         self.store_arrow_function_expression(arrow_expression);
-        None
       }
       Expr::Assign(assignment_expression) => {
         self.store_assignment_expression(assignment_expression);
-        None
       }
       Expr::Await(await_expression) => {
         self.store_await_expression(await_expression);
-        None
       }
       Expr::Bin(binary_expression) => {
         self.store_binary_expression(binary_expression);
-        None
       }
       Expr::Call(call_expression) => {
         self.convert_call_expression(call_expression, false, false);
-        None
       }
       Expr::Class(class_expression) => {
         self.store_class_expression(class_expression, &TYPE_CLASS_EXPRESSION);
-        None
       }
       Expr::Cond(conditional_expression) => {
         self.store_conditional_expression(conditional_expression);
-        None
       }
       Expr::Fn(function_expression) => {
         self.convert_function(
@@ -314,74 +306,57 @@ impl<'a> AstConverter<'a> {
           &TYPE_FUNCTION_EXPRESSION,
           function_expression.ident.as_ref(),
         );
-        None
       }
       Expr::Ident(identifier) => {
         self.convert_identifier(identifier);
-        None
       }
       Expr::Lit(literal) => {
         self.convert_literal(literal);
-        None
       }
       Expr::Member(member_expression) => {
         self.convert_member_expression(member_expression, false, false);
-        None
       }
       Expr::MetaProp(meta_property) => {
         self.store_meta_property(meta_property);
-        None
       }
       Expr::New(new_expression) => {
         self.store_new_expression(new_expression);
-        None
       }
       Expr::Object(object_literal) => {
         self.store_object_expression(object_literal);
-        None
       }
       Expr::OptChain(optional_chain_expression) => {
         self.store_chain_expression(optional_chain_expression, false);
-        None
       }
       Expr::Paren(parenthesized_expression) => {
-        Some(self.convert_parenthesized_expression(parenthesized_expression))
+        self.convert_parenthesized_expression(parenthesized_expression)
       }
       Expr::PrivateName(private_name) => {
         self.store_private_identifier(private_name);
-        None
       }
       Expr::Seq(sequence_expression) => {
         self.store_sequence_expression(sequence_expression);
-        None
       }
       Expr::SuperProp(super_property) => {
         self.convert_super_property(super_property);
-        None
       }
       Expr::TaggedTpl(tagged_template_expression) => {
         self.store_tagged_template_expression(tagged_template_expression);
-        None
       }
       Expr::This(this_expression) => {
         self.store_this_expression(this_expression);
-        None
       }
       Expr::Tpl(template_literal) => {
         self.store_template_literal(template_literal);
-        None
       }
       Expr::Unary(unary_expression) => {
         self.store_unary_expression(unary_expression);
-        None
       }
       Expr::Update(update_expression) => {
         self.store_update_expression(update_expression);
-        None
       }
       Expr::Yield(yield_expression) => {
         self.store_yield_expression(yield_expression);
-        None
       }
       Expr::JSXMember(_) => unimplemented!("Cannot convert Expr::JSXMember"),
       Expr::JSXNamespacedName(_) => unimplemented!("Cannot convert Expr::JSXNamespacedName"),
@@ -527,11 +502,9 @@ impl<'a> AstConverter<'a> {
     }
   }
 
-  fn convert_parenthesized_expression(
-    &mut self,
-    parenthesized_expression: &ParenExpr,
-  ) -> (u32, u32) {
-    let start = self.index_converter.convert(
+  fn convert_parenthesized_expression(&mut self, parenthesized_expression: &ParenExpr) {
+    // We are doing this for the side effect of keeping annotations for call expressions
+    self.index_converter.convert(
       parenthesized_expression.span.lo.0 - 1,
       matches!(
         &*parenthesized_expression.expr,
@@ -539,34 +512,25 @@ impl<'a> AstConverter<'a> {
       ),
     );
     self.convert_expression(&parenthesized_expression.expr);
-    let end = self
-      .index_converter
-      .convert(parenthesized_expression.span.hi.0 - 1, false);
-    (start, end)
   }
 
-  pub fn convert_pattern(&mut self, pattern: &Pat) -> Option<(u32, u32)> {
+  pub fn convert_pattern(&mut self, pattern: &Pat) {
     match pattern {
       Pat::Array(array_pattern) => {
         self.store_array_pattern(array_pattern);
-        None
       }
       Pat::Assign(assignment_pattern) => {
         self.convert_assignment_pattern(assignment_pattern);
-        None
       }
       Pat::Expr(expression) => self.convert_expression(expression),
       Pat::Ident(binding_identifier) => {
         self.convert_binding_identifier(binding_identifier);
-        None
       }
       Pat::Object(object) => {
         self.store_object_pattern(object);
-        None
       }
       Pat::Rest(rest_pattern) => {
         self.store_rest_element(rest_pattern);
-        None
       }
       Pat::Invalid(_) => unimplemented!("Cannot convert Pat::Invalid"),
     }
@@ -625,26 +589,22 @@ impl<'a> AstConverter<'a> {
     }
   }
 
-  pub(crate) fn convert_property_name(&mut self, property_name: &PropName) -> Option<(u32, u32)> {
+  pub(crate) fn convert_property_name(&mut self, property_name: &PropName) {
     match property_name {
       PropName::Computed(computed_property_name) => {
         self.convert_expression(computed_property_name.expr.as_ref())
       }
       PropName::Ident(ident) => {
         self.convert_identifier(ident);
-        None
       }
       PropName::Str(string) => {
         self.store_literal_string(string);
-        None
       }
       PropName::Num(number) => {
         self.store_literal_number(number);
-        None
       }
       PropName::BigInt(bigint) => {
         self.store_literal_bigint(bigint);
-        None
       }
     }
   }

--- a/rust/parse_ast/src/convert_ast/converter.rs
+++ b/rust/parse_ast/src/convert_ast/converter.rs
@@ -1,6 +1,6 @@
 use swc_common::Span;
 use swc_ecma_ast::{
-  AssignTarget, AssignTargetPat, Callee, CallExpr, ClassMember, Decl, ExportSpecifier, Expr,
+  AssignTarget, AssignTargetPat, CallExpr, Callee, ClassMember, Decl, ExportSpecifier, Expr,
   ExprOrSpread, ForHead, ImportSpecifier, Lit, ModuleDecl, ModuleExportName, ModuleItem,
   NamedExport, ObjectPatProp, OptChainBase, ParenExpr, Pat, Program, PropName, PropOrSpread,
   SimpleAssignTarget, Stmt, VarDeclOrExpr,

--- a/test/utils.js
+++ b/test/utils.js
@@ -268,8 +268,8 @@ function getFileNamesAndRemoveOutput(directory) {
 				});
 				return false;
 			}
-			if (fileName === '_actual.js') {
-				unlinkSync(path.join(directory, '_actual.js'));
+			if (fileName.startsWith('_actual.')) {
+				unlinkSync(path.join(directory, fileName));
 				return false;
 			}
 			return true;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
I discovered that most of the enums implement a Spanned trait that provides derived positions for the SWC AST enums. Using this, we can simplify the logic in some places.