### PR TITLE
perf: use pre-allocated arrays for known result sizes

### DIFF
--- a/scripts/ast-types.js
+++ b/scripts/ast-types.js
@@ -174,12 +174,10 @@ export const AST_NODES = {
           for (let index = 0; index < length; index++) {
             const nodePosition = buffer[bodyPosition + 1 + index];
             body[index] = convertNode(
-
                 node,
                 (buffer[nodePosition + 3] & 1) === 0 ? scope.instanceScope : scope,
                 nodePosition,
                 buffer
-
             );
           }
         } else {

--- a/scripts/ast-types.js
+++ b/scripts/ast-types.js
@@ -168,20 +168,22 @@ export const AST_NODES = {
 		fields: [['body', 'NodeList']],
 		scriptedFields: {
 			body: ` const bodyPosition = $position;
-        const body: (MethodDefinition | PropertyDefinition)[] = (node.body = []);
 			  if (bodyPosition) {
 			    const length = buffer[bodyPosition];
+			    const body: (MethodDefinition | PropertyDefinition)[] = (node.body = new Array(length));
           for (let index = 0; index < length; index++) {
             const nodePosition = buffer[bodyPosition + 1 + index];
-            body.push(
-              convertNode(
+            body[index] = convertNode(
+
                 node,
                 (buffer[nodePosition + 3] & 1) === 0 ? scope.instanceScope : scope,
                 nodePosition,
                 buffer
-              )
+
             );
           }
+        } else {
+          node.body = [];
         }`
 		},
 		useMacro: false

--- a/scripts/generate-buffer-parsers.js
+++ b/scripts/generate-buffer-parsers.js
@@ -230,10 +230,10 @@ function convertNodeList(
 ): any[] {
   if (position === 0) return EMPTY_ARRAY as never[];
   const length = buffer[position++];
-  const list: any[] = [];
+  const list: any[] = new Array(length);
   for (let index = 0; index < length; index++) {
     const nodePosition = buffer[position++];
-    list.push(nodePosition ? convertNode(parent, parentScope, nodePosition, buffer) : null);
+    list[index] = nodePosition ? convertNode(parent, parentScope, nodePosition, buffer) : null;
   }
   return list;
 }

--- a/scripts/generate-buffer-to-ast.js
+++ b/scripts/generate-buffer-to-ast.js
@@ -239,10 +239,10 @@ export function convertNode(position: number, buffer: AstBuffer): any {
 function convertNodeList(position: number, buffer: AstBuffer): any[] {
   if (position === 0) return EMPTY_ARRAY as never[];
   const length = buffer[position++];
-  const list: any[] = [];
+  const list: any[] = new Array(length);
   for (let index = 0; index < length; index++) {
     const nodePosition = buffer[position++];
-    list.push(nodePosition ? convertNode(nodePosition, buffer) : null);
+    list[index] = nodePosition ? convertNode(nodePosition, buffer) : null;
   }
   return list;
 }

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -179,18 +179,18 @@ export default class Bundle {
 			inputBase
 		);
 		const executableModule = inlineDynamicImports
-		? [{ alias: null, modules: includedModules }]
-		: preserveModules
-			? includedModules.map(module => ({ alias: null, modules: [module] }))
-			: getChunkAssignments(
-					this.graph.entryModules,
-					manualChunkAliasByEntry,
-					experimentalMinChunkSize,
-					this.inputOptions.onLog
-				)
+			? [{ alias: null, modules: includedModules }]
+			: preserveModules
+				? includedModules.map(module => ({ alias: null, modules: [module] }))
+				: getChunkAssignments(
+						this.graph.entryModules,
+						manualChunkAliasByEntry,
+						experimentalMinChunkSize,
+						this.inputOptions.onLog
+					);
 		const chunks: Chunk[] = new Array(executableModule.length);
 		const chunkByModule = new Map<Module, Chunk>();
-		let index = 0
+		let index = 0;
 		for (const { alias, modules } of executableModule) {
 			sortByExecutionOrder(modules);
 			const chunk = new Chunk(

--- a/src/ast/bufferParsers.ts
+++ b/src/ast/bufferParsers.ts
@@ -405,8 +405,6 @@ const bufferParsers: ((node: any, position: number, buffer: AstBuffer) => void)[
 					nodePosition,
 					buffer
 				);
-
-
 			}
 		} else {
 			node.body = [];

--- a/src/ast/bufferParsers.ts
+++ b/src/ast/bufferParsers.ts
@@ -408,6 +408,8 @@ const bufferParsers: ((node: any, position: number, buffer: AstBuffer) => void)[
 					)
 				;
 			}
+		} else {
+			node.body = []
 		}
 	},
 	function classDeclaration(node: ClassDeclaration, position, buffer) {

--- a/src/ast/bufferParsers.ts
+++ b/src/ast/bufferParsers.ts
@@ -392,21 +392,21 @@ const bufferParsers: ((node: any, position: number, buffer: AstBuffer) => void)[
 		node.expression = convertNode(node, scope, buffer[position], buffer);
 	},
 	function classBody(node: ClassBody, position, buffer) {
-		const { scope } = node;
 		const bodyPosition = buffer[position];
-		const body: (MethodDefinition | PropertyDefinition)[] = (node.body = []);
 		if (bodyPosition) {
+			const { scope } = node;
 			const length = buffer[bodyPosition];
+			const body: (MethodDefinition | PropertyDefinition)[] = (node.body = new Array(length));
 			for (let index = 0; index < length; index++) {
 				const nodePosition = buffer[bodyPosition + 1 + index];
-				body.push(
+				body[index] = 
 					convertNode(
 						node,
 						(buffer[nodePosition + 3] & 1) === 0 ? scope.instanceScope : scope,
 						nodePosition,
 						buffer
 					)
-				);
+				;
 			}
 		}
 	},

--- a/src/ast/bufferParsers.ts
+++ b/src/ast/bufferParsers.ts
@@ -392,24 +392,24 @@ const bufferParsers: ((node: any, position: number, buffer: AstBuffer) => void)[
 		node.expression = convertNode(node, scope, buffer[position], buffer);
 	},
 	function classBody(node: ClassBody, position, buffer) {
+		const { scope } = node;
 		const bodyPosition = buffer[position];
 		if (bodyPosition) {
-			const { scope } = node;
 			const length = buffer[bodyPosition];
 			const body: (MethodDefinition | PropertyDefinition)[] = (node.body = new Array(length));
 			for (let index = 0; index < length; index++) {
 				const nodePosition = buffer[bodyPosition + 1 + index];
-				body[index] = 
-					convertNode(
-						node,
-						(buffer[nodePosition + 3] & 1) === 0 ? scope.instanceScope : scope,
-						nodePosition,
-						buffer
-					)
-				;
+				body[index] = convertNode(
+					node,
+					(buffer[nodePosition + 3] & 1) === 0 ? scope.instanceScope : scope,
+					nodePosition,
+					buffer
+				);
+
+
 			}
 		} else {
-			node.body = []
+			node.body = [];
 		}
 	},
 	function classDeclaration(node: ClassDeclaration, position, buffer) {

--- a/src/ast/bufferParsers.ts
+++ b/src/ast/bufferParsers.ts
@@ -917,10 +917,10 @@ function convertNodeList(
 ): any[] {
 	if (position === 0) return EMPTY_ARRAY as never[];
 	const length = buffer[position++];
-	const list: any[] = [];
+	const list: any[] = new Array(length);
 	for (let index = 0; index < length; index++) {
 		const nodePosition = buffer[position++];
-		list.push(nodePosition ? convertNode(parent, parentScope, nodePosition, buffer) : null);
+		list[index] = nodePosition ? convertNode(parent, parentScope, nodePosition, buffer) : null;
 	}
 	return list;
 }

--- a/src/ast/nodes/ClassBody.ts
+++ b/src/ast/nodes/ClassBody.ts
@@ -28,14 +28,12 @@ export default class ClassBody extends NodeBase {
 
 	parseNode(esTreeNode: GenericEsTreeNode): this {
 		const body: NodeBase[] = (this.body = new Array(esTreeNode.body.length));
-		let index = 0
+		let index = 0;
 		for (const definition of esTreeNode.body) {
-			body[index++] = 
-				new (this.scope.context.getNodeConstructor(definition.type))(
-					this,
-					definition.static ? this.scope : this.scope.instanceScope
-				).parseNode(definition)
-			;
+			body[index++] = new (this.scope.context.getNodeConstructor(definition.type))(
+				this,
+				definition.static ? this.scope : this.scope.instanceScope
+			).parseNode(definition);
 		}
 		return super.parseNode(esTreeNode);
 	}

--- a/src/ast/nodes/ClassBody.ts
+++ b/src/ast/nodes/ClassBody.ts
@@ -27,14 +27,15 @@ export default class ClassBody extends NodeBase {
 	}
 
 	parseNode(esTreeNode: GenericEsTreeNode): this {
-		const body: NodeBase[] = (this.body = []);
+		const body: NodeBase[] = (this.body = new Array(esTreeNode.body.length));
+		let index = 0
 		for (const definition of esTreeNode.body) {
-			body.push(
+			body[index++] = 
 				new (this.scope.context.getNodeConstructor(definition.type))(
 					this,
 					definition.static ? this.scope : this.scope.instanceScope
 				).parseNode(definition)
-			);
+			;
 		}
 		return super.parseNode(esTreeNode);
 	}

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -275,15 +275,16 @@ export class NodeBase extends ExpressionEntity implements ExpressionNode {
 			} else if (typeof value !== 'object' || value === null) {
 				(this as GenericEsTreeNode)[key] = value;
 			} else if (Array.isArray(value)) {
-				(this as GenericEsTreeNode)[key] = [];
+				(this as GenericEsTreeNode)[key] = new Array(value.length);
+				let index = 0;
 				for (const child of value) {
-					(this as GenericEsTreeNode)[key].push(
+					(this as GenericEsTreeNode)[key][index++] = 
 						child === null
 							? null
 							: new (this.scope.context.getNodeConstructor(child.type))(this, this.scope).parseNode(
 									child
 								)
-					);
+					;
 				}
 			} else {
 				(this as GenericEsTreeNode)[key] = new (this.scope.context.getNodeConstructor(value.type))(

--- a/src/ast/nodes/shared/Node.ts
+++ b/src/ast/nodes/shared/Node.ts
@@ -278,13 +278,12 @@ export class NodeBase extends ExpressionEntity implements ExpressionNode {
 				(this as GenericEsTreeNode)[key] = new Array(value.length);
 				let index = 0;
 				for (const child of value) {
-					(this as GenericEsTreeNode)[key][index++] = 
+					(this as GenericEsTreeNode)[key][index++] =
 						child === null
 							? null
 							: new (this.scope.context.getNodeConstructor(child.type))(this, this.scope).parseNode(
 									child
-								)
-					;
+								);
 				}
 			} else {
 				(this as GenericEsTreeNode)[key] = new (this.scope.context.getNodeConstructor(value.type))(

--- a/src/finalisers/es.ts
+++ b/src/finalisers/es.ts
@@ -134,16 +134,17 @@ function getImportBlock(
 
 function getExportBlock(exports: ChunkExports, { _, cnst }: GenerateCodeSnippets): string[] {
 	const exportBlock: string[] = [];
-	const exportDeclaration: string[] = [];
+	const exportDeclaration: string[] = new Array(exports.length);
+	let index = 0;
 	for (const specifier of exports) {
 		if (specifier.expression) {
 			exportBlock.push(`${cnst} ${specifier.local}${_}=${_}${specifier.expression};`);
 		}
-		exportDeclaration.push(
+		exportDeclaration[index++] = 
 			specifier.exported === specifier.local
 				? specifier.local
 				: `${specifier.local} as ${stringifyIdentifierIfNeeded(specifier.exported)}`
-		);
+		;
 	}
 	if (exportDeclaration.length > 0) {
 		exportBlock.push(`export${_}{${_}${exportDeclaration.join(`,${_}`)}${_}};`);

--- a/src/finalisers/es.ts
+++ b/src/finalisers/es.ts
@@ -140,11 +140,10 @@ function getExportBlock(exports: ChunkExports, { _, cnst }: GenerateCodeSnippets
 		if (specifier.expression) {
 			exportBlock.push(`${cnst} ${specifier.local}${_}=${_}${specifier.expression};`);
 		}
-		exportDeclaration[index++] = 
+		exportDeclaration[index++] =
 			specifier.exported === specifier.local
 				? specifier.local
-				: `${specifier.local} as ${stringifyIdentifierIfNeeded(specifier.exported)}`
-		;
+				: `${specifier.local} as ${stringifyIdentifierIfNeeded(specifier.exported)}`;
 	}
 	if (exportDeclaration.length > 0) {
 		exportBlock.push(`export${_}{${_}${exportDeclaration.join(`,${_}`)}${_}};`);

--- a/src/utils/astConverterHelpers.ts
+++ b/src/utils/astConverterHelpers.ts
@@ -18,9 +18,9 @@ export const convertAnnotations = (
 ): readonly RollupAnnotation[] => {
 	if (position === 0) return EMPTY_ARRAY;
 	const length = buffer[position++];
-	const list: any[] = [];
+	const list: any[] = new Array(length);
 	for (let index = 0; index < length; index++) {
-		list.push(convertAnnotation(buffer[position++], buffer));
+		list[index] = convertAnnotation(buffer[position++], buffer);
 	}
 	return list;
 };

--- a/src/utils/bufferToAst.ts
+++ b/src/utils/bufferToAst.ts
@@ -1103,10 +1103,10 @@ export function convertNode(position: number, buffer: AstBuffer): any {
 function convertNodeList(position: number, buffer: AstBuffer): any[] {
 	if (position === 0) return EMPTY_ARRAY as never[];
 	const length = buffer[position++];
-	const list: any[] = [];
+	const list: any[] = new Array(length);
 	for (let index = 0; index < length; index++) {
 		const nodePosition = buffer[position++];
-		list.push(nodePosition ? convertNode(nodePosition, buffer) : null);
+		list[index] = nodePosition ? convertNode(nodePosition, buffer) : null;
 	}
 	return list;
 }


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

When the final size of an array is known, it would be more performant to use a pre-allocated array. This will prevent the internal resizing that happens when `Array.prototype.push` exceeds the array's memory allocation, which the JS engine will then internally re-allocate and apply unnecessary pressure on the GC to clean up the "dead" memory.

Note: This PR is a draft because I will add all relevant files in this single PR, which might take some time