### PR TITLE
Handle TLA dynamic import cycles in chunkAssignment

### DIFF
--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_config.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_config.js
@@ -1,0 +1,6 @@
+module.exports = defineTest({
+	description:
+		'splitting module in cycles that is dynamically imported by a module with TLA into a separate chunk',
+	formats: ['es', 'system'],
+	expectedWarnings: ['CIRCULAR_DEPENDENCY']
+});

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/es/generated-a.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/es/generated-a.js
@@ -1,0 +1,11 @@
+class B {
+  async foo() {
+    const foo = await import('./generated-foo.js');
+    return new foo.Foo();
+  }
+}
+await Promise.resolve();
+
+class A extends B {}
+
+export { A };

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/es/generated-foo.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/es/generated-foo.js
@@ -1,0 +1,7 @@
+import { A } from './generated-a.js';
+
+class Foo extends A {
+  foo() { console.log("hello"); }
+}
+
+export { Foo as default };

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/es/main.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/es/main.js
@@ -1,0 +1,10 @@
+import { A } from './generated-a.js';
+import Foo from './generated-foo.js';
+
+class Bar extends A {
+  bar() {
+    return new Foo().foo();
+  }
+}
+
+new Bar().bar();

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/system/generated-a.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/system/generated-a.js
@@ -1,0 +1,18 @@
+System.register([], (function (exports, module) {
+  'use strict';
+  return {
+    execute: (async function () {
+
+      class B {
+        async foo() {
+          const foo = await module.import('./generated-foo.js');
+          return new foo.Foo();
+        }
+      }
+      await Promise.resolve();
+
+      class A extends B {} exports("A", A);
+
+    })
+  };
+}));

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/system/generated-foo.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/system/generated-foo.js
@@ -1,0 +1,16 @@
+System.register(['./generated-a.js'], (function (exports) {
+  'use strict';
+  var A;
+  return {
+    setters: [function (module) {
+      A = module.A;
+    }],
+    execute: (function () {
+
+      class Foo extends A {
+        foo() { console.log("hello"); }
+      } exports("default", Foo);
+
+    })
+  };
+}));

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/system/main.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/_expected/system/main.js
@@ -1,0 +1,22 @@
+System.register(['./generated-a.js', './generated-foo.js'], (function () {
+  'use strict';
+  var A, Foo;
+  return {
+    setters: [function (module) {
+      A = module.A;
+    }, function (module) {
+      Foo = module.default;
+    }],
+    execute: (function () {
+
+      class Bar extends A {
+        bar() {
+          return new Foo().foo();
+        }
+      }
+
+      new Bar().bar();
+
+    })
+  };
+}));

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/a.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/a.js
@@ -1,0 +1,3 @@
+import B from "./b.js"
+
+export default class A extends B {}

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/b.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/b.js
@@ -1,0 +1,7 @@
+export default class B {
+  async foo() {
+    const foo = await import("./foo.js");
+    return new foo.Foo();
+  }
+}
+await Promise.resolve();

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/foo.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/foo.js
@@ -1,0 +1,5 @@
+import A from "./a.js"
+
+export default class Foo extends A {
+  foo() { console.log("hello") }
+}

--- a/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/main.js
+++ b/test/chunking-form/samples/splitting-cycles-module-with-TLA-and-dynamic-importer/main.js
@@ -1,0 +1,10 @@
+import A from "./a.js"
+import Foo from "./foo.js"
+
+class Bar extends A {
+  bar() {
+    return new Foo().foo();
+  }
+}
+
+new Bar().bar();


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
related to #6154 
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
The reason this issue was raised is that a dynamic import is treated as a TLA dynamic import when it appears in a module with TLA. As a result, an otherwise normal module graph is considered to contain cycles.

In my opinion, a bundler generally should not care about cycles introduced by TLA dynamic imports, other than possibly emitting a warning. However, in the case described in the issue, this TLA dynamic import cycle is a false positive.

Therefore, in this PR, introducing a fallback logic for chunk assignment to handle these scenarios. But the warning caused by the false positive still remains.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
