### PR TITLE
build(rust): mimalloc-safe/no_opt_arch on aarch64

### DIFF
--- a/rust/bindings_napi/Cargo.toml
+++ b/rust/bindings_napi/Cargo.toml
@@ -38,7 +38,7 @@ mimalloc-safe = { version = "0.1.54", features = ["local_dynamic_tls"] }
 # Disable architecture specific optimizations on aarch64 platforms
 # Mimalloc assumes `armv8.1-a` is supported, which is not always the case
 # Ref: https://github.com/rollup/rollup/issues/6047
-[target.'cfg(target_arch = "aarch64")'.dependencies]
+[target.'cfg(all(target_arch = "aarch64", not(target_vendor = "apple")))'.dependencies]
 mimalloc-safe = { version = "0.1.54", features = ["no_opt_arch"] }
 
 [build-dependencies]

--- a/rust/bindings_napi/Cargo.toml
+++ b/rust/bindings_napi/Cargo.toml
@@ -18,11 +18,28 @@ xxhash = { path = "../xxhash" }
 [target.'cfg(not(any(target_os = "linux", target_os = "freebsd")))'.dependencies]
 mimalloc-safe = { version = "0.1.54" }
 
-[target.'cfg(any(all(target_os = "linux", not(target_arch = "aarch64"), not(target_arch = "loongarch64"), not(all(target_arch = "riscv64", target_env = "musl"))), all(target_os = "freebsd", not(target_arch = "aarch64"))))'.dependencies]
+# Readable version of the target specifier
+# cfg(
+# 	any(
+# 		all(
+# 			target_os = "linux",
+# 			not(target_arch = "loongarch64"),
+# 			not(all(target_arch = "riscv64", target_env = "musl"))
+# 		),
+# 		all(
+# 			target_os = "freebsd",
+# 			not(target_arch = "aarch64")
+# 		)
+# 	)
+# )
+[target.'cfg(any(all(target_os = "linux", not(target_arch = "loongarch64"), not(all(target_arch = "riscv64", target_env = "musl"))), all(target_os = "freebsd", not(target_arch = "aarch64"))))'.dependencies]
 mimalloc-safe = { version = "0.1.54", features = ["local_dynamic_tls"] }
 
-[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
-mimalloc-safe = { version = "0.1.54", features = ["local_dynamic_tls", "no_opt_arch"] }
+# Disable architecture specific optimizations on aarch64 platforms
+# Mimalloc assumes `armv8.1-a` is supported, which is not always the case
+# Ref: https://github.com/rollup/rollup/issues/6047
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+mimalloc-safe = { version = "0.1.54", features = ["no_opt_arch"] }
 
 [build-dependencies]
 napi-build = "2.2.3"


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no
- [x] N/A

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- closes #6047 (hopefully for good)

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

initially introduced by #6055 for linux, this did not include android devices as it is considerd its own operating system with linux being the "vendor"; triplets are quite inconsistent and confusing at times!

this change conservatively disables arch-specific optimizations for all aarch64 targets, to ensure broad compatibility.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
