### PR TITLE
Reduce max hash size to 21

### DIFF
--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -24,7 +24,7 @@ Rollup now includes native code that is automatically installed (and removed) as
 
 The browser build (`@rollup/browser` on NPM) now relies on a WASM artifact that needs to be provided as well. If you are using the browser build with Vite, you'll need to add `"@rollup/browser"` to `optimizeDeps.exclude`, otherwise `npm run dev` fails with an invalid path to the `.wasm` file (see also [vitejs #14609](https://github.com/vitejs/vite/issues/14609)). Otherwise it should work without any specific intervention.
 
-Otherwise, an obvious change is that Rollup now uses url-safe base64 hashes in file names instead of the older base16 hashes. This provides more hash safety but means that hash length is now limited to at most 22 characters for technical reasons.
+Otherwise, an obvious change is that Rollup now uses url-safe base64 hashes in file names instead of the older base16 hashes. This provides more hash safety but means that hash length is now limited to at most 21 characters for technical reasons.
 
 When bundling CLI apps, Rollup will now automatically preserve shebang comments in entry files if the output [`format`](../configuration-options/index.md#output-format) is `es` or `cjs`. Previously, you would have needed to add the comment via a plugin.
 

--- a/src/utils/hashPlaceholders.ts
+++ b/src/utils/hashPlaceholders.ts
@@ -8,7 +8,7 @@ const hashPlaceholderRight = '}~';
 const hashPlaceholderOverhead = hashPlaceholderLeft.length + hashPlaceholderRight.length;
 
 // This is the size of a 128-bits xxhash with base64url encoding
-const MAX_HASH_SIZE = 22;
+const MAX_HASH_SIZE = 21;
 export const DEFAULT_HASH_SIZE = 8;
 
 export type HashPlaceholderGenerator = (optionName: string, hashSize: number) => string;

--- a/test/function/samples/hashing/maximum-hash-size/_config.js
+++ b/test/function/samples/hashing/maximum-hash-size/_config.js
@@ -1,9 +1,9 @@
 module.exports = defineTest({
 	description: 'throws when the maximum hash size is exceeded',
-	options: { output: { chunkFileNames: '[hash:23].js' } },
+	options: { output: { chunkFileNames: '[hash:22].js' } },
 	generateError: {
 		code: 'VALIDATION_ERROR',
 		message:
-			'Hashes cannot be longer than 22 characters, received 23. Check the "output.chunkFileNames" option.'
+			'Hashes cannot be longer than 21 characters, received 22. Check the "output.chunkFileNames" option.'
 	}
 });


### PR DESCRIPTION
In certain cases, the maximum length was actually 21, resulting in unexpected file names and off-by-one-sourcemaps.

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [x] yes Technically yes, but I would still be willing to release this in a minor version as 22 was broken and not working as expected.
- [ ] no

List any relevant issue numbers:
- resolves #5720 

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This reduces the maximum allowed hash size from 22 to 21 as for base64, sometimes the hash size would be just 21, resulting in unexpected files names and off-by-one source maps.