### PR TITLE
fix: set hasDeoptimizedCache to true as early as possible

### DIFF
--- a/src/ast/nodes/LogicalExpression.ts
+++ b/src/ast/nodes/LogicalExpression.ts
@@ -69,6 +69,7 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 
 	deoptimizeCache(): void {
 		if (this.hasDeoptimizedCache) return;
+		this.hasDeoptimizedCache = true;
 		if (this.usedBranch) {
 			const unusedBranch = this.usedBranch === this.left ? this.right : this.left;
 			this.usedBranch = null;
@@ -85,7 +86,6 @@ export default class LogicalExpression extends NodeBase implements Deoptimizable
 		// Request another pass because we need to ensure "include" runs again if
 		// it is rendered
 		context.requestTreeshakingPass();
-		this.hasDeoptimizedCache = true;
 	}
 
 	deoptimizePath(path: ObjectPath): void {

--- a/test/function/samples/deoptimize-logical-expressions-2/_config.js
+++ b/test/function/samples/deoptimize-logical-expressions-2/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'Successfully built despite the deoptimization of a logical expression'
+});

--- a/test/function/samples/deoptimize-logical-expressions-2/main.js
+++ b/test/function/samples/deoptimize-logical-expressions-2/main.js
@@ -1,0 +1,8 @@
+function foo() {
+	return bar || 'a';
+}
+let bar = true;
+export default function () {
+	bar = false;
+	return foo() !== 'b' || (foo() == 'c' && foo() == 'd');
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
related https://github.com/rollup/rollup/issues/5770#issuecomment-2598186894
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Unfortunately, it seems quite difficult to create a minimal reproduction for this issue. If there really is a problem, it’s likely caused by `expression.deoptimizeCache()` re-triggering the current `getLiteralValueAtPath` method. So, In this PR, `hasDeoptimizedCache` is set to true as early as possible to check if that fixes the issue.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
