### PR TITLE
Correct the logic of include in BinaryExpression and don't optimize external references away

### DIFF
--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -123,8 +123,9 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 
 	getRenderedLiteralValue() {
 		// Only optimize `'export' in ns`
-		if (this.operator !== 'in' || !(this.right.variable instanceof NamespaceVariable))
+		if (this.operator !== 'in' || !(this.right.variable instanceof NamespaceVariable)) {
 			return UnknownValue;
+		}
 
 		if (this.renderedLiteralValue !== UNASSIGNED) return this.renderedLiteralValue;
 		return (this.renderedLiteralValue = getRenderedLiteralValue(
@@ -151,12 +152,13 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 	include(
 		context: InclusionContext,
 		includeChildrenRecursively: IncludeChildren,
-		_options?: InclusionOptions
+		options?: InclusionOptions
 	) {
+		if (!this.included) this.includeNode(context);
 		if (typeof this.getRenderedLiteralValue() === 'symbol') {
-			return super.include(context, includeChildrenRecursively, _options);
+			this.left.include(context, includeChildrenRecursively, options);
+			this.right.include(context, includeChildrenRecursively, options);
 		}
-		this.included = true;
 	}
 
 	includeNode(context: InclusionContext) {

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -120,7 +120,8 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 
 	getRenderedLiteralValue() {
 		// Only optimize `'export' in ns`
-		if (this.operator !== 'in' || !this.right.variable?.isNamespace) return UnknownValue;
+		if (this.operator !== 'in' || !(this.right.variable instanceof NamespaceVariable))
+			return UnknownValue;
 
 		if (this.renderedLiteralValue !== UNASSIGNED) return this.renderedLiteralValue;
 		return (this.renderedLiteralValue = getRenderedLiteralValue(
@@ -149,10 +150,10 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 		includeChildrenRecursively: IncludeChildren,
 		_options?: InclusionOptions
 	) {
-		this.included = true;
 		if (typeof this.getRenderedLiteralValue() === 'symbol') {
-			super.include(context, includeChildrenRecursively, _options);
+			return super.include(context, includeChildrenRecursively, _options);
 		}
+		this.included = true;
 	}
 
 	includeNode(context: InclusionContext) {

--- a/src/ast/nodes/BinaryExpression.ts
+++ b/src/ast/nodes/BinaryExpression.ts
@@ -13,6 +13,7 @@ import {
 	UNKNOWN_PATH
 } from '../utils/PathTracker';
 import { getRenderedLiteralValue } from '../utils/renderLiteralValue';
+import ExternalVariable from '../variables/ExternalVariable';
 import NamespaceVariable from '../variables/NamespaceVariable';
 import ExpressionStatement from './ExpressionStatement';
 import type { LiteralValue } from './Literal';
@@ -106,7 +107,9 @@ export default class BinaryExpression extends NodeBase implements DeoptimizableE
 
 		// Optimize `'export' in namespace`
 		if (this.operator === 'in' && this.right.variable instanceof NamespaceVariable) {
-			return this.right.variable.context.traceExport(String(leftValue))[0] != null;
+			const [variable] = this.right.variable.context.traceExport(String(leftValue));
+			if (variable instanceof ExternalVariable) return UnknownValue;
+			return !!variable;
 		}
 
 		const rightValue = this.right.getLiteralValueAtPath(EMPTY_PATH, recursionTracker, origin);

--- a/test/form/samples/external-namespace-optimzation-in-operator/_config.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/_config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	description: 'disables optimization for external namespace when using the in operator',
 	options: {
-		external: ['node:crypto']
+		external: ['node:crypto', './ext.js']
 	}
 };

--- a/test/form/samples/external-namespace-optimzation-in-operator/_expected.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/_expected.js
@@ -1,5 +1,27 @@
 import * as nc from 'node:crypto';
+import * as ext from './ext.js';
+
+function _mergeNamespaces(n, m) {
+	m.forEach(function (e) {
+		e && typeof e !== 'string' && !Array.isArray(e) && Object.keys(e).forEach(function (k) {
+			if (k !== 'default' && !(k in n)) {
+				var d = Object.getOwnPropertyDescriptor(e, k);
+				Object.defineProperty(n, k, d.get ? d : {
+					enumerable: true,
+					get: function () { return e[k]; }
+				});
+			}
+		});
+	});
+	return Object.freeze(n);
+}
+
+var pt = /*#__PURE__*/_mergeNamespaces({
+	__proto__: null
+}, [ext]);
 
 const crypto = 'webcrypto' in nc;
+const direct = 'whatever' in ext;
+const indirect = 'whatever' in pt;
 
-export { crypto };
+export { crypto, direct, indirect };

--- a/test/form/samples/external-namespace-optimzation-in-operator/ext.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/ext.js
@@ -1,0 +1,1 @@
+export const whatever = 1

--- a/test/form/samples/external-namespace-optimzation-in-operator/main.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/main.js
@@ -1,2 +1,7 @@
 import * as nc from 'node:crypto';
+import * as ext from './ext.js';
+import * as pt from './passthrough.js';
+
 export const crypto = 'webcrypto' in nc;
+export const direct = 'whatever' in ext;
+export const indirect = 'whatever' in pt;

--- a/test/form/samples/external-namespace-optimzation-in-operator/passthrough.js
+++ b/test/form/samples/external-namespace-optimzation-in-operator/passthrough.js
@@ -1,0 +1,1 @@
+export * from './ext.js'

--- a/test/form/samples/namespace-optimization-in-operator/_expected.js
+++ b/test/form/samples/namespace-optimization-in-operator/_expected.js
@@ -1,3 +1,4 @@
 function c() {}
 
 console.log(c());
+console.log(true);

--- a/test/form/samples/namespace-optimization-in-operator/main.js
+++ b/test/form/samples/namespace-optimization-in-operator/main.js
@@ -1,4 +1,5 @@
 import * as foo from './foo';
 
-if ('d' in foo) console.log(foo.d())
-if ('c' in foo) console.log(foo.c())
+if ('d' in foo) console.log(foo.d());
+if ('c' in foo) console.log(foo.c());
+console.log('c' in foo);

--- a/test/form/samples/optimization-in-operator/_config.js
+++ b/test/form/samples/optimization-in-operator/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'keep foo structure'
+});

--- a/test/form/samples/optimization-in-operator/_expected.js
+++ b/test/form/samples/optimization-in-operator/_expected.js
@@ -1,0 +1,11 @@
+var foo = {
+	a: 1,
+	b: 1
+};
+
+function check(name) {
+	if (name in foo) return true;
+	return false;
+}
+
+export { check as default };

--- a/test/form/samples/optimization-in-operator/foo.js
+++ b/test/form/samples/optimization-in-operator/foo.js
@@ -1,0 +1,4 @@
+export default {
+	a: 1,
+	b: 1
+};

--- a/test/form/samples/optimization-in-operator/main.js
+++ b/test/form/samples/optimization-in-operator/main.js
@@ -1,0 +1,6 @@
+import foo from './foo';
+
+export default function check(name) {
+	if (name in foo) return true;
+	return false;
+}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #6040
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

There was an issue with the previous `BinaryExpression` include logic: if `included` was set to `true` before calling `super.include()`, the `include()` logic for `left` and `right` would not be executed.

Include changes from #6042.