### PR TITLE
Fix retrieval of literal values for chained namespaces

### DIFF
--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -234,6 +234,12 @@ export default class MemberExpression
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown | SkippedChain {
+		if (this.variable) {
+			return this.variable.getLiteralValueAtPath(path, recursionTracker, origin);
+		}
+		if (this.isUndefined) {
+			return undefined;
+		}
 		return getChainElementLiteralValueAtPath(this, this.object, path, recursionTracker, origin);
 	}
 

--- a/test/function/samples/optional-chaining-namespace/_config.js
+++ b/test/function/samples/optional-chaining-namespace/_config.js
@@ -1,0 +1,10 @@
+module.exports = defineTest({
+	description: 'handles optional chaining with namespace',
+	options: {
+		onLog(_level, log) {
+			if (log.code !== 'MISSING_EXPORT') {
+				throw new Error(`Unexpected log code: ${log.code}`);
+			}
+		}
+	}
+});

--- a/test/function/samples/optional-chaining-namespace/main.js
+++ b/test/function/samples/optional-chaining-namespace/main.js
@@ -1,0 +1,4 @@
+import * as other from './other.js';
+
+assert.ok(other?.default ? true : false);
+assert.ok(other?.doesNotExist ? false : true);

--- a/test/function/samples/optional-chaining-namespace/other.js
+++ b/test/function/samples/optional-chaining-namespace/other.js
@@ -1,0 +1,1 @@
+export default { value: 42 };


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There is a bug when using optional chaining on namespaces which is fixed here, see test case.

cc @FlorianRohm