### PR TITLE
Fix more variable deconflicting issues

### DIFF
--- a/src/ast/nodes/ArrayPattern.ts
+++ b/src/ast/nodes/ArrayPattern.ts
@@ -87,8 +87,21 @@ export default class ArrayPattern extends NodeBase implements DeclarationPattern
 		let included = false;
 		const includedPatternPath = getIncludedPatternPath(destructuredInitPath);
 		for (const element of this.elements) {
-			included =
-				element?.includeDestructuredIfNecessary(context, includedPatternPath, init) || included;
+			if (element) {
+				element.included ||= included;
+				included =
+					element.includeDestructuredIfNecessary(context, includedPatternPath, init) || included;
+			}
+		}
+		if (included) {
+			// This is necessary so that if any pattern element is included, all are
+			// included for proper deconflicting
+			for (const element of this.elements) {
+				if (element && !element.included) {
+					element.included = true;
+					element.includeDestructuredIfNecessary(context, includedPatternPath, init);
+				}
+			}
 		}
 		return (this.included ||= included);
 	}

--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -70,6 +70,12 @@ export default class AssignmentPattern extends NodeBase implements DeclarationPa
 			this.included;
 		if ((included ||= this.right.shouldBeIncluded(context))) {
 			this.right.includePath(UNKNOWN_PATH, context, false);
+			if (!this.left.included) {
+				this.left.included = true;
+				// Unfortunately, we need to include the left side again now, so that
+				// any declared variables are properly included.
+				this.left.includeDestructuredIfNecessary(context, destructuredInitPath, init);
+			}
 		}
 		return (this.included = included);
 	}

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-array-pattern/_config.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-array-pattern/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'makes sure to deconflict all variables in an array pattern if included'
+});

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-array-pattern/dep.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-array-pattern/dep.js
@@ -1,0 +1,2 @@
+const Foo = { ok: true };
+export { Foo as default };

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-array-pattern/main.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-array-pattern/main.js
@@ -1,0 +1,6 @@
+import bar from './dep.js';
+
+const [Foo, Bar] = [1, 2];
+
+assert.deepStrictEqual(bar, { ok: true });
+assert.deepStrictEqual(Bar, 2);

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects-array/_config.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects-array/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description:
+		'makes sure to deconflict variables that are destructured for side effects in their array pattern default values only'
+});

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects-array/dep.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects-array/dep.js
@@ -1,0 +1,2 @@
+const Foo = { ok: true };
+export { Foo as default };

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects-array/main.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects-array/main.js
@@ -1,0 +1,9 @@
+import bar from './dep.js';
+let mutated = false;
+const [
+	Foo = (() => {
+		mutated = true;
+	})()
+] = [];
+assert.ok(mutated);
+assert.deepStrictEqual(bar, { ok: true });

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects/_config.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description:
+		'makes sure to deconflict variables that are destructured for side effects in their default values only'
+});

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects/dep.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects/dep.js
@@ -1,0 +1,2 @@
+const Foo = { ok: true };
+export { Foo as default };

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects/main.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-default-side-effects/main.js
@@ -1,0 +1,9 @@
+import bar from './dep.js';
+let mutated = false;
+const {
+	Foo = (() => {
+		mutated = true;
+	})()
+} = {};
+assert.ok(mutated);
+assert.deepStrictEqual(bar, { ok: true });

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-key-side-effects/_config.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-key-side-effects/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description:
+		'makes sure to deconflict variables that are destructured for side effects in their key only'
+});

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-key-side-effects/dep.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-key-side-effects/dep.js
@@ -1,0 +1,2 @@
+const Foo = { ok: true };
+export { Foo as default };

--- a/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-key-side-effects/main.js
+++ b/test/function/samples/object-expression-treeshaking/deconflict-destructured-for-key-side-effects/main.js
@@ -1,0 +1,10 @@
+import bar from './dep.js';
+let mutated = false;
+const {
+	[(() => {
+		mutated = true;
+		return 'Foo';
+	})()]: Foo
+} = { Foo: true };
+assert.ok(mutated);
+assert.deepStrictEqual(bar, { ok: true });


### PR DESCRIPTION
…key or default side effect

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This resolves various situations I found where the corresponding variables would not be included in a necessary situation, leaving to situations where the deconflicting logic fails.