### PR TITLE
fix: forward __NO_SIDE_EFFECTS__ annotations to function expressions in variable declarations

### DIFF
--- a/rust/parse_ast/src/ast_nodes/variable_declarator.rs
+++ b/rust/parse_ast/src/ast_nodes/variable_declarator.rs
@@ -17,7 +17,7 @@ impl AstConverter<'_> {
     );
     let forwarded_annotations = match &variable_declarator.init {
       Some(expression) => match &**expression {
-        Expr::Arrow(_) => {
+        Expr::Arrow(_) | Expr::Fn(_) => {
           let annotations = self
             .index_converter
             .take_collected_annotations(AnnotationKind::NoSideEffects);

--- a/test/form/samples/no-side-effects-function-declaration/functions.js
+++ b/test/form/samples/no-side-effects-function-declaration/functions.js
@@ -20,22 +20,49 @@ export function fnB (args) {
   return args
 }
 
-export const fnC = /*#__NO_SIDE_EFFECTS__*/ (args) => {
+export const fnC1 = /*#__NO_SIDE_EFFECTS__*/ (args) => {
   console.log(args)
   return args
 }
 
+export const fnC2 = /*#__NO_SIDE_EFFECTS__*/ function (args) {
+  console.log(args);
+  return args;
+}
 
 /*#__NO_SIDE_EFFECTS__*/
-const fnD = (args) => {
+const fnD1 = (args) => {
   console.log(args)
   return args
 }
 
-export { fnD }
+/*#__NO_SIDE_EFFECTS__*/
+const fnD2 = function (args) {
+  console.log(args);
+  return args;
+}
+
+export { fnD1, fnD2 }
 
 /*#__NO_SIDE_EFFECTS__*/
-export const fnE = (args) => {
+export const fnE1 = (args) => {
+  console.log(args)
+  return args
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+export const fnE2 = function (args) {
+  console.log(args);
+  return args;
+}
+
+/**
+ * This is a jsdoc comment, with pure annotation
+ *
+ * @param {any} args
+ * @__NO_SIDE_EFFECTS__
+ */
+export const fnF1 = (args) => {
   console.log(args)
   return args
 }
@@ -46,9 +73,9 @@ export const fnE = (args) => {
  * @param {any} args
  * @__NO_SIDE_EFFECTS__
  */
-export const fnF = (args) => {
-  console.log(args)
-  return args
+export const fnF2 = function (args) {
+  console.log(args);
+  return args;
 }
 
 // #__NO_SIDE_EFFECTS__
@@ -60,16 +87,28 @@ export async function fnG(args) {
 /**
  * #__NO_SIDE_EFFECTS__
  */
-export const fnH = async (args) => {
+export const fnH1 = async (args) => {
   console.log(args)
   return args
 }
 
-export const fnI = /*#__NO_SIDE_EFFECTS__*/ async (args) => {
+/**
+ * #__NO_SIDE_EFFECTS__
+ */
+export const fnH2 = async function (args) {
+  console.log(args);
+  return args;
+}
+
+export const fnI1 = /*#__NO_SIDE_EFFECTS__*/ async (args) => {
   console.log(args)
   return args
 }
 
+export const fnI2 = /*#__NO_SIDE_EFFECTS__*/ async function (args) {
+  console.log(args);
+  return args;
+}
 
 /**
  * #__NO_SIDE_EFFECTS__

--- a/test/form/samples/no-side-effects-function-declaration/main.js
+++ b/test/form/samples/no-side-effects-function-declaration/main.js
@@ -1,21 +1,50 @@
-import fnDefault, { fnPure, fnEffects, fnA, fnB, fnC, fnD, fnE, fnF, fnI, fnG, fnJ, fnK, fnAlias, fnFromSub } from './functions'
+import fnDefault, {
+	fnA,
+	fnAlias,
+	fnB,
+	fnC1,
+	fnC2,
+	fnD1,
+	fnD2,
+	fnE1,
+	fnE2,
+	fnEffects,
+	fnF1,
+	fnF2,
+	fnFromSub,
+	fnG,
+	fnH1,
+	fnH2,
+	fnI1,
+	fnI2,
+	fnJ,
+	fnK,
+	fnPure
+} from './functions';
 
-const pure = fnPure(1)
-const effects = fnEffects(2)
+const pure = fnPure(1);
+const effects = fnEffects(2);
 
-const a = fnA(1)
-const b = fnB(2)
-const c = fnC(3)
-const d = fnD(4)
-const e = fnE(5)
-const f = fnF(6)
-const g = fnG(7)
-const i = fnI(8)
-const j = fnJ(9)
-const k = fnK(10)
+const a = fnA(1);
+const b = fnB(2);
+const c = fnC1(3);
+const d = fnC2(3);
+const e = fnD1(4);
+const f = fnD2(4);
+const g = fnE1(5);
+const h = fnE2(5);
+const i = fnF1(6);
+const j = fnF2(6);
+const k = fnG(7);
+const l = fnH1(7);
+const m = fnH2(7);
+const n = fnI1(8);
+const o = fnI2(8);
+const p = fnJ(9);
+const q = fnK(10);
 
-const defaults = fnDefault(3)
-const alias = fnAlias(6)
-const fromSub = fnFromSub(7)
+const defaults = fnDefault(3);
+const alias = fnAlias(6);
+const fromSub = fnFromSub(7);
 
-const _ = /*#__PURE__*/ fnEffects(1)
+const _ = /*#__PURE__*/ fnEffects(1);


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

### Description

When a `/*#__NO_SIDE_EFFECTS__*/` annotation (or its JSDoc equivalents `@__NO_SIDE_EFFECTS__` / `#__NO_SIDE_EFFECTS__`) precedes a `const`/`let`/`var` declaration, the Rust AST converter needs to forward the annotation from the `VariableDeclaration` node to the actual function value in the initializer so that `annotationNoSideEffects` gets set on the function node.

Previously, this forwarding only handled `Expr::Arrow` (arrow functions). As a result, function expressions (`function() {}`) assigned to a variable with a leading `#__NO_SIDE_EFFECTS__` annotation were silently ignored—the annotation was consumed but never attached to the `FunctionExpression` node—so those variables were never tree-shaken.

The fix adds `Expr::Fn` to the match arm in `variable_declarator.rs`, so leading `#__NO_SIDE_EFFECTS__` annotations are also forwarded to function expression initializers.

The existing test `no-side-effects-function-declaration` has been extended to cover function expressions alongside arrow functions for all annotation styles (inline, leading block comment, JSDoc `@__NO_SIDE_EFFECTS__`, and JSDoc `#__NO_SIDE_EFFECTS__`).

Note: inline annotations placed directly before the `function` keyword (e.g. `const fn = /*#__NO_SIDE_EFFECTS__*/ function() {}`) already worked correctly and continue to do so, as those comments are attached to the `FunctionExpression` node directly by the parser.