### PR TITLE
feat: support ROLLUP_FILE_URL_OBJ asset references for URL object ins…

### DIFF
--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -1427,7 +1427,7 @@ Emits a new file that is included in the build output and returns a `referenceId
 
 When emitting chunks or assets, either a `name` or a `fileName` can be supplied. If a `fileName` is provided, it will be used unmodified as the name of the generated file, throwing an error if this causes a conflict. Otherwise, if a `name` is supplied, this will be used as substitution for `[name]` in the corresponding [`output.chunkFileNames`](../configuration-options/index.md#output-chunkfilenames) or [`output.assetFileNames`](../configuration-options/index.md#output-assetfilenames) pattern, possibly adding a unique number to the end of the file name to avoid conflicts. If neither a `name` nor `fileName` is supplied, a default name will be used. Prebuilt chunks must always have a `fileName`.
 
-You can reference the URL of an emitted file in any code returned by a [`load`](#load) or [`transform`](#transform) plugin hook via `import.meta.ROLLUP_FILE_URL_referenceId`. See [File URLs](#file-urls) for more details and an example.
+You can reference the URL of an emitted file in any code returned by a [`load`](#load) or [`transform`](#transform) plugin hook via `import.meta.ROLLUP_FILE_URL_referenceId` (returns a string) or `import.meta.ROLLUP_FILE_URL_OBJ_referenceId` (returns a URL object). See [File URLs](#file-urls) for more details and an example.
 
 The generated code that replaces `import.meta.ROLLUP_FILE_URL_referenceId` can be customized via the [`resolveFileUrl`](#resolvefileurl) plugin hook. You can also use [`this.getFileName(referenceId)`](#this-getfilename) to determine the file name as soon as it is available. If the file name is not set explicitly, then
 
@@ -2122,6 +2122,17 @@ export const size = 6;
 ```
 
 If you build this code, both the main chunk and the worklet will share the code from `config.js` via a shared chunk. This enables us to make use of the browser cache to reduce transmitted data and speed up loading the worklet.
+
+You can also use `import.meta.ROLLUP_FILE_URL_OBJ_referenceId` to get a URL object directly instead of a string. This is more efficient when you need the URL object itself, as it avoids creating the object twice:
+
+```js
+// Using ROLLUP_FILE_URL (returns string, requires wrapping in new URL())
+const urlString = import.meta.ROLLUP_FILE_URL_referenceId;
+const urlObject = new URL(urlString);
+
+// Using ROLLUP_FILE_URL_OBJ (returns URL object directly)
+const urlObject = import.meta.ROLLUP_FILE_URL_OBJ_referenceId;
+```
 
 ## Transformers
 

--- a/test/chunking-form/samples/resolve-file-url-obj/_config.js
+++ b/test/chunking-form/samples/resolve-file-url-obj/_config.js
@@ -1,0 +1,29 @@
+module.exports = defineTest({
+	description: 'allows to use ROLLUP_FILE_URL_OBJ to get URL objects directly',
+	options: {
+		plugins: [
+			{
+				resolveId(id) {
+					if (id === 'url-test') {
+						return id;
+					}
+				},
+				load(id) {
+					if (id === 'url-test') {
+						const assetId = this.emitFile({
+							type: 'asset',
+							name: 'test.txt',
+							source: 'test content'
+						});
+						return `
+							// Test string URL replacement
+							export const assetString = import.meta.ROLLUP_FILE_URL_${assetId};
+							// Test URL object replacement
+							export const assetObject = import.meta.ROLLUP_FILE_URL_OBJ_${assetId};
+						`;
+					}
+				}
+			}
+		]
+	}
+});

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/amd/assets/test-r6af3lUh.txt
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/amd/assets/test-r6af3lUh.txt
@@ -1,0 +1,1 @@
+test content

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/amd/main.js
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/amd/main.js
@@ -1,0 +1,11 @@
+define(['require'], (function (require) { 'use strict';
+
+	// Test string URL replacement
+								const assetString = new URL(require.toUrl('./assets/test-r6af3lUh.txt'), document.baseURI).href;
+								// Test URL object replacement
+								const assetObject = new URL(require.toUrl('./assets/test-r6af3lUh.txt'), document.baseURI);
+
+	console.log('String URL:', assetString);
+	console.log('URL Object:', assetObject);
+
+}));

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/cjs/assets/test-r6af3lUh.txt
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/cjs/assets/test-r6af3lUh.txt
@@ -1,0 +1,1 @@
+test content

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/cjs/main.js
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/cjs/main.js
@@ -1,0 +1,9 @@
+'use strict';
+
+// Test string URL replacement
+							const assetString = (typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__dirname + '/assets/test-r6af3lUh.txt').href : new URL('assets/test-r6af3lUh.txt', document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.src || document.baseURI).href);
+							// Test URL object replacement
+							const assetObject = (typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__dirname + '/assets/test-r6af3lUh.txt') : new URL('assets/test-r6af3lUh.txt', document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.src || document.baseURI));
+
+console.log('String URL:', assetString);
+console.log('URL Object:', assetObject);

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/es/assets/test-r6af3lUh.txt
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/es/assets/test-r6af3lUh.txt
@@ -1,0 +1,1 @@
+test content

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/es/main.js
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/es/main.js
@@ -1,0 +1,7 @@
+// Test string URL replacement
+							const assetString = new URL('assets/test-r6af3lUh.txt', import.meta.url).href;
+							// Test URL object replacement
+							const assetObject = new URL('assets/test-r6af3lUh.txt', import.meta.url);
+
+console.log('String URL:', assetString);
+console.log('URL Object:', assetObject);

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/system/assets/test-r6af3lUh.txt
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/system/assets/test-r6af3lUh.txt
@@ -1,0 +1,1 @@
+test content

--- a/test/chunking-form/samples/resolve-file-url-obj/_expected/system/main.js
+++ b/test/chunking-form/samples/resolve-file-url-obj/_expected/system/main.js
@@ -1,0 +1,16 @@
+System.register([], (function (exports, module) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			// Test string URL replacement
+										const assetString = new URL('assets/test-r6af3lUh.txt', module.meta.url).href;
+										// Test URL object replacement
+										const assetObject = new URL('assets/test-r6af3lUh.txt', module.meta.url);
+
+			console.log('String URL:', assetString);
+			console.log('URL Object:', assetObject);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/resolve-file-url-obj/main.js
+++ b/test/chunking-form/samples/resolve-file-url-obj/main.js
@@ -1,0 +1,4 @@
+import { assetString, assetObject } from 'url-test';
+
+console.log('String URL:', assetString);
+console.log('URL Object:', assetObject);


### PR DESCRIPTION
…tead of string

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

- implements https://github.com/rollup/rollup/issues/5857

### Description

Adds support for `import.meta.ROLLUP_FILE_URL_OBJ_referenceId` as discussed.
