### PR TITLE
Use spawn to run CLI tests

### DIFF
--- a/test/cli/index.js
+++ b/test/cli/index.js
@@ -59,18 +59,18 @@ async function runTest(config) {
 			killSignal: 'SIGKILL'
 		};
 		const childProcess = config.spawnArgs
-			? spawn('node', [rollupBinary, ...config.spawnArgs], spawnOptions)
+			? spawn('node', [config.spawnScript || rollupBinary, ...config.spawnArgs], spawnOptions)
 			: exec(config.command.replace(/(^| )rollup($| )/g, ` node ${rollupBinary} `), spawnOptions);
 
 		childProcess.stdout.on('data', data => {
-			stdout += data;
+			stdout += String(data);
 		});
 
 		childProcess.stderr.on('data', async data => {
-			stderr += data;
+			stderr += String(data);
 			if (config.abortOnStderr) {
 				try {
-					if (await config.abortOnStderr(data)) {
+					if (await config.abortOnStderr(String(data))) {
 						childProcess.kill('SIGTERM');
 					}
 				} catch (error) {

--- a/test/cli/samples/allow-output-prefix/_config.js
+++ b/test/cli/samples/allow-output-prefix/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'allows output options to be prefixed with "output."',
-	command: 'rollup main.js --output.format es --output.footer "console.log(\'Rollup!\')"'
+	spawnArgs: ['main.js', '--output.format', 'es', '--output.footer', "console.log('Rollup!')"]
 });

--- a/test/cli/samples/amd/_config.js
+++ b/test/cli/samples/amd/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'sets AMD module ID and define function',
-	command: 'rollup -i main.js -f amd --amd.id foo --amd.define defn'
+	spawnArgs: ['-i', 'main.js', '-f', 'amd', '--amd.id', 'foo', '--amd.define', 'defn']
 });

--- a/test/cli/samples/banner-intro-outro-footer/_config.js
+++ b/test/cli/samples/banner-intro-outro-footer/_config.js
@@ -1,5 +1,18 @@
 module.exports = defineTest({
 	description: 'adds banner/intro/outro/footer',
-	command:
-		'rollup -i main.js -f iife --indent --banner "// banner" --intro "// intro" --outro "// outro" --footer "// footer"'
+	spawnArgs: [
+		'-i',
+		'main.js',
+		'-f',
+		'iife',
+		'--indent',
+		'--banner',
+		'// banner',
+		'--intro',
+		'// intro',
+		'--outro',
+		'// outro',
+		'--footer',
+		'// footer'
+	]
 });

--- a/test/cli/samples/code-splitting-named-default-inputs/_config.js
+++ b/test/cli/samples/code-splitting-named-default-inputs/_config.js
@@ -2,8 +2,15 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'allows defining names via CLI',
-	command:
-		'rollup entry1=main1.js "Entry 2"="main 2.js" "main3.js" --entryFileNames [name]-[hash].js -f es',
+	spawnArgs: [
+		'entry1=main1.js',
+		'Entry 2=main 2.js',
+		'main3.js',
+		'--entryFileNames',
+		'[name]-[hash].js',
+		'-f',
+		'es'
+	],
 	result(code) {
 		assert.equal(
 			code,

--- a/test/cli/samples/code-splitting-named-inputs/_config.js
+++ b/test/cli/samples/code-splitting-named-inputs/_config.js
@@ -2,8 +2,18 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'allows defining names via CLI',
-	command:
-		'rollup --entryFileNames [name]-[hash].js --input entry1=main1.js -i "Entry 2"="main 2.js" -i "main3.js"  -f es',
+	spawnArgs: [
+		'--entryFileNames',
+		'[name]-[hash].js',
+		'--input',
+		'entry1=main1.js',
+		'-i',
+		'Entry 2=main 2.js',
+		'-i',
+		'main3.js',
+		'-f',
+		'es'
+	],
 	result(code) {
 		assert.equal(
 			code,

--- a/test/cli/samples/config-async-function/_config.js
+++ b/test/cli/samples/config-async-function/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'supports using an async function as config',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/config-cjs-dirname/_config.js
+++ b/test/cli/samples/config-cjs-dirname/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'does not transpile cjs configs and provides correct __filename',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/config-cwd-case-insensitive-es6/_config.js
+++ b/test/cli/samples/config-cwd-case-insensitive-es6/_config.js
@@ -5,7 +5,7 @@ function toggleCase(s) {
 module.exports = defineTest({
 	onlyWindows: true,
 	description: "can load ES6 config with cwd that doesn't match realpath",
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	cwd: __dirname.replace(/^[a-z]:\\/i, toggleCase),
 	execute: true
 });

--- a/test/cli/samples/config-cwd-case-insensitive/_config.js
+++ b/test/cli/samples/config-cwd-case-insensitive/_config.js
@@ -5,7 +5,7 @@ function toggleCase(s) {
 module.exports = defineTest({
 	onlyWindows: true,
 	description: "can load config with cwd that doesn't match realpath",
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	cwd: __dirname.replace(/^[a-z]:\\/i, toggleCase),
 	execute: true
 });

--- a/test/cli/samples/config-defineConfig-cjs/_config.js
+++ b/test/cli/samples/config-defineConfig-cjs/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses cjs config file which return config wrapped by defineConfig',
-	command: 'rollup --config rollup.config.js',
+	spawnArgs: ['--config', 'rollup.config.js'],
 	execute: true
 });

--- a/test/cli/samples/config-defineConfig-mjs/_config.js
+++ b/test/cli/samples/config-defineConfig-mjs/_config.js
@@ -4,6 +4,6 @@ const { hasEsBuild } = require('../../../testHelpers');
 module.exports = defineTest({
 	skip: !hasEsBuild,
 	description: 'uses mjs config file which return config wrapped by defineConfig',
-	command: 'rollup --config rollup.config.mjs',
+	spawnArgs: ['--config', 'rollup.config.mjs'],
 	execute: true
 });

--- a/test/cli/samples/config-env-multiple/_config.js
+++ b/test/cli/samples/config-env-multiple/_config.js
@@ -1,6 +1,13 @@
 module.exports = defineTest({
 	description: 'passes environment variables to config file via multiple --environment values',
-	command:
-		'rollup --config --environment PRODUCTION,FOO:bar --environment SECOND,KEY:value --environment FOO:foo',
+	spawnArgs: [
+		'--config',
+		'--environment',
+		'PRODUCTION,FOO:bar',
+		'--environment',
+		'SECOND,KEY:value',
+		'--environment',
+		'FOO:foo'
+	],
 	execute: true
 });

--- a/test/cli/samples/config-env/_config.js
+++ b/test/cli/samples/config-env/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'passes environment variables to config file',
-	command: 'rollup --config --environment PRODUCTION,FOO:bar,HOST:http://localhost:4000',
+	spawnArgs: ['--config', '--environment', 'PRODUCTION,FOO:bar,HOST:http://localhost:4000'],
 	execute: true
 });

--- a/test/cli/samples/config-es6/_config.js
+++ b/test/cli/samples/config-es6/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses ES6 module config file',
-	command: 'rollup --config rollup.config.js --bundleConfigAsCjs',
+	spawnArgs: ['--config', 'rollup.config.js', '--bundleConfigAsCjs'],
 	execute: true
 });

--- a/test/cli/samples/config-external-function/_config.js
+++ b/test/cli/samples/config-external-function/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'external option gets passed from config',
-	command: 'rollup -c -e assert,external-module'
+	spawnArgs: ['-c', '-e', 'assert,external-module']
 });

--- a/test/cli/samples/config-external/_config.js
+++ b/test/cli/samples/config-external/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'external option gets passed from config',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/config-function-modify-command/_config.js
+++ b/test/cli/samples/config-function-modify-command/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'allows cleaning up and modifying the command args in the config file',
-	command: 'rollup --config rollup.config.mjs --some-option="foo" --another-option=42',
+	spawnArgs: ['--config', 'rollup.config.mjs', '--some-option="foo"', '--another-option=42'],
 	execute: true
 });

--- a/test/cli/samples/config-function/_config.js
+++ b/test/cli/samples/config-function/_config.js
@@ -1,6 +1,6 @@
 module.exports = defineTest({
 	description:
 		'if the config file returns a function then this will be called with the command args',
-	command: 'rollup --config rollup.config.mjs --silent',
+	spawnArgs: ['--config', 'rollup.config.mjs', '--silent'],
 	execute: true
 });

--- a/test/cli/samples/config-import-attributes-key/_config.js
+++ b/test/cli/samples/config-import-attributes-key/_config.js
@@ -1,6 +1,12 @@
 module.exports = defineTest({
 	description: 'supports modify the import attributes key in the config file',
-	command:
-		'rollup --config rollup.config.ts --configPlugin typescript --configImportAttributesKey with',
+	spawnArgs: [
+		'--config',
+		'rollup.config.ts',
+		'--configPlugin',
+		'typescript',
+		'--configImportAttributesKey',
+		'with'
+	],
 	minNodeVersion: 22
 });

--- a/test/cli/samples/config-import-meta/_config.js
+++ b/test/cli/samples/config-import-meta/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'uses correct import.meta.{url,filename,dirname} in config files',
-	command: 'rollup -c --bundleConfigAsCjs'
+	spawnArgs: ['-c', '--bundleConfigAsCjs']
 });

--- a/test/cli/samples/config-json/_config.js
+++ b/test/cli/samples/config-json/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'allows config file to import json',
-	command: 'rollup --config rollup.config.js --bundleConfigAsCjs',
+	spawnArgs: ['--config', 'rollup.config.js', '--bundleConfigAsCjs'],
 	execute: true
 });

--- a/test/cli/samples/config-missing-export/_config.js
+++ b/test/cli/samples/config-missing-export/_config.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'throws error if config does not export an object',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	error(error) {
 		assert.ok(/Config file must export an options object/.test(error.message));
 	}

--- a/test/cli/samples/config-mjs-plugins/_config.js
+++ b/test/cli/samples/config-mjs-plugins/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'supports native esm as well as CJS plugins when using .mjs in Node 13+',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/config-mjs/_config.js
+++ b/test/cli/samples/config-mjs/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses config file (.mjs)',
-	command: 'rollup --config rollup.config.mjs',
+	spawnArgs: ['--config', 'rollup.config.mjs'],
 	execute: true
 });

--- a/test/cli/samples/config-multiple-getfilename/_config.js
+++ b/test/cli/samples/config-multiple-getfilename/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'returns correct file names for multiple outputs (#3467)',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/config-multiple-source-maps/_config.js
+++ b/test/cli/samples/config-multiple-source-maps/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'correctly generates sourcemaps for multiple outputs',
-	command: 'rollup -c --bundleConfigAsCjs'
+	spawnArgs: ['-c', '--bundleConfigAsCjs']
 });

--- a/test/cli/samples/config-no-output/_config.js
+++ b/test/cli/samples/config-no-output/_config.js
@@ -3,7 +3,7 @@ const { readFileSync, unlinkSync } = require('node:fs');
 
 module.exports = defineTest({
 	description: 'uses -o from CLI',
-	command: 'rollup -c -o output.js',
+	spawnArgs: ['-c', '-o', 'output.js'],
 	test() {
 		const output = readFileSync('output.js', 'utf8');
 		assert.equal(output.trim(), 'console.log(42);');

--- a/test/cli/samples/config-override/_config.js
+++ b/test/cli/samples/config-override/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'overrides config file with command line arguments',
-	command: 'rollup -c -i main.js -f cjs',
+	spawnArgs: ['-c', '-i', 'main.js', '-f', 'cjs'],
 	execute: true
 });

--- a/test/cli/samples/config-plugin-entry/_config.js
+++ b/test/cli/samples/config-plugin-entry/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'allows plugins to set options.entry',
-	command: 'rollup -c --bundleConfigAsCjs'
+	spawnArgs: ['-c', '--bundleConfigAsCjs']
 });

--- a/test/cli/samples/config-promise-cjs/_config.js
+++ b/test/cli/samples/config-promise-cjs/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses cjs config file which returns a Promise',
-	command: 'rollup --config rollup.config.cjs',
+	spawnArgs: ['--config', 'rollup.config.cjs'],
 	execute: true
 });

--- a/test/cli/samples/config-promise-mjs/_config.js
+++ b/test/cli/samples/config-promise-mjs/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses mjs config file which returns a Promise',
-	command: 'rollup --config rollup.config.mjs',
+	spawnArgs: ['--config', 'rollup.config.mjs'],
 	execute: true
 });

--- a/test/cli/samples/config-promise/_config.js
+++ b/test/cli/samples/config-promise/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses config file which returns a Promise',
-	command: 'rollup --config rollup.config.mjs',
+	spawnArgs: ['--config', 'rollup.config.mjs'],
 	execute: true
 });

--- a/test/cli/samples/config-true/_config.js
+++ b/test/cli/samples/config-true/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'defaults to rollup.config.js',
-	command: 'rollup -c --bundleConfigAsCjs',
+	spawnArgs: ['-c', '--bundleConfigAsCjs'],
 	execute: true
 });

--- a/test/cli/samples/config-ts/_config.js
+++ b/test/cli/samples/config-ts/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'supports loading TypeScript config files via plugin option',
-	command: 'rollup --config rollup.config.ts --configPlugin typescript',
+	spawnArgs: ['--config', 'rollup.config.ts', '--configPlugin', 'typescript'],
 	execute: true
 });

--- a/test/cli/samples/config-warnings/_config.js
+++ b/test/cli/samples/config-warnings/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'displays warnings when a config is loaded',
-	command: 'rollup -c --bundleConfigAsCjs',
+	spawnArgs: ['-c', '--bundleConfigAsCjs'],
 	stderr: stderr =>
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/config/_config.js
+++ b/test/cli/samples/config/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses config file',
-	command: 'rollup --config rollup.config.js',
+	spawnArgs: ['--config', 'rollup.config.js'],
 	execute: true
 });

--- a/test/cli/samples/context/_config.js
+++ b/test/cli/samples/context/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'Uses --context to set `this` value',
-	command: 'rollup main.js --format commonjs --context window'
+	spawnArgs: ['main.js', '--format', 'commonjs', '--context', 'window']
 });

--- a/test/cli/samples/custom-frame-with-pos/_config.js
+++ b/test/cli/samples/custom-frame-with-pos/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'custom (plugin generated) code frame taking priority over pos generated one',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	error: () => true,
 	stderr: stderr =>
 		assertIncludes(

--- a/test/cli/samples/custom-frame/_config.js
+++ b/test/cli/samples/custom-frame/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'errors with plugin generated code frames also contain stack',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	error: () => true,
 	stderr: stderr => {
 		assertIncludes(

--- a/test/cli/samples/deconflict-entry-point-in-subdir/_config.js
+++ b/test/cli/samples/deconflict-entry-point-in-subdir/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'deconflict entry points with the same name in different directories',
-	command: 'rollup --input main.js --input sub/main.js --format es --dir _actual'
+	spawnArgs: ['--input', 'main.js', '--input', 'sub/main.js', '--format', 'es', '--dir', '_actual']
 });

--- a/test/cli/samples/duplicate-import-options/_config.js
+++ b/test/cli/samples/duplicate-import-options/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'throws if different types of entries are combined',
-	command: 'rollup main.js --format es --input main.js',
+	spawnArgs: ['main.js', '--format', 'es', '--input', 'main.js'],
 	error: () => true,
 	stderr(stderr) {
 		assertIncludes(stderr, '[!] Either use --input, or pass input path as argument');

--- a/test/cli/samples/emit-file-multiple-dirs/_config.js
+++ b/test/cli/samples/emit-file-multiple-dirs/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'writes files emitted by plugins in different output dirs',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/empty-chunk-multiple/_config.js
+++ b/test/cli/samples/empty-chunk-multiple/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'shows warning when multiple chunks empty',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	error: () => true,
 	stderr: stderr => assertIncludes(stderr, '(!) Generated empty chunks\n"main1" and "main2"')
 });

--- a/test/cli/samples/empty-chunk/_config.js
+++ b/test/cli/samples/empty-chunk/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'shows warning when chunk empty',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	error: () => true,
 	stderr: stderr => assertIncludes(stderr, '(!) Generated an empty chunk\n"main"')
 });

--- a/test/cli/samples/external-modules-auto-global/_config.js
+++ b/test/cli/samples/external-modules-auto-global/_config.js
@@ -2,8 +2,15 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'populates options.external with --global keys',
-	command:
-		'rollup main.js --format iife --globals mathematics:Math,promises:Promise --external promises',
+	spawnArgs: [
+		'main.js',
+		'--format',
+		'iife',
+		'--globals',
+		'mathematics:Math,promises:Promise',
+		'--external',
+		'promises'
+	],
 	execute: true,
 	stderr(stderr) {
 		assert.ok(!stderr.includes('(!)'));

--- a/test/cli/samples/external-modules/_config.js
+++ b/test/cli/samples/external-modules/_config.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'allows external modules to be specified with --external=foo,bar,baz',
-	command: 'rollup main.js --format cjs --external=path,util',
+	spawnArgs: ['main.js', '--format', 'cjs', '--external=path,util'],
 	execute: true,
 	stderr(stderr) {
 		assert.ok(!stderr.includes('(!)'));

--- a/test/cli/samples/fail-after-warnings/_config.js
+++ b/test/cli/samples/fail-after-warnings/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'errors on warnings with --failAfterWarnings',
-	command: 'rollup -i main.js --failAfterWarnings',
+	spawnArgs: ['-i', 'main.js', '--failAfterWarnings'],
 	error: () => true,
 	stderr: stderr => {
 		assertIncludes(stderr, '[!] Warnings occurred and --failAfterWarnings flag present');

--- a/test/cli/samples/filter-logs/_config.js
+++ b/test/cli/samples/filter-logs/_config.js
@@ -2,8 +2,11 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'filters logs via CLI',
-	command:
-		'rollup --config --filterLogs="pluginCode:FIRST,pluginCode:SECOND" --filterLogs=pluginCode:THIRD',
+	spawnArgs: [
+		'--config',
+		'--filterLogs="pluginCode:FIRST,pluginCode:SECOND"',
+		'--filterLogs=pluginCode:THIRD'
+	],
 	env: {
 		FORCE_COLOR: undefined,
 		NO_COLOR: true,

--- a/test/cli/samples/force-exit/_config.js
+++ b/test/cli/samples/force-exit/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'force exits even with open handles',
-	command: 'rollup --config rollup.config.js --forceExit'
+	spawnArgs: ['--config', 'rollup.config.js', '--forceExit']
 });

--- a/test/cli/samples/format-aliases/_config.js
+++ b/test/cli/samples/format-aliases/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'supports format aliases',
-	command: 'rollup --config'
+	spawnArgs: ['--config']
 });

--- a/test/cli/samples/generated-code-preset-override/_config.js
+++ b/test/cli/samples/generated-code-preset-override/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'overrides the generatedCode option when using presets',
-	command: 'rollup --config --generatedCode es5 --generatedCode.arrowFunctions'
+	spawnArgs: ['--config', '--generatedCode', 'es5', '--generatedCode.arrowFunctions']
 });

--- a/test/cli/samples/generated-code-unknown-preset/_config.js
+++ b/test/cli/samples/generated-code-unknown-preset/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'overrides the generatedCode option when using presets',
-	command: 'rollup main.js --format es --generatedCode unknown',
+	spawnArgs: ['main.js', '--format', 'es', '--generatedCode', 'unknown'],
 	error: () => true,
 	stderr: stderr => {
 		assertIncludes(

--- a/test/cli/samples/get-chunk-name/_config.js
+++ b/test/cli/samples/get-chunk-name/_config.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert');
 module.exports = defineTest({
 	description: 'get right chunk name for preserve modules',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	result(code) {
 		assert.ok(
 			code.includes(`//→ ${__dirname.replace(/^(\/|[a-zA-Z]:\\)/, '').replace(/\\/g, '/')}/main.js`)

--- a/test/cli/samples/handles-errors-cause/_config.js
+++ b/test/cli/samples/handles-errors-cause/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'prints error cause',
-	command: 'rollup --config rollup.config.mjs',
+	spawnArgs: ['--config', 'rollup.config.mjs'],
 	// We expect an error and want to make assertions about the output
 	error: () => true,
 	stderr: stderr => {

--- a/test/cli/samples/handles-uncaught-errors-under-watch/_config.js
+++ b/test/cli/samples/handles-uncaught-errors-under-watch/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'handles uncaught errors under watch',
-	command: 'rollup --config rollup.config.js -w',
+	spawnArgs: ['--config', 'rollup.config.js', '-w'],
 	error: () => true,
 	stderr(stderr) {
 		assertIncludes(stderr, 'Uncaught RollupError: [plugin test] LOL');

--- a/test/cli/samples/handles-uncaught-errors/_config.js
+++ b/test/cli/samples/handles-uncaught-errors/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'handles uncaught errors',
-	command: 'rollup --config rollup.config.js',
+	spawnArgs: ['--config', 'rollup.config.js'],
 	error: () => true,
 	stderr(stderr) {
 		assertIncludes(stderr, 'TypeError: foo');

--- a/test/cli/samples/import-esm-package/_config.js
+++ b/test/cli/samples/import-esm-package/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'allows to import ESM dependencies from transpiled config files',
 	skipIfWindows: true,
-	command: "rollup --config --configPlugin '{transform:c => c}'"
+	spawnArgs: ['--config', '--configPlugin', '{transform:c => c}']
 });

--- a/test/cli/samples/indent-none/_config.js
+++ b/test/cli/samples/indent-none/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'disables indentation with --no-indent',
-	command: 'rollup main.js --format umd --no-indent'
+	spawnArgs: ['main.js', '--format', 'umd', '--no-indent']
 });

--- a/test/cli/samples/interop/_config.js
+++ b/test/cli/samples/interop/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'does not include the interop block',
-	command: 'rollup -i main.js -f cjs --external test --interop default'
+	spawnArgs: ['-i', 'main.js', '-f', 'cjs', '--external', 'test', '--interop', 'default']
 });

--- a/test/cli/samples/jsx/_config.js
+++ b/test/cli/samples/jsx/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'supports jsx presets via CLI',
-	command: 'rollup -i main.js --jsx react --external react'
+	spawnArgs: ['-i', 'main.js', '--jsx', 'react', '--external', 'react']
 });

--- a/test/cli/samples/log-side-effects/_config.js
+++ b/test/cli/samples/log-side-effects/_config.js
@@ -3,7 +3,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'logs side effects',
-	command: 'rollup --config',
+	spawnArgs: ['--config'],
 	env: { FORCE_COLOR: undefined, NO_COLOR: true },
 	stderr: stderr =>
 		assertIncludes(

--- a/test/cli/samples/logs/_config.js
+++ b/test/cli/samples/logs/_config.js
@@ -11,7 +11,7 @@ const REGULAR = '\u001B[22m';
 module.exports = defineTest({
 	description: 'displays logs',
 	skipIfWindows: true,
-	command: 'rollup --config',
+	spawnArgs: ['--config'],
 	env: { FORCE_COLOR: '1', TERM: 'xterm' },
 	stderr(stderr) {
 		assert.strictEqual(

--- a/test/cli/samples/merge-deprecations/_config.js
+++ b/test/cli/samples/merge-deprecations/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'merges deprecated with current options',
-	command: 'rollup --config rollup.config.js'
+	spawnArgs: ['--config', 'rollup.config.js']
 });

--- a/test/cli/samples/merge-treeshake-false/_config.js
+++ b/test/cli/samples/merge-treeshake-false/_config.js
@@ -1,5 +1,14 @@
 module.exports = defineTest({
 	description: 'sets all tree-shaking to false if one option disables it',
-	command:
-		'rollup main.js --format es --external external --treeshake.moduleSideEffects no-external --no-treeshake --no-treeshake.unknownGlobalSideEffects'
+	spawnArgs: [
+		'main.js',
+		'--format',
+		'es',
+		'--external',
+		'external',
+		'--treeshake.moduleSideEffects',
+		'no-external',
+		'--no-treeshake',
+		'--no-treeshake.unknownGlobalSideEffects'
+	]
 });

--- a/test/cli/samples/merge-treeshake/_config.js
+++ b/test/cli/samples/merge-treeshake/_config.js
@@ -1,5 +1,14 @@
 module.exports = defineTest({
 	description: 'merges treeshake options',
-	command:
-		'rollup main.js --format es --external external --treeshake.moduleSideEffects no-external --treeshake --no-treeshake.unknownGlobalSideEffects'
+	spawnArgs: [
+		'main.js',
+		'--format',
+		'es',
+		'--external',
+		'external',
+		'--treeshake.moduleSideEffects',
+		'no-external',
+		'--treeshake',
+		'--no-treeshake.unknownGlobalSideEffects'
+	]
 });

--- a/test/cli/samples/module-name/_config.js
+++ b/test/cli/samples/module-name/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'generates UMD export with correct name',
-	command: 'rollup main.js --format umd --name myBundle --indent'
+	spawnArgs: ['main.js', '--format', 'umd', '--name', 'myBundle', '--indent']
 });

--- a/test/cli/samples/multiple-configs/_config.js
+++ b/test/cli/samples/multiple-configs/_config.js
@@ -3,7 +3,7 @@ const assert = require('node:assert');
 module.exports = defineTest({
 	description:
 		'generates output file when multiple configurations are specified and one build fails',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	error: error => {
 		assert.ok(/Unexpected Exception/.test(error.message));
 		return true;

--- a/test/cli/samples/multiple-targets-different-plugins/_config.js
+++ b/test/cli/samples/multiple-targets-different-plugins/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'generates multiple output files, only one of which is minified',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/multiple-targets-shared-config/_config.js
+++ b/test/cli/samples/multiple-targets-shared-config/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'uses shared config for each target',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/multiple-targets/_config.js
+++ b/test/cli/samples/multiple-targets/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'generates multiple output files when multiple targets are specified',
-	command: 'rollup -c'
+	spawnArgs: ['-c']
 });

--- a/test/cli/samples/no-color/_config.js
+++ b/test/cli/samples/no-color/_config.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'respects the NO_COLOR environment variable',
-	command: 'rollup -i main1.js -i main2.js -f es',
+	spawnArgs: ['-i', 'main1.js', '-i', 'main2.js', '-f', 'es'],
 	env: { FORCE_COLOR: undefined, NO_COLOR: true },
 	result(code) {
 		assert.equal(

--- a/test/cli/samples/no-conflict/_config.js
+++ b/test/cli/samples/no-conflict/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'respects noConflict option',
-	command: 'rollup --config rollup.config.js'
+	spawnArgs: ['--config', 'rollup.config.js']
 });

--- a/test/cli/samples/no-strict/_config.js
+++ b/test/cli/samples/no-strict/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'use no strict option',
-	command: 'rollup -i main.js -f iife --no-strict --indent'
+	spawnArgs: ['-i', 'main.js', '-f', 'iife', '--no-strict', '--indent']
 });

--- a/test/cli/samples/no-treeshake/_config.js
+++ b/test/cli/samples/no-treeshake/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'generates IIFE export with all code and overrides config',
-	command: 'rollup -c --no-treeshake'
+	spawnArgs: ['-c', '--no-treeshake']
 });

--- a/test/cli/samples/node-config-auto-prefix/_config.js
+++ b/test/cli/samples/node-config-auto-prefix/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'uses config file installed from npm, automatically adding a rollup-config- prefix',
-	command: 'rollup --config node:foo',
+	spawnArgs: ['--config', 'node:foo'],
 	execute: true
 });

--- a/test/cli/samples/node-config-not-found/_config.js
+++ b/test/cli/samples/node-config-not-found/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'throws if a config in node_modules cannot be found',
-	command: 'rollup --config node:baz',
+	spawnArgs: ['--config', 'node:baz'],
 	error: () => true,
 	stderr(stderr) {
 		assertIncludes(stderr, '[!] Could not resolve config file "node:baz"');

--- a/test/cli/samples/node-config/_config.js
+++ b/test/cli/samples/node-config/_config.js
@@ -1,6 +1,6 @@
 module.exports = defineTest({
 	description: 'uses config file installed from npm',
-	command: 'rollup --config node:bar',
+	spawnArgs: ['--config', 'node:bar'],
 	cwd: __dirname,
 	execute: true
 });

--- a/test/cli/samples/paths-output-option/_config.js
+++ b/test/cli/samples/paths-output-option/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'allows paths to be set as an output option',
-	command: 'rollup --config rollup.config.js'
+	spawnArgs: ['--config', 'rollup.config.js']
 });

--- a/test/cli/samples/plugin/absolute-esm/_config.js
+++ b/test/cli/samples/plugin/absolute-esm/_config.js
@@ -2,5 +2,5 @@ const path = require('node:path');
 
 module.exports = defineTest({
 	description: 'ESM CLI --plugin /absolute/path',
-	command: `rollup main.js -p "${__dirname}${path.sep}my-esm-plugin.mjs={comment: 'Absolute ESM'}"`
+	spawnArgs: ['main.js', '-p', `${__dirname}${path.sep}my-esm-plugin.mjs={comment: 'Absolute ESM'}`]
 });

--- a/test/cli/samples/plugin/absolute/_config.js
+++ b/test/cli/samples/plugin/absolute/_config.js
@@ -2,5 +2,5 @@ const path = require('node:path');
 
 module.exports = defineTest({
 	description: 'CLI --plugin /absolute/path',
-	command: `rollup main.js -p "${__dirname}${path.sep}my-plugin.js={VALUE: 'absolute', ZZZ: 1}"`
+	spawnArgs: ['main.js', '-p', `${__dirname}${path.sep}my-plugin.js={VALUE: 'absolute', ZZZ: 1}`]
 });

--- a/test/cli/samples/plugin/advanced/_config.js
+++ b/test/cli/samples/plugin/advanced/_config.js
@@ -1,4 +1,10 @@
 module.exports = defineTest({
 	description: 'advanced CLI --plugin functionality with rollup config',
-	command: `rollup -c -p node-resolve,commonjs -p "terser={output: {beautify: true, indent_level: 2}}"`
+	spawnArgs: [
+		'-c',
+		'-p',
+		'node-resolve,commonjs',
+		'-p',
+		'terser={output: {beautify: true, indent_level: 2}}'
+	]
 });

--- a/test/cli/samples/plugin/basic/_config.js
+++ b/test/cli/samples/plugin/basic/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'basic CLI --plugin functionality',
-	command: `rollup main.js -f cjs --plugin @rollup/plugin-buble`
+	spawnArgs: ['main.js', '-f', 'cjs', '--plugin', '@rollup/plugin-buble']
 });

--- a/test/cli/samples/property-read-side-effects/_config.js
+++ b/test/cli/samples/property-read-side-effects/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'allows disabling side-effects when accessing properties',
-	command: 'rollup main.js --format es --no-treeshake.propertyReadSideEffects'
+	spawnArgs: ['main.js', '--format', 'es', '--no-treeshake.propertyReadSideEffects']
 });

--- a/test/cli/samples/propertyReadSideEffects-always/_config.js
+++ b/test/cli/samples/propertyReadSideEffects-always/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'verify property accesses are retained for getters with side effects',
-	command: `rollup main.js --validate --treeshake.propertyReadSideEffects=always`
+	spawnArgs: ['main.js', '--validate', '--treeshake.propertyReadSideEffects=always']
 });

--- a/test/cli/samples/silent-onwarn/_config.js
+++ b/test/cli/samples/silent-onwarn/_config.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'triggers onwarn with --silent',
-	command: 'rollup -c --silent',
+	spawnArgs: ['-c', '--silent'],
 	stderr: stderr => {
 		assert.equal(stderr, '');
 		return true;

--- a/test/cli/samples/silent/_config.js
+++ b/test/cli/samples/silent/_config.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'does not print logs with --silent',
-	command: 'rollup --config --silent',
+	spawnArgs: ['--config', '--silent'],
 	stderr: stderr => {
 		assert.equal(stderr, '');
 		return true;

--- a/test/cli/samples/sourcemap-hidden/_config.js
+++ b/test/cli/samples/sourcemap-hidden/_config.js
@@ -3,7 +3,7 @@ const { readFileSync, unlinkSync } = require('node:fs');
 
 module.exports = defineTest({
 	description: 'omits sourcemap comments',
-	command: 'rollup -i main.js -f es -m hidden -o output.js',
+	spawnArgs: ['-i', 'main.js', '-f', 'es', '-m', 'hidden', '-o', 'output.js'],
 	test() {
 		assert.equal(readFileSync('output.js', 'utf8').trim(), 'console.log( 42 );');
 		unlinkSync('output.js');

--- a/test/cli/samples/sourcemap-newline/_config.js
+++ b/test/cli/samples/sourcemap-newline/_config.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 
 module.exports = defineTest({
 	description: 'adds a newline after the sourceMappingURL comment (#756)',
-	command: 'rollup -i main.js -f es -m inline',
+	spawnArgs: ['-i', 'main.js', '-f', 'es', '-m', 'inline'],
 	result: code => {
 		assert.equal(code.slice(-1), '\n');
 	}

--- a/test/cli/samples/stdin/stdin-error/_config.js
+++ b/test/cli/samples/stdin/stdin-error/_config.js
@@ -2,7 +2,8 @@ const { assertIncludes } = require('../../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'handles stdin errors',
-	command: `node wrapper.js`,
+	spawnScript: 'wrapper.js',
+	spawnArgs: [],
 	error(error) {
 		assertIncludes(error.message, 'Could not load -: Stream is broken.');
 	}

--- a/test/cli/samples/stdout-code-splitting/_config.js
+++ b/test/cli/samples/stdout-code-splitting/_config.js
@@ -6,9 +6,17 @@ const STANDARD = '\u001B[22m\u001B[39m';
 module.exports = defineTest({
 	description: 'bundles multiple files to stdout while adding file names',
 	skipIfWindows: true,
-	command:
-		'node wrapper.js -i main1.js -i main2.js -f es ' +
-		`-p '{buildStart(){this.emitFile({type: "asset",source:"Hello"})}}'`,
+	spawnScript: 'wrapper.js',
+	spawnArgs: [
+		'-i',
+		'main1.js',
+		'-i',
+		'main2.js',
+		'-f',
+		'es',
+		'-p',
+		'{buildStart(){this.emitFile({type: "asset",source:"Hello"})}}'
+	],
 	env: { FORCE_COLOR: '1', TERM: 'xterm' },
 	result(code) {
 		assert.equal(

--- a/test/cli/samples/stdout-only-inline-sourcemaps/_config.js
+++ b/test/cli/samples/stdout-only-inline-sourcemaps/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'fails when using non-inline sourcemaps when bundling to stdout',
-	command: 'rollup -i main.js -f es -m',
+	spawnArgs: ['-i', 'main.js', '-f', 'es', '-m'],
 	error: () => true,
 	stderr: stderr => {
 		assertIncludes(stderr, '[!] Only inline sourcemaps are supported when bundling to stdout.\n');

--- a/test/cli/samples/stdout-single-input/_config.js
+++ b/test/cli/samples/stdout-single-input/_config.js
@@ -1,4 +1,4 @@
 module.exports = defineTest({
 	description: 'bundles a single input to stdout without modifications',
-	command: 'rollup -i main.js -f es -m inline'
+	spawnArgs: ['-i', 'main.js', '-f', 'es', '-m', 'inline']
 });

--- a/test/cli/samples/symlinked-config/_config.js
+++ b/test/cli/samples/symlinked-config/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'loads a symlinked config file',
-	command: 'rollup -c --bundleConfigAsCjs',
+	spawnArgs: ['-c', '--bundleConfigAsCjs'],
 	execute: true
 });

--- a/test/cli/samples/symlinked-named-config/_config.js
+++ b/test/cli/samples/symlinked-named-config/_config.js
@@ -1,5 +1,5 @@
 module.exports = defineTest({
 	description: 'loads a symlinked config file with the given name',
-	command: 'rollup --config my.rollup.config.js --bundleConfigAsCjs',
+	spawnArgs: ['--config', 'my.rollup.config.js', '--bundleConfigAsCjs'],
 	execute: true
 });

--- a/test/cli/samples/treeshake-preset-override/_config.js
+++ b/test/cli/samples/treeshake-preset-override/_config.js
@@ -1,5 +1,10 @@
 module.exports = defineTest({
 	description: 'overrides the treeshake option when using presets',
-	command:
-		'rollup --config --treeshake recommended --treeshake.unknownGlobalSideEffects --no-treeshake.moduleSideEffects'
+	spawnArgs: [
+		'--config',
+		'--treeshake',
+		'recommended',
+		'--treeshake.unknownGlobalSideEffects',
+		'--no-treeshake.moduleSideEffects'
+	]
 });

--- a/test/cli/samples/treeshake-unknown-preset/_config.js
+++ b/test/cli/samples/treeshake-unknown-preset/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'overrides the treeshake option when using presets',
-	command: 'rollup main.js --format es --treeshake unknown',
+	spawnArgs: ['main.js', '--format', 'es', '--treeshake', 'unknown'],
 	error: () => true,
 	stderr: stderr => {
 		assertIncludes(

--- a/test/cli/samples/unfulfilled-hook-actions-error/_config.js
+++ b/test/cli/samples/unfulfilled-hook-actions-error/_config.js
@@ -4,7 +4,8 @@ const { assertIncludes, assertDoesNotInclude, hasEsBuild } = require('../../../t
 module.exports = defineTest({
 	skip: !hasEsBuild,
 	description: 'does not show unfulfilled hook actions if there are errors',
-	command: 'node build.mjs',
+	spawnScript: 'build.mjs',
+	spawnArgs: [],
 	after(error) {
 		// exit code check has to be here as error(err) is only called upon failure
 		assert.strictEqual(error, undefined);

--- a/test/cli/samples/unfulfilled-hook-actions-manual-exit/_config.js
+++ b/test/cli/samples/unfulfilled-hook-actions-manual-exit/_config.js
@@ -5,7 +5,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 module.exports = defineTest({
 	description:
 		'does not show unfulfilled hook actions when exiting manually with a non-zero exit code',
-	command: 'rollup -c --silent',
+	spawnArgs: ['-c', '--silent'],
 	after(error) {
 		assert.strictEqual(error && error.code, 1);
 	},

--- a/test/cli/samples/unfulfilled-hook-actions/_config.js
+++ b/test/cli/samples/unfulfilled-hook-actions/_config.js
@@ -3,7 +3,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'show errors with non-zero exit code for unfulfilled async plugin actions on exit',
-	command: 'rollup -c --silent',
+	spawnArgs: ['-c', '--silent'],
 	after(error) {
 		// exit code check has to be here as error(err) is only called upon failure
 		assert.strictEqual(error && error.code, 1);

--- a/test/cli/samples/validate/_config.js
+++ b/test/cli/samples/validate/_config.js
@@ -3,7 +3,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 module.exports = defineTest({
 	description: 'use CLI --validate to test whether output is well formed',
 	skipIfWindows: true,
-	command: `rollup main.js --outro 'console.log("end"); /*' -o _actual/out.js --validate`,
+	spawnArgs: ['main.js', '--outro', 'console.log("end"); /*', '-o', '_actual/out.js', '--validate'],
 	error: () => true,
 	stderr: stderr =>
 		assertIncludes(

--- a/test/cli/samples/wait-for-bundle-input-object/_config.js
+++ b/test/cli/samples/wait-for-bundle-input-object/_config.js
@@ -7,7 +7,7 @@ let third;
 
 module.exports = defineTest({
 	description: 'waits for multiple named bundle inputs',
-	command: 'rollup -c --waitForBundleInput',
+	spawnArgs: ['-c', '--waitForBundleInput'],
 	before() {
 		second = path.resolve(__dirname, 'second.js');
 		third = path.resolve(__dirname, 'third.js');

--- a/test/cli/samples/wait-for-bundle-input/_config.js
+++ b/test/cli/samples/wait-for-bundle-input/_config.js
@@ -6,7 +6,7 @@ let mainFile;
 
 module.exports = defineTest({
 	description: 'waits for bundle input',
-	command: 'rollup -c --waitForBundleInput',
+	spawnArgs: ['-c', '--waitForBundleInput'],
 	before() {
 		mainFile = path.resolve(__dirname, 'main.js');
 	},

--- a/test/cli/samples/warn-broken-sourcemap/_config.js
+++ b/test/cli/samples/warn-broken-sourcemap/_config.js
@@ -4,7 +4,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'displays warnings for broken sourcemaps',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr => {
 		unlinkSync(path.resolve(__dirname, 'bundle'));
 		unlinkSync(path.resolve(__dirname, 'bundle.map'));

--- a/test/cli/samples/warn-broken-sourcemaps/_config.js
+++ b/test/cli/samples/warn-broken-sourcemaps/_config.js
@@ -4,7 +4,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'displays warnings for broken sourcemaps',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr => {
 		unlinkSync(path.resolve(__dirname, 'bundle'));
 		unlinkSync(path.resolve(__dirname, 'bundle.map'));

--- a/test/cli/samples/warn-circular-multiple/_config.js
+++ b/test/cli/samples/warn-circular-multiple/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns for multiple circular dependencies',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr =>
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-circular/_config.js
+++ b/test/cli/samples/warn-circular/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns for circular dependencies',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr(stderr) {
 		assertIncludes(stderr, '(!) Circular dependency\nmain.js -> dep.js -> main.js\n');
 	}

--- a/test/cli/samples/warn-eval-multiple/_config.js
+++ b/test/cli/samples/warn-eval-multiple/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns when eval is used multiple times',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr =>
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-eval/_config.js
+++ b/test/cli/samples/warn-eval/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns when eval is used',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr =>
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-import-export/_config.js
+++ b/test/cli/samples/warn-import-export/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns about import and export related issues',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr => {
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-missing-global-multiple/_config.js
+++ b/test/cli/samples/warn-missing-global-multiple/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns when there are multiple missing globals',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr =>
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-missing-global/_config.js
+++ b/test/cli/samples/warn-missing-global/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns when there is a missing global variable name',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr =>
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-mixed-exports-multiple/_config.js
+++ b/test/cli/samples/warn-mixed-exports-multiple/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns when mixed exports are used',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr => {
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-multiple/_config.js
+++ b/test/cli/samples/warn-multiple/_config.js
@@ -3,7 +3,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'aggregates warnings of different types',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr => {
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-plugin-loc/_config.js
+++ b/test/cli/samples/warn-plugin-loc/_config.js
@@ -3,7 +3,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'correctly adds locations to plugin warnings',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr => {
 		assertIncludes(
 			stderr.replaceAll(__dirname + path.sep, 'CWD/'),

--- a/test/cli/samples/warn-plugin/_config.js
+++ b/test/cli/samples/warn-plugin/_config.js
@@ -3,7 +3,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'displays warnings from plugins',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	env: { FORCE_COLOR: undefined, NO_COLOR: true },
 	stderr: stderr => {
 		assertIncludes(

--- a/test/cli/samples/warn-this/_config.js
+++ b/test/cli/samples/warn-this/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'warns "this" is used on the top level',
-	command: 'rollup -c',
+	spawnArgs: ['-c'],
 	stderr: stderr =>
 		assertIncludes(
 			stderr,

--- a/test/cli/samples/warn-unknown-options/_config.js
+++ b/test/cli/samples/warn-unknown-options/_config.js
@@ -1,4 +1,12 @@
 module.exports = defineTest({
 	description: 'warns about unknown CLI options',
-	command: 'rollup --config rollup.config.js --format es --configAnswer 42 --unknownOption'
+	spawnArgs: [
+		'--config',
+		'rollup.config.js',
+		'--format',
+		'es',
+		'--configAnswer',
+		'42',
+		'--unknownOption'
+	]
 });

--- a/test/cli/samples/watch/bundle-error/_config.js
+++ b/test/cli/samples/watch/bundle-error/_config.js
@@ -6,7 +6,7 @@ let mainFile;
 
 module.exports = defineTest({
 	description: 'recovers from errors during bundling',
-	command: 'rollup -cw --bundleConfigAsCjs',
+	spawnArgs: ['-cw', '--bundleConfigAsCjs'],
 	before() {
 		mainFile = path.resolve(__dirname, 'main.js');
 		writeFileSync(mainFile, '<=>');

--- a/test/cli/samples/watch/clearScreen/_config.js
+++ b/test/cli/samples/watch/clearScreen/_config.js
@@ -5,7 +5,8 @@ const UNDERLINE = '\u001B[4m';
 
 module.exports = defineTest({
 	description: 'clears the screen before bundling',
-	command: 'node wrapper.js -cw',
+	spawnScript: 'wrapper.js',
+	spawnArgs: ['-cw'],
 	env: { FORCE_COLOR: '1', TERM: 'xterm' },
 	abortOnStderr(data) {
 		if (data.includes('waiting for changes')) {

--- a/test/cli/samples/watch/close-error/_config.js
+++ b/test/cli/samples/watch/close-error/_config.js
@@ -1,6 +1,6 @@
 module.exports = defineTest({
 	description: 'displays errors when closing the watcher',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	abortOnStderr(data) {
 		if (data.includes('[!] (plugin faulty-close) Error: Close bundle failed')) {
 			return true;

--- a/test/cli/samples/watch/close-on-generate-error/_config.js
+++ b/test/cli/samples/watch/close-on-generate-error/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'closes the bundle on generate errors',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	abortOnStderr(data) {
 		if (data.includes('Bundle closed')) {
 			return true;

--- a/test/cli/samples/watch/close-stdin/_config.js
+++ b/test/cli/samples/watch/close-stdin/_config.js
@@ -1,6 +1,7 @@
 module.exports = defineTest({
 	description: 'does not close the watcher when stdin closes to support watch mode in containers',
-	command: 'node wrapper.js main.js --watch --format es --file _actual/out.js',
+	spawnScript: 'wrapper.js',
+	spawnArgs: ['main.js', '--watch', '--format', 'es', '--file', '_actual/out.js'],
 	abortOnStderr(data) {
 		if (data.includes('waiting for changes')) {
 			return true;

--- a/test/cli/samples/watch/filter-logs/_config.js
+++ b/test/cli/samples/watch/filter-logs/_config.js
@@ -2,8 +2,12 @@ const { assertIncludes } = require('../../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'filters logs via CLI in watch mode',
-	command:
-		'rollup --config --watch --filterLogs="pluginCode:FIRST,pluginCode:SECOND" --filterLogs=pluginCode:THIRD',
+	spawnArgs: [
+		'--config',
+		'--watch',
+		'--filterLogs=pluginCode:FIRST,pluginCode:SECOND',
+		'--filterLogs=pluginCode:THIRD'
+	],
 	env: {
 		FORCE_COLOR: undefined,
 		NO_COLOR: true,

--- a/test/cli/samples/watch/no-clearScreen-command/_config.js
+++ b/test/cli/samples/watch/no-clearScreen-command/_config.js
@@ -4,7 +4,16 @@ const UNDERLINE = '\u001B[4m';
 
 module.exports = defineTest({
 	description: 'allows disabling clearing the screen from the command line',
-	command: 'node wrapper.js main.js --format es --file _actual.js --watch --no-watch.clearScreen',
+	spawnScript: 'wrapper.js',
+	spawnArgs: [
+		'main.js',
+		'--format',
+		'es',
+		'--file',
+		'_actual.js',
+		'--watch',
+		'--no-watch.clearScreen'
+	],
 	env: { FORCE_COLOR: '1', TERM: 'xterm' },
 	abortOnStderr(data) {
 		if (data.includes('waiting for changes')) {

--- a/test/cli/samples/watch/no-clearScreen/_config.js
+++ b/test/cli/samples/watch/no-clearScreen/_config.js
@@ -4,7 +4,8 @@ const UNDERLINE = '\u001B[4m';
 
 module.exports = defineTest({
 	description: 'allows disabling clearing the screen',
-	command: 'node wrapper.js -cw',
+	spawnScript: 'wrapper.js',
+	spawnArgs: ['-cw'],
 	env: { FORCE_COLOR: '1', TERM: 'xterm' },
 	abortOnStderr(data) {
 		if (data.includes('waiting for changes')) {

--- a/test/cli/samples/watch/no-config-file/_config.js
+++ b/test/cli/samples/watch/no-config-file/_config.js
@@ -1,6 +1,6 @@
 module.exports = defineTest({
 	description: 'watches without a config file',
-	command: 'rollup main.js --watch --format es --file _actual/main.js',
+	spawnArgs: ['main.js', '--watch', '--format', 'es', '--file', '_actual/main.js'],
 	abortOnStderr(data) {
 		if (data.includes(`created _actual/main.js`)) {
 			return true;

--- a/test/cli/samples/watch/no-watch-by-default/_config.js
+++ b/test/cli/samples/watch/no-watch-by-default/_config.js
@@ -2,7 +2,8 @@ const { assertIncludes } = require('../../../../testHelpers');
 
 module.exports = defineTest({
 	description: 'does not watch if --watch is missing',
-	command: 'node wrapper.js -c --no-watch.clearScreen',
+	spawnScript: 'wrapper.js',
+	spawnArgs: ['-c', '--no-watch.clearScreen'],
 	stderr: stderr => assertIncludes(stderr, 'main.js → _actual.js...\ncreated _actual.js in'),
 	abortOnStderr(data) {
 		if (data.includes('waiting for changes')) {

--- a/test/cli/samples/watch/no-watched-config/_config.js
+++ b/test/cli/samples/watch/no-watched-config/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'throws if no config is watched',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	error: () => true,
 	stderr(stderr) {
 		assertIncludes(

--- a/test/cli/samples/watch/node-config-file/_config.js
+++ b/test/cli/samples/watch/node-config-file/_config.js
@@ -1,6 +1,6 @@
 module.exports = defineTest({
 	description: 'watches using a node_modules config files',
-	command: 'rollup --watch --config node:custom',
+	spawnArgs: ['--watch', '--config', 'node:custom'],
 	abortOnStderr(data) {
 		if (data.includes(`created _actual/main.js`)) {
 			return true;

--- a/test/cli/samples/watch/watch-config-early-update/_config.js
+++ b/test/cli/samples/watch/watch-config-early-update/_config.js
@@ -7,7 +7,7 @@ let stopUpdate;
 
 module.exports = defineTest({
 	description: 'immediately reloads the config file if a change happens while it is parsed',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	before() {
 		// This test writes a config file that prints a message to stderr which signals to the test that
 		// the config files has been parsed, at which point the test replaces the config file. The

--- a/test/cli/samples/watch/watch-config-error/_config.js
+++ b/test/cli/samples/watch/watch-config-error/_config.js
@@ -6,7 +6,7 @@ let configFile;
 
 module.exports = defineTest({
 	description: 'keeps watching the config file in case the config is changed to an invalid state',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	before() {
 		configFile = path.resolve(__dirname, 'rollup.config.mjs');
 		writeFileSync(

--- a/test/cli/samples/watch/watch-config-initial-error/_config.js
+++ b/test/cli/samples/watch/watch-config-initial-error/_config.js
@@ -7,7 +7,7 @@ let configFile;
 module.exports = defineTest({
 	description: 'keeps watching the config file in case the initial file contains an error',
 	retry: true,
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	before() {
 		configFile = path.join(__dirname, 'rollup.config.mjs');
 		writeFileSync(configFile, 'throw new Error("Config contains initial errors");');

--- a/test/cli/samples/watch/watch-config-no-update/_config.js
+++ b/test/cli/samples/watch/watch-config-no-update/_config.js
@@ -14,7 +14,7 @@ const configContent =
 
 module.exports = defineTest({
 	description: 'does not rebuild if the config file is updated without change',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	before() {
 		configFile = path.resolve(__dirname, 'rollup.config.mjs');
 		writeFileSync(configFile, configContent);

--- a/test/cli/samples/watch/watch-event-hooks-error/_config.js
+++ b/test/cli/samples/watch/watch-event-hooks-error/_config.js
@@ -2,7 +2,8 @@ const { assertIncludes } = require('../../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'onError event hook shell commands write to stderr',
-	command: 'node wrapper.js -cw --watch.onError "echo error"',
+	spawnScript: 'wrapper.js',
+	spawnArgs: ['-cw', '--watch.onError', 'echo error'],
 	abortOnStderr(data) {
 		if (data.includes('waiting for changes')) {
 			return true;

--- a/test/cli/samples/watch/watch-event-hooks/_config.js
+++ b/test/cli/samples/watch/watch-event-hooks/_config.js
@@ -3,8 +3,18 @@ const { assertIncludes } = require('../../../../testHelpers.js');
 module.exports = defineTest({
 	description: 'event hook shell commands write to stderr',
 	retry: true,
-	command:
-		'node wrapper.js -cw --watch.onStart "echo start" --watch.onBundleStart "echo bundleStart" --watch.onBundleEnd "echo bundleEnd" --watch.onEnd "echo end"',
+	spawnScript: 'wrapper.js',
+	spawnArgs: [
+		'-cw',
+		'--watch.onStart',
+		'echo start',
+		'--watch.onBundleStart',
+		'echo bundleStart',
+		'--watch.onBundleEnd',
+		'echo bundleEnd',
+		'--watch.onEnd',
+		'echo end'
+	],
 	abortOnStderr(data) {
 		process.stderr.write(data);
 		if (data.includes('waiting for changes')) {

--- a/test/cli/samples/watch/watch-output-contain-input/_config.js
+++ b/test/cli/samples/watch/watch-output-contain-input/_config.js
@@ -2,7 +2,7 @@ const { assertIncludes } = require('../../../../testHelpers.js');
 
 module.exports = defineTest({
 	description: 'throws if output contains input',
-	command: 'rollup -cw',
+	spawnArgs: ['-cw'],
 	error: () => true,
 	stderr(stderr) {
 		assertIncludes(

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -111,6 +111,10 @@ export interface TestConfigCli extends TestConfigBase {
 	 * Run rollup as a child process with the given arguments.
 	 */
 	spawnArgs?: string[];
+	/**
+	 * Instead of Rollup, run this Node script when spawning a child process.
+	 */
+	spawnScript?: string;
 	cwd?: string;
 	/**
 	 * Environment variables to set for the test.


### PR DESCRIPTION
This ensures that abortOnStderr works

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The Linux and Windows CLI watch tests take very long because killing the child process does not work when using child_process.exec. It does work for .spawn, though, at least on Linux. This changes most of the tests to use spawn instead, which should also make them slightly faster as they no longer require an in-between process.