### PR TITLE
Re-enable TypeScript test

### DIFF
--- a/.github/actions/install-and-cache-node-deps/action.yml
+++ b/.github/actions/install-and-cache-node-deps/action.yml
@@ -14,7 +14,7 @@ runs:
         restore-keys: node-modules-${{ runner.os }}-${{ runner.arch }}
     - name: Install Node dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      run: npm ${{ github.ref == 'refs/heads/master' && 'ci' || 'install' }} --ignore-scripts && npm run prepare --if-present
+      run: npm ${{ github.ref == 'refs/heads/master' && 'ci' || 'install' }} --ignore-scripts && npm run prepare:patch
       shell: bash
     - name: Save Node dependencies cache
       if: steps.cache-node-modules.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "lint:rust": "cd rust && cargo fmt && cargo clippy --fix --allow-dirty",
     "lint:rust:nofix": "cd rust && cargo fmt --check && cargo clippy",
     "perf": "npm run build:bootstrap:cjs && node --expose-gc scripts/perf-report/index.js",
-    "prepare": "husky && patch-package && node scripts/check-release.js || npm run build:prepare",
+    "prepare": "husky && npm run prepare:patch && node scripts/check-release.js || npm run build:prepare",
+    "prepare:patch": "patch-package",
     "prepublishOnly": "node scripts/check-release.js && node scripts/prepublish.js",
     "postpublish": "node scripts/postpublish.js",
     "prepublish:napi": "napi prepublish --no-gh-release",
@@ -86,7 +87,7 @@
     "test:package": "node scripts/test-package.js",
     "test:options": "node scripts/test-options.js",
     "test:only": "mocha test/test.js",
-    "test:typescript": "echo skipped",
+    "test:typescript": "shx rm -rf test/typescript/dist && shx cp -r dist test/typescript/ && tsc --noEmit -p test/typescript && tsc --noEmit -p . && tsc --noEmit -p scripts && vue-tsc --noEmit -p docs",
     "test:browser": "mocha test/browser/index.js",
     "watch": "rollup --config rollup.config.ts --configPlugin typescript --watch"
   },


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
As part of the fix yesterday, I needed to disable the TypeScript test as it relied on patch-package working in the cached node_modules. This should re-enable it and also show us whether we need to invalidate some images.
