### PR TITLE
fix: reset variable's renderBaseName at the end of renderModules

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -708,6 +708,11 @@ export default class Chunk {
 		}
 		if (footer) magicString.append(footer);
 
+		for (const variable of this.renderBaseNameResetSet) {
+			variable.renderBaseName = null;
+		}
+		this.renderBaseNameResetSet.clear();
+
 		return {
 			chunk: this,
 			magicString,
@@ -1292,10 +1297,6 @@ export default class Chunk {
 		if (isEmpty && this.getExportNames().length === 0 && dependencies.size === 0) {
 			onLog(LOGLEVEL_WARN, logEmptyChunk(this.getChunkName()));
 		}
-		for (const variable of this.renderBaseNameResetSet) {
-			variable.renderBaseName = null;
-		}
-		this.renderBaseNameResetSet.clear();
 		return { accessedGlobals, indent, magicString, renderedSource, usedModules, usesTopLevelAwait };
 	}
 

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -196,6 +196,7 @@ export default class Chunk {
 	private readonly renderedModules: Record<string, RenderedModule> = Object.create(null);
 	private sortedExportNames: string[] | null = null;
 	private strictFacade = false;
+	private renderBaseNameResetSet = new Set<Variable>();
 
 	constructor(
 		private readonly orderedModules: readonly Module[],
@@ -1291,6 +1292,10 @@ export default class Chunk {
 		if (isEmpty && this.getExportNames().length === 0 && dependencies.size === 0) {
 			onLog(LOGLEVEL_WARN, logEmptyChunk(this.getChunkName()));
 		}
+		for (const variable of this.renderBaseNameResetSet) {
+			variable.renderBaseName = null;
+		}
+		this.renderBaseNameResetSet.clear();
 		return { accessedGlobals, indent, magicString, renderedSource, usedModules, usesTopLevelAwait };
 	}
 
@@ -1410,7 +1415,8 @@ export default class Chunk {
 			syntheticExports,
 			this.exportNamesByVariable,
 			this.accessedGlobalsByScope,
-			this.includedNamespaces
+			this.includedNamespaces,
+			this.renderBaseNameResetSet
 		);
 	}
 

--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -32,7 +32,8 @@ const DECONFLICT_IMPORTED_VARIABLES_BY_FORMAT: {
 		externalLiveBindings: boolean,
 		chunkByModule: ReadonlyMap<Module, Chunk>,
 		externalChunkByModule: ReadonlyMap<ExternalModule, ExternalChunk>,
-		syntheticExports: ReadonlySet<SyntheticNamedExportVariable>
+		syntheticExports: ReadonlySet<SyntheticNamedExportVariable>,
+		renderBaseNameResetSet: Set<Variable>
 	) => void;
 } = {
 	amd: deconflictImportsOther,
@@ -57,7 +58,8 @@ export function deconflictChunk(
 	syntheticExports: ReadonlySet<SyntheticNamedExportVariable>,
 	exportNamesByVariable: ReadonlyMap<Variable, readonly string[]>,
 	accessedGlobalsByScope: ReadonlyMap<ChildScope, ReadonlySet<string>>,
-	includedNamespaces: ReadonlySet<Module>
+	includedNamespaces: ReadonlySet<Module>,
+	renderBaseNameResetSet: Set<Variable>
 ): void {
 	const reversedModules = [...modules].reverse();
 	for (const module of reversedModules) {
@@ -78,7 +80,8 @@ export function deconflictChunk(
 		externalLiveBindings,
 		chunkByModule,
 		externalChunkByModule,
-		syntheticExports
+		syntheticExports,
+		renderBaseNameResetSet
 	);
 
 	for (const module of reversedModules) {
@@ -147,7 +150,9 @@ function deconflictImportsOther(
 	preserveModules: boolean,
 	externalLiveBindings: boolean,
 	chunkByModule: ReadonlyMap<Module, Chunk>,
-	externalChunkByModule: ReadonlyMap<ExternalModule, ExternalChunk>
+	externalChunkByModule: ReadonlyMap<ExternalModule, ExternalChunk>,
+	_unused: ReadonlySet<SyntheticNamedExportVariable>,
+	renderBaseNameResetSet: Set<Variable>
 ): void {
 	for (const chunk of dependencies) {
 		chunk.variableName = getSafeName(chunk.suggestedVariableName, usedNames, null);
@@ -206,6 +211,9 @@ function deconflictImportsOther(
 					chunk.variableName,
 					chunk.getVariableExportName(variable) as string | null
 				);
+				if (renderBaseNameResetSet) {
+					renderBaseNameResetSet.add(variable);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

-   resolves #5095

### Description

**Disclaimer**: I do not consider this a complete fix. This submission is merely to share my thoughts and approach to solving the issue.

Based on the description in [Rollup issue #5095](https://github.com/rollup/rollup/issues/5095), the `preserveModules` setting in the first output affects the `renderBaseName` property of the `Variable` object. As a result, this property is not reset during the execution of the second output, leading to incorrect variable names being output.

My solution involves collecting the `Variable` objects that have had their `renderBaseName` modified during the execution of `deconflictImportsOther`. Then, at the end of the ~`renderModules()`~`render()` execution in the `Chunk`, I reset the `renderBaseName` properties of these `Variable` objects.

But I feel that this solution is too makeshift and too specific to this issue. I wonder if there are other properties that might need to be reset after chunk rendering. This problem is quite challenging for me.
