### PR TITLE
Correct the behavior when multiple transform filter options are specified

### DIFF
--- a/src/utils/pluginFilter.ts
+++ b/src/utils/pluginFilter.ts
@@ -76,7 +76,7 @@ function normalizeFilter(filter: StringFilter): NormalizedStringFilter {
 	}
 	if (Array.isArray(filter)) {
 		return {
-			include: ensureArray(filter)
+			include: filter
 		};
 	}
 	return {

--- a/src/utils/pluginFilter.ts
+++ b/src/utils/pluginFilter.ts
@@ -64,7 +64,7 @@ function createFilter(
 		if (include?.some(filter => filter(input))) {
 			return true;
 		}
-		return !!include && include.length > 0 ? false : true;
+		return !(include && include.length > 0);
 	};
 }
 

--- a/src/utils/pluginFilter.ts
+++ b/src/utils/pluginFilter.ts
@@ -3,12 +3,6 @@ import type { StringFilter, StringOrRegExp } from '../rollup/types';
 import { ensureArray } from './ensureArray';
 import { isAbsolute, normalize, resolve } from './path';
 
-const FALLBACK_TRUE = 1;
-const FALLBACK_FALSE = 0;
-type FallbackValues = typeof FALLBACK_TRUE | typeof FALLBACK_FALSE;
-
-type PluginFilterWithFallback = (input: string) => boolean | FallbackValues;
-
 export type PluginFilter = (input: string) => boolean;
 export type TransformHookFilter = (id: string, code: string) => boolean;
 
@@ -58,7 +52,7 @@ function patternToCodeFilter(pattern: StringOrRegExp): PluginFilter {
 function createFilter(
 	exclude: PluginFilter[] | undefined,
 	include: PluginFilter[] | undefined
-): PluginFilterWithFallback | undefined {
+): PluginFilter | undefined {
 	if (!exclude && !include) {
 		return;
 	}
@@ -70,7 +64,7 @@ function createFilter(
 		if (include?.some(filter => filter(input))) {
 			return true;
 		}
-		return !!include && include.length > 0 ? FALLBACK_FALSE : FALLBACK_TRUE;
+		return !!include && include.length > 0 ? false : true;
 	};
 }
 
@@ -91,7 +85,7 @@ function normalizeFilter(filter: StringFilter): NormalizedStringFilter {
 	};
 }
 
-function createIdFilter(filter: StringFilter | undefined): PluginFilterWithFallback | undefined {
+function createIdFilter(filter: StringFilter | undefined): PluginFilter | undefined {
 	if (!filter) return;
 	const { exclude, include } = normalizeFilter(filter);
 	const excludeFilter = exclude?.map(patternToIdFilter);
@@ -99,7 +93,7 @@ function createIdFilter(filter: StringFilter | undefined): PluginFilterWithFallb
 	return createFilter(excludeFilter, includeFilter);
 }
 
-function createCodeFilter(filter: StringFilter | undefined): PluginFilterWithFallback | undefined {
+function createCodeFilter(filter: StringFilter | undefined): PluginFilter | undefined {
 	if (!filter) return;
 	const { exclude, include } = normalizeFilter(filter);
 	const excludeFilter = exclude?.map(patternToCodeFilter);
@@ -122,18 +116,14 @@ export function createFilterForTransform(
 	return (id, code) => {
 		let fallback = true;
 		if (idFilterFunction) {
-			const idResult = idFilterFunction(id);
-			if (typeof idResult === 'boolean') {
-				return idResult;
-			}
-			fallback &&= !!idResult;
+			fallback &&= idFilterFunction(id);
 		}
+		if (!fallback) {
+			return false;
+		}
+
 		if (codeFilterFunction) {
-			const codeResult = codeFilterFunction(code);
-			if (typeof codeResult === 'boolean') {
-				return codeResult;
-			}
-			fallback &&= !!codeResult;
+			fallback &&= codeFilterFunction(code);
 		}
 		return fallback;
 	};

--- a/test/function/samples/plugin-hook-filters/_config.js
+++ b/test/function/samples/plugin-hook-filters/_config.js
@@ -76,7 +76,7 @@ const expectedCalledHooks = {
 			'transform-{ code: { include: [ /import\\.\\w+\\.a/ ] } }',
 			"transform-{ code: { include: 'import.meta.a', exclude: 'import.meta.b' } }",
 			"transform-{ id: { exclude: '**/ba*.js' }, code: 'import.meta.a' }",
-			"transform-{\n  id: { include: '**/foo.js', exclude: '**/ba*.js' },\n  code: 'import.meta.b'\n}"
+			"transform-{\n  id: { include: '**/foo.js', exclude: '**/ba*.js' },\n  code: 'import.meta.a'\n}"
 		]
 	}
 };
@@ -116,7 +116,7 @@ addPlugin('transform', { code: { include: /import\.meta\.\w+/, exclude: /import\
 addPlugin('transform', { id: { exclude: '**/ba*.js' }, code: 'import.meta.a' });
 addPlugin('transform', {
 	id: { include: '**/foo.js', exclude: '**/ba*.js' },
-	code: 'import.meta.b'
+	code: 'import.meta.a'
 });
 
 function addPlugin(hook, filter) {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no (I think this is not a breaking change as the previous behavior does not work well)

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

When multiple filter options were specified for a transform hook, the hook ran when either of it matched.
For example, the following filter matched for modules that whose id is `foo` or whose code contains `a`.
```js
{
  filter: { id: ['foo'], code: 'a' }
}
```
This is not useful.
This PR fixes that behavior. After this PR, the filter above only matches if the module id is `foo` **and** the code contains `a`.
The previous behavior (that is probably rarely needed) can be achieved by using multiple plugins:
```js
const filters = [{ id: ['foo'] }, { code: 'a' }]
const plugins = filters.map(filter => ({ name: 'plugin', transform: { filter, handler() { /* process the module */ } } }))
```

refs https://github.com/rolldown/rolldown/pull/4059

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
