### PR TITLE
Support watch mode in yarn, gradle and containers

### DIFF
--- a/cli/run/watch-cli.ts
+++ b/cli/run/watch-cli.ts
@@ -30,10 +30,6 @@ export async function watch(command: Record<string, any>): Promise<void> {
 
 	onExit(close);
 	process.on('uncaughtException', closeWithError);
-	if (!process.stdin.isTTY) {
-		process.stdin.on('end', close);
-		process.stdin.resume();
-	}
 
 	async function loadConfigFromFileAndTrack(configFile: string): Promise<void> {
 		let configFileData: string | null = null;
@@ -134,7 +130,7 @@ export async function watch(command: Record<string, any>): Promise<void> {
 
 				case 'END': {
 					runWatchHook('onEnd');
-					if (!silent && isTTY) {
+					if (!silent) {
 						stderr(`\n[${dateTime()}] waiting for changes...`);
 					}
 				}

--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert');
-const { exec } = require('node:child_process');
+const { exec, spawn } = require('node:child_process');
 const { existsSync, readFileSync } = require('node:fs');
 const path = require('node:path');
 const process = require('node:process');
@@ -11,6 +11,7 @@ const {
 } = require('../utils.js');
 
 const cwd = process.cwd();
+const rollupBinary = `${path.resolve(__dirname, '../../dist/bin')}${path.sep}rollup`;
 
 removeSync(path.resolve(__dirname, 'node_modules'));
 copySync(
@@ -29,16 +30,12 @@ runTestSuiteWithSamples(
 			path.basename(directory) + ': ' + config.description,
 			async () => {
 				process.chdir(config.cwd || directory);
-				const command = config.command.replace(
-					/(^| )rollup($| )/g,
-					`node ${path.resolve(__dirname, '../../dist/bin')}${path.sep}rollup `
-				);
 				try {
-					await runTest(config, command);
+					await runTest(config);
 				} catch (error) {
 					if (config.retry) {
 						console.error('Initial test run failed: ' + error.message + '\nRETRYING...\n');
-						return runTest(config, command);
+						return runTest(config);
 					}
 					throw error;
 				}
@@ -48,98 +45,29 @@ runTestSuiteWithSamples(
 	() => process.chdir(cwd)
 );
 
-async function runTest(config, command) {
+async function runTest(config) {
 	if (config.before) {
 		await config.before();
 	}
 	return new Promise((resolve, reject) => {
-		const childProcess = exec(
-			command,
-			{
-				timeout: 40_000,
-				env: { ...process.env, FORCE_COLOR: '0', ...config.env },
-				killSignal: 'SIGKILL'
-			},
-			async (error, code, stderr) => {
-				try {
-					if (config.after) {
-						await config.after(error, code, stderr);
-					}
-					if (error && !error.killed) {
-						if (config.error) {
-							if (!config.error(error)) {
-								return resolve();
-							}
-						} else {
-							return reject(error);
-						}
-					}
-					if (childProcess.signalCode === 'SIGKILL') {
-						return reject(new Error('Test aborted due to timeout.'));
-					}
+		let stdout = '';
+		let stderr = '';
 
-					if ('stderr' in config) {
-						const shouldContinue = config.stderr(stderr);
-						if (!shouldContinue) return resolve();
-					} else if (stderr) {
-						console.error(stderr);
-					}
+		const spawnOptions = {
+			timeout: 40_000,
+			env: { ...process.env, FORCE_COLOR: '0', ...config.env },
+			killSignal: 'SIGKILL'
+		};
+		const childProcess = config.spawnArgs
+			? spawn('node', [rollupBinary, ...config.spawnArgs], spawnOptions)
+			: exec(config.command.replace(/(^| )rollup($| )/g, ` node ${rollupBinary} `), spawnOptions);
 
-					let unintendedError;
-
-					if (config.execute) {
-						try {
-							const function_ = new Function('require', 'module', 'exports', 'assert', code);
-							const module = {
-								exports: {}
-							};
-							function_(require, module, module.exports, assert);
-
-							if (config.error) {
-								unintendedError = new Error('Expected an error while executing output');
-							}
-
-							if (config.exports) {
-								config.exports(module.exports);
-							}
-						} catch (error) {
-							if (config.error) {
-								config.error(error);
-							} else {
-								unintendedError = error;
-							}
-						}
-
-						if (config.show || unintendedError) {
-							console.log(code + '\n\n\n');
-						}
-
-						if (config.solo) console.groupEnd();
-
-						return unintendedError ? reject(unintendedError) : resolve();
-					}
-					if (config.result) {
-						config.result(code);
-						return resolve();
-					}
-					if (config.test) {
-						config.test();
-						return resolve();
-					}
-					if (existsSync('_expected') && statSync('_expected').isDirectory()) {
-						assertDirectoriesAreEqual('_actual', '_expected');
-						return resolve();
-					}
-					const expected = readFileSync('_expected.js', 'utf8');
-					assert.equal(normaliseOutput(code), normaliseOutput(expected));
-					return resolve();
-				} catch (error) {
-					return reject(error);
-				}
-			}
-		);
+		childProcess.stdout.on('data', data => {
+			stdout += data;
+		});
 
 		childProcess.stderr.on('data', async data => {
+			stderr += data;
 			if (config.abortOnStderr) {
 				try {
 					if (await config.abortOnStderr(data)) {
@@ -149,6 +77,95 @@ async function runTest(config, command) {
 					childProcess.kill('SIGTERM');
 					reject(error);
 				}
+			}
+		});
+
+		childProcess.on('error', error => {
+			console.log('GOT AN ERROR', error);
+			reject(error);
+			childProcess.kill('SIGKILL');
+		});
+
+		childProcess.on('close', async code => {
+			try {
+				let error;
+				if (code > 0) {
+					error = new Error(stderr);
+					error.code = code;
+				}
+				if (config.after) {
+					await config.after(error, stdout, stderr);
+				}
+				if (error && !childProcess.killed) {
+					if (config.error) {
+						if (!config.error(error)) {
+							return resolve();
+						}
+					} else {
+						return reject(error);
+					}
+				}
+				if (childProcess.signalCode === 'SIGKILL') {
+					return reject(new Error('Test aborted due to timeout.'));
+				}
+
+				if ('stderr' in config) {
+					const shouldContinue = config.stderr(stderr);
+					if (!shouldContinue) return resolve();
+				} else if (stderr) {
+					console.error(stderr);
+				}
+
+				let unintendedError;
+
+				if (config.execute) {
+					try {
+						const function_ = new Function('require', 'module', 'exports', 'assert', stdout);
+						const module = {
+							exports: {}
+						};
+						function_(require, module, module.exports, assert);
+
+						if (config.error) {
+							unintendedError = new Error('Expected an error while executing output');
+						}
+
+						if (config.exports) {
+							config.exports(module.exports);
+						}
+					} catch (error) {
+						if (config.error) {
+							config.error(error);
+						} else {
+							unintendedError = error;
+						}
+					}
+
+					if (config.show || unintendedError) {
+						console.log(stdout + '\n\n\n');
+					}
+
+					if (config.solo) console.groupEnd();
+
+					return unintendedError ? reject(unintendedError) : resolve();
+				}
+				if (config.result) {
+					config.result(stdout);
+					return resolve();
+				}
+				if (config.test) {
+					config.test();
+					return resolve();
+				}
+				if (existsSync('_expected') && statSync('_expected').isDirectory()) {
+					assertDirectoriesAreEqual('_actual', '_expected');
+					return resolve();
+				}
+				const expected = readFileSync('_expected.js', 'utf8');
+				assert.equal(normaliseOutput(stdout), normaliseOutput(expected));
+				return resolve();
+			} catch (error) {
+				return reject(error);
 			}
 		});
 	});

--- a/test/cli/samples/unfulfilled-hook-actions-error/_config.js
+++ b/test/cli/samples/unfulfilled-hook-actions-error/_config.js
@@ -7,7 +7,7 @@ module.exports = defineTest({
 	command: 'node build.mjs',
 	after(error) {
 		// exit code check has to be here as error(err) is only called upon failure
-		assert.strictEqual(error, null);
+		assert.strictEqual(error, undefined);
 	},
 	stderr(stderr) {
 		assertIncludes(stderr, 'Error: Error must be displayed.');

--- a/test/cli/samples/watch/close-stdin/_config.js
+++ b/test/cli/samples/watch/close-stdin/_config.js
@@ -1,5 +1,9 @@
 module.exports = defineTest({
-	description: 'closes the watcher when stdin closes',
-	retry: true,
-	command: 'node wrapper.js main.js --watch --format es --file _actual/out.js'
+	description: 'does not close the watcher when stdin closes to support watch mode in containers',
+	command: 'node wrapper.js main.js --watch --format es --file _actual/out.js',
+	abortOnStderr(data) {
+		if (data.includes('waiting for changes')) {
+			return true;
+		}
+	}
 });

--- a/test/cli/samples/watch/close-stdin/wrapper.js
+++ b/test/cli/samples/watch/close-stdin/wrapper.js
@@ -1,9 +1,6 @@
 #!/usr/bin/env node
 
-const { mkdirSync, readFileSync, writeFileSync } = require('node:fs');
-const { resolve } = require('node:path');
 const { Readable } = require('node:stream');
-const chokidar = require('chokidar');
 
 delete process.stdin;
 process.stdin = new Readable({
@@ -13,18 +10,6 @@ process.stdin = new Readable({
 	}
 });
 
-const outputDir = resolve(__dirname, '_actual');
-mkdirSync(outputDir, {recursive: true});
-const outputFile = resolve(outputDir, 'out.js');
-const INITIAL_OUTPUT = 'NOT WRITTEN';
-writeFileSync(outputFile, INITIAL_OUTPUT);
-
-const watcher = chokidar.watch(outputFile).on('change', () => {
-	if (readFileSync(outputFile, 'utf8') !== INITIAL_OUTPUT) {
-		watcher.close();
-		// This closes stdin
-		process.stdin.push(null);
-	}
-});
+process.stdin.push(null)
 
 require('../../../../../dist/bin/rollup');

--- a/test/cli/samples/watch/signal-close-watcher/_config.js
+++ b/test/cli/samples/watch/signal-close-watcher/_config.js
@@ -2,7 +2,8 @@ const { assertIncludes } = require('../../../../utils.js');
 
 module.exports = defineTest({
 	description: 'calls closeWatcher plugin hooks when rollup is terminated due to a signal',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
+	skipIfWindows: true,
 	abortOnStderr(data) {
 		if (data.includes('created _actual')) {
 			return true;

--- a/test/cli/samples/watch/watch-config-no-update/_config.js
+++ b/test/cli/samples/watch/watch-config-no-update/_config.js
@@ -31,7 +31,7 @@ module.exports = defineTest({
 	},
 	stderr(stderr) {
 		if (
-			!/^rollup v\d+\.\d+\.\d+(-\d+)?\nbundles main.js → _actual[/\\]main.js...\ncreated _actual[/\\]main.js in \d+ms\n$/.test(
+			!/^rollup v\d+\.\d+\.\d+(-\d+)?\nbundles main.js → _actual[/\\]main.js...\ncreated _actual[/\\]main.js in \d+ms\n\n\[\d+-\d+-\d+ \d+:\d+:\d+] waiting for changes...\n$/.test(
 				stderr
 			)
 		) {

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -98,7 +98,15 @@ export interface TestConfigCli extends TestConfigBase {
 	 * Called before the test is run.
 	 */
 	before?: () => void | Promise<void>;
+	/**
+	 * Run command in a shell.
+	 * Will be overridden by "spawnArgs" if that is used.
+	 */
 	command?: string;
+	/**
+	 * Run rollup as a child process with the given arguments.
+	 */
+	spawnArgs?: string[];
 	cwd?: string;
 	/**
 	 * Environment variables to set for the test.


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5649
- resolves #5331

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There was a logic to stop watch mode when stdin closes when running in a non-TTY context. I think this logic was not really serving a purpose as it does not make sense to run watch mode in a pipe IMO. However, it was breaking watch mode when running it from yarn, gradle, or docker containers. This is fixed here.