### PR TITLE
feat: optimize `in` checks on namespaces to keep them treeshake-able

### DIFF
--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -92,7 +92,7 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 	renderedLiteralValue: string | typeof UnknownValue | typeof UNASSIGNED = UNASSIGNED;
 
 	deoptimizeCache(): void {
-		this.renderedLiteralValue = UNASSIGNED;
+		this.renderedLiteralValue = UnknownValue;
 	}
 
 	getLiteralValueAtPath(

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -106,7 +106,9 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 
 		// Optimize `'export' in namespace`
 		if (this.operator === 'in' && this.right.variable?.isNamespace) {
-			return !!(this.right.variable as NamespaceVariable).context.traceExport(String(leftValue));
+			return (
+				(this.right.variable as NamespaceVariable).context.traceExport(String(leftValue))[0] != null
+			);
 		}
 
 		const rightValue = this.right.getLiteralValueAtPath(EMPTY_PATH, recursionTracker, origin);

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -22,7 +22,12 @@ import {
 	type LiteralValueOrUnknown,
 	UnknownValue
 } from './shared/Expression';
-import { type ExpressionNode, type IncludeChildren, NodeBase } from './shared/Node';
+import {
+	doNotDeoptimize,
+	type ExpressionNode,
+	type IncludeChildren,
+	NodeBase
+} from './shared/Node';
 
 type Operator =
 	| '!='
@@ -139,13 +144,6 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 		return type !== INTERACTION_ACCESSED || path.length > 1;
 	}
 
-	applyDeoptimizations(): void {
-		this.deoptimized = true;
-		if (this.operator !== 'in' || !this.right.variable?.isNamespace) {
-			this.scope.context.requestTreeshakingPass();
-		}
-	}
-
 	include(
 		context: InclusionContext,
 		includeChildrenRecursively: IncludeChildren,
@@ -182,3 +180,5 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 		}
 	}
 }
+
+BinaryExpression.prototype.applyDeoptimizations = doNotDeoptimize;

--- a/src/ast/nodes/UnaryExpression.ts
+++ b/src/ast/nodes/UnaryExpression.ts
@@ -10,6 +10,7 @@ import {
 	type ObjectPath,
 	SHARED_RECURSION_TRACKER
 } from '../utils/PathTracker';
+import { getRenderedLiteralValue } from '../utils/renderLiteralValue';
 import Identifier from './Identifier';
 import type { LiteralValue } from './Literal';
 import type * as NodeType from './NodeType';
@@ -141,34 +142,5 @@ export default class UnaryExpression extends NodeBase {
 }
 
 const CHARACTERS_THAT_DO_NOT_REQUIRE_SPACE = /[\s([=%&*+-/<>^|,?:;]/;
-
-function getRenderedLiteralValue(value: unknown) {
-	if (value === undefined) {
-		// At the moment, the undefined only happens when the operator is void
-		return 'void 0';
-	}
-	if (typeof value === 'boolean') {
-		return String(value);
-	}
-	if (typeof value === 'string') {
-		return JSON.stringify(value);
-	}
-	if (typeof value === 'number') {
-		return getSimplifiedNumber(value);
-	}
-	return UnknownValue;
-}
-
-function getSimplifiedNumber(value: number) {
-	if (Object.is(-0, value)) {
-		return '-0';
-	}
-	const exp = value.toExponential();
-	const [base, exponent] = exp.split('e');
-	const floatLength = base.split('.')[1]?.length || 0;
-	const finalizedExp = `${base.replace('.', '')}e${parseInt(exponent) - floatLength}`;
-	const stringifiedValue = String(value).replace('+', '');
-	return finalizedExp.length < stringifiedValue.length ? finalizedExp : stringifiedValue;
-}
 
 UnaryExpression.prototype.includeNode = onlyIncludeSelf;

--- a/src/ast/utils/renderLiteralValue.ts
+++ b/src/ast/utils/renderLiteralValue.ts
@@ -1,0 +1,29 @@
+import { UnknownValue } from '../nodes/shared/Expression';
+
+export function getRenderedLiteralValue(value: unknown) {
+	if (value === undefined) {
+		return 'void 0';
+	}
+	if (typeof value === 'boolean') {
+		return String(value);
+	}
+	if (typeof value === 'string') {
+		return JSON.stringify(value);
+	}
+	if (typeof value === 'number') {
+		return getSimplifiedNumber(value);
+	}
+	return UnknownValue;
+}
+
+function getSimplifiedNumber(value: number) {
+	if (Object.is(-0, value)) {
+		return '-0';
+	}
+	const exp = value.toExponential();
+	const [base, exponent] = exp.split('e');
+	const floatLength = base.split('.')[1]?.length || 0;
+	const finalizedExp = `${base.replace('.', '')}e${parseInt(exponent) - floatLength}`;
+	const stringifiedValue = String(value).replace('+', '');
+	return finalizedExp.length < stringifiedValue.length ? finalizedExp : stringifiedValue;
+}

--- a/test/form/samples/namespace-optimization-in-operator/_config.js
+++ b/test/form/samples/namespace-optimization-in-operator/_config.js
@@ -1,0 +1,8 @@
+module.exports = defineTest({
+	description:
+		'it does static optimization of internal namespaces when checking whether an export exists',
+	expectedWarnings: [
+		// That's a bit of an annoyance that Rollup still complains despite the if gate...
+		'MISSING_EXPORT'
+	]
+});

--- a/test/form/samples/namespace-optimization-in-operator/_expected.js
+++ b/test/form/samples/namespace-optimization-in-operator/_expected.js
@@ -1,0 +1,3 @@
+function c() {}
+
+console.log(c());

--- a/test/form/samples/namespace-optimization-in-operator/foo.js
+++ b/test/form/samples/namespace-optimization-in-operator/foo.js
@@ -1,0 +1,3 @@
+export function a() {}
+export function b() {}
+export function c() {}

--- a/test/form/samples/namespace-optimization-in-operator/main.js
+++ b/test/form/samples/namespace-optimization-in-operator/main.js
@@ -1,0 +1,4 @@
+import * as foo from './foo';
+
+if ('d' in foo) console.log(foo.d())
+if ('c' in foo) console.log(foo.c())


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

Currently, using the `in` operator on a namespace completely disables treeshaking, even if the left hand-side of the expression can be statically resolved. This makes checking for the existence of an export annoying, as demonstrated [here](https://rollupjs.org/repl/?version=4.45.1&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMmltcG9ydCUyMColMjBhcyUyMHQlMjBmcm9tJTIwJy4lMkZ0ZXN0LmpzJyU1Q24lNUNuZXhwb3J0JTIwZnVuY3Rpb24lMjBmbigpJTIwJTdCJTVDbiUyMCUyMGlmJTIwKCdtYXliZSclMjBpbiUyMHQpJTVDbiUyMCUyMCUyMCUyMHQubWF5YmUoKSU1Q24lN0QlMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSUyQyUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTdEJTJDJTdCJTIyY29kZSUyMiUzQSUyMmV4cG9ydCUyMGZ1bmN0aW9uJTIwYSgpJTIwJTdCJTVDbiUyMCUyMGNvbnNvbGUubG9nKCdJJTIwYW0lMjBmdW5jdGlvbiUyMGEnKSU1Q24lN0QlNUNuJTVDbmV4cG9ydCUyMGZ1bmN0aW9uJTIwYigpJTIwJTdCJTVDbiUyMCUyMGNvbnNvbGUubG9nKCdJJTIwYW0lMjBmdW5jdGlvbiUyMGInKSU1Q24lN0QlNUNuJTVDbmV4cG9ydCUyMGZ1bmN0aW9uJTIwbWF5YmUoKSUyMCU3QiU1Q24lMjAlMjBjb25zb2xlLmxvZygnTWF5YmUlMjBJJTIwZXhpc3QlMkMlMjBtYXliZSUyMG5vdC4uLiUyMCUzQSknKSU1Q24lN0QlMjIlMkMlMjJpc0VudHJ5JTIyJTNBZmFsc2UlMkMlMjJuYW1lJTIyJTNBJTIydGVzdC5qcyUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlN0QlN0Q=).

This PR optimizes these checks to collapse the expression to a boolean, that is also used for DCE which allows getting rid of eventual compat code and what not in libraries.

There is still a slight annoyance with how warnings are emitted, as shown by the added test. Despite the gate Rollup still emits a warning about the unresolved export. This is minor and I felt like it'd require more invasive changes, so I didn't address this here.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
