### PR TITLE
Throw a warning for circular chunks

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -183,6 +183,7 @@ export default class Chunk {
 	namespaceVariableName = '';
 	suggestedVariableName: string;
 	variableName = '';
+	isManualChunk = false;
 
 	private readonly accessedGlobalsByScope = new Map<ChildScope, Set<string>>();
 	private readonly dynamicEntryModules: Module[] = [];
@@ -257,6 +258,7 @@ export default class Chunk {
 			}
 		}
 		this.suggestedVariableName = makeLegal(this.generateVariableName());
+		this.isManualChunk = manualChunkAlias !== null;
 	}
 
 	private static generateFacade(

--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -114,6 +114,7 @@ const ADDON_ERROR = 'ADDON_ERROR',
 	CANNOT_EMIT_FROM_OPTIONS_HOOK = 'CANNOT_EMIT_FROM_OPTIONS_HOOK',
 	CHUNK_NOT_GENERATED = 'CHUNK_NOT_GENERATED',
 	CHUNK_INVALID = 'CHUNK_INVALID',
+	CIRCULAR_CHUNK = 'CIRCULAR_CHUNK',
 	CIRCULAR_DEPENDENCY = 'CIRCULAR_DEPENDENCY',
 	CIRCULAR_REEXPORT = 'CIRCULAR_REEXPORT',
 	CONST_REASSIGN = 'CONST_REASSIGN',
@@ -299,6 +300,18 @@ export function logCircularDependency(cyclePath: string[]): RollupLog {
 		code: CIRCULAR_DEPENDENCY,
 		ids: cyclePath,
 		message: `Circular dependency: ${cyclePath.map(relativeId).join(' -> ')}`
+	};
+}
+
+export function logCircularChunk(cyclePath: string[], isManualChunkConflict: boolean): RollupLog {
+	return {
+		code: CIRCULAR_CHUNK,
+		ids: cyclePath,
+		message: `Circular chunk: ${cyclePath.join(' -> ')}. ${
+			isManualChunkConflict
+				? `Please adjust the manual chunk logic for these chunks.`
+				: `Consider disabling the "output.onlyExplicitManualChunks" option, as enabling it causes the static dependencies of the manual chunk "${cyclePath.at(-2)}" to be bundled into the chunk "${cyclePath.at(-1)}".`
+		}`
 	};
 }
 

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_config.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_config.js
@@ -1,0 +1,18 @@
+module.exports = defineTest({
+	description: 'Throw a warning for circular chunks caused by manual chunks conflict',
+	options: {
+		output: {
+			manualChunks(id) {
+				if (id.endsWith('a.js') || id.endsWith('c.js')) return 'ac';
+				if (id.endsWith('b.js')) return 'b';
+			}
+		}
+	},
+	expectedWarnings: ['CIRCULAR_CHUNK'],
+	logs: new Array(4).fill(null).map(() => ({
+		code: 'CIRCULAR_CHUNK',
+		ids: ['b', 'ac', 'b'],
+		level: 'warn',
+		message: 'Circular chunk: b -> ac -> b. Please adjust the manual chunk logic for these chunks.'
+	}))
+});

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/amd/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/amd/generated-ac.js
@@ -1,0 +1,12 @@
+define(['exports', './generated-b'], (function (exports, b) { 'use strict';
+
+	const c = 'c';
+	console.log(c);
+
+	const a = 'a';
+	console.log(a + b.b);
+
+	exports.a = a;
+	exports.c = c;
+
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/amd/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/amd/generated-b.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-ac'], (function (exports, ac) { 'use strict';
+
+	const b = 'b';
+	console.log(b + ac.c);
+
+	exports.b = b;
+
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/amd/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(['./generated-ac', './generated-b'], (function (ac, b) { 'use strict';
+
+	console.log(ac.a);
+
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/cjs/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/cjs/generated-ac.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var b = require('./generated-b.js');
+
+const c = 'c';
+console.log(c);
+
+const a = 'a';
+console.log(a + b.b);
+
+exports.a = a;
+exports.c = c;

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/cjs/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/cjs/generated-b.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var ac = require('./generated-ac.js');
+
+const b = 'b';
+console.log(b + ac.c);
+
+exports.b = b;

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/cjs/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/cjs/main.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var ac = require('./generated-ac.js');
+require('./generated-b.js');
+
+console.log(ac.a);

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/es/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/es/generated-ac.js
@@ -1,0 +1,9 @@
+import { b } from './generated-b.js';
+
+const c = 'c';
+console.log(c);
+
+const a = 'a';
+console.log(a + b);
+
+export { a, c };

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/es/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/es/generated-b.js
@@ -1,0 +1,6 @@
+import { c } from './generated-ac.js';
+
+const b = 'b';
+console.log(b + c);
+
+export { b };

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/es/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/es/main.js
@@ -1,0 +1,4 @@
+import { a } from './generated-ac.js';
+import './generated-b.js';
+
+console.log(a);

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/system/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/system/generated-ac.js
@@ -1,0 +1,18 @@
+System.register(['./generated-b.js'], (function (exports) {
+	'use strict';
+	var b;
+	return {
+		setters: [function (module) {
+			b = module.b;
+		}],
+		execute: (function () {
+
+			const c = exports("c", 'c');
+			console.log(c);
+
+			const a = exports("a", 'a');
+			console.log(a + b);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/system/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/system/generated-b.js
@@ -1,0 +1,15 @@
+System.register(['./generated-ac.js'], (function (exports) {
+	'use strict';
+	var c;
+	return {
+		setters: [function (module) {
+			c = module.c;
+		}],
+		execute: (function () {
+
+			const b = exports("b", 'b');
+			console.log(b + c);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/system/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/_expected/system/main.js
@@ -1,0 +1,14 @@
+System.register(['./generated-ac.js', './generated-b.js'], (function () {
+	'use strict';
+	var a;
+	return {
+		setters: [function (module) {
+			a = module.a;
+		}, null],
+		execute: (function () {
+
+			console.log(a);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/a.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/a.js
@@ -1,0 +1,4 @@
+import { b } from './b.js';
+const a = 'a';
+console.log(a + b);
+export { a }

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/b.js
@@ -1,0 +1,4 @@
+import { c } from './c.js';
+const b = 'b';
+console.log(b + c);
+export { b }

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/c.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/c.js
@@ -1,0 +1,3 @@
+const c = 'c';
+console.log(c);
+export { c }

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-manual-chunks-conflict/main.js
@@ -1,0 +1,2 @@
+import {a} from './a.js';
+console.log(a);

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_config.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_config.js
@@ -1,0 +1,19 @@
+module.exports = defineTest({
+	description: 'Throw a warning for circular chunks caused by onlyExplicitManualChunks',
+	options: {
+		output: {
+			manualChunks(id) {
+				if (id.endsWith('a.js') || id.endsWith('c.js')) return 'ac';
+			},
+			onlyExplicitManualChunks: true
+		}
+	},
+	expectedWarnings: ['CIRCULAR_CHUNK'],
+	logs: new Array(4).fill(null).map(() => ({
+		code: 'CIRCULAR_CHUNK',
+		ids: ['main', 'ac', 'main'],
+		level: 'warn',
+		message:
+			'Circular chunk: main -> ac -> main. Consider disabling the "output.onlyExplicitManualChunks" option, as enabling it causes the static dependencies of the manual chunk "ac" to be bundled into the chunk "main".'
+	}))
+});

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/generated-ac.js
@@ -1,0 +1,12 @@
+define(['exports', './main'], (function (exports, main) { 'use strict';
+
+	const c = 'c';
+	console.log(c);
+
+	const a = 'a';
+	console.log(a + main.b);
+
+	exports.a = a;
+	exports.c = c;
+
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/main.js
@@ -1,0 +1,10 @@
+define(['exports', './generated-ac', './main'], (function (exports, ac, main) { 'use strict';
+
+	const b = 'b';
+	console.log(b + ac.c);
+
+	console.log(ac.a);
+
+	exports.b = b;
+
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/generated-ac.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var main = require('./main.js');
+
+const c = 'c';
+console.log(c);
+
+const a = 'a';
+console.log(a + main.b);
+
+exports.a = a;
+exports.c = c;

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/main.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var ac = require('./generated-ac.js');
+require('./main.js');
+
+const b = 'b';
+console.log(b + ac.c);
+
+console.log(ac.a);
+
+exports.b = b;

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/generated-ac.js
@@ -1,0 +1,9 @@
+import { b } from './main.js';
+
+const c = 'c';
+console.log(c);
+
+const a = 'a';
+console.log(a + b);
+
+export { a, c };

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/main.js
@@ -1,0 +1,9 @@
+import { c, a } from './generated-ac.js';
+import './main.js';
+
+const b = 'b';
+console.log(b + c);
+
+console.log(a);
+
+export { b };

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/generated-ac.js
@@ -1,0 +1,18 @@
+System.register(['./main.js'], (function (exports) {
+	'use strict';
+	var b;
+	return {
+		setters: [function (module) {
+			b = module.b;
+		}],
+		execute: (function () {
+
+			const c = exports("c", 'c');
+			console.log(c);
+
+			const a = exports("a", 'a');
+			console.log(a + b);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/main.js
@@ -1,0 +1,18 @@
+System.register(['./generated-ac.js', './main.js'], (function (exports) {
+	'use strict';
+	var c, a;
+	return {
+		setters: [function (module) {
+			c = module.c;
+			a = module.a;
+		}, null],
+		execute: (function () {
+
+			const b = exports("b", 'b');
+			console.log(b + c);
+
+			console.log(a);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/a.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/a.js
@@ -1,0 +1,4 @@
+import { b } from './b.js';
+const a = 'a';
+console.log(a + b);
+export { a }

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/b.js
@@ -1,0 +1,4 @@
+import { c } from './c.js';
+const b = 'b';
+console.log(b + c);
+export { b }

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/c.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/c.js
@@ -1,0 +1,3 @@
+const c = 'c';
+console.log(c);
+export { c }

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/main.js
@@ -1,0 +1,2 @@
+import {a} from './a.js';
+console.log(a);

--- a/test/chunking-form/samples/circular-manual-chunks/_config.js
+++ b/test/chunking-form/samples/circular-manual-chunks/_config.js
@@ -1,6 +1,6 @@
 module.exports = defineTest({
 	description: 'handles manual chunks with circular dependencies',
-	expectedWarnings: ['CIRCULAR_DEPENDENCY'],
+	expectedWarnings: ['CIRCULAR_DEPENDENCY', 'CIRCULAR_CHUNK'],
 	options: {
 		input: 'main',
 		output: { manualChunks: { lib1: ['lib1'], lib2: ['lib2'] } }

--- a/test/function/samples/circular-namespace-reexport-manual-chunks/_config.js
+++ b/test/function/samples/circular-namespace-reexport-manual-chunks/_config.js
@@ -17,6 +17,12 @@ module.exports = defineTest({
 	},
 	warnings: [
 		{
+			code: 'CIRCULAR_CHUNK',
+			ids: ['types.js', 'formatters.js', 'types.js'],
+			message:
+				'Circular chunk: types.js -> formatters.js -> types.js. Please adjust the manual chunk logic for these chunks.'
+		},
+		{
 			code: 'CIRCULAR_DEPENDENCY',
 			ids: [ID_INDEX, ID_TYPES, ID_INDEX],
 			message: 'Circular dependency: index.js -> types.js -> index.js'


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
Related to #6189
<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

Code splitting is one of the most important features of a bundler. For example, manual bundling is often used for rarely changed third-party packages like `React` or `Vue`. However, most users do not know the dependency graph of these third-party packages, so the `manualChunks` option may be configured incorrectly, as in this issue.

In this PR, we introduce a warning for circular chunks, which may be caused by two scenarios. First, manual chunks conflict with each other. In this case, Rollup has no room for further improvement. Second, the issue is caused by `output.onlyExplicitManualChunks`. In this case, we can do better in the future by bundling the static dependencies of manual chunks into a separate chunk, if bundling them into the entry module would cause circular chunks.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->