### PR TITLE
docs: update packagephobia link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <a href="https://nodejs.org/en/about/previous-releases">
     <img src="https://img.shields.io/node/v/rollup.svg" alt="node compatibility">
   </a>
-  <a href="https://packagephobia.now.sh/result?p=rollup">
-    <img src="https://packagephobia.now.sh/badge?p=rollup" alt="install size" >
+  <a href="https://packagephobia.com/result?p=rollup">
+    <img src="https://packagephobia.com/badge?p=rollup" alt="install size" >
   </a>
   <a href="https://codecov.io/gh/rollup/rollup">
     <img src="https://codecov.io/gh/rollup/rollup/graph/badge.svg" alt="code coverage" >


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

n/a

### Description

https://packagephobia.now.sh is the old link, updated to https://packagephobia.com
