### PR TITLE
refactor: Use object.prototype to check for reserved properties

### DIFF
--- a/src/finalisers/shared/setupNamespace.ts
+++ b/src/finalisers/shared/setupNamespace.ts
@@ -13,14 +13,18 @@ export default function setupNamespace(
 	log?: LogHandler
 ): string {
 	const parts = name.split('.');
-	// Check if the key is exist in the prototype of the object
-	const isReserved = parts[0] in {};
+	// Check if the key exists in the object's prototype.
+	const isReserved = parts[0] in Object.prototype;
 	if (log && isReserved) {
 		log(LOGLEVEL_WARN, logReservedNamespace(parts[0]));
 	}
 	parts[0] =
-		(typeof globals === 'function' ? globals(parts[0]) : isReserved ? null : globals[parts[0]]) ||
-		parts[0];
+		(typeof globals === 'function'
+			? globals(parts[0])
+			: isReserved
+				? parts[0]
+				: globals[parts[0]]) || parts[0];
+
 	parts.pop();
 
 	let propertyPath = root;
@@ -43,14 +47,18 @@ export function assignToDeepVariable(
 	log?: LogHandler
 ): string {
 	const parts = deepName.split('.');
-	// Check if the key is exist in the prototype of the object
-	const isReserved = parts[0] in {};
+	// Check if the key exists in the object's prototype.
+	const isReserved = parts[0] in Object.prototype;
 	if (log && isReserved) {
 		log(LOGLEVEL_WARN, logReservedNamespace(parts[0]));
 	}
 	parts[0] =
-		(typeof globals === 'function' ? globals(parts[0]) : isReserved ? null : globals[parts[0]]) ||
-		parts[0];
+		(typeof globals === 'function'
+			? globals(parts[0])
+			: isReserved
+				? parts[0]
+				: globals[parts[0]]) || parts[0];
+
 	const last = parts.pop()!;
 
 	let propertyPath = root;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description:
This PR includes the following improvements:

1. **Refactoring the use of the `in` operator**: Replaced the use of the `in` operator on an empty object `{}` with `Object.prototype` to properly check if `parts[0]` is a property of JavaScript's built-in objects. The previous approach always returned `false`, making the check ineffective.

2. **Optimization of null assignment logic**: When `isReserved` is `true`, assigning `null` to `parts[0]` was unnecessary. Instead, `parts[0]` is now retained to avoid redundant null assignments and improve the overall logic.


