### PR TITLE
feat(5858): make closeBundle hook receive the last error

### DIFF
--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -885,7 +885,7 @@ Can be used to clean up any external service that may be running. Rollup's CLI w
 
 If a plugin wants to retain resources across builds in watch mode, they can check for [`this.meta.watchMode`](#this-meta) in this hook and perform the necessary cleanup for watch mode in [`closeWatcher`](#closewatcher).
 
-If an error occurs during build or the `buildEnd' hook, it is passed to this hook as first argument.
+If an error occurs during build or the `buildEnd` hook, it is passed to this hook as first argument.
 
 ### footer
 

--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -877,13 +877,15 @@ Cf. [`output.banner/output.footer`](../configuration-options/index.md#output-ban
 
 |  |  |
 | --: | :-- |
-| Type: | `closeBundle: () => Promise<void> \| void` |
+| Type: | `closeBundle: (error?: Error) => Promise<void> \| void` |
 | Kind: | async, parallel |
 | Previous: | [`buildEnd`](#buildend) if there was a build error, otherwise when [`bundle.close()`](../javascript-api/index.md#rollup-rollup) is called, in which case this would be the last hook to be triggered |
 
 Can be used to clean up any external service that may be running. Rollup's CLI will make sure this hook is called after each run, but it is the responsibility of users of the JavaScript API to manually call `bundle.close()` once they are done generating bundles. For that reason, any plugin relying on this feature should carefully mention this in its documentation.
 
 If a plugin wants to retain resources across builds in watch mode, they can check for [`this.meta.watchMode`](#this-meta) in this hook and perform the necessary cleanup for watch mode in [`closeWatcher`](#closewatcher).
+
+If an error occurred during the build or the `buildEnd` hook, it will be passed to this hook as the first argument.
 
 ### footer
 

--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -885,7 +885,7 @@ Can be used to clean up any external service that may be running. Rollup's CLI w
 
 If a plugin wants to retain resources across builds in watch mode, they can check for [`this.meta.watchMode`](#this-meta) in this hook and perform the necessary cleanup for watch mode in [`closeWatcher`](#closewatcher).
 
-If an error occurred during the build or the `buildEnd` hook, it will be passed to this hook as the first argument.
+If an error occurs during build or the `buildEnd' hook, it is passed to this hook as first argument.
 
 ### footer
 

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -79,8 +79,13 @@ export async function rollupInternal(
 			if (watchFiles.length > 0) {
 				error_.watchFiles = watchFiles;
 			}
-			await graph.pluginDriver.hookParallel('buildEnd', [error_]);
-			await graph.pluginDriver.hookParallel('closeBundle', []);
+			try {
+				await graph.pluginDriver.hookParallel('buildEnd', [error_]);
+			} catch (buildEndError: any) {
+				await graph.pluginDriver.hookParallel('closeBundle', [buildEndError]);
+				throw buildEndError;
+			}
+			await graph.pluginDriver.hookParallel('closeBundle', [error_]);
 			throw error_;
 		}
 		await graph.pluginDriver.hookParallel('buildEnd', []);

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -84,30 +84,9 @@ export async function rollupInternal(
 				await graph.pluginDriver.hookParallel('buildEnd', [error_]);
 			} catch (buildEndError: any) {
 				// Create a compound error object to include both errors, based on the original error
-				// structuredClone cannot be used because properties might be non-enumerable
 				const compoundError = getRollupError({
-					binding: error_.binding,
-					cause: error_.cause,
-					code: error_.code,
-					exporter: error_.exporter,
-					frame: error_.frame,
-					hook: error_.hook,
-					id: error_.id,
-					ids: error_.ids,
-					loc: error_.loc,
-					message: `There was an error during the build:\n  ${error_.message}\nAdditionally, handling the error in the 'buildEnd' hook caused the following error:\n  ${buildEndError.message}`,
-					meta: error_.meta,
-					names: error_.names,
-					plugin: error_.plugin,
-					pluginCode: error_.pluginCode,
-					pos: error_.pos,
-					reexporter: error_.reexporter,
-					stack: error_.stack,
-					url: error_.url
-				});
-				Object.defineProperty(compoundError, 'watchFiles', {
-					value: error_.watchFiles,
-					writable: true
+					...error_,
+					message: `There was an error during the build:\n  ${error_.message}\nAdditionally, handling the error in the 'buildEnd' hook caused the following error:\n  ${buildEndError.message}`
 				});
 				await graph.pluginDriver.hookParallel('closeBundle', [compoundError]);
 				throw compoundError;

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -9,6 +9,7 @@ import { LOGLEVEL_DEBUG, LOGLEVEL_INFO, LOGLEVEL_WARN } from '../utils/logging';
 import { getLogHandler } from '../utils/logHandler';
 import {
 	error,
+	getRollupError,
 	logAlreadyClosed,
 	logCannotEmitFromOptionsHook,
 	logMissingFileOrDirOption,
@@ -82,11 +83,30 @@ export async function rollupInternal(
 			try {
 				await graph.pluginDriver.hookParallel('buildEnd', [error_]);
 			} catch (buildEndError: any) {
-				if (watchFiles.length > 0) {
-					buildEndError.watchFiles = watchFiles;
-				}
-				await graph.pluginDriver.hookParallel('closeBundle', [buildEndError]);
-				throw buildEndError;
+				// Create a compound error object to include both errors, based on the original error
+				// structuredClone cannot be used because properties might be non-enumerable
+				const compoundError = getRollupError({
+					binding: error_.binding,
+					cause: error_.cause,
+					code: error_.code,
+					exporter: error_.exporter,
+					frame: error_.frame,
+					hook: error_.hook,
+					id: error_.id,
+					ids: error_.ids,
+					loc: error_.loc,
+					message: `There was an error during the build:\n  ${error_.message}\nAdditionally, handling the error in the 'buildEnd' hook caused the following error:\n  ${buildEndError.message}`,
+					meta: error_.meta,
+					names: error_.names,
+					plugin: error_.plugin,
+					pluginCode: error_.pluginCode,
+					pos: error_.pos,
+					reexporter: error_.reexporter,
+					stack: error_.stack,
+					url: error_.url
+				});
+				await graph.pluginDriver.hookParallel('closeBundle', [compoundError]);
+				throw compoundError;
 			}
 			await graph.pluginDriver.hookParallel('closeBundle', [error_]);
 			throw error_;

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -82,6 +82,9 @@ export async function rollupInternal(
 			try {
 				await graph.pluginDriver.hookParallel('buildEnd', [error_]);
 			} catch (buildEndError: any) {
+				if (watchFiles.length > 0) {
+					buildEndError.watchFiles = watchFiles;
+				}
 				await graph.pluginDriver.hookParallel('closeBundle', [buildEndError]);
 				throw buildEndError;
 			}

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -105,6 +105,10 @@ export async function rollupInternal(
 					stack: error_.stack,
 					url: error_.url
 				});
+				Object.defineProperty(compoundError, 'watchFiles', {
+					value: error_.watchFiles,
+					writable: true
+				});
 				await graph.pluginDriver.hookParallel('closeBundle', [compoundError]);
 				throw compoundError;
 			}

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -70,30 +70,25 @@ export async function rollupInternal(
 
 	await catchUnfinishedHookActions(graph.pluginDriver, async () => {
 		try {
-			timeStart('initialize', 2);
-			await graph.pluginDriver.hookParallel('buildStart', [inputOptions]);
-			timeEnd('initialize', 2);
-			await graph.build();
-		} catch (error_: any) {
-			const watchFiles = Object.keys(graph.watchFiles);
-			if (watchFiles.length > 0) {
-				error_.watchFiles = watchFiles;
-			}
 			try {
+				timeStart('initialize', 2);
+				await graph.pluginDriver.hookParallel('buildStart', [inputOptions]);
+				timeEnd('initialize', 2);
+				await graph.build();
+			} catch (error_: any) {
+				const watchFiles = Object.keys(graph.watchFiles);
+				if (watchFiles.length > 0) {
+					error_.watchFiles = watchFiles;
+				}
 				await graph.pluginDriver.hookParallel('buildEnd', [error_]);
-			} catch (buildEndError: any) {
-				await graph.pluginDriver.hookParallel('closeBundle', [buildEndError]);
-				throw buildEndError;
+				throw error_;
 			}
+			await graph.pluginDriver.hookParallel('buildEnd', []);
+		} catch (error_: any) {
 			await graph.pluginDriver.hookParallel('closeBundle', [error_]);
 			throw error_;
 		}
-		try {
-			await graph.pluginDriver.hookParallel('buildEnd', []);
-		} catch (buildEndError: any) {
-			await graph.pluginDriver.hookParallel('closeBundle', [buildEndError]);
-			throw buildEndError;
-		}
+		await graph.pluginDriver.hookParallel('closeBundle', []);
 	});
 
 	timeEnd('BUILD', 1);

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -88,7 +88,12 @@ export async function rollupInternal(
 			await graph.pluginDriver.hookParallel('closeBundle', [error_]);
 			throw error_;
 		}
-		await graph.pluginDriver.hookParallel('buildEnd', []);
+		try {
+			await graph.pluginDriver.hookParallel('buildEnd', []);
+		} catch (buildEndError: any) {
+			await graph.pluginDriver.hookParallel('closeBundle', [buildEndError]);
+			throw buildEndError;
+		}
 	});
 
 	timeEnd('BUILD', 1);

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -404,7 +404,7 @@ export interface FunctionPluginHooks {
 	augmentChunkHash: (this: PluginContext, chunk: RenderedChunk) => string | void;
 	buildEnd: (this: PluginContext, error?: Error) => void;
 	buildStart: (this: PluginContext, options: NormalizedInputOptions) => void;
-	closeBundle: (this: PluginContext) => void;
+	closeBundle: (this: PluginContext, error?: Error) => void;
 	closeWatcher: (this: PluginContext) => void;
 	generateBundle: (
 		this: PluginContext,

--- a/test/hooks/index.js
+++ b/test/hooks/index.js
@@ -1103,15 +1103,22 @@ describe('hooks', () => {
 			})
 			.then(bundle => bundle.close())
 			.catch(error => {
+				// Ensure error correctly copies the original build error
+				assert.strictEqual(error.cause.message, "Expected ';', '}' or <eof>");
+				assert.strictEqual(error.code, 'PARSE_ERROR');
+				assert.strictEqual(error.frame, '1: some broken code\n        ^');
+				assert.strictEqual(error.id, 'input');
+				assert.deepStrictEqual(error.loc, { file: 'input', line: 1, column: 5 });
 				assert.strictEqual(
 					error.message,
-					'input (1:5): There was an error during the build:\n' +
+					'There was an error during the build:\n' +
 						"  input (1:5): Expected ';', '}' or <eof> (Note that you need plugins to import files that are not JavaScript)\n" +
 						"Additionally, handling the error in the 'buildEnd' hook caused the following error:\n" +
 						'  [plugin at position 2] build end error'
 				);
-				assert.strictEqual(error.frame, '1: some broken code\n        ^');
-				assert.strictEqual(error.cause.message, "Expected ';', '}' or <eof>");
+				assert.strictEqual(error.name, 'RollupError');
+				assert.strictEqual(error.pos, 5);
+				assert.ok(error.stack.startsWith(`${error.name}: ${error.message}\n`));
 			})
 			.then(() => {
 				assert.ok(buildEndError);


### PR DESCRIPTION
Hello!

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #5858 

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

- Closes #5858
- Closes #5868

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

The `closeBundle` hook now receives the last error:

```js
const plugin = {
  name: 'example',
  closeBundle(error) {
    if (error) console.warn('Oh no :(')
  }
}
```

If an error is thrown in `buildEnd`, `closeBundle` will receive this error:

```js
const plugin = {
  name: 'example',
  buildEnd(error) {
    throw new Error('build end')
  },
  closeBundle(error) {
    // error comes from buildEnd
  }
}
```

In case the build fails and `buildEnd` also fails, `closeBundle` will receive a compound error created out of both previous errors.
