### PR TITLE
fix: keep the message of stack up-to-date

### DIFF
--- a/test/cli/samples/config-type-module/_config.js
+++ b/test/cli/samples/config-type-module/_config.js
@@ -8,7 +8,7 @@ module.exports = defineTest({
 	stderr: stderr => {
 		assertIncludes(
 			stderr,
-			'ReferenceError: module is not defined in ES module scope\n' +
+			'Original error: module is not defined in ES module scope\n' +
 				"This file is being treated as an ES module because it has a '.js' file extension and"
 		);
 		assertIncludes(

--- a/test/utils.js
+++ b/test/utils.js
@@ -86,6 +86,9 @@ function normaliseError(error) {
  * @param {RollupError} expected
  */
 exports.compareError = function compareError(actual, expected) {
+	if (actual.stack) {
+		assert.ok(actual.stack.includes(expected.message));
+	}
 	actual = normaliseError(actual);
 	if (expected.frame) {
 		expected.frame = deindent(expected.frame);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
related #5635 
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
We can see that the error message in the description of the issue above is incomplete. It lacks some tips, such as `(Note that you need @rollup/plugin-json to import JSON files)`. The reason is that the stack message is outdated, so this PR ensures that the stack message is always up-to-date.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
