### PR TITLE
fix: include left-side effect of optional chaining in the end of hasEffectsAsChainElement

### DIFF
--- a/src/ast/nodes/CallExpression.ts
+++ b/src/ast/nodes/CallExpression.ts
@@ -106,7 +106,8 @@ export default class CallExpression
 		}
 		return (
 			!this.annotationPure &&
-			this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context)
+			(calleeHasEffects ||
+				this.callee.hasEffectsOnInteractionAtPath(EMPTY_PATH, this.interaction, context))
 		);
 	}
 

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -296,7 +296,7 @@ export default class MemberExpression
 		}
 		// We only apply deoptimizations lazily once we know we are not skipping
 		if (!this.deoptimized) this.applyDeoptimizations();
-		return this.property.hasEffects(context) || this.hasAccessEffect(context);
+		return objectHasEffects || this.property.hasEffects(context) || this.hasAccessEffect(context);
 	}
 
 	hasEffectsAsAssignmentTarget(context: HasEffectsContext, checkAccess: boolean): boolean {

--- a/test/form/samples/optional-chaining-with-smallest-treeshake/_config.js
+++ b/test/form/samples/optional-chaining-with-smallest-treeshake/_config.js
@@ -1,0 +1,6 @@
+module.exports = defineTest({
+	description: 'preserve optional chaining with smallest treeshake',
+	options: {
+		treeshake: 'smallest'
+	}
+});

--- a/test/form/samples/optional-chaining-with-smallest-treeshake/_expected.js
+++ b/test/form/samples/optional-chaining-with-smallest-treeshake/_expected.js
@@ -1,0 +1,2 @@
+while (global[++i]?.key) {} //retained
+while (global(++i)?.key) {} //retained

--- a/test/form/samples/optional-chaining-with-smallest-treeshake/main.js
+++ b/test/form/samples/optional-chaining-with-smallest-treeshake/main.js
@@ -1,0 +1,2 @@
+while (global[++i]?.key) {} //retained
+while (global(++i)?.key) {} //retained


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #5633
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
It seems that we forget to check out left-side effect of optional chaining in the end of `hasEffectsAsChainElement` method.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
