### PR TITLE
Call and await closeWatcher hooks on exit signals

### DIFF
--- a/cli/run/watch-cli.ts
+++ b/cli/run/watch-cli.ts
@@ -28,7 +28,7 @@ export async function watch(command: Record<string, any>): Promise<void> {
 	const configFile = command.config ? await getConfigPath(command.config) : null;
 	const runWatchHook = createWatchHooks(command);
 
-	onExit(close as any);
+	onExit(close);
 	process.on('uncaughtException', closeWithError);
 	if (!process.stdin.isTTY) {
 		process.stdin.on('end', close);
@@ -146,14 +146,16 @@ export async function watch(command: Record<string, any>): Promise<void> {
 		});
 	}
 
-	async function close(code: number | null | undefined): Promise<void> {
+	function close(code: number | null | undefined, _signal?: NodeJS.Signals | null): true {
 		process.removeListener('uncaughtException', closeWithError);
 		// removing a non-existent listener is a no-op
 		process.stdin.removeListener('end', close);
-
-		if (watcher) await watcher.close();
 		if (configWatcher) configWatcher.close();
-		if (code) process.exit(code);
+		Promise.resolve(watcher?.close()).finally(() => {
+			process.exit(typeof code === 'number' ? code : undefined);
+		});
+		// Tell signal-exit that we are handling this gracefully
+		return true;
 	}
 
 	// return a promise that never resolves to keep the process running

--- a/test/cli/node_modules/rollup-plugin-esm-test/index.mjs
+++ b/test/cli/node_modules/rollup-plugin-esm-test/index.mjs
@@ -1,8 +1,8 @@
 export function esmTest() {
 	return {
 		transform(code, id) {
-			if (id.includes("\0")) return null;
-			const name = JSON.stringify(id.replace(/^.*\/advanced-esm\//, "esm-test: "));
+			if (id.includes('\0')) return null;
+			const name = JSON.stringify(id.replace(/^.*\/advanced-esm\//, 'esm-test: '));
 			return `console.log(${name});\n${code}`;
 		}
 	};

--- a/test/cli/samples/watch/signal-close-watcher/_config.js
+++ b/test/cli/samples/watch/signal-close-watcher/_config.js
@@ -1,0 +1,14 @@
+const { assertIncludes } = require('../../../../utils.js');
+
+module.exports = defineTest({
+	description: 'calls closeWatcher plugin hooks when rollup is terminated due to a signal',
+	command: 'rollup -cw',
+	abortOnStderr(data) {
+		if (data.includes('created _actual')) {
+			return true;
+		}
+	},
+	stderr(stderr) {
+		assertIncludes(stderr, 'close first\nclose second');
+	}
+});

--- a/test/cli/samples/watch/signal-close-watcher/_expected/main.js
+++ b/test/cli/samples/watch/signal-close-watcher/_expected/main.js
@@ -1,0 +1,3 @@
+var main = 42;
+
+export { main as default };

--- a/test/cli/samples/watch/signal-close-watcher/main.js
+++ b/test/cli/samples/watch/signal-close-watcher/main.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/cli/samples/watch/signal-close-watcher/rollup.config.mjs
+++ b/test/cli/samples/watch/signal-close-watcher/rollup.config.mjs
@@ -1,0 +1,22 @@
+export default {
+	input: 'main.js',
+	output: {
+		dir: '_actual',
+		format: 'es'
+	},
+	plugins: [
+		{
+			name: 'first',
+			closeWatcher() {
+				console.error('close first');
+			}
+		},
+		{
+			name: 'second',
+			async closeWatcher() {
+				await new Promise(resolve => setTimeout(resolve));
+				console.error('close second');
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5615

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Previously, `signal-exit` would not await our async handling of the `closeWatcher` hook. This meant that when killing the watcher e.g. via `SIGINT`, those hooks would not be called. This is fixed here by synchronously returning `true` from the close handler.
