### PR TITLE
Disable local_dynamic_tls for OpenHarmony

### DIFF
--- a/rust/bindings_napi/Cargo.toml
+++ b/rust/bindings_napi/Cargo.toml
@@ -24,7 +24,8 @@ mimalloc-safe = { version = "0.1.54" }
 # 		all(
 # 			target_os = "linux",
 # 			not(target_arch = "loongarch64"),
-# 			not(all(target_arch = "riscv64", target_env = "musl"))
+# 			not(all(target_arch = "riscv64", target_env = "musl")),
+# 			not(target_env = "ohos")
 # 		),
 # 		all(
 # 			target_os = "freebsd",
@@ -32,7 +33,7 @@ mimalloc-safe = { version = "0.1.54" }
 # 		)
 # 	)
 # )
-[target.'cfg(any(all(target_os = "linux", not(target_arch = "loongarch64"), not(all(target_arch = "riscv64", target_env = "musl"))), all(target_os = "freebsd", not(target_arch = "aarch64"))))'.dependencies]
+[target.'cfg(any(all(target_os = "linux", not(target_arch = "loongarch64"), not(all(target_arch = "riscv64", target_env = "musl")), not(target_env = "ohos")), all(target_os = "freebsd", not(target_arch = "aarch64"))))'.dependencies]
 mimalloc-safe = { version = "0.1.54", features = ["local_dynamic_tls"] }
 
 # Disable architecture specific optimizations on aarch64 platforms

--- a/rust/bindings_napi/src/lib.rs
+++ b/rust/bindings_napi/src/lib.rs
@@ -5,6 +5,7 @@ use parse_ast::parse_ast;
 #[cfg(all(
   not(all(target_os = "linux", target_arch = "loongarch64")),
   not(all(target_os = "linux", target_arch = "riscv64", target_env = "musl")),
+  not(all(target_os = "linux", target_env = "ohos")),
   not(all(target_os = "freebsd", target_arch = "aarch64")),
   not(debug_assertions)
 ))]


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

On the OpenHarmony platform, if I use a Node.js that is statically linked with libc++ (built with the --partly-static parameter) to load rollup, it works smoothly.

However, if I use a Node.js that is dynamically linked with libc++ (built with the default parameters) to load rollup, it will encounter the following error:

```
Error relocating /data/node_modules/@rollup/rollup-openharmony-arm64/rollup.openharmony-arm64.node: __emutls_get_address: symbol not found
```

To avoid this error, we have two options to choose from:

1. Disable local_dynamic_tls for OpenHarmony.
2. Link libc++ into rollup (refer to here: https://ohos.rs/docs/more/emu-tls.html).

To improve the compatibility of rollup on OpenHarmony and reduce maintenance costs, I chose option 1. This solution also refers to the handling in rolldown(https://github.com/rolldown/rolldown/pull/5258).