### PR TITLE
fix: Update postinstall script to handle missing patch-package when rollup is installed as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "prepare": "husky && node scripts/check-release.js || npm run build:prepare",
     "prepublishOnly": "node scripts/check-release.js && node scripts/prepublish.js",
     "postpublish": "node scripts/postpublish.js",
-    "postinstall": "patch-package",
+    "postinstall": "patch-package || true",
     "prepublish:napi": "napi prepublish --no-gh-release",
     "release": "node scripts/prepare-release.js",
     "release:docs": "git fetch --update-head-ok origin master:master && git branch --force documentation-published master && git push origin documentation-published",


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

-  resolves #6168

### Description

This is a quick hotfix by tacking ` || true` to the end of the postinstall script added in `v4.53.0` to swallow the error encountered when the `patch-package` package is not available. Without some sort of error swallowing here, the `v4.53.0` release is effectively blocking when used within a project where 1) postinstall scripts are desired and 2) `patch-package` is not a direct/indirect dependency.

Realize there are a handful of other ways to resolve this situation. No worries if another approach is chosen. 

<img width="872" height="120" alt="Screenshot 2025-11-07 at 12 36 19 PM" src="https://github.com/user-attachments/assets/a6bb0b24-04bf-45a0-bf93-801bfef8b6d2" />