### PR TITLE
Add originalFIleName property to emitted assets

### DIFF
--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -574,7 +574,8 @@ See [`onLog`](#onlog) for more information.
 
 ```typescript
 interface PreRenderedAsset {
-	name?: string;
+	name: string | undefined;
+	originalFileName: string | null;
 	source: string | Uint8Array;
 	type: 'asset';
 }

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -161,6 +161,7 @@ export interface EmittedAsset {
 	fileName?: string;
 	name?: string;
 	needsCodeReference?: boolean;
+	originalFileName?: string | null;
 	source?: string | Uint8Array;
 	type: 'asset';
 }
@@ -821,6 +822,7 @@ export interface SerializedTimings {
 
 export interface PreRenderedAsset {
 	name: string | undefined;
+	originalFileName: string | null;
 	source: string | Uint8Array;
 	type: 'asset';
 }

--- a/src/utils/FileEmitter.ts
+++ b/src/utils/FileEmitter.ts
@@ -37,6 +37,7 @@ import { makeUnique, renderNamePattern } from './renderNamePattern';
 function generateAssetFileName(
 	name: string | undefined,
 	source: string | Uint8Array,
+	originalFileName: string | null,
 	sourceHash: string,
 	outputOptions: NormalizedOutputOptions,
 	bundle: OutputBundleWithPlaceholders
@@ -45,7 +46,7 @@ function generateAssetFileName(
 	return makeUnique(
 		renderNamePattern(
 			typeof outputOptions.assetFileNames === 'function'
-				? outputOptions.assetFileNames({ name, source, type: 'asset' })
+				? outputOptions.assetFileNames({ name, originalFileName, source, type: 'asset' })
 				: outputOptions.assetFileNames,
 			'output.assetFileNames',
 			{
@@ -80,6 +81,7 @@ type ConsumedPrebuiltChunk = EmittedPrebuiltChunk & {
 
 type ConsumedAsset = EmittedAsset & {
 	needsCodeReference: boolean;
+	originalFileName: string | null;
 	referenceId: string;
 };
 
@@ -91,6 +93,7 @@ interface EmittedFile {
 	[key: string]: unknown;
 	fileName?: string;
 	name?: string;
+	originalFileName?: string | null;
 	type: EmittedFileType;
 }
 
@@ -336,10 +339,15 @@ export class FileEmitter {
 			emittedAsset.source === undefined
 				? undefined
 				: getValidSource(emittedAsset.source, emittedAsset, null);
+		const originalFileName = emittedAsset.originalFileName || null;
+		if (typeof originalFileName === 'string') {
+			this.graph.watchFiles[originalFileName] = true;
+		}
 		const consumedAsset: ConsumedAsset = {
 			fileName: emittedAsset.fileName,
 			name: emittedAsset.name,
 			needsCodeReference: !!emittedAsset.needsCodeReference,
+			originalFileName,
 			referenceId: '',
 			source,
 			type: 'asset'
@@ -445,7 +453,7 @@ export class FileEmitter {
 		source: string | Uint8Array,
 		{ bundle, fileNamesBySource, getHash, outputOptions }: FileEmitterOutput
 	): void {
-		let { fileName, needsCodeReference, referenceId } = consumedFile;
+		let { fileName, needsCodeReference, originalFileName, referenceId } = consumedFile;
 
 		// Deduplicate assets if an explicit fileName is not provided
 		if (!fileName) {
@@ -455,6 +463,7 @@ export class FileEmitter {
 				fileName = generateAssetFileName(
 					consumedFile.name,
 					source,
+					originalFileName,
 					sourceHash,
 					outputOptions,
 					bundle
@@ -475,6 +484,7 @@ export class FileEmitter {
 				fileName,
 				name: consumedFile.name,
 				needsCodeReference,
+				originalFileName,
 				source,
 				type: 'asset'
 			};
@@ -494,6 +504,7 @@ export class FileEmitter {
 			const assetFileName = generateAssetFileName(
 				consumedFile.name,
 				consumedFile.source!,
+				consumedFile.originalFileName,
 				sourceHash,
 				outputOptions,
 				bundle
@@ -519,6 +530,7 @@ export class FileEmitter {
 			fileName,
 			name: usedConsumedFile!.name,
 			needsCodeReference,
+			originalFileName: usedConsumedFile!.originalFileName,
 			source: usedConsumedFile!.source!,
 			type: 'asset'
 		};

--- a/src/utils/renderChunks.ts
+++ b/src/utils/renderChunks.ts
@@ -388,7 +388,12 @@ function emitSourceMapAndGetComment(
 		url = sourcemapBaseUrl
 			? new URL(sourcemapFileName, sourcemapBaseUrl).toString()
 			: sourcemapFileName;
-		pluginDriver.emitFile({ fileName, source: map.toString(), type: 'asset' });
+		pluginDriver.emitFile({
+			fileName,
+			originalFileName: null,
+			source: map.toString(),
+			type: 'asset'
+		});
 	}
 	return sourcemap === 'hidden' ? '' : `//# ${SOURCEMAPPING_URL}=${url}\n`;
 }

--- a/test/chunking-form/samples/emit-file/filenames-function-patterns/_config.js
+++ b/test/chunking-form/samples/emit-file/filenames-function-patterns/_config.js
@@ -38,6 +38,7 @@ module.exports = defineTest({
 					fileInfo,
 					{
 						name: 'test.txt',
+						originalFileName: null,
 						source: 'hello world',
 						type: 'asset'
 					},

--- a/test/function/samples/emit-file/original-file-name/_config.js
+++ b/test/function/samples/emit-file/original-file-name/_config.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert');
+const path = require('node:path');
+
+const ORIGINAL_FILE_NAME = path.join(__dirname, 'original.txt');
+
+module.exports = defineTest({
+	description: 'forwards the original file name to other hooks',
+	options: {
+		output: {
+			assetFileNames(info) {
+				if (info.name === 'with_original.txt') {
+					assert.strictEqual(info.originalFileName, ORIGINAL_FILE_NAME);
+				} else {
+					assert.strictEqual(info.originalFileName, null);
+				}
+				return info.name;
+			}
+		},
+		plugins: [
+			{
+				name: 'test',
+				buildStart() {
+					this.emitFile({
+						type: 'asset',
+						name: 'with_original.txt',
+						originalFileName: ORIGINAL_FILE_NAME,
+						source: 'with original file name'
+					});
+					this.emitFile({
+						type: 'asset',
+						name: 'with_original_null.txt',
+						originalFileName: null,
+						source: 'with original file name null'
+					});
+					this.emitFile({
+						type: 'asset',
+						name: 'without_original.txt',
+						source: 'without original file name'
+					});
+				},
+				generateBundle(options, bundle) {
+					assert.strictEqual(bundle['with_original.txt'].originalFileName, ORIGINAL_FILE_NAME);
+					assert.strictEqual(bundle['with_original_null.txt'].originalFileName, null);
+					assert.strictEqual(bundle['without_original.txt'].originalFileName, null);
+				}
+			}
+		]
+	}
+});

--- a/test/function/samples/emit-file/original-file-name/main.js
+++ b/test/function/samples/emit-file/original-file-name/main.js
@@ -1,0 +1,13 @@
+let effect = false;
+
+var b = {
+	get a() {
+		effect = true;
+	}
+};
+
+function X() {}
+X.prototype = b;
+new X().a;
+
+assert.ok(effect);

--- a/test/function/samples/sourcemap-true-generatebundle/_config.js
+++ b/test/function/samples/sourcemap-true-generatebundle/_config.js
@@ -22,6 +22,7 @@ module.exports = main;
 						fileName: 'main.js.map',
 						name: undefined,
 						needsCodeReference: false,
+						originalFileName: null,
 						source:
 							'{"version":3,"file":"main.js","sources":["main.js"],"sourcesContent":["export default 42;\\n"],"names":[],"mappings":";;AAAA,WAAe,EAAE;;;;"}',
 						type: 'asset'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #4724 

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This is a long-requested feature for emitting assets. It adds a new optional property `originalFileName` to `this.emitFile({type: 'asset'})` calls that will be present in the `output.assetFileNames` option and in the `generateBundle` hook to identify from which file an asset was emitted.
This was a long-requested feature, but I was hesitant to implement it because it requires changes in plugins that emit files to work. In short:

Plugins that use `this.emitFile` for an asset that corresponds to an actual source file should not set the `originalFileName` property to the absolute path of the source file.

Not only will this property then passed on, the source file will also automatically be watched in watch mode.

cc @patak-dev @sapphi-red @yyx990803 @antfu: As Vite implements many asset handling plugins, does this API look fine to you and would you be interested in supporting it in Vite?