### PR TITLE
Feature/watch on invalidate

### DIFF
--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -2978,7 +2978,7 @@ Whether to skip the `bundle.write()` step when a rebuild is triggered.
 | ----: | :--------------------- |
 | Type: | `(id: string) => void` |
 
-An optional function that will be called with the module ID that invalidated the build.
+An optional function that will be called immediately every time a module changes that is part of the build. It receives the id of the changed module as argument. This is different from the [`watchChange`](../plugin-development/index.md#watchchange) plugin hook, which is only called once the running build has finished. This may for instance be used to prevent additional steps from being performed if we know another build will be started anyway once the current build finished. This callback may be called multiple times per build as it tracks every change.
 
 ## Deprecated options
 

--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -2864,6 +2864,7 @@ interface WatcherOptions {
 	exclude?: string | RegExp | (string | RegExp)[];
 	include?: string | RegExp | (string | RegExp)[];
 	skipWrite?: boolean;
+	onInvalidate?: (id: string) => void;
 }
 ```
 
@@ -2970,6 +2971,14 @@ export default {
 | Default: | `false`                                    |
 
 Whether to skip the `bundle.write()` step when a rebuild is triggered.
+
+### watch.onInvalidate
+
+|       |                        |
+| ----: | :--------------------- |
+| Type: | `(id: string) => void` |
+
+An optional function that will be called with the module ID that invalidated the build.
 
 ## Deprecated options
 

--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -700,7 +700,7 @@ You can use [`this.getModuleInfo`](#this-getmoduleinfo) to find out the previous
 | Kind: | async, parallel |
 | Previous/Next: | This hook can be triggered at any time both during the build and the output generation phases. If that is the case, the current build will still proceed but a new build will be scheduled to start once the current build has completed, starting again with [`options`](#options) |
 
-Notifies a plugin whenever Rollup has detected a change to a monitored file in `--watch` mode. If a Promise is returned, Rollup will wait for the Promise to resolve before scheduling another build. This hook cannot be used by output plugins. The second argument contains additional details of the change event.
+Notifies a plugin whenever Rollup has detected a change to a monitored file in `--watch` mode. If a build is currently running, this hook is called once the build finished. It will be called once for every file that changed. If a Promise is returned, Rollup will wait for the Promise to resolve before scheduling another build. This hook cannot be used by output plugins. The second argument contains additional details of the change event. If you need to be notified immediately when a file changed, you can use the [`watch.onInvalidate`](../configuration-options/index.md#watch-oninvalidate) configuration option.
 
 ## Output Generation Hooks
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -969,6 +969,7 @@ export interface WatcherOptions {
 	exclude?: string | RegExp | (string | RegExp)[];
 	include?: string | RegExp | (string | RegExp)[];
 	skipWrite?: boolean;
+	onInvalidate?: (id: string) => void;
 }
 
 export interface RollupWatchOptions extends InputOptions {

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -182,10 +182,7 @@ export class Task {
 			}
 		}
 		this.watcher.invalidate({ event: details.event, id });
-
-		if (this.watchOptions.onInvalidate) {
-			this.watchOptions.onInvalidate(id);
-		}
+		this.watchOptions.onInvalidate?.(id);
 	}
 
 	async run(): Promise<void> {

--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -145,6 +145,7 @@ export class Task {
 	private skipWrite: boolean;
 	private watched = new Set<string>();
 	private readonly watcher: Watcher;
+	private readonly watchOptions: WatcherOptions;
 
 	constructor(watcher: Watcher, options: MergedRollupOptions) {
 		this.watcher = watcher;
@@ -157,10 +158,10 @@ export class Task {
 			return undefined as never;
 		});
 
-		const watchOptions: WatcherOptions = this.options.watch || {};
-		this.filter = createFilter(watchOptions.include, watchOptions.exclude);
+		this.watchOptions = this.options.watch || {};
+		this.filter = createFilter(this.watchOptions.include, this.watchOptions.exclude);
 		this.fileWatcher = new FileWatcher(this, {
-			...watchOptions.chokidar,
+			...this.watchOptions.chokidar,
 			disableGlobbing: true,
 			ignoreInitial: true
 		});
@@ -181,6 +182,10 @@ export class Task {
 			}
 		}
 		this.watcher.invalidate({ event: details.event, id });
+
+		if (this.watchOptions.onInvalidate) {
+			this.watchOptions.onInvalidate(id);
+		}
 	}
 
 	async run(): Promise<void> {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

-  resolves #5795

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR add the `onInvalidate?: (id: string) => void` option to the `WatcherOptions` that allows to configure a function that is called immediately after the build has been invalidated during the watch mode.

This allows to immediately have the information during the running build process and properly terminate/skip some parts of the process since the whole build will be restarted.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Example usage:

```rollup.config.ts
let buildInvalidated = false;

export default defineConfig({
  input: "src/index.ts",
  output: {
    file: "dist/index.js",
    format: "cjs",
    exports: "auto",
  },
  plugins: [{
    name: "preBuild",
    async buildStart() {
      buildInvalidated = false;
          
      let done = false;
      const proc = childProcess.exec("DO SOMETHING");
      proc.on("exit", () => done = true);
      
      while (!done) {
        if (buildInvalidated) {
          proc.kill("SIGINT");
          return
        }
      }
    },
  }, {
    name: "postBuild",
    writeBundle() {
      // Skip if it was invalidated
      if (buildInvalidated) {
        return;
      }
      
      // Do some post build tasks
    },
  }],
});
```