### PR TITLE
fix: preserve constant identifiers in unary expressions instead of magic numbers

### DIFF
--- a/src/ast/nodes/UnaryExpression.ts
+++ b/src/ast/nodes/UnaryExpression.ts
@@ -114,9 +114,13 @@ export default class UnaryExpression extends NodeBase {
 	): void {
 		if (!this.deoptimized) this.applyDeoptimizations();
 		this.included = true;
+		// Check if the argument is an identifier that should be preserved as a reference for readability
+		const shouldPreserveArgument =
+			this.argument instanceof Identifier && this.argument.variable?.included;
 		if (
 			typeof this.getRenderedLiteralValue(includeChildrenRecursively) === 'symbol' ||
-			this.argument.shouldBeIncluded(context)
+			this.argument.shouldBeIncluded(context) ||
+			shouldPreserveArgument
 		) {
 			this.argument.include(context, includeChildrenRecursively);
 			this.renderedLiteralValue = UnknownValue;

--- a/test/form/samples/unary-expressions-preserve-constants/_config.js
+++ b/test/form/samples/unary-expressions-preserve-constants/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description:
+		'Preserves constant identifiers in unary expressions when constants are used elsewhere'
+});

--- a/test/form/samples/unary-expressions-preserve-constants/_expected.js
+++ b/test/form/samples/unary-expressions-preserve-constants/_expected.js
@@ -1,0 +1,25 @@
+const BOB = 3;
+const ALICE = 5;
+
+function getBob() {
+	return {x: BOB, y: -BOB, z: +BOB};
+}
+
+function getAlice() {
+	console.log(ALICE);
+	return ~ALICE;
+}
+
+// Test with different operators
+function testOperators() {
+	return {
+		negate: -BOB,
+		plus: +BOB, 
+		not: !BOB,
+		bitwise: ~BOB,
+		typeof: typeof BOB,
+		void: void BOB
+	};
+}
+
+export { ALICE, BOB, getAlice, getBob, testOperators };

--- a/test/form/samples/unary-expressions-preserve-constants/main.js
+++ b/test/form/samples/unary-expressions-preserve-constants/main.js
@@ -1,0 +1,23 @@
+export const BOB = 3;
+export const ALICE = 5;
+
+export function getBob() {
+	return {x: BOB, y: -BOB, z: +BOB};
+}
+
+export function getAlice() {
+	console.log(ALICE);
+	return ~ALICE;
+}
+
+// Test with different operators
+export function testOperators() {
+	return {
+		negate: -BOB,
+		plus: +BOB, 
+		not: !BOB,
+		bitwise: ~BOB,
+		typeof: typeof BOB,
+		void: void BOB
+	};
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5967
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
-  This was a regression in PR #5775 which caused unary expressions with constant identifiers (like !MY_CONSTANT) to be replaced with magic numbers (false), losing code readability
- Added logic to check if the unary expression's argument is an identifier referencing an included variable, and if so, preserves the full expression instead of inlining the literal value
- This helps maintain both the tree-shaking optimization benefits while preserving readable constant names in the output 

