### PR TITLE
Avoid chunks TLA dynamic import circular when TLA dynamic import used in non-entry modules

### DIFF
--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -285,9 +285,12 @@ function analyzeModuleGraph(entries: Iterable<Module>): {
 					dynamicEntryModules.add(resolution);
 					allEntriesSet.add(resolution);
 					dynamicImportsForCurrentEntry.add(resolution);
-					if (resolution.includedDirectTopLevelAwaitingDynamicImporters.has(currentEntry)) {
-						awaitedDynamicEntryModules.add(resolution);
-						awaitedDynamicImportsForCurrentEntry.add(resolution);
+					for (const includedDirectTopLevelAwaitingDynamicImporter of resolution.includedDirectTopLevelAwaitingDynamicImporters) {
+						if (modulesToHandle.has(includedDirectTopLevelAwaitingDynamicImporter)) {
+							awaitedDynamicEntryModules.add(resolution);
+							awaitedDynamicImportsForCurrentEntry.add(resolution);
+							break;
+						}
 					}
 				}
 			}

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -268,12 +268,12 @@ function analyzeModuleGraph(entries: Iterable<Module>): {
 		const awaitedDynamicImportsForCurrentEntry = new Set<Module>();
 		dynamicImportModulesByEntry[entryIndex] = dynamicImportsForCurrentEntry;
 		awaitedDynamicImportModulesByEntry[entryIndex] = awaitedDynamicImportsForCurrentEntry;
-		const modulesToHandle = new Set([currentEntry]);
-		for (const module of modulesToHandle) {
+		const staticDependencies = new Set([currentEntry]);
+		for (const module of staticDependencies) {
 			getOrCreate(dependentEntriesByModule, module, getNewSet<number>).add(entryIndex);
 			for (const dependency of module.getDependenciesToBeIncluded()) {
 				if (!(dependency instanceof ExternalModule)) {
-					modulesToHandle.add(dependency);
+					staticDependencies.add(dependency);
 				}
 			}
 			for (const { resolution } of module.dynamicImports) {
@@ -286,7 +286,7 @@ function analyzeModuleGraph(entries: Iterable<Module>): {
 					allEntriesSet.add(resolution);
 					dynamicImportsForCurrentEntry.add(resolution);
 					for (const includedDirectTopLevelAwaitingDynamicImporter of resolution.includedDirectTopLevelAwaitingDynamicImporters) {
-						if (modulesToHandle.has(includedDirectTopLevelAwaitingDynamicImporter)) {
+						if (staticDependencies.has(includedDirectTopLevelAwaitingDynamicImporter)) {
 							awaitedDynamicEntryModules.add(resolution);
 							awaitedDynamicImportsForCurrentEntry.add(resolution);
 							break;

--- a/test/chunking-form/samples/top-level-await-import-2/_config.js
+++ b/test/chunking-form/samples/top-level-await-import-2/_config.js
@@ -1,0 +1,5 @@
+module.exports = defineTest({
+	description:
+		'avoiding circular TLA dynamic imports between chunks even with TLA dynamic imports in non-entry modules',
+	formats: ['es', 'system']
+});

--- a/test/chunking-form/samples/top-level-await-import-2/_expected/es/generated-foo-prefix.js
+++ b/test/chunking-form/samples/top-level-await-import-2/_expected/es/generated-foo-prefix.js
@@ -1,0 +1,3 @@
+const fooPrefix = 'fooPrefix';
+
+export { fooPrefix as f };

--- a/test/chunking-form/samples/top-level-await-import-2/_expected/es/generated-foo.js
+++ b/test/chunking-form/samples/top-level-await-import-2/_expected/es/generated-foo.js
@@ -1,0 +1,5 @@
+import { f as fooPrefix } from './generated-foo-prefix.js';
+
+const foo = fooPrefix + 'foo';
+
+export { foo };

--- a/test/chunking-form/samples/top-level-await-import-2/_expected/es/main.js
+++ b/test/chunking-form/samples/top-level-await-import-2/_expected/es/main.js
@@ -1,0 +1,9 @@
+import { f as fooPrefix } from './generated-foo-prefix.js';
+
+const { foo } = await import('./generated-foo.js');
+
+function getFoo() {
+	return unknownFlag ? foo : fooPrefix;
+}
+
+console.log(getFoo());

--- a/test/chunking-form/samples/top-level-await-import-2/_expected/system/generated-foo-prefix.js
+++ b/test/chunking-form/samples/top-level-await-import-2/_expected/system/generated-foo-prefix.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const fooPrefix = exports("f", 'fooPrefix');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/top-level-await-import-2/_expected/system/generated-foo.js
+++ b/test/chunking-form/samples/top-level-await-import-2/_expected/system/generated-foo.js
@@ -1,0 +1,14 @@
+System.register(['./generated-foo-prefix.js'], (function (exports) {
+	'use strict';
+	var fooPrefix;
+	return {
+		setters: [function (module) {
+			fooPrefix = module.f;
+		}],
+		execute: (function () {
+
+			const foo = exports("foo", fooPrefix + 'foo');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/top-level-await-import-2/_expected/system/main.js
+++ b/test/chunking-form/samples/top-level-await-import-2/_expected/system/main.js
@@ -1,0 +1,20 @@
+System.register(['./generated-foo-prefix.js'], (function (exports, module) {
+	'use strict';
+	var fooPrefix;
+	return {
+		setters: [function (module) {
+			fooPrefix = module.f;
+		}],
+		execute: (async function () {
+
+			const { foo } = await module.import('./generated-foo.js');
+
+			function getFoo() {
+				return unknownFlag ? foo : fooPrefix;
+			}
+
+			console.log(getFoo());
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/top-level-await-import-2/foo-prefix.js
+++ b/test/chunking-form/samples/top-level-await-import-2/foo-prefix.js
@@ -1,0 +1,1 @@
+export const fooPrefix = 'fooPrefix';

--- a/test/chunking-form/samples/top-level-await-import-2/foo.js
+++ b/test/chunking-form/samples/top-level-await-import-2/foo.js
@@ -1,0 +1,2 @@
+import { fooPrefix } from './foo-prefix.js';
+export const foo = fooPrefix + 'foo';

--- a/test/chunking-form/samples/top-level-await-import-2/lib.js
+++ b/test/chunking-form/samples/top-level-await-import-2/lib.js
@@ -1,0 +1,7 @@
+import { fooPrefix } from './foo-prefix.js';
+
+const { foo } = await import('./foo.js');
+
+export function getFoo() {
+	return unknownFlag ? foo : fooPrefix;
+}

--- a/test/chunking-form/samples/top-level-await-import-2/main.js
+++ b/test/chunking-form/samples/top-level-await-import-2/main.js
@@ -1,0 +1,3 @@
+import { getFoo } from './lib.js';
+
+console.log(getFoo());


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #5929
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
