### PR TITLE
fix:  marking the reassigned during the initialization phase

### DIFF
--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -89,6 +89,7 @@ export default class AssignmentExpression extends NodeBase {
 			if (variable?.kind === 'const') {
 				this.scope.context.error(logConstVariableReassignError(), this.left.start);
 			}
+			this.scope.findVariable(this.left.name)?.markReassignedInInitialization();
 		}
 		this.left.setAssignedValue(this.right);
 	}

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -108,7 +108,7 @@ export default class LocalVariable extends Variable {
 		recursionTracker: PathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown {
-		if (this.isReassigned) {
+		if (this.isReassigned || this.isReassignedInInitialization) {
 			return UnknownValue;
 		}
 		return recursionTracker.withTrackedEntityAtPath(

--- a/src/ast/variables/Variable.ts
+++ b/src/ast/variables/Variable.ts
@@ -19,6 +19,7 @@ export default class Variable extends ExpressionEntity {
 	isId = false;
 	// both NamespaceVariable and ExternalVariable can be namespaces
 	declare isNamespace?: boolean;
+	declare isReassignedInInitialization?: boolean;
 	kind: VariableKind | null = null;
 	declare module?: Module | ExternalModule;
 	renderBaseName: string | null = null;
@@ -29,6 +30,9 @@ export default class Variable extends ExpressionEntity {
 	readonly isReassigned = false;
 	markReassigned() {
 		(this as { isReassigned: boolean }).isReassigned = true;
+	}
+	markReassignedInInitialization() {
+		this.isReassignedInInitialization = true;
 	}
 
 	constructor(public name: string) {

--- a/test/function/samples/mark-reassigned-during-initialization/_config.js
+++ b/test/function/samples/mark-reassigned-during-initialization/_config.js
@@ -1,0 +1,6 @@
+module.exports = defineTest({
+	description: 'Keep the code that declares the value of foo',
+	options: {
+		treeshake: 'smallest'
+	}
+});

--- a/test/function/samples/mark-reassigned-during-initialization/dep.js
+++ b/test/function/samples/mark-reassigned-during-initialization/dep.js
@@ -1,0 +1,7 @@
+export const foo = (() => {
+	let foo = false;
+	{
+		foo = true;
+	}
+	return foo;
+})();

--- a/test/function/samples/mark-reassigned-during-initialization/main.js
+++ b/test/function/samples/mark-reassigned-during-initialization/main.js
@@ -1,0 +1,3 @@
+import { foo } from './dep';
+
+assert.equal(foo ? 1 : 2, 1);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
relative #5650 #5408
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
@lukastaegert Hi, lukas, It seems that marking the reassigned during the initialization phase can resolve these issues. However, I’m not entirely sure if this is a perfect solution, as it would result in the existence of two reassigned fields, one being `isReassignedInInitialization` and the other `isReassigned`. I hope this PR can provide a small contribution to help us solve this problem.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
