### PR TITLE
fix(build): make relative imports in amd/cjs relative to the current module

### DIFF
--- a/src/ast/nodes/MetaProperty.ts
+++ b/src/ast/nodes/MetaProperty.ts
@@ -205,7 +205,7 @@ const relativeUrlMechanisms: Record<
 > = {
 	amd: (relativePath, asObject: boolean) => {
 		if (relativePath[0] !== '.') relativePath = './' + relativePath;
-		return getResolveUrl(`require.toUrl('${escapeId(relativePath)}'), document.baseURI`, asObject);
+		return getResolveUrl(`require.toUrl('${escapeId(relativePath)}'), new URL(module.uri, document.baseURI).href`, asObject);
 	},
 	cjs: (relativePath, asObject: boolean) =>
 		`(typeof document === 'undefined' ? ${getFileUrlFromRelativePath(relativePath, asObject)} : ${getRelativeUrlFromDocument(relativePath, asObject)})`,


### PR DESCRIPTION

<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

If you agree with the change itself, I can try to implement a regression test. Right now I would mainly like feedback if there is a reason for the old implementation. 

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [ ] no

Not sure here, yes, it changes the behavior, but I think it was broken before... so not sure what to check here. 

List any relevant issue numbers:
 - https://github.com/vitejs/vite/issues/20860 would be fixed if copied code was updated in Vite

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->


Make relative imports in amd/cjs relative to the current module instead of the baseURI. 
This is basically a backport of a change I'm trying to land in vite: 
https://github.com/vitejs/vite/pull/20861

Copied description: 
As far as I can tell rollup itself uses `module.uri` to replace `import.meta.url` in `amd` modules. So I assume it's okay to use it.
https://github.com/rollup/rollup/blob/ce6cb93098850a46fa242e37b74a919e99a5de28/src/ast/nodes/MetaProperty.ts#L209

An alternative could be to use `resolve.toUrl(module.id)` but it seems unneccessary if other parts of the code already rely on `module.uri`.

FWIW I've verified that `import.meta.url` gets transpiled to `new URL(module.uri, document.baseURI).href` in my setup with amd modules. Using `import.meta.url` directly for the imports here does not work as it happens too late in the transpilation process (getting errors that `module` may not be used outside of module scope).


There is more debug output and context in the original ticket/PR