### PR TITLE
Set maxParallelFileOps to 1000

### DIFF
--- a/docs/configuration-options/index.md
+++ b/docs/configuration-options/index.md
@@ -637,7 +637,7 @@ Note that when a relative path is directly marked as "external" using the [`exte
 | -------: | :------------------------------ |
 |    Type: | `number`                        |
 |     CLI: | `--maxParallelFileOps <number>` |
-| Default: | `Infinity`                      |
+| Default: | 1000                            |
 
 Limits the number of files rollup will open in parallel when reading modules or writing chunks. Without a limit or with a high enough value, builds can fail with an "EMFILE: too many open files". This depends on how many open file handles the operating system allows. If you set the limit too low and use plugins that rely on the [`this.load`](../plugin-development/index.md#this-load) context function, such as the `commonjs` plugin, then it can happen that builds stall without an error message as it limits the number of parallel `load` calls.
 

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -176,8 +176,11 @@ const getMaxParallelFileOps = (
 	config: InputOptions
 ): NormalizedInputOptions['maxParallelFileOps'] => {
 	const maxParallelFileOps = config.maxParallelFileOps;
-	if (typeof maxParallelFileOps !== 'number' || maxParallelFileOps <= 0) return Infinity;
-	return maxParallelFileOps;
+	if (typeof maxParallelFileOps === 'number') {
+		if (maxParallelFileOps <= 0) return Infinity;
+		return maxParallelFileOps;
+	}
+	return 1000;
 };
 
 const getModuleContext = (

--- a/test/function/samples/options-hook/_config.js
+++ b/test/function/samples/options-hook/_config.js
@@ -11,9 +11,8 @@ module.exports = defineTest({
 				name: 'test-plugin',
 				buildStart(options) {
 					// The fs option is not json stringifiable
-					const { fs, maxParallelFileOps, ...restOptions } = options;
+					const { fs, ...restOptions } = options;
 					assert.ok(fs);
-					assert.strictEqual(maxParallelFileOps, Infinity);
 					assert.deepStrictEqual(JSON.parse(JSON.stringify(restOptions)), {
 						context: 'undefined',
 						experimentalCacheExpiry: 10,
@@ -22,6 +21,7 @@ module.exports = defineTest({
 						jsx: false,
 						logLevel: 'info',
 						makeAbsoluteExternalsRelative: 'ifRelativeSource',
+						maxParallelFileOps: 1000,
 						perf: false,
 						plugins: [
 							{


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #5989

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Apparently, removing the limit caused issues for quite a few people. As a quick fix, this will set the limit to a much higher value. We will try to find a better solution in the mid term.