### PR TITLE
Fix "Couldn't find package" error when installing rollup using yarn

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -481,6 +481,7 @@ jobs:
     timeout-minutes: 15
     needs:
       - lint
+      - build-freebsd
       - test
       - smoke-test
     # This needs to be adapted for Rollup 5


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- #5491
- #5704

### Description

`publish` job needs `build-freebsd`. That change was missing in PR #5698.

Without the change, `publish` would run before `build-freebsd` finishes and the workflow can't find an napi artifact for FreeBSD arm64 when downloading. That leads to the following error when one tries to install rollup using yarn as reported at https://github.com/rollup/rollup/issues/5491#issuecomment-2439891799

```
error Couldn't find package "@rollup/rollup-freebsd-arm64@4.24.1" required by "rollup" on the "npm" registry.
```