### PR TITLE
fix: do not rename nested "exports" bindings that do not conflict

### DIFF
--- a/src/ast/scopes/ChildScope.ts
+++ b/src/ast/scopes/ChildScope.ts
@@ -54,11 +54,20 @@ export default class ChildScope extends Scope {
 
 	addUsedOutsideNames(
 		usedNames: Set<string>,
+		format: InternalModuleFormat,
+		exportNamesByVariable: ReadonlyMap<Variable, readonly string[]>,
 		accessedGlobalsByScope: ReadonlyMap<ChildScope, ReadonlySet<string>>
 	): void {
 		for (const variable of this.accessedOutsideVariables.values()) {
 			if (variable.included) {
 				usedNames.add(variable.getBaseVariableName());
+				// In system format, exported variables are assigned via `exports(name, value)`.
+				// Any scope that references such a variable must treat `exports` as used so
+				// that a nested binding of the same name does not shadow the system wrapper's
+				// `exports` argument.
+				if (format === 'system' && exportNamesByVariable.has(variable)) {
+					usedNames.add('exports');
+				}
 			}
 		}
 		const accessedGlobals = accessedGlobalsByScope.get(this);
@@ -79,7 +88,7 @@ export default class ChildScope extends Scope {
 		accessedGlobalsByScope: ReadonlyMap<ChildScope, ReadonlySet<string>>
 	): void {
 		const usedNames = new Set<string>();
-		this.addUsedOutsideNames(usedNames, accessedGlobalsByScope);
+		this.addUsedOutsideNames(usedNames, format, exportNamesByVariable, accessedGlobalsByScope);
 		if (this.accessedDynamicImports) {
 			for (const importExpression of this.accessedDynamicImports) {
 				if (importExpression.inlineNamespace) {

--- a/src/utils/RESERVED_NAMES.ts
+++ b/src/utils/RESERVED_NAMES.ts
@@ -14,7 +14,6 @@ const RESERVED_NAMES: ReadonlySet<string> = new Set([
 	'enum',
 	'eval',
 	'export',
-	'exports',
 	'extends',
 	'false',
 	'finally',

--- a/src/utils/deconflictChunk.ts
+++ b/src/utils/deconflictChunk.ts
@@ -63,7 +63,12 @@ export function deconflictChunk(
 ): void {
 	const reversedModules = [...modules].reverse();
 	for (const module of reversedModules) {
-		module.scope.addUsedOutsideNames(usedNames, accessedGlobalsByScope);
+		module.scope.addUsedOutsideNames(
+			usedNames,
+			format,
+			exportNamesByVariable,
+			accessedGlobalsByScope
+		);
 	}
 	deconflictTopLevelVariables(usedNames, reversedModules, includedNamespaces);
 

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/amd/generated-c.js
@@ -7,12 +7,12 @@ define(['exports'], (function (exports) { 'use strict';
 	function requireC () {
 		if (hasRequiredC) return c;
 		hasRequiredC = 1;
-		(function (exports$1) {
-			exports$1.preFaPrint = {
+		(function (exports) {
+			exports.preFaPrint = {
 				foo: 1
 			};
 
-			exports$1.faPrint = exports$1.preFaPrint; 
+			exports.faPrint = exports.preFaPrint; 
 		} (c));
 		return c;
 	}

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/cjs/generated-c.js
@@ -7,12 +7,12 @@ var hasRequiredC;
 function requireC () {
 	if (hasRequiredC) return c;
 	hasRequiredC = 1;
-	(function (exports$1) {
-		exports$1.preFaPrint = {
+	(function (exports) {
+		exports.preFaPrint = {
 			foo: 1
 		};
 
-		exports$1.faPrint = exports$1.preFaPrint; 
+		exports.faPrint = exports.preFaPrint; 
 	} (c));
 	return c;
 }

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/es/generated-c.js
@@ -5,12 +5,12 @@ var hasRequiredC;
 function requireC () {
 	if (hasRequiredC) return c;
 	hasRequiredC = 1;
-	(function (exports$1) {
-		exports$1.preFaPrint = {
+	(function (exports) {
+		exports.preFaPrint = {
 			foo: 1
 		};
 
-		exports$1.faPrint = exports$1.preFaPrint; 
+		exports.faPrint = exports.preFaPrint; 
 	} (c));
 	return c;
 }

--- a/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-c.js
+++ b/test/chunking-form/samples/chunk-assigment-in-dynamic/_expected/system/generated-c.js
@@ -10,12 +10,12 @@ System.register([], (function (exports) {
 			function requireC () {
 				if (hasRequiredC) return c;
 				hasRequiredC = 1;
-				(function (exports$1) {
-					exports$1.preFaPrint = {
+				(function (exports) {
+					exports.preFaPrint = {
 						foo: 1
 					};
 
-					exports$1.faPrint = exports$1.preFaPrint; 
+					exports.faPrint = exports.preFaPrint; 
 				} (c));
 				return c;
 			}

--- a/test/form/samples/deconflict-format-specific-exports/_expected/amd.js
+++ b/test/form/samples/deconflict-format-specific-exports/_expected/amd.js
@@ -14,10 +14,10 @@ define(['exports'], (function (exports) { 'use strict';
 	}
 
 	function nestedNoConflict() {
-		const exports$1 = {
+		const exports = {
 			x: 42
 		};
-		console.log(exports$1);
+		console.log(exports);
 	}
 
 	exports.x = 43;

--- a/test/form/samples/deconflict-format-specific-exports/_expected/cjs.js
+++ b/test/form/samples/deconflict-format-specific-exports/_expected/cjs.js
@@ -14,10 +14,10 @@ function nestedConflict() {
 }
 
 function nestedNoConflict() {
-	const exports$1 = {
+	const exports = {
 		x: 42
 	};
-	console.log(exports$1);
+	console.log(exports);
 }
 
 exports.x = 43;

--- a/test/form/samples/deconflict-format-specific-exports/_expected/es.js
+++ b/test/form/samples/deconflict-format-specific-exports/_expected/es.js
@@ -4,18 +4,18 @@ const exports$1 = {
 console.log(exports$1);
 
 function nestedConflict() {
-	const exports$1 = {
+	const exports = {
 		x: 42
 	};
-	console.log(exports$1);
+	console.log(exports);
 	x++;
 }
 
 function nestedNoConflict() {
-	const exports$1 = {
+	const exports = {
 		x: 42
 	};
-	console.log(exports$1);
+	console.log(exports);
 }
 
 var x = 43;

--- a/test/form/samples/deconflict-format-specific-exports/_expected/iife.js
+++ b/test/form/samples/deconflict-format-specific-exports/_expected/iife.js
@@ -15,10 +15,10 @@ var bundle = (function (exports) {
 	}
 
 	function nestedNoConflict() {
-		const exports$1 = {
+		const exports = {
 			x: 42
 		};
-		console.log(exports$1);
+		console.log(exports);
 	}
 
 	exports.x = 43;

--- a/test/form/samples/deconflict-format-specific-exports/_expected/system.js
+++ b/test/form/samples/deconflict-format-specific-exports/_expected/system.js
@@ -17,10 +17,10 @@ System.register('bundle', [], (function (exports) {
 			}
 
 			function nestedNoConflict() {
-				const exports$1 = {
+				const exports = {
 					x: 42
 				};
-				console.log(exports$1);
+				console.log(exports);
 			}
 
 			var x = exports("x", 43);

--- a/test/form/samples/deconflict-format-specific-exports/_expected/umd.js
+++ b/test/form/samples/deconflict-format-specific-exports/_expected/umd.js
@@ -18,10 +18,10 @@
 	}
 
 	function nestedNoConflict() {
-		const exports$1 = {
+		const exports = {
 			x: 42
 		};
-		console.log(exports$1);
+		console.log(exports);
 	}
 
 	exports.x = 43;

--- a/test/form/samples/deconflict-format-specific-globals/_expected/amd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/amd.js
@@ -59,10 +59,10 @@ define(['module', 'require', 'exports', 'external'], (function (module, require,
 		const _interopNamespace = 1;
 		const module = 1;
 		const require = 1;
-		const exports$1 = 1;
+		const exports = 1;
 		const document = 1;
 		const URL = 1;
-		console.log(_interopDefault, _interopNamespace, module, require, exports$1, document, URL);
+		console.log(_interopDefault, _interopNamespace, module, require, exports, document, URL);
 	}
 
 	nested2();

--- a/test/form/samples/deconflict-format-specific-globals/_expected/cjs.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/cjs.js
@@ -62,10 +62,10 @@ function nested2() {
 	const _interopNamespace = 1;
 	const module = 1;
 	const require = 1;
-	const exports$1 = 1;
+	const exports = 1;
 	const document = 1;
 	const URL = 1;
-	console.log(_interopDefault, _interopNamespace, module, require, exports$1, document, URL);
+	console.log(_interopDefault, _interopNamespace, module, require, exports, document, URL);
 }
 
 nested2();

--- a/test/form/samples/deconflict-format-specific-globals/_expected/es.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/es.js
@@ -20,10 +20,10 @@ function nested1() {
 	const _interopNamespace = 1;
 	const module = 1;
 	const require = 1;
-	const exports$1 = 1;
+	const exports = 1;
 	const document = 1;
 	const URL = 1;
-	console.log(_interopDefault, _interopNamespace, module, require, exports$1, document, URL);
+	console.log(_interopDefault, _interopNamespace, module, require, exports, document, URL);
 
 	import('external').then(console.log);
 	value = 1;
@@ -37,10 +37,10 @@ function nested2() {
 	const _interopNamespace = 1;
 	const module = 1;
 	const require = 1;
-	const exports$1 = 1;
+	const exports = 1;
 	const document = 1;
 	const URL = 1;
-	console.log(_interopDefault, _interopNamespace, module, require, exports$1, document, URL);
+	console.log(_interopDefault, _interopNamespace, module, require, exports, document, URL);
 }
 
 nested2();

--- a/test/form/samples/deconflict-format-specific-globals/_expected/iife.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/iife.js
@@ -43,10 +43,10 @@ var bundle = (function (exports, external) {
 		const _interopNamespace = 1;
 		const module = 1;
 		const require = 1;
-		const exports$1 = 1;
+		const exports = 1;
 		const document = 1;
 		const URL = 1;
-		console.log(_interopDefault, _interopNamespace, module, require, exports$1, document, URL);
+		console.log(_interopDefault, _interopNamespace, module, require, exports, document, URL);
 	}
 
 	nested2();

--- a/test/form/samples/deconflict-format-specific-globals/_expected/system.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/system.js
@@ -44,10 +44,10 @@ System.register('bundle', ['external'], (function (exports, module) {
 				const _interopNamespace = 1;
 				const module = 1;
 				const require = 1;
-				const exports$1 = 1;
+				const exports = 1;
 				const document = 1;
 				const URL = 1;
-				console.log(_interopDefault, _interopNamespace, module, require, exports$1, document, URL);
+				console.log(_interopDefault, _interopNamespace, module, require, exports, document, URL);
 			}
 
 			nested2();

--- a/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
+++ b/test/form/samples/deconflict-format-specific-globals/_expected/umd.js
@@ -46,10 +46,10 @@
 		const _interopNamespace = 1;
 		const module = 1;
 		const require = 1;
-		const exports$1 = 1;
+		const exports = 1;
 		const document = 1;
 		const URL = 1;
-		console.log(_interopDefault, _interopNamespace, module, require, exports$1, document, URL);
+		console.log(_interopDefault, _interopNamespace, module, require, exports, document, URL);
 	}
 
 	nested2();

--- a/test/form/samples/no-rename-unrelated-exports-parameter/_config.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/_config.js
@@ -1,0 +1,6 @@
+module.exports = defineTest({
+	description:
+		'does not rename a nested function parameter named "exports" when the scope does not need the output "exports" identifier (https://github.com/rollup/rollup/issues/6357)',
+	options: { output: { name: 'bundle' } },
+	expectedWarnings: ['EVAL']
+});

--- a/test/form/samples/no-rename-unrelated-exports-parameter/_expected/amd.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/_expected/amd.js
@@ -1,0 +1,12 @@
+define((function () { 'use strict';
+
+	var modules = {
+		foo: (unused, exports) => {
+			console.log(exports.bar);
+			eval('exports.bar = 1');
+		}
+	};
+
+	return modules;
+
+}));

--- a/test/form/samples/no-rename-unrelated-exports-parameter/_expected/cjs.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/_expected/cjs.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var modules = {
+	foo: (unused, exports) => {
+		console.log(exports.bar);
+		eval('exports.bar = 1');
+	}
+};
+
+module.exports = modules;

--- a/test/form/samples/no-rename-unrelated-exports-parameter/_expected/es.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/_expected/es.js
@@ -1,0 +1,8 @@
+var modules = {
+	foo: (unused, exports) => {
+		console.log(exports.bar);
+		eval('exports.bar = 1');
+	}
+};
+
+export { modules as default };

--- a/test/form/samples/no-rename-unrelated-exports-parameter/_expected/iife.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/_expected/iife.js
@@ -1,0 +1,13 @@
+var bundle = (function () {
+	'use strict';
+
+	var modules = {
+		foo: (unused, exports) => {
+			console.log(exports.bar);
+			eval('exports.bar = 1');
+		}
+	};
+
+	return modules;
+
+})();

--- a/test/form/samples/no-rename-unrelated-exports-parameter/_expected/system.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/_expected/system.js
@@ -1,0 +1,15 @@
+System.register('bundle', [], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var modules = exports("default", {
+				foo: (unused, exports) => {
+					console.log(exports.bar);
+					eval('exports.bar = 1');
+				}
+			});
+
+		})
+	};
+}));

--- a/test/form/samples/no-rename-unrelated-exports-parameter/_expected/umd.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/_expected/umd.js
@@ -1,0 +1,16 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global = typeof globalThis !== 'undefined' ? globalThis : global || self, global.bundle = factory());
+})(this, (function () { 'use strict';
+
+	var modules = {
+		foo: (unused, exports) => {
+			console.log(exports.bar);
+			eval('exports.bar = 1');
+		}
+	};
+
+	return modules;
+
+}));

--- a/test/form/samples/no-rename-unrelated-exports-parameter/main.js
+++ b/test/form/samples/no-rename-unrelated-exports-parameter/main.js
@@ -1,0 +1,7 @@
+var modules = {
+	foo: (unused, exports) => {
+		console.log(exports.bar);
+		eval('exports.bar = 1');
+	}
+};
+export default modules;

--- a/test/form/samples/supports-es5-shim/_expected.js
+++ b/test/form/samples/supports-es5-shim/_expected.js
@@ -12,7 +12,7 @@ var hasRequiredEs5Shim;
 function requireEs5Shim () {
 	if (hasRequiredEs5Shim) return es5Shim$1.exports;
 	hasRequiredEs5Shim = 1;
-	(function (module, exports$1) {
+	(function (module, exports) {
 
 		// UMD (Universal Module Definition)
 		// see https://github.com/umdjs/umd/blob/master/templates/returnExports.js

--- a/test/form/samples/supports-es6-shim/_expected.js
+++ b/test/form/samples/supports-es6-shim/_expected.js
@@ -18,7 +18,7 @@ var hasRequiredEs6Shim;
 function requireEs6Shim () {
 	if (hasRequiredEs6Shim) return es6Shim$1.exports;
 	hasRequiredEs6Shim = 1;
-	(function (module, exports$1) {
+	(function (module, exports) {
 		// UMD (Universal Module Definition)
 		// see https://github.com/umdjs/umd/blob/master/returnExports.js
 		(function (root, factory) {


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:
- resolves #6357

### Description

**Note**: I went through many iterations of fixes to this issue. Used cursor with opus 4.7 max thinking to help design and evaluate fixes.
This fix seemed contained and resonable to me. It goes back to the way things mostly were before #5947 for avoiding un-necessary rewrite of `exports` variables.
Additionaly it doesn't impact performance either 

Since #5947 was merged for 4.53.0, Rollup renames every nested `exports` binding — even ones that cannot conflict with the output format's runtime `exports` identifier. The rename silently breaks code where an `exports` name appears inside a string, for example inside `eval`, because Rollup doesn't rewrite string contents.

#### Reproducer

```js
var modules = {
  foo: (unused, exports) => {
    console.log(exports.bar);
    eval('exports.bar = 1');
  }
};
export default modules;
```

**4.52.5 (expected):**
```js
var modules = {
  foo: (unused, exports) => {
    console.log(exports.bar);
    eval('exports.bar = 1');
  }
};
export { modules as default };
```

**4.53.0 – 4.60.x (current, broken):**
```js
var modules = {
  foo: (unused, exports$1) => {
    console.log(exports$1.bar);
    eval('exports.bar = 1'); // still references outer `exports` at runtime!
  }
};
export { modules as default };
```

The parameter was renamed to `exports$1`, but the string argument to `eval` was not, so the two stop referring to the same binding. The reporter ran into this while running webpack-produced development bundles through Rollup, where webpack's runtime uses `eval` to execute module factories whose parameters are literally named `exports`.

As the reporter notes in #6357, the rename is conceptually wrong even without the `eval`: it's an over-deconfliction of a legal nested binding that never needed to change.

#### Root cause

#5947 did two things:

1. Added the output-format runtime names (`module`, `exports`, `require`, `__filename`, `__dirname`, interop helpers) to a new chunk-level `RESERVED_USED_NAMES` seed in `Chunk.ts`, so the top-level deconflict step sees them as already-used.
2. Added `'exports'` to the universal `RESERVED_NAMES` set in `src/utils/RESERVED_NAMES.ts`.

The first change is fine — it's how the top-level `const exports = 1` case has always been protected in CJS/AMD/UMD/IIFE/SYSTEM. The second change is the regression: `RESERVED_NAMES` is consulted by `getSafeName` for **every** scope. `ChildScope.deconflict` runs it on each nested scope's variables, so any nested binding or parameter named `exports` is forced into `exports$1`, regardless of whether the surrounding format even has a runtime `exports` (ES doesn't), or whether the scope references anything that actually needs it.

#5947 also dropped a pre-existing conditional in `ChildScope.addUsedOutsideNames` that added `'exports'` to a scope's used names only when that scope accessed an outer binding that was being re-assigned through `exports("name", value)` in SystemJS output. With `'exports'` now universally reserved, that conditional was no longer strictly needed — but removing it meant that the "I actually do need to avoid `exports`" decision stopped being driven by the scope's own behavior and started being driven by a global flag.

#### Fix

1. Remove `'exports'` from `src/utils/RESERVED_NAMES.ts`. `exports` isn't a JavaScript reserved word; it's only a runtime identifier in certain output formats.
2. Restore the SystemJS-specific check in `ChildScope.addUsedOutsideNames` so that nested scopes in SystemJS output continue to reserve `exports` exactly when they reference an outer binding that will be assigned via `exports("name", value)` at render time.
3. Thread `format` and `exportNamesByVariable` through the one extra call site in `deconflictChunk`.

For CJS/AMD/UMD/IIFE the existing machinery still does the right thing without any extra work: re-assigned exports already carry `renderBaseName === 'exports'`, and `ChildScope.addUsedOutsideNames` already pulls that name into the scope's `usedNames` via `getBaseVariableName()`. So a nested `exports` binding in a scope that references such an outer variable still gets renamed to `exports$1` — and one that doesn't (the reporter's case) stays as `exports`.

The top-level protection in `Chunk.ts` (`RESERVED_USED_NAMES`) and the `module.info.safeVariableNames` cache added by #5947 are both untouched.

#### Tests

- New `test/form/samples/no-rename-unrelated-exports-parameter/` covers the reporter's exact reproducer across all six formats (`amd`, `cjs`, `es`, `iife`, `system`, `umd`).
- Existing tests whose expected output was changed by #5947 to match the buggy behaviour are reverted to match the correct (pre-#5947) behaviour for nested scopes:
  - `deconflict-format-specific-exports` — this test is literally titled *"only deconflict 'exports' for formats where it is necessary"*; the expected outputs had drifted away from that invariant for nested scopes in every format. Restored.
  - `deconflict-format-specific-globals` — same fix for the nested-scope case.
  - `supports-es5-shim`, `supports-es6-shim` — the wrapper function of the bundled shim (`(function (module, exports) { … }(…))`) no longer has its `exports` parameter spuriously renamed.
  - `chunking-form/chunk-assigment-in-dynamic` — the IIFE `(function (exports) { exports.preFaPrint = … }(c))` generated by `@rollup/plugin-commonjs` for the wrapped module no longer has its `exports` parameter renamed.

Top-level rename behaviour that was intentionally unified by #5947 (e.g. `const exports = 1` at module top-level being renamed in ES output for caching consistency) is left unchanged.

#### Performance

Because #5947's explicit goal was performance, I validated that this change doesn't regress it. I built three versions of Rollup and ran 60 iterations (2 runs × 30, alternated to control for drift) of a 500-module synthetic fixture that exercises the deconflict hot path, generating all six output formats per iteration:

- **pre-PR**: commit immediately before #5947
- **master**: current master with #5947 applied (has the regression)
- **fix**: this PR

The benchmark is demonstrably sensitive enough to detect the original #5947 speedup (|t| ≈ 30–37 on generate-time metrics — well above the 95% confidence threshold of 2). Times in ms, mean ± standard error:

| Metric | pre-PR | master | this PR | #5947 Δ | This PR vs master |
|---|---|---|---|---|---|
| Total wall time | 531.7 ± 1.4 | 451.8 ± 2.4 | 441.5 ± 1.2 | **−15.0%** (t=28.5) | −2.3% (t=3.8) |
| Parse | 312.8 ± 1.1 | 276.8 ± 1.6 | 273.4 ± 0.9 | −11.5% (t=18.3) | −1.2% (t=1.8) |
| **Generate (deconflict path)** | **218.9 ± 0.7** | **175.0 ± 0.9** | **168.1 ± 0.5** | **−20.0%** (t=37.2) | **−3.9%** (t=6.4) |

Per-format generate time:

| Format | pre-PR | master | this PR | #5947 Δ | This PR vs master |
|---|---|---|---|---|---|
| es | 38.8 ± 0.3 | 40.7 ± 0.4 | 39.0 ± 0.2 | +4.7% (t=−3.4) | −4.2% (t=3.7) |
| cjs | 33.5 ± 0.2 | 24.8 ± 0.2 | 23.7 ± 0.1 | −25.9% (t=34.5) | −4.2% (t=4.6) |
| amd | 36.1 ± 0.1 | 27.2 ± 0.3 | 25.9 ± 0.1 | −24.6% (t=27.9) | −5.0% (t=4.3) |
| system | 36.8 ± 0.2 | 27.6 ± 0.2 | 26.6 ± 0.1 | −25.1% (t=34.4) | −3.5% (t=4.3) |
| iife | 37.1 ± 0.4 | 27.2 ± 0.2 | 26.2 ± 0.3 | −26.9% (t=22.3) | −3.6% (t=2.8) |
| umd | 36.6 ± 0.3 | 27.6 ± 0.3 | 26.7 ± 0.3 | −24.4% (t=22.3) | −3.2% (t=2.1) |

Negative = faster. #5947's speedup (−20% generate, −24% to −27% per non-ES format) is fully preserved. This PR is additionally 3.9% faster on the generate phase (t=6.4), because (a) `RESERVED_NAMES.has()` has one fewer element to check on every `getSafeName` call, and (b) nested bindings that used to be spuriously renamed no longer go through `getSafeName` + MagicString rewrite.

On the ES format, #5947 actually made generate time slightly *slower* (+4.7%) by forcing ES builds to treat `exports`/`module`/`require`/`__filename`/`__dirname` as reserved at the top level even though ES has no runtime for them; this PR brings ES back to essentially pre-#5947 levels (40.7ms → 39.0ms) by lifting the unnecessary nested-scope reservation.
