### PR TITLE
Ensure that all properties of throw statements are included

### DIFF
--- a/src/ast/nodes/ThrowStatement.ts
+++ b/src/ast/nodes/ThrowStatement.ts
@@ -1,13 +1,9 @@
 import type MagicString from 'magic-string';
 import type { RenderOptions } from '../../utils/renderHelpers';
 import { type InclusionContext } from '../ExecutionContext';
+import { UNKNOWN_PATH } from '../utils/PathTracker';
 import type * as NodeType from './NodeType';
-import {
-	type ExpressionNode,
-	type IncludeChildren,
-	onlyIncludeSelf,
-	StatementBase
-} from './shared/Node';
+import { type ExpressionNode, type IncludeChildren, StatementBase } from './shared/Node';
 
 export default class ThrowStatement extends StatementBase {
 	declare argument: ExpressionNode;
@@ -23,6 +19,13 @@ export default class ThrowStatement extends StatementBase {
 		context.brokenFlow = true;
 	}
 
+	includeNode(context: InclusionContext) {
+		if (!this.included) {
+			this.included = true;
+			this.argument.includePath(UNKNOWN_PATH, context);
+		}
+	}
+
 	render(code: MagicString, options: RenderOptions): void {
 		this.argument.render(code, options, { preventASI: true });
 		if (this.argument.start === this.start + 5 /* 'throw'.length */) {
@@ -30,5 +33,3 @@ export default class ThrowStatement extends StatementBase {
 		}
 	}
 }
-
-ThrowStatement.prototype.includeNode = onlyIncludeSelf;

--- a/test/function/samples/object-expression-treeshaking/throw-object/_config.js
+++ b/test/function/samples/object-expression-treeshaking/throw-object/_config.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+module.exports = defineTest({
+	description: 'allows to throw object expressions with all properties',
+	exports({ test }) {
+		try {
+			test();
+		} catch (error) {
+			assert.deepStrictEqual(error, { my: 'info' });
+		}
+	}
+});

--- a/test/function/samples/object-expression-treeshaking/throw-object/main.js
+++ b/test/function/samples/object-expression-treeshaking/throw-object/main.js
@@ -1,0 +1,3 @@
+export function test() {
+	throw { my: 'info' };
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5824

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Currently, there is no mechanism to ensure throw statements include all properties.