### PR TITLE
fix: avoid duplicate rollupjs.org prefix

### DIFF
--- a/cli/run/batchWarnings.ts
+++ b/cli/run/batchWarnings.ts
@@ -262,7 +262,7 @@ const deferredHandlers: Record<string, (warnings: RollupLog[]) => void> = {
 
 function defaultBody(log: RollupLog): void {
 	if (log.url) {
-		info(getRollupUrl(log.url));
+		info(log.url);
 	}
 
 	const loc = formatLocation(log);

--- a/test/cli/samples/logs/_config.js
+++ b/test/cli/samples/logs/_config.js
@@ -20,17 +20,17 @@ module.exports = defineTest({
 ${BOLD}main.js${REGULAR} → ${BOLD}stdout${REGULAR}...${NOCOLOR}
 ${BOLD}${CYAN}[plugin test] simple-info${NOCOLOR}${REGULAR}
 ${BOLD}${CYAN}[plugin test] complex-info${NOCOLOR}${REGULAR}
-${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
+${GRAY}https://my-url.net${NOCOLOR}
 ${BOLD}${BLUE}[plugin test] simple-debug${NOCOLOR}${REGULAR}
 ${BOLD}${BLUE}[plugin test] complex-debug${NOCOLOR}${REGULAR}
-${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
+${GRAY}https://my-url.net${NOCOLOR}
 ${BOLD}${CYAN}[plugin test] main.js (1:12): transform-info${NOCOLOR}${REGULAR}
-${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
+${GRAY}https://my-url.net${NOCOLOR}
 ${BOLD}CWD/main.js:1:12${REGULAR}
 ${GRAY}1: assert.ok( true );
                ^${NOCOLOR}
 ${BOLD}${BLUE}[plugin test] main.js (1:13): transform-debug${NOCOLOR}${REGULAR}
-${GRAY}https://rollupjs.org/https://my-url.net${NOCOLOR}
+${GRAY}https://my-url.net${NOCOLOR}
 ${BOLD}CWD/main.js:1:13${REGULAR}
 ${GRAY}1: assert.ok( true );
                 ^${NOCOLOR}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Not yet, I'll check how to do that

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

Urls are currently prefixed with `https://rollupjs.org/` twice

```
(!) If you do not supply "output.name", you may not be able to access the exports of an IIFE bundle.
https://rollupjs.org/https://rollupjs.org/configuration-options/#output-name
```

I'm removing it here, but we could also remove all other `getRollupUrl` calls