### PR TITLE
fix: get the right chunk name for preserve modules in Windows

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1069,9 +1069,15 @@ export default class Chunk {
 			? sanitizedId.slice(0, -extensionName.length)
 			: sanitizedId;
 		if (isAbsolute(idWithoutExtension)) {
-			return preserveModulesRoot && resolve(idWithoutExtension).startsWith(preserveModulesRoot)
-				? idWithoutExtension.slice(preserveModulesRoot.length).replace(/^[/\\]/, '')
-				: relative(this.inputBase, idWithoutExtension);
+			if (preserveModulesRoot && resolve(idWithoutExtension).startsWith(preserveModulesRoot)) {
+				return idWithoutExtension.slice(preserveModulesRoot.length).replace(/^[/\\]/, '');
+			} else {
+				// handle edge case in Windows
+				if (this.inputBase === '/' && !idWithoutExtension.startsWith('/')) {
+					return relative(this.inputBase, idWithoutExtension.replace(/^[a-zA-Z]:[/\\]/, '/'));
+				}
+				return relative(this.inputBase, idWithoutExtension);
+			}
 		} else {
 			return (
 				this.outputOptions.virtualDirname.replace(/\/$/, '') + '/' + basename(idWithoutExtension)

--- a/test/cli/samples/get-chunk-name/_config.js
+++ b/test/cli/samples/get-chunk-name/_config.js
@@ -1,0 +1,9 @@
+const assert = require('node:assert');
+module.exports = defineTest({
+	description: 'get right chunk name for preserve modules',
+	command: 'rollup -c',
+	result(code) {
+		assert.ok(code.includes(`//→ ${__dirname.replace(/\//, '')}/main.js`));
+		assert.ok(code.includes(`//→ sub.js`));
+	}
+});

--- a/test/cli/samples/get-chunk-name/_config.js
+++ b/test/cli/samples/get-chunk-name/_config.js
@@ -3,7 +3,9 @@ module.exports = defineTest({
 	description: 'get right chunk name for preserve modules',
 	command: 'rollup -c',
 	result(code) {
-		assert.ok(code.includes(`//→ ${__dirname.replace(/\//, '')}/main.js`));
+		assert.ok(
+			code.includes(`//→ ${__dirname.replace(/^(\/|[a-zA-Z]:\\)/, '').replace(/\\/g, '/')}/main.js`)
+		);
 		assert.ok(code.includes(`//→ sub.js`));
 	}
 });

--- a/test/cli/samples/get-chunk-name/main.js
+++ b/test/cli/samples/get-chunk-name/main.js
@@ -1,0 +1,2 @@
+import sub from '/sub.js';
+assert.ok(sub);

--- a/test/cli/samples/get-chunk-name/rollup.config.mjs
+++ b/test/cli/samples/get-chunk-name/rollup.config.mjs
@@ -1,0 +1,21 @@
+export default {
+	input: 'main.js',
+	output: {
+		format: 'es',
+		preserveModules: true
+	},
+	plugins: [
+		{
+			resolveId(id) {
+				if (id.endsWith('sub.js')) {
+					return id;
+				}
+			},
+			load(id) {
+				if (id.endsWith('sub.js')) {
+					return 'export default "sub.js url"';
+				}
+			}
+		}
+	]
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #5620 
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
remove the Windows drive prefix if the inputBase is `/`.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
