### PR TITLE
fix: export field order prefer esm

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -32,8 +32,8 @@
   "exports": {
     ".": {
       "types": "./dist/rollup.browser.d.ts",
-      "require": "./dist/rollup.browser.js",
-      "import": "./dist/es/rollup.browser.js"
+      "import": "./dist/es/rollup.browser.js",
+      "require": "./dist/rollup.browser.js"
     },
     "./dist/*": "./dist/*"
   }

--- a/package.json
+++ b/package.json
@@ -227,8 +227,8 @@
   "exports": {
     ".": {
       "types": "./dist/rollup.d.ts",
-      "require": "./dist/rollup.js",
-      "import": "./dist/es/rollup.js"
+      "import": "./dist/es/rollup.js",
+      "require": "./dist/rollup.js"
     },
     "./loadConfigFile": {
       "types": "./dist/loadConfigFile.d.ts",
@@ -237,13 +237,13 @@
     },
     "./getLogFilter": {
       "types": "./dist/getLogFilter.d.ts",
-      "require": "./dist/getLogFilter.js",
-      "import": "./dist/es/getLogFilter.js"
+      "import": "./dist/es/getLogFilter.js",
+      "require": "./dist/getLogFilter.js"
     },
     "./parseAst": {
       "types": "./dist/parseAst.d.ts",
-      "require": "./dist/parseAst.js",
-      "import": "./dist/es/parseAst.js"
+      "import": "./dist/es/parseAst.js",
+      "require": "./dist/parseAst.js"
     },
     "./dist/*": "./dist/*",
     "./package.json": "./package.json"


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

I'm not totally clear on how I would approach testing this 😓.

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:


### Description

The way the `exports` field is configured in the `package.json`'s cause the commonjs version of the package to _always_ be used in environments that pass in both a `require` and `import` condition (most bundled envs).

This is because the way export conditions are matched is in the object order it checks each condition to see if it was provided. In this case since `require` is earlier in the list it is always preferred.
