### PR TITLE
Fix `treeshake: false` breaking destructured namespace imports

### DIFF
--- a/src/Module.ts
+++ b/src/Module.ts
@@ -713,6 +713,10 @@ export default class Module {
 	}
 
 	includeAllExports(includeNamespaceMembers: boolean): void {
+		if (includeNamespaceMembers) {
+			this.namespace.setMergedNamespaces(this.includeAndGetAdditionalMergedNamespaces());
+		}
+
 		if (this.allExportsIncluded) return;
 		this.allExportsIncluded = true;
 		if (!this.isExecuted) {
@@ -741,10 +745,6 @@ export default class Module {
 					variable.module.reexported = true;
 				}
 			}
-		}
-
-		if (includeNamespaceMembers) {
-			this.namespace.setMergedNamespaces(this.includeAndGetAdditionalMergedNamespaces());
 		}
 	}
 

--- a/test/function/samples/no-treeshake-react/_config.js
+++ b/test/function/samples/no-treeshake-react/_config.js
@@ -1,0 +1,10 @@
+module.exports = defineTest({
+	description: 'passes when bundling React without tree-shaking',
+	options: {
+		treeshake: false,
+		plugins: [
+			require('@rollup/plugin-node-resolve').default(),
+			require('@rollup/plugin-commonjs')()
+		]
+	}
+});

--- a/test/function/samples/no-treeshake-react/main.js
+++ b/test/function/samples/no-treeshake-react/main.js
@@ -1,0 +1,3 @@
+import * as React from 'react';
+const { createContext } = React;
+assert(createContext() === 'foo');

--- a/test/function/samples/no-treeshake-react/node_modules/react/cjs/react.production.js
+++ b/test/function/samples/no-treeshake-react/node_modules/react/cjs/react.production.js
@@ -1,0 +1,4 @@
+"use strict";
+exports.createContext = function () {
+  return 'foo';
+};

--- a/test/function/samples/no-treeshake-react/node_modules/react/index.js
+++ b/test/function/samples/no-treeshake-react/node_modules/react/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./cjs/react.production.js');

--- a/test/function/samples/no-treeshake-react/node_modules/react/package.json
+++ b/test/function/samples/no-treeshake-react/node_modules/react/package.json
@@ -1,0 +1,8 @@
+{
+    "main": "index.js",
+    "exports": {
+        ".": {
+            "default": "./index.js"
+        }
+    }
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- resolves #5899

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

`setMergedNamespaces` is skipped if `includeAllExports(false)` is called prior to `includeAllExports(true)`, which somehow only happens with `treeshake: false`.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
