### PR TITLE
chore: remove tslib from devDeps

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -13,7 +13,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 # Licenses of bundled dependencies
 The published Rollup artifact additionally contains code with the following licenses:
-MIT, ISC, 0BSD
+MIT, ISC
 
 # Bundled dependencies:
 ## @jridgewell/sourcemap-codec
@@ -635,26 +635,6 @@ Repository: micromatch/to-regex-range
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
-
----------------------------------------
-
-## tslib
-License: 0BSD
-By: Microsoft Corp.
-Repository: https://github.com/Microsoft/tslib.git
-
-> Copyright (c) Microsoft Corporation.
-> 
-> Permission to use, copy, modify, and/or distribute this software for any
-> purpose with or without fee is hereby granted.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
-> REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-> AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
-> INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
-> LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
-> OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-> PERFORMANCE OF THIS SOFTWARE.
 
 ---------------------------------------
 

--- a/build-plugins/generate-license-file.ts
+++ b/build-plugins/generate-license-file.ts
@@ -10,7 +10,7 @@ async function generateLicenseFile(
 	const coreLicense = await readFile('LICENSE-CORE.md', 'utf8');
 	const licenses = new Set<string>();
 	const dependencyLicenseTexts = [...dependencies]
-		.filter(({ name }) => name !== '@rollup/browser')
+		.filter(({ name }) => name !== '@rollup/browser' && name !== 'tslib')
 		.sort(({ name: nameA }, { name: nameB }) => (nameA! > nameB! ? 1 : -1))
 		.map(({ name, license, licenseText, author, maintainers, contributors, repository }) => {
 			let text = `## ${name}\n`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
         "source-map-support": "^0.5.21",
         "systemjs": "^6.15.1",
         "terser": "^5.46.1",
-        "tslib": "^2.8.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.58.2",
         "vite": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
     "source-map-support": "^0.5.21",
     "systemjs": "^6.15.1",
     "terser": "^5.46.1",
-    "tslib": "^2.8.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^7.3.2",


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->

 #### Summary
 Remove tslib from devDependencies and exclude it from the generated LICENSE.md.

 #### Background
 tslib was added as a dev dependency in 4678513 (2018) when the project switched to rollup-plugin-typescript. However, TypeScript's importHelpers compiler option has never been enabled in this project's tsconfig.json. Without importHelpers: true, TypeScript inlines helper functions directly into each file rather than importing them from tslib, meaning tslib has never been used in the build output.

#### Why tslib appeared in LICENSE.md
@rollup/plugin-typescript unconditionally resolves tslib during initialization via its internal getTsLibPath() function, regardless of whether importHelpers is enabled. This causes rollup-plugin-license to detect tslib as a bundled dependency even though no tslib code is present in any of the dist output files.

tslib first appeared in LICENSE.md when PR #5420 was reverted in 10bc150 (#5736). Prior to PR #4355, @rollup/plugin-typescript was listed in the external configuration in rollup.config.ts, which prevented the plugin's internal tslib resolution from being visible to rollup-plugin-license. After PR #4355 removed the external list, the plugin's resolveId hook began registering tslib, making it detectable as a bundled dependency — even though it was never actually included in the output.

Additionally, even after removing tslib from devDependencies, it remains in node_modules as a transitive dependency (via @tybys/wasm-util), so @rollup/plugin-typescript continues to resolve it successfully. This is why the LICENSE.md is not automatically corrected by simply removing the devDependencies entry.

 #### Verification
- Confirmed that no tslib code exists in any .js files under dist/ or dist/es/ (only a source path reference remains in dist/bin/rollup.map)
- Confirmed that importHelpers is not set in tsconfig.json

####  Changes
- package.json: Remove tslib from devDependencies
- build-plugins/generate-license-file.ts: Exclude tslib from the license file generation
- LICENSE.md: Regenerated — tslib section and 0BSD license type removed