### PR TITLE
disables optimization for external namespace when using the in operator

### DIFF
--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -13,7 +13,7 @@ import {
 	UNKNOWN_PATH
 } from '../utils/PathTracker';
 import { getRenderedLiteralValue } from '../utils/renderLiteralValue';
-import type NamespaceVariable from '../variables/NamespaceVariable';
+import NamespaceVariable from '../variables/NamespaceVariable';
 import ExpressionStatement from './ExpressionStatement';
 import type { LiteralValue } from './Literal';
 import type * as NodeType from './NodeType';
@@ -105,10 +105,8 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 		if (typeof leftValue === 'symbol') return UnknownValue;
 
 		// Optimize `'export' in namespace`
-		if (this.operator === 'in' && this.right.variable?.isNamespace) {
-			return (
-				(this.right.variable as NamespaceVariable).context.traceExport(String(leftValue))[0] != null
-			);
+		if (this.operator === 'in' && this.right.variable instanceof NamespaceVariable) {
+			return this.right.variable.context.traceExport(String(leftValue))[0] != null;
 		}
 
 		const rightValue = this.right.getLiteralValueAtPath(EMPTY_PATH, recursionTracker, origin);

--- a/test/form/samples/external-namespace-optimzation-in-operator/_config.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/_config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	description: 'disables optimization for external namespace when using the in operator',
+	options: {
+		external: ['node:crypto']
+	}
+};

--- a/test/form/samples/external-namespace-optimzation-in-operator/_expected.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/_expected.js
@@ -1,0 +1,5 @@
+import * as nc from 'node:crypto';
+
+const crypto = 'webcrypto' in nc;
+
+export { crypto };

--- a/test/form/samples/external-namespace-optimzation-in-operator/main.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/main.js
@@ -1,0 +1,2 @@
+import * as nc from 'node:crypto';
+export const crypto = 'webcrypto' in nc;


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

resolves #6035
related PR #6029 
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
We overlooked that `externalVariable.isNameSpace` could also be `true`.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
