### PR TITLE
Include all paths of reexports if namespace is used

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -258,6 +258,7 @@ export default class Module {
 	declare transformFiles?: EmittedFile[];
 
 	private allExportNames: Set<string> | null = null;
+	private allExportsIncluded = false;
 	private ast: Program | null = null;
 	declare private astContext: AstContext;
 	private readonly context: string;
@@ -711,6 +712,8 @@ export default class Module {
 	}
 
 	includeAllExports(includeNamespaceMembers: boolean): void {
+		if (this.allExportsIncluded) return;
+		this.allExportsIncluded = true;
 		if (!this.isExecuted) {
 			markModuleAndImpureDependenciesAsExecuted(this);
 			this.graph.needsTreeshakingPass = true;
@@ -732,9 +735,7 @@ export default class Module {
 			const [variable] = this.getVariableForExportName(name);
 			if (variable) {
 				variable.deoptimizePath(UNKNOWN_PATH);
-				if (!variable.included) {
-					this.includeVariable(variable, UNKNOWN_PATH, inclusionContext);
-				}
+				this.includeVariable(variable, UNKNOWN_PATH, inclusionContext);
 				if (variable instanceof ExternalVariable) {
 					variable.module.reexported = true;
 				}

--- a/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/_config.js
+++ b/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'includes paths across namespace reeports'
+});

--- a/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/dep.js
+++ b/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/dep.js
@@ -1,0 +1,1 @@
+export { default as object } from './object.js';

--- a/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/lib.js
+++ b/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/lib.js
@@ -1,0 +1,1 @@
+export * as lib from './dep.js';

--- a/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/main.js
+++ b/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/main.js
@@ -1,0 +1,8 @@
+import { lib } from './lib.js';
+
+assert.strictEqual(lib.object.a, 'a');
+log(lib);
+
+function log(lib) {
+	assert.strictEqual(lib.object.b, 'b');
+}

--- a/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/object.js
+++ b/test/function/samples/object-expression-treeshaking/include-namespace-reexport-path/object.js
@@ -1,0 +1,4 @@
+export default {
+	a: 'a',
+	b: 'b'
+};


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5828

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When we include a namespace object, we always include all paths of all exports and reexports. However to avoid infinite recursions when a namespace references itself, there was a check to only include reexports when they were not included yet. This could lead to a situation where a reexport was already included, but not with all possible paths.
This PR fixes this by replacing it with a general check if all exports of a namespace have already been included. This should also benefit performance slightly.