### PR TITLE
fix: consider function expression in thenable when tree-shaking dynamic imports

### DIFF
--- a/src/ast/utils/identifyNode.ts
+++ b/src/ast/utils/identifyNode.ts
@@ -1,6 +1,7 @@
 import type ArrowFunctionExpression from '../nodes/ArrowFunctionExpression';
 import type AwaitExpression from '../nodes/AwaitExpression';
 import type CallExpression from '../nodes/CallExpression';
+import type FunctionExpression from '../nodes/FunctionExpression';
 import type Identifier from '../nodes/Identifier';
 import type ImportExpression from '../nodes/ImportExpression';
 import type MemberExpression from '../nodes/MemberExpression';
@@ -20,6 +21,10 @@ export function isPropertyNode(node: unknown): node is Property {
 
 export function isArrowFunctionExpressionNode(node: unknown): node is ArrowFunctionExpression {
 	return node instanceof NodeBase && node.type === nodeType.ArrowFunctionExpression;
+}
+
+export function isFunctionExpressionNode(node: unknown): node is FunctionExpression {
+	return node instanceof NodeBase && node.type === nodeType.FunctionExpression;
 }
 
 export function isCallExpressionNode(node: unknown): node is CallExpression {

--- a/src/ast/variables/LocalVariable.ts
+++ b/src/ast/variables/LocalVariable.ts
@@ -25,6 +25,7 @@ import type { VariableKind } from '../nodes/shared/VariableKinds';
 import {
 	isArrowFunctionExpressionNode,
 	isCallExpressionNode,
+	isFunctionExpressionNode,
 	isIdentifierNode,
 	isImportExpressionNode,
 	isMemberExpressionNode
@@ -237,7 +238,8 @@ export default class LocalVariable extends Variable {
 				 */
 				if (
 					this.kind === 'parameter' &&
-					isArrowFunctionExpressionNode(declaration.parent) &&
+					(isArrowFunctionExpressionNode(declaration.parent) ||
+						isFunctionExpressionNode(declaration.parent)) &&
 					isCallExpressionNode(declaration.parent.parent) &&
 					isMemberExpressionNode(declaration.parent.parent.callee) &&
 					isIdentifierNode(declaration.parent.parent.callee.property) &&

--- a/test/form/samples/treeshake-deterministic-dynamic-import/_expected.js
+++ b/test/form/samples/treeshake-deterministic-dynamic-import/_expected.js
@@ -29,6 +29,12 @@ async function entry() {
     }
     f(m);
   });
+  Promise.resolve().then(function () { return sub2; }).then(function(m){
+    function f(m){
+      console.log(m.baz2);
+    }
+    f(m);
+  });
   Promise.resolve().then(function () { return sub2; }).then(({ baz2 }) => baz2);
   Promise.resolve().then(function () { return sub2; }).then(function({ reexported }) { });
 

--- a/test/form/samples/treeshake-deterministic-dynamic-import/main.js
+++ b/test/form/samples/treeshake-deterministic-dynamic-import/main.js
@@ -14,6 +14,12 @@ export async function entry() {
     }
     f(m);
   })
+  import('./sub2.js').then(function(m){
+    function f(m){
+      console.log(m.baz2)
+    }
+    f(m);
+  })
   import('./sub2.js').then(({ baz2 }) => baz2)
   import('./sub2.js').then(function({ reexported }) { reexported })
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #5975 
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This issue occurred because we overlooked the possibility of function expression in thenable in #5954.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
