### PR TITLE
docs: fix typo 'interations' -> 'iterations' in chunkAssignment comment

### DIFF
--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -143,7 +143,7 @@ interface ChunkPartition {
  * per dynamic entry to marks all dynamic entry dependencies as "dirty" and put
  * them back into the iteration. As an additional optimization, we note for
  * each dynamic entry which dynamic dependent entries have changed and only
- * intersect those entries again on subsequent interations.
+ * intersect those entries again on subsequent iterations.
  *
  * Then we remove the dynamic entries from the list of dependent entries for
  * those chunks that are already loaded for that dynamic entry and create


### PR DESCRIPTION

**Repo:** rollup/rollup (⭐ 24000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Fixes a small typo in the JSDoc-style block comment for `getChunkAssignments` in `src/utils/chunkAssignment.ts`: `interations` → `iterations`.

## Why
The comment describes a non-trivial chunk assignment algorithm and is one of the main places future contributors look to understand the iterative dirty-marking optimization. A misspelled keyword like `interations` hurts readability and makes the comment harder to grep for. Caught via `codespell` over the source tree (only typo found in `src/`).

## Testing
Comment-only change; no behavior affected. Verified by re-running `codespell` on `src/` — no remaining hits. No build or test run needed.

## Risk
Low — single-character fix inside a comment, no code paths touched.
