### PR TITLE
Ensure that functions provided to a constructor are properly deoptimized

### DIFF
--- a/src/ast/nodes/shared/IdentifierBase.ts
+++ b/src/ast/nodes/shared/IdentifierBase.ts
@@ -142,6 +142,7 @@ export default class IdentifierBase extends NodeBase {
 	includePath(path: ObjectPath, context: InclusionContext): void {
 		if (!this.included) {
 			this.included = true;
+			if (!this.deoptimized) this.applyDeoptimizations();
 			if (this.variable !== null) {
 				this.scope.context.includeVariableInModule(this.variable, path, context);
 			}

--- a/test/function/samples/parameters-promise-constructor/_config.js
+++ b/test/function/samples/parameters-promise-constructor/_config.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+
+module.exports = defineTest({
+	description: 'correctly handles parameters of promise constructor',
+	async exports({ result }) {
+		assert.strictEqual(await result, 42);
+	}
+});

--- a/test/function/samples/parameters-promise-constructor/main.js
+++ b/test/function/samples/parameters-promise-constructor/main.js
@@ -1,0 +1,12 @@
+const value = 42;
+
+export function test(callback) {
+	return callback ? execute(undefined, callback) : new Promise(execute);
+
+	function execute(resolve) {
+		if (resolve) resolve(value);
+		else resolve('FAIL');
+	}
+}
+
+export const result = test().then(r => r);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5826 

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
There was a small asymmetry in the handling of identifiers that has the effect that in certain situations, identifiers would not be added as "usedPlaces", which again would mean that the call argument detection logic would not see them and lead to wrong results.