### PR TITLE
Automatically remove REPL artefacts label from PRs

### DIFF
--- a/.github/workflows/performance-report.yml
+++ b/.github/workflows/performance-report.yml
@@ -17,7 +17,9 @@ permissions:
 
 jobs:
   build-artefacts:
-    if: ${{ github.event.pull_request.head.repo.full_name == 'rollup/rollup' || contains( toJson(github.event.pull_request.labels), 'x⁸ ⚙️ build repl artefacts' ) }}
+    if: >-
+      ${{ github.event.pull_request.head.repo.full_name == 'rollup/rollup' ||
+          (github.event.action == 'labeled' && github.event.label.name == 'x⁸ ⚙️ build repl artefacts') }}
     strategy:
       matrix:
         settings:

--- a/.github/workflows/repl-artefacts.yml
+++ b/.github/workflows/repl-artefacts.yml
@@ -19,10 +19,17 @@ jobs:
   upload:
     permissions:
       pull-requests: write # for peter-evans/find-comment and peter-evans/create-or-update-comment
-    if: ${{ github.event.pull_request.head.repo.full_name == 'rollup/rollup' || contains( toJson(github.event.pull_request.labels), 'x⁸ ⚙️ build repl artefacts' ) }}
+    if: >-
+      ${{ github.event.pull_request.head.repo.full_name == 'rollup/rollup' ||
+          (github.event.action == 'labeled' && github.event.label.name == 'x⁸ ⚙️ build repl artefacts') }}
     runs-on: ubuntu-latest
     name: Upload
     steps:
+      - name: Remove 'x⁸ ⚙️ build repl artefacts' label if triggered by label
+        if: ${{ github.event.action == 'labeled' }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label 'x⁸ ⚙️ build repl artefacts'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout Commit
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
In order to reduce the opportunity to abuse this label, I want to directly remove it when added to a pull request and only run on non-Rollup repos when the label was just added.