### PR TITLE
chore: fix the `noConflict` option in REPL.

### DIFF
--- a/docs/repl/stores/options.ts
+++ b/docs/repl/stores/options.ts
@@ -297,7 +297,7 @@ export const useOptions = defineStore('options2', () => {
 	});
 	const optionOutputNoConflict = getBoolean({
 		available: () => optionOutputFormat.value.value === 'umd',
-		name: 'output.noConflice'
+		name: 'output.noConflict'
 	});
 	const optionOutputName = getString({
 		available: isIifeFormat,


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

*nope*

### Description

In the REPL, the `noConflict` option is erroneously written as `noConflice`.

![options](https://github.com/user-attachments/assets/160c499c-1807-4231-9271-7235a4b4f52c)

>  Rollup completed with warnings:
Unknown output options: noConflice. Allowed options: amd, assetFileNames, banner, chunkFileNames, compact, dir, dynamicImportInCjs, entryFileNames, esModule, experimentalMinChunkSize, exports, extend, externalImportAssertions, externalImportAttributes, externalLiveBindings, file, footer, format, freeze, generatedCode, globals, hashCharacters, hoistTransitiveImports, importAttributesKey, indent, inlineDynamicImports, interop, intro, manualChunks, minifyInternalExports, name, noConflict, outro, paths, plugins, preserveModules, preserveModulesRoot, reexportProtoFromExternal, sanitizeFileName, sourcemap, sourcemapBaseUrl, sourcemapExcludeSources, sourcemapFile, sourcemapFileNames, sourcemapIgnoreList, sourcemapPathTransform, strict, systemNullSetters, validate