### PR TITLE
Pin Rust at 1.82 to circumvent a segfault for now

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -149,7 +149,7 @@ jobs:
             build: >-
               set -e &&
               export JEMALLOC_SYS_WITH_LG_PAGE=16 &&
-              rustup default stable &&
+              rustup default 1.82.0 &&
               rustup target add aarch64-unknown-linux-gnu &&
               npm run build:napi -- --release --target aarch64-unknown-linux-gnu
           - host: ubuntu-latest
@@ -158,7 +158,7 @@ jobs:
             build: >-
               set -e &&
               export JEMALLOC_SYS_WITH_LG_PAGE=16 &&
-              rustup default stable &&
+              rustup default 1.82.0 &&
               rustup target add aarch64-unknown-linux-musl &&
               RUSTFLAGS='-C target-feature=-crt-static -C linker=aarch64-linux-musl-gcc' npm run build:napi -- --release --target aarch64-unknown-linux-musl
           - host: ubuntu-latest
@@ -204,6 +204,8 @@ jobs:
             docker: ghcr.io/darkyzhou/napi-rs-nodejs-rust:trixie-loongarch64
             build: >-
               set -e &&
+              rustup default 1.82.0 &&
+              rustup target add loongarch64-unknown-linux-gnu &&
               npm run build:napi -- --release --target loongarch64-unknown-linux-gnu
     name: Build ${{ matrix.settings.name || matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
@@ -220,7 +222,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
         with:
-          toolchain: stable
+          toolchain: 1.82.0
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.82.0
           targets: x86_64-unknown-linux-gnu
       - name: Cache cargo
         uses: actions/cache@v4
@@ -84,7 +84,7 @@ jobs:
       - name: Install Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.82.0
           targets: x86_64-unknown-linux-gnu
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/repl-artefacts.yml
+++ b/.github/workflows/repl-artefacts.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Install Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: 1.82.0
           targets: wasm32-unknown-unknown
+      - name: Add target manually
+        run: rustup target add wasm32-unknown-unknown
       - name: Cache cargo
         uses: actions/cache@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ Rollup now includes some Rust code. To compile it, you need to set up the Rust t
 Make sure you use the same toolchain version as specified in the `/rust/rust-toolchain.toml` file. You should be able to install it with the following commands:
 
 ```shell
-rustup toolchain install stable
-rustup default stable
+rustup toolchain install 1.82.0
+rustup default 1.82.0
 ```
 
 You should also install the `wasm32-unknown-unknown` target:

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "stable"
+channel = "1.82.0"


### PR DESCRIPTION
See #5761

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
#5761

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There is currently a condition where Rollup can segfault that is apparently solved when using the older 1.82 Rust toolchain.