### PR TITLE
perf: replace startsWith with strict equality

### DIFF
--- a/docs/.vitepress/verify-anchors.ts
+++ b/docs/.vitepress/verify-anchors.ts
@@ -40,7 +40,7 @@ function verifyAnchorsOnPage(page: string, slugs: Set<string>) {
 	let match: (RegExpExecArray & { groups?: { href?: string } }) | null;
 	while ((match = markdownLinkRegExp.exec(text)) !== null) {
 		const [href] = match;
-		if (href.startsWith('#')) {
+		if (href[0] === '#') {
 			const anchor = href.slice(1);
 			if (!slugs.has(anchor)) {
 				console.log(slugs);

--- a/docs/repl/helpers/query.ts
+++ b/docs/repl/helpers/query.ts
@@ -16,7 +16,7 @@ export async function useUpdateStoresFromQuery() {
 	try {
 		if (query.shareable) {
 			const rawJson = atob(query.shareable.replace(/_/g, '/').replace(/-/g, '+'));
-			const json = rawJson.startsWith('%') ? decodeURIComponent(rawJson) : rawJson;
+			const json = rawJson[0] === '%' ? decodeURIComponent(rawJson) : rawJson;
 			const {
 				modules: queryModules,
 				options: queryOptions,

--- a/scripts/test-options.js
+++ b/scripts/test-options.js
@@ -73,7 +73,7 @@ for (const line of splitHelpText) {
 	}
 }
 
-const helpOptionLines = splitHelpText.filter(line => line.startsWith('-'));
+const helpOptionLines = splitHelpText.filter(line => line[0] === '-');
 
 const cliFlagsText = commandReferenceText
 	.split('\n## ')
@@ -85,7 +85,7 @@ const cliMarkdownSection = cliFlagsText.match(/```\n([\S\s]*?)\n```/);
 if (!cliMarkdownSection) {
 	throw new Error('Could not find markdown section in "Command line flags" section.');
 }
-const optionListLines = cliMarkdownSection[1].split('\n').filter(line => line.startsWith('-'));
+const optionListLines = cliMarkdownSection[1].split('\n').filter(line => line[0] === '-');
 
 for (const [index, line] of helpOptionLines.entries()) {
 	const optionListLine = optionListLines[index];

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -966,7 +966,7 @@ export default class Chunk {
 							variable.isNamespace &&
 							namespaceInteropHelpersByInteropType[interop(module.id)] &&
 							(this.imports.has(variable) ||
-								!this.exportNamesByVariable.get(variable)?.every(name => name.startsWith('*')))
+								!this.exportNamesByVariable.get(variable)?.every(name => name[0] === '*'))
 						) {
 							// We only need to deconflict it if the namespace is actually
 							// created as a variable, i.e. because it is used internally or
@@ -1143,7 +1143,7 @@ export default class Chunk {
 				return idWithoutExtension.slice(preserveModulesRoot.length).replace(/^[/\\]/, '');
 			} else {
 				// handle edge case in Windows
-				if (this.inputBase === '/' && !idWithoutExtension.startsWith('/')) {
+				if (this.inputBase === '/' && idWithoutExtension[0] !== '/') {
 					return relative(this.inputBase, idWithoutExtension.replace(/^[a-zA-Z]:[/\\]/, '/'));
 				}
 				return relative(this.inputBase, idWithoutExtension);

--- a/src/utils/getLogFilter.ts
+++ b/src/utils/getLogFilter.ts
@@ -5,7 +5,7 @@ export const getLogFilter: GetLogFilter = filters => {
 	if (filters.length === 0) return () => true;
 	const normalizedFilters = filters.map(filter =>
 		filter.split('&').map(subFilter => {
-			const inverted = subFilter.startsWith('!');
+			const inverted = subFilter[0] === '!';
 			if (inverted) subFilter = subFilter.slice(1);
 			const [key, ...value] = subFilter.split(':');
 			return { inverted, key: key.split('.'), parts: value.join(':').split('*') };

--- a/src/utils/options/normalizeInputOptions.ts
+++ b/src/utils/options/normalizeInputOptions.ts
@@ -97,7 +97,7 @@ const getIdMatcher = <T extends any[]>(
 		return () => true;
 	}
 	if (typeof option === 'function') {
-		return (id, ...parameters) => (!id.startsWith('\0') && option(id, ...parameters)) || false;
+		return (id, ...parameters) => (id[0] !== '\0' && option(id, ...parameters)) || false;
 	}
 	if (option) {
 		const ids = new Set<string>();
@@ -241,7 +241,7 @@ const getHasModuleSideEffects = (
 	}
 	if (typeof moduleSideEffectsOption === 'function') {
 		return (id, external) =>
-			id.startsWith('\0') ? true : moduleSideEffectsOption(id, external) !== false;
+			id[0] === '\0' ? true : moduleSideEffectsOption(id, external) !== false;
 	}
 	if (Array.isArray(moduleSideEffectsOption)) {
 		const ids = new Set(moduleSideEffectsOption);

--- a/test/function/samples/external-ignore-reserved-null-marker/_config.js
+++ b/test/function/samples/external-ignore-reserved-null-marker/_config.js
@@ -2,7 +2,7 @@ module.exports = defineTest({
 	description: 'external function ignores \\0 started ids',
 	options: {
 		external(id) {
-			if (id.startsWith('\0')) {
+			if (id[0] === '\0') {
 				throw new Error('\\0 started ids should not be tested as external');
 			}
 			return true;

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -497,7 +497,7 @@ const replaceStringifyValues = (key, value) => {
 		}
 	}
 
-	return key.startsWith('_')
+	return key[0] === '_'
 		? undefined
 		: typeof value == 'bigint'
 			? `~BigInt${value.toString()}`


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
When determining the value of the first letter of a string, using strict equality is more efficient than startsWith. refer to [link](https://perf.link/#eyJpZCI6InpyZjd5OHg5Mm13IiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXS5tYXAoKCkgPT4gTWF0aC5yYW5kb20oKS50b1N0cmluZygxNikpIiwidGVzdHMiOlt7Im5hbWUiOiJGaW5kIGl0ZW0gMTAwIiwiY29kZSI6ImRhdGEuZmluZCh4ID0%2BIHguc3RhcnRzV2l0aCgnLicpKSIsInJ1bnMiOls2MDAwMCw1NTAwMCw1NzAwMCw3MjAwMCwyNzAwMCw5MzAwMCw5NjAwMCw4MTAwMCwxMTEwMDAsMzAwMCwyODAwMCwxMzAwMDAsMTUwMDAsMjEwMDAsMTU0MDAwLDEwMDAsNTYwMDAsODkwMDAsMzkwMDAsMzMwMDAsMTIwMDAsMzAwMCwyNDAwMCw0MDAwMCwxMjAwMCwxMjAwMCwzNjAwMCwxNTYwMDAsMTA3MDAwLDIwMDAwLDE3MjAwMCwzMzAwMCwyNTAwMCw3MDAwLDEzMDAwLDEyNTAwMCwxNTYwMDAsMTMwMDAsNTgwMDAsMTY5MDAwLDEyMDAwLDIwMDAsMTkwMDAsNDYwMDAsMzAwMCw3NTAwMCwzNDAwMCwxOTAwMCw4NTAwMCwxMzkwMDAsMTY3MDAwLDM4MDAwLDQzMDAwLDQ1MDAwLDM3MDAwLDMzMDAwLDg4MDAwLDE4MDAwLDM3MDAwLDI5MDAwLDQwMDAwLDM0MDAwLDYwMDAwLDQ1MDAwLDEyMzAwMCwyMDAwMCwxMDAwMCw3NjAwMCwxNDAwMCw1NDAwMCw0MzAwMCw3NzAwMCw1MDAwLDU2MDAwLDIwMDAsNDkwMDAsNDMwMDAsNDUwMDAsNDcwMDAsNzQwMDAsMzEwMDAsMjkwMDAsMzkwMDAsMzQwMDAsNDgwMDAsNTIwMDAsMTIwMDAsMjIwMDAsMjAwMCwyMDAwLDIwMDAwLDE1MDAwLDU0MDAwLDQ1MDAwLDkwMDAsMjAwMDAsMTQwMDAsNzAwMCw1NDAwMCw0MTAwMF0sIm9wcyI6NDg1MDB9LHsibmFtZSI6IkZpbmQgaXRlbSAyMDAiLCJjb2RlIjoiZGF0YS5maW5kKHggPT4geFswXSA9PT0gJy4nKSIsInJ1bnMiOls4NTAwMCw3NzAwMCw4NzAwMCw5MjAwMCwyOTAwMCwxMTMwMDAsMTE5MDAwLDExMDAwMCwxMzUwMDAsMTAwMCwzMjAwMCwxNTUwMDAsMjMwMDAsMzMwMDAsMTEzMDAwLDE2NTAwMCw3NDAwMCwxMTQwMDAsMjMwMDAsNDIwMDAsMTAwMDAsMTM4MDAwLDQyMDAwLDU2MDAwLDE3MDAwLDE4MDAwMCw0NjAwMCwxNzcwMDAsMTM1MDAwLDIxMDAwLDE2NzAwMCwzNDAwMCwxOTAwMCw4MDAwLDQwMDAsMTU0MDAwLDE3ODAwMCwxOTYwMDAsODQwMDAsMTg3MDAwLDE2MDAwLDExMDAwLDI0MDAwLDQ3MDAwLDE4NDAwMCw5MzAwMCw0NzAwMCwxOTYwMDAsOTAwMDAsMTY2MDAwLDE4MTAwMCw1MDAwMCwzOTAwMCw1NDAwMCw1NjAwMCwzODAwMCwxMTIwMDAsMjQwMDAsNTEwMDAsNDQwMDAsMzMwMDAsNDUwMDAsNzUwMDAsMjUwMDAsMTQyMDAwLDExMDAwLDE4MzAwMCw5NjAwMCwxMDAwLDUxMDAwLDU3MDAwLDk5MDAwLDE5NjAwMCw3MTAwMCwyMDAwLDY5MDAwLDY2MDAwLDYxMDAwLDY1MDAwLDEwMzAwMCwzNTAwMCwyMTAwMCw1MjAwMCw1OTAwMCwyMzAwMCw0NTAwMCwxMzgwMDAsMzMwMDAsMjAwMCwyMDAwLDI4MDAwLDExMDAwLDU4MDAwLDYyMDAwLDYwMDAsMzAwMDAsMTMwMDAsMjAwMCw3MTAwMCw2NDAwMF0sIm9wcyI6NzIwNDB9XSwidXBkYXRlZCI6IjIwMjUtMDgtMDdUMTQ6MTI6NTUuNDEwWiJ9)
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
