### PR TITLE
Call includeNode for self or children nodes in includeDestructuredIfNecessary

### DIFF
--- a/src/ast/nodes/ArrayPattern.ts
+++ b/src/ast/nodes/ArrayPattern.ts
@@ -86,24 +86,19 @@ export default class ArrayPattern extends NodeBase implements DeclarationPattern
 	): boolean {
 		let included = false;
 		const includedPatternPath = getIncludedPatternPath(destructuredInitPath);
-		for (const element of this.elements) {
+		for (const element of [...this.elements].reverse()) {
 			if (element) {
-				element.included ||= included;
+				if (included && !element.included) {
+					element.includeNode(context);
+				}
 				included =
 					element.includeDestructuredIfNecessary(context, includedPatternPath, init) || included;
 			}
 		}
-		if (included) {
-			// This is necessary so that if any pattern element is included, all are
-			// included for proper deconflicting
-			for (const element of this.elements) {
-				if (element && !element.included) {
-					element.included = true;
-					element.includeDestructuredIfNecessary(context, includedPatternPath, init);
-				}
-			}
+		if (!this.included && included) {
+			this.includeNode(context);
 		}
-		return (this.included ||= included);
+		return this.included;
 	}
 
 	markDeclarationReached(): void {

--- a/src/ast/nodes/AssignmentPattern.ts
+++ b/src/ast/nodes/AssignmentPattern.ts
@@ -71,13 +71,16 @@ export default class AssignmentPattern extends NodeBase implements DeclarationPa
 		if ((included ||= this.right.shouldBeIncluded(context))) {
 			this.right.include(context, false);
 			if (!this.left.included) {
-				this.left.included = true;
+				this.left.includeNode(context);
 				// Unfortunately, we need to include the left side again now, so that
 				// any declared variables are properly included.
 				this.left.includeDestructuredIfNecessary(context, destructuredInitPath, init);
 			}
 		}
-		return (this.included = included);
+		if (!this.included && included) {
+			this.includeNode(context);
+		}
+		return this.included;
 	}
 
 	includeNode(context: InclusionContext) {

--- a/src/ast/nodes/Identifier.ts
+++ b/src/ast/nodes/Identifier.ts
@@ -115,8 +115,9 @@ export default class Identifier extends IdentifierBase implements DeclarationPat
 		}
 		const { propertyReadSideEffects } = this.scope.context.options
 			.treeshake as NormalizedTreeshakingOptions;
+		let included = this.included;
 		if (
-			(this.included ||=
+			(included ||=
 				destructuredInitPath.length > 0 &&
 				!context.brokenFlow &&
 				propertyReadSideEffects &&
@@ -131,9 +132,11 @@ export default class Identifier extends IdentifierBase implements DeclarationPat
 				this.scope.context.includeVariableInModule(this.variable, EMPTY_PATH, context);
 			}
 			init.includePath(destructuredInitPath, context);
-			return true;
 		}
-		return false;
+		if (!this.included && included) {
+			this.includeNode(context);
+		}
+		return this.included;
 	}
 
 	markDeclarationReached(): void {

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -445,8 +445,9 @@ export default class MemberExpression
 		destructuredInitPath: ObjectPath,
 		init: ExpressionEntity
 	): boolean {
+		let included = this.included;
 		if (
-			(this.included ||=
+			(included ||=
 				destructuredInitPath.length > 0 &&
 				!context.brokenFlow &&
 				init.hasEffectsOnInteractionAtPath(
@@ -456,9 +457,11 @@ export default class MemberExpression
 				))
 		) {
 			init.include(context, false);
-			return true;
 		}
-		return false;
+		if (!this.included && included) {
+			this.includeNode(context);
+		}
+		return this.included;
 	}
 
 	initialise(): void {

--- a/src/ast/nodes/MemberExpression.ts
+++ b/src/ast/nodes/MemberExpression.ts
@@ -7,7 +7,7 @@ import { logIllegalImportReassignment, logMissingExport } from '../../utils/logs
 import type { NodeRenderOptions, RenderOptions } from '../../utils/renderHelpers';
 import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
-import { createHasEffectsContext, createInclusionContext } from '../ExecutionContext';
+import { createInclusionContext } from '../ExecutionContext';
 import type {
 	NodeInteraction,
 	NodeInteractionAccessed,
@@ -440,28 +440,14 @@ export default class MemberExpression
 		}
 	}
 
-	includeDestructuredIfNecessary(
-		context: InclusionContext,
-		destructuredInitPath: ObjectPath,
-		init: ExpressionEntity
-	): boolean {
-		let included = this.included;
-		if (
-			(included ||=
-				destructuredInitPath.length > 0 &&
-				!context.brokenFlow &&
-				init.hasEffectsOnInteractionAtPath(
-					destructuredInitPath,
-					NODE_INTERACTION_UNKNOWN_ACCESS,
-					createHasEffectsContext()
-				))
-		) {
-			init.include(context, false);
-		}
-		if (!this.included && included) {
-			this.includeNode(context);
-		}
-		return this.included;
+	includeDestructuredIfNecessary(): boolean {
+		/* istanbul ignore next */
+		this.scope.context.error(
+			{
+				message: 'includeDestructuredIfNecessary is currently not supported for MemberExpressions'
+			},
+			this.start
+		);
 	}
 
 	initialise(): void {

--- a/src/ast/nodes/ObjectPattern.ts
+++ b/src/ast/nodes/ObjectPattern.ts
@@ -87,25 +87,23 @@ export default class ObjectPattern extends NodeBase implements DeclarationPatter
 		destructuredInitPath: ObjectPath,
 		init: ExpressionEntity
 	): boolean {
-		if (!this.properties.length) return false;
+		if (!this.properties.length) return this.included;
 
 		const lastProperty = this.properties.at(-1)!;
-		const lastPropertyIncluded = lastProperty.includeDestructuredIfNecessary(
-			context,
-			destructuredInitPath,
-			init
-		);
+		let included = lastProperty.includeDestructuredIfNecessary(context, destructuredInitPath, init);
 		const lastPropertyIsRestElement = lastProperty.type === NodeType.RestElement;
 
-		let included = lastPropertyIsRestElement ? lastPropertyIncluded : false;
 		for (const property of this.properties.slice(0, -1)) {
-			if (lastPropertyIsRestElement && lastPropertyIncluded) {
+			if (lastPropertyIsRestElement && included && !property.included) {
 				property.includeNode(context);
 			}
 			included =
 				property.includeDestructuredIfNecessary(context, destructuredInitPath, init) || included;
 		}
-		return (this.included ||= included);
+		if (!this.included && included) {
+			this.includeNode(context);
+		}
+		return this.included;
 	}
 
 	markDeclarationReached(): void {

--- a/src/ast/nodes/Property.ts
+++ b/src/ast/nodes/Property.ts
@@ -84,13 +84,16 @@ export default class Property extends MethodBase implements DeclarationPatternNo
 		if ((included ||= this.key.hasEffects(createHasEffectsContext()))) {
 			this.key.include(context, false);
 			if (!this.value.included) {
-				this.value.included = true;
+				this.value.includeNode(context);
 				// Unfortunately, we need to include the value again now, so that any
 				// declared variables are properly included.
 				(this.value as PatternNode).includeDestructuredIfNecessary(context, path, init);
 			}
 		}
-		return (this.included = included);
+		if (!this.included && included) {
+			this.includeNode(context);
+		}
+		return this.included;
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren) {

--- a/src/ast/nodes/RestElement.ts
+++ b/src/ast/nodes/RestElement.ts
@@ -73,12 +73,15 @@ export default class RestElement extends NodeBase implements DeclarationPatternN
 		destructuredInitPath: ObjectPath,
 		init: ExpressionEntity
 	): boolean {
-		return (this.included =
-			this.argument.includeDestructuredIfNecessary(
-				context,
-				getIncludedPatternPath(destructuredInitPath),
-				init
-			) || this.included);
+		const included = this.argument.includeDestructuredIfNecessary(
+			context,
+			getIncludedPatternPath(destructuredInitPath),
+			init
+		);
+		if (!this.included && included) {
+			this.includeNode(context);
+		}
+		return this.included;
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren) {

--- a/test/function/samples/keep-the-non-first-assignment-in-destructuring-unknown-array-variables/_config.js
+++ b/test/function/samples/keep-the-non-first-assignment-in-destructuring-unknown-array-variables/_config.js
@@ -1,0 +1,6 @@
+module.exports = defineTest({
+	description: 'Keep the non-first assignment in destructuring unknown array variables',
+	context: {
+		unknownVariable: []
+	}
+});

--- a/test/function/samples/keep-the-non-first-assignment-in-destructuring-unknown-array-variables/main.js
+++ b/test/function/samples/keep-the-non-first-assignment-in-destructuring-unknown-array-variables/main.js
@@ -1,0 +1,2 @@
+const [a, last2 = { foo: true }] = unknownVariable;
+assert.ok(last2.foo);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
resolves #6075 
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
By directly assigning the `included` value of a child node (e.g., element.included = true), the first include logic of that child in `includeNode` may be bypassed. Therefore, this PR uses `childNode.includeNode` instead of setting `element.included = true` directly. In addition, `includeNode` is also executed on the current node itself in `includeDestructuredIfNecessary` for the same reason. Finally, this PR fixes incorrect logic in `ObjectPattern` and simplifies the logic in `ArrayPattern`.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
