### PR TITLE
Fix example selection in REPL

### DIFF
--- a/docs/repl/components/InputHeader.vue
+++ b/docs/repl/components/InputHeader.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script setup lang="ts">
+import examplesById from 'examples.json';
 import { useModules } from '../stores/modules';
 import { useOptions } from '../stores/options';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "vite": "^5.4.3",
         "vitepress": "^1.3.4",
         "vue": "^3.5.3",
+        "vue-tsc": "^2.1.6",
         "wasm-pack": "^0.13.0",
         "yargs-parser": "^21.1.1"
       },
@@ -3357,19 +3358,30 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.4.tgz",
-      "integrity": "sha512-kO9k4kTLfxpg+6lq7/KAIv3m2d62IHuCL6GbVgYZTpfKvIGoAIlDxK7pFcB/eczN2+ydg/vnyaeZ6SGyZrJw2w==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.5.tgz",
+      "integrity": "sha512-F4tA0DCO5Q1F5mScHmca0umsi2ufKULAnMOVBfMsZdT4myhVl4WdKRwCaKcfOkIEuyrAVvtq1ESBdZ+rSyLVww==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "2.4.4"
+        "@volar/source-map": "2.4.5"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.4.tgz",
-      "integrity": "sha512-xG3PZqOP2haG8XG4Pg3PD1UGDAdqZg24Ru8c/qYjYAnmcj6GBR64mstx+bZux5QOyRaJK+/lNM/RnpvBD3489g==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.5.tgz",
+      "integrity": "sha512-varwD7RaKE2J/Z+Zu6j3mNNJbNT394qIxXwdvz/4ao/vxOfyClZpSDtLKkwWmecinkOVos5+PWkWraelfMLfpw==",
       "dev": true
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.5.tgz",
+      "integrity": "sha512-mcT1mHvLljAEtHviVcBuOyAwwMKz1ibXTi5uYtP/pf4XxoAzpdkQ+Br2IC0NPCvLCbjPZmbf3I0udndkfB1CDg==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "2.4.5",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.4",
@@ -13616,6 +13628,23 @@
       "license": "MIT",
       "peerDependencies": {
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.6.tgz",
+      "integrity": "sha512-f98dyZp5FOukcYmbFpuSCJ4Z0vHSOSmxGttZJCsFeX0M4w/Rsq0s4uKXjcSRsZqsRgQa6z7SfuO+y0HVICE57Q==",
+      "dev": true,
+      "dependencies": {
+        "@volar/typescript": "~2.4.1",
+        "@vue/language-core": "2.1.6",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/w3c-keyname": {

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "vite": "^5.4.3",
     "vitepress": "^1.3.4",
     "vue": "^3.5.3",
+    "vue-tsc": "^2.1.6",
     "wasm-pack": "^0.13.0",
     "yargs-parser": "^21.1.1"
   },
@@ -203,7 +204,8 @@
     "semver": "^7.6.3",
     "ws": "^8.18.0"
   },
-  "overrides_comments": {
+  "comments": {
+    "vue-tsc": "This is necessary so that prettier-plugin-organize-imports works correctly in Vue templatges",
     "ws": "mermaid requires an older 8.13.0 version via puppeteer with vulnerabilities"
   },
   "files": [


### PR DESCRIPTION
prettier-plugin-organize-imports was removing the import without vue-tsc installed

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Via the introduction of prettier-plugin-organize-imports, an import in one of the REPL Vue files was removed that broke the example selection dropdown. This is fixed by also making vue-tsc a dependency. I hope at some time I will find some time to set up some E2E Tests for the REPL to avoid such things in the future...
