### PR TITLE
Consider that the body of ClassBody might be of type StaticBlock

### DIFF
--- a/src/ast/nodes/ClassBody.ts
+++ b/src/ast/nodes/ClassBody.ts
@@ -5,11 +5,12 @@ import ClassBodyScope from '../scopes/ClassBodyScope';
 import type MethodDefinition from './MethodDefinition';
 import type * as NodeType from './NodeType';
 import type PropertyDefinition from './PropertyDefinition';
+import type StaticBlock from './StaticBlock';
 import type ClassNode from './shared/ClassNode';
 import { type GenericEsTreeNode, type IncludeChildren, NodeBase } from './shared/Node';
 
 export default class ClassBody extends NodeBase {
-	declare body: (MethodDefinition | PropertyDefinition)[];
+	declare body: (MethodDefinition | PropertyDefinition | StaticBlock)[];
 	declare scope: ClassBodyScope;
 	declare type: NodeType.tClassBody;
 

--- a/src/ast/nodes/StaticBlock.ts
+++ b/src/ast/nodes/StaticBlock.ts
@@ -7,7 +7,7 @@ import {
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import BlockScope from '../scopes/BlockScope';
 import type ChildScope from '../scopes/ChildScope';
-import type * as NodeType from './NodeType';
+import * as NodeType from './NodeType';
 import { type IncludeChildren, StatementBase, type StatementNode } from './shared/Node';
 
 export default class StaticBlock extends StatementBase {
@@ -42,4 +42,8 @@ export default class StaticBlock extends StatementBase {
 			super.render(code, options);
 		}
 	}
+}
+
+export function isStaticBlock(statement: StatementNode): statement is StaticBlock {
+	return statement.type === NodeType.StaticBlock;
 }

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -123,8 +123,9 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 		this.deoptimized = true;
 		for (const definition of this.body.body) {
 			if (
+				!isStaticBlock(definition) &&
 				!(
-					(!isStaticBlock(definition) && definition.static) ||
+					definition.static ||
 					(definition instanceof MethodDefinition && definition.kind === 'constructor')
 				)
 			) {

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -15,6 +15,7 @@ import type ClassBody from '../ClassBody';
 import Identifier from '../Identifier';
 import type Literal from '../Literal';
 import MethodDefinition from '../MethodDefinition';
+import { isStaticBlock } from '../StaticBlock';
 import { type ExpressionEntity, type LiteralValueOrUnknown } from './Expression';
 import { type ExpressionNode, type IncludeChildren, NodeBase } from './Node';
 import { ObjectEntity, type ObjectProperty } from './ObjectEntity';
@@ -123,7 +124,7 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 		for (const definition of this.body.body) {
 			if (
 				!(
-					definition.static ||
+					(!isStaticBlock(definition) && definition.static) ||
 					(definition instanceof MethodDefinition && definition.kind === 'constructor')
 				)
 			) {
@@ -141,6 +142,7 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 		const staticProperties: ObjectProperty[] = [];
 		const dynamicMethods: ObjectProperty[] = [];
 		for (const definition of this.body.body) {
+			if (isStaticBlock(definition)) continue;
 			const properties = definition.static ? staticProperties : dynamicMethods;
 			const definitionKind = (definition as MethodDefinition | { kind: undefined }).kind;
 			// Note that class fields do not end up on the prototype


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
I am working on implementing decorator support. During this process, I found that `ClassBody` did not consider that `body` might be of type `StaticBlock`. This PR fixes this issue.
The estree link:https://github.com/estree/estree/blob/master/es2022.md#classbody
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
