### PR TITLE
Extract the static dependencies imported by manual chunks into separate chunks

### DIFF
--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -536,7 +536,7 @@ jobs:
         env:
           CI: true
       - name: Upload coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.coverage
         with:
           fail_ci_if_error: true

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -1,7 +1,7 @@
 import ExternalModule from '../ExternalModule';
 import Module from '../Module';
 import type { LogHandler } from '../rollup/types';
-import { getNewSet, getOrCreate } from './getOrCreate';
+import { getNewArray, getNewSet, getOrCreate } from './getOrCreate';
 import { concatLazy } from './iterators';
 import { logOptimizeChunkStatus } from './logs';
 import { timeEnd, timeStart } from './timers';
@@ -157,11 +157,12 @@ export function getChunkAssignments(
 	isManualChunksFunctionForm: boolean,
 	onlyExplicitManualChunks: boolean
 ): ChunkDefinitions {
-	const { chunkDefinitions, modulesInManualChunks } = getChunkDefinitionsFromManualChunks(
-		manualChunkAliasByEntry,
-		isManualChunksFunctionForm,
-		onlyExplicitManualChunks
-	);
+	const { chunkDefinitions, combinedManualChunkAliasMaskByModule, modulesInManualChunks } =
+		getChunkDefinitionsFromManualChunks(
+			manualChunkAliasByEntry,
+			isManualChunksFunctionForm,
+			onlyExplicitManualChunks
+		);
 	const {
 		allEntries,
 		dependentEntriesByModule,
@@ -200,6 +201,14 @@ export function getChunkAssignments(
 		alreadyLoadedAtomsByEntry,
 		awaitedAlreadyLoadedAtomsByEntry
 	);
+	if (combinedManualChunkAliasMaskByModule.size > 0) {
+		extractManualChunkStaticDependenciesFromEntryChunkAtoms(
+			chunkAtoms,
+			combinedManualChunkAliasMaskByModule,
+			chunkDefinitions,
+			allEntries
+		);
+	}
 	const { chunks, sideEffectAtoms, sizeByAtom } =
 		getChunksWithSameDependentEntriesAndCorrelatedAtoms(
 			chunkAtoms,
@@ -223,15 +232,35 @@ function getChunkDefinitionsFromManualChunks(
 	manualChunkAliasByEntry: ReadonlyMap<Module, string>,
 	isManualChunksFunctionForm: boolean,
 	onlyExplicitManualChunks: boolean
-): { chunkDefinitions: ChunkDefinitions; modulesInManualChunks: Set<Module> } {
+): {
+	chunkDefinitions: ChunkDefinitions;
+	combinedManualChunkAliasMaskByModule: ReadonlyMap<Module, bigint>;
+	modulesInManualChunks: Set<Module>;
+} {
 	const modulesInManualChunks = new Set(manualChunkAliasByEntry.keys());
 	const manualChunkModulesByAlias: Record<string, Module[]> = Object.create(null);
+	const combinedManualChunkAliasMaskByModule = new Map<Module, bigint>();
 	const sortedEntriesWithAlias = [...manualChunkAliasByEntry].sort(
 		([entryA], [entryB]) => entryA.execIndex - entryB.execIndex
 	);
+	let nextAliasMask = 1n;
+	const maskByAlias = new Map();
 	for (const [entry, alias] of sortedEntriesWithAlias) {
 		if (isManualChunksFunctionForm && onlyExplicitManualChunks) {
 			(manualChunkModulesByAlias[alias] ||= []).push(entry);
+			traverseStaticDependencies(entry, modulesInManualChunks, (module: Module) => {
+				let aliasMask = maskByAlias.get(alias);
+				if (!aliasMask) {
+					aliasMask = nextAliasMask;
+					maskByAlias.set(alias, aliasMask);
+					nextAliasMask <<= 1n;
+				}
+				const combinedAliasMask = combinedManualChunkAliasMaskByModule.get(module);
+				combinedManualChunkAliasMaskByModule.set(
+					module,
+					combinedAliasMask ? combinedAliasMask | aliasMask : aliasMask
+				);
+			});
 		} else {
 			addStaticDependenciesToManualChunk(
 				entry,
@@ -246,7 +275,11 @@ function getChunkDefinitionsFromManualChunks(
 	for (const [alias, modules] of manualChunks) {
 		chunkDefinitions[index++] = { alias, modules };
 	}
-	return { chunkDefinitions, modulesInManualChunks };
+	return {
+		chunkDefinitions,
+		combinedManualChunkAliasMaskByModule,
+		modulesInManualChunks
+	};
 }
 
 function addStaticDependenciesToManualChunk(
@@ -261,6 +294,22 @@ function addStaticDependenciesToManualChunk(
 		for (const dependency of module.dependencies) {
 			if (!(dependency instanceof ExternalModule || modulesInManualChunks.has(dependency))) {
 				modulesToHandle.add(dependency);
+			}
+		}
+	}
+}
+
+function traverseStaticDependencies(
+	entry: Module,
+	manualChunkModules: Set<Module>,
+	handleStaticDependency: (module: Module) => void
+): void {
+	const modulesToHandle = new Set([entry]);
+	for (const module of modulesToHandle) {
+		for (const dependency of module.dependencies) {
+			if (!(dependency instanceof ExternalModule || manualChunkModules.has(dependency))) {
+				modulesToHandle.add(dependency);
+				handleStaticDependency(dependency);
 			}
 		}
 	}
@@ -560,6 +609,37 @@ function removeUnnecessaryDependentEntries(
 			}
 		}
 		chunkMask <<= 1n;
+	}
+}
+
+function extractManualChunkStaticDependenciesFromEntryChunkAtoms(
+	chunkAtoms: ModulesWithDependentEntries[],
+	combinedManualChunkAliasMaskByModule: ReadonlyMap<Module, bigint>,
+	chunkDefinitions: ChunkDefinitions,
+	allEntries: readonly Module[]
+) {
+	const entries = new Set(allEntries);
+	for (const chunkAtom of chunkAtoms) {
+		const { modules } = chunkAtom;
+		const extractedModules = new Set<Module>();
+		const modulesByCombinedManualChunkAliasMask = new Map<bigint, Module[]>();
+		const isEntryChunkAtom = modules.find(module => entries.has(module));
+		if (!isEntryChunkAtom) continue;
+		for (const module of modules) {
+			const combinedAliasMask = combinedManualChunkAliasMaskByModule.get(module);
+			if (combinedAliasMask) {
+				getOrCreate(modulesByCombinedManualChunkAliasMask, combinedAliasMask, getNewArray).push(
+					module
+				);
+				extractedModules.add(module);
+			}
+		}
+		if (extractedModules.size > 0) {
+			chunkAtom.modules = chunkAtom.modules.filter(module => !extractedModules.has(module));
+		}
+		for (const [, modules] of modulesByCombinedManualChunkAliasMask) {
+			chunkDefinitions.push({ alias: null, modules });
+		}
 	}
 }
 

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -21,10 +21,11 @@ interface ModulesWithDependentEntries {
 	 * The indices of the entries depending on this chunk
 	 */
 	dependentEntries: Set<number>;
+	hasEntryModule: boolean;
 	modules: Module[];
 }
 
-interface ChunkDescription extends ModulesWithDependentEntries {
+interface ChunkDescription {
 	/**
 	 * These are the atoms (=initial chunks) that are contained in this chunk
 	 */
@@ -37,6 +38,8 @@ interface ChunkDescription extends ModulesWithDependentEntries {
 	correlatedAtoms: bigint;
 	dependencies: Set<ChunkDescription>;
 	dependentChunks: Set<ChunkDescription>;
+	dependentEntries: Set<number>;
+	modules: Module[];
 	pure: boolean;
 	size: number;
 }
@@ -186,7 +189,8 @@ export function getChunkAssignments(
 			dependentEntriesByModule,
 			modulesInManualChunks,
 			chunkDefinitions
-		)
+		),
+		new Set(allEntries)
 	);
 	const staticDependencyAtomsByEntry = getStaticDependencyAtomsByEntry(allEntries, chunkAtoms);
 	// Warning: This will consume dynamicallyDependentEntriesByDynamicEntry.
@@ -213,8 +217,7 @@ export function getChunkAssignments(
 		extractManualChunkStaticDependenciesFromEntryChunkAtoms(
 			chunkAtoms,
 			combinedManualChunkAliasMaskByModule,
-			chunkDefinitions,
-			allEntries
+			chunkDefinitions
 		);
 	}
 	const { chunks, sideEffectAtoms, sizeByAtom } =
@@ -501,7 +504,8 @@ function getDynamicallyDependentEntriesByDynamicEntry(
 }
 
 function getChunksWithSameDependentEntries(
-	moduleWithDependentEntries: Iterable<ModuleWithDependentEntries>
+	moduleWithDependentEntries: Iterable<ModuleWithDependentEntries>,
+	allEntriesSet: Set<Module>
 ): ModulesWithDependentEntries[] {
 	const chunkModules: Record<string, ModulesWithDependentEntries> = Object.create(null);
 	for (const { dependentEntries, module } of moduleWithDependentEntries) {
@@ -509,10 +513,13 @@ function getChunksWithSameDependentEntries(
 		for (const entryIndex of dependentEntries) {
 			chunkSignature |= 1n << BigInt(entryIndex);
 		}
-		(chunkModules[String(chunkSignature)] ||= {
+		const atom = (chunkModules[String(chunkSignature)] ||= {
 			dependentEntries: new Set(dependentEntries),
+			hasEntryModule: false,
 			modules: []
-		}).modules.push(module);
+		});
+		atom.modules.push(module);
+		atom.hasEntryModule ||= allEntriesSet.has(module);
 	}
 	return Object.values(chunkModules);
 }
@@ -629,16 +636,13 @@ function removeUnnecessaryDependentEntries(
 function extractManualChunkStaticDependenciesFromEntryChunkAtoms(
 	chunkAtoms: ModulesWithDependentEntries[],
 	combinedManualChunkAliasMaskByModule: ReadonlyMap<Module, bigint>,
-	chunkDefinitions: ChunkDefinitions,
-	allEntries: readonly Module[]
+	chunkDefinitions: ChunkDefinitions
 ) {
-	const entries = new Set(allEntries);
 	for (const chunkAtom of chunkAtoms) {
-		const { modules } = chunkAtom;
+		const { modules, hasEntryModule } = chunkAtom;
+		if (!hasEntryModule) continue;
 		const extractedModules = new Set<Module>();
 		const modulesByCombinedManualChunkAliasMask = new Map<bigint, Module[]>();
-		const isEntryChunkAtom = modules.some(module => entries.has(module));
-		if (!isEntryChunkAtom) continue;
 		for (const module of modules) {
 			const combinedAliasMask = combinedManualChunkAliasMaskByModule.get(module);
 			if (combinedAliasMask) {

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -244,7 +244,7 @@ function getChunkDefinitionsFromManualChunks(
 		([entryA], [entryB]) => entryA.execIndex - entryB.execIndex
 	);
 	let nextAliasMask = 1n;
-	const maskByAlias = new Map();
+	const maskByAlias = new Map<string, bigint>();
 	for (const [entry, alias] of sortedEntriesWithAlias) {
 		if (isManualChunksFunctionForm && onlyExplicitManualChunks) {
 			(manualChunkModulesByAlias[alias] ||= []).push(entry);
@@ -307,7 +307,13 @@ function traverseStaticDependencies(
 	const modulesToHandle = new Set([entry]);
 	for (const module of modulesToHandle) {
 		for (const dependency of module.dependencies) {
-			if (!(dependency instanceof ExternalModule || manualChunkModules.has(dependency))) {
+			if (
+				!(
+					dependency instanceof ExternalModule ||
+					manualChunkModules.has(dependency) ||
+					modulesToHandle.has(dependency)
+				)
+			) {
 				modulesToHandle.add(dependency);
 				handleStaticDependency(dependency);
 			}

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -8,6 +8,14 @@ import { timeEnd, timeStart } from './timers';
 
 type ChunkDefinitions = { alias: string | null; modules: Module[] }[];
 
+interface ModuleWithDependentEntries {
+	/**
+	 * The indices of the entries depending on this chunk
+	 */
+	dependentEntries: Set<number>;
+	module: Module;
+}
+
 interface ModulesWithDependentEntries {
 	/**
 	 * The indices of the entries depending on this chunk
@@ -493,10 +501,10 @@ function getDynamicallyDependentEntriesByDynamicEntry(
 }
 
 function getChunksWithSameDependentEntries(
-	modulesWithDependentEntries: Iterable<ModulesWithDependentEntries>
+	moduleWithDependentEntries: Iterable<ModuleWithDependentEntries>
 ): ModulesWithDependentEntries[] {
 	const chunkModules: Record<string, ModulesWithDependentEntries> = Object.create(null);
-	for (const { dependentEntries, modules } of modulesWithDependentEntries) {
+	for (const { dependentEntries, module } of moduleWithDependentEntries) {
 		let chunkSignature = 0n;
 		for (const entryIndex of dependentEntries) {
 			chunkSignature |= 1n << BigInt(entryIndex);
@@ -504,7 +512,7 @@ function getChunksWithSameDependentEntries(
 		(chunkModules[String(chunkSignature)] ||= {
 			dependentEntries: new Set(dependentEntries),
 			modules: []
-		}).modules.push(...modules);
+		}).modules.push(module);
 	}
 	return Object.values(chunkModules);
 }
@@ -523,7 +531,7 @@ function* getModulesWithDependentEntriesAndHandleTLACycles(
 				});
 				continue;
 			}
-			yield { dependentEntries, modules: [module] };
+			yield { dependentEntries, module };
 		}
 	}
 }

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -629,7 +629,7 @@ function extractManualChunkStaticDependenciesFromEntryChunkAtoms(
 		const { modules } = chunkAtom;
 		const extractedModules = new Set<Module>();
 		const modulesByCombinedManualChunkAliasMask = new Map<bigint, Module[]>();
-		const isEntryChunkAtom = modules.find(module => entries.has(module));
+		const isEntryChunkAtom = modules.some(module => entries.has(module));
 		if (!isEntryChunkAtom) continue;
 		for (const module of modules) {
 			const combinedAliasMask = combinedManualChunkAliasMaskByModule.get(module);

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -306,7 +306,6 @@ function analyzeModuleGraph(
 	const allEntriesSet = new Set<Module>(entries);
 	// Each entry is defined by its position in this array
 	const allEntriesAndManualChunks = entries.map(module => [module]).concat(manualChunkModules);
-	// TODO Lukas add performance improvement for large module sets
 	const dynamicImportModulesByEntry: Set<Module>[] = new Array(allEntriesAndManualChunks.length);
 	const awaitedDynamicImportModulesByEntry: Set<Module>[] = new Array(
 		allEntriesAndManualChunks.length
@@ -319,10 +318,13 @@ function analyzeModuleGraph(
 		awaitedDynamicImportModulesByEntry[entryOrManualChunkIndex] =
 			awaitedDynamicImportsForCurrentEntry;
 		const staticDependencies = new Set(currentEntryModules);
+		// If we have a very large manual chunk, tracking if it is already added to the dependencies will improve performance
+		const addedManualChunks = new Set<Module[]>();
 		for (const module of staticDependencies) {
 			getOrCreate(dependentEntriesByModule, module, getNewSet<number>).add(entryOrManualChunkIndex);
 			const manualChunkMembers = manualChunkModulesByModule.get(module);
-			if (manualChunkMembers) {
+			if (manualChunkMembers && !addedManualChunks.has(manualChunkMembers)) {
+				addedManualChunks.add(manualChunkMembers);
 				for (const manualChunkMember of manualChunkMembers) {
 					staticDependencies.add(manualChunkMember);
 				}

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -1,7 +1,7 @@
 import ExternalModule from '../ExternalModule';
 import Module from '../Module';
 import type { LogHandler } from '../rollup/types';
-import { getNewArray, getNewSet, getOrCreate } from './getOrCreate';
+import { getNewSet, getOrCreate } from './getOrCreate';
 import { concatLazy } from './iterators';
 import { logOptimizeChunkStatus } from './logs';
 import { timeEnd, timeStart } from './timers';
@@ -21,7 +21,6 @@ interface ModulesWithDependentEntries {
 	 * The indices of the entries depending on this chunk
 	 */
 	dependentEntries: Set<number>;
-	hasEntryModule: boolean;
 	modules: Module[];
 }
 
@@ -168,20 +167,19 @@ export function getChunkAssignments(
 	isManualChunksFunctionForm: boolean,
 	onlyExplicitManualChunks: boolean
 ): ChunkDefinitions {
-	const { chunkDefinitions, combinedManualChunkAliasMaskByModule, modulesInManualChunks } =
-		getChunkDefinitionsFromManualChunks(
-			manualChunkAliasByEntry,
-			isManualChunksFunctionForm,
-			onlyExplicitManualChunks
-		);
+	const { chunkDefinitions, modulesInManualChunks } = getChunkDefinitionsFromManualChunks(
+		manualChunkAliasByEntry,
+		isManualChunksFunctionForm,
+		onlyExplicitManualChunks
+	);
 	const {
-		allEntries,
+		entriesAndManualChunksCount,
 		dependentEntriesByModule,
 		dynamicallyDependentEntriesByDynamicEntry,
 		dynamicImportsByEntry,
 		dynamicallyDependentEntriesByAwaitedDynamicEntry,
 		awaitedDynamicImportsByEntry
-	} = analyzeModuleGraph(entries);
+	} = analyzeModuleGraph(entries, chunkDefinitions);
 
 	// Each chunk is identified by its position in this array
 	const chunkAtoms = getChunksWithSameDependentEntries(
@@ -189,23 +187,25 @@ export function getChunkAssignments(
 			dependentEntriesByModule,
 			modulesInManualChunks,
 			chunkDefinitions
-		),
-		new Set(allEntries)
+		)
 	);
-	const staticDependencyAtomsByEntry = getStaticDependencyAtomsByEntry(allEntries, chunkAtoms);
+	const staticDependencyAtomsByEntry = getStaticDependencyAtomsByEntry(
+		entriesAndManualChunksCount,
+		chunkAtoms
+	);
 	// Warning: This will consume dynamicallyDependentEntriesByDynamicEntry.
 	// If we no longer want this, we should make a copy here.
 	const alreadyLoadedAtomsByEntry = getAlreadyLoadedAtomsByEntry(
 		staticDependencyAtomsByEntry,
 		dynamicallyDependentEntriesByDynamicEntry,
 		dynamicImportsByEntry,
-		allEntries
+		entriesAndManualChunksCount
 	);
 	const awaitedAlreadyLoadedAtomsByEntry = getAlreadyLoadedAtomsByEntry(
 		staticDependencyAtomsByEntry,
 		dynamicallyDependentEntriesByAwaitedDynamicEntry,
 		awaitedDynamicImportsByEntry,
-		allEntries
+		entriesAndManualChunksCount
 	);
 	// This mutates the dependentEntries in chunkAtoms
 	removeUnnecessaryDependentEntries(
@@ -213,13 +213,6 @@ export function getChunkAssignments(
 		alreadyLoadedAtomsByEntry,
 		awaitedAlreadyLoadedAtomsByEntry
 	);
-	if (combinedManualChunkAliasMaskByModule.size > 0) {
-		extractManualChunkStaticDependenciesFromEntryChunkAtoms(
-			chunkAtoms,
-			combinedManualChunkAliasMaskByModule,
-			chunkDefinitions
-		);
-	}
 	const { chunks, sideEffectAtoms, sizeByAtom } =
 		getChunksWithSameDependentEntriesAndCorrelatedAtoms(
 			chunkAtoms,
@@ -243,35 +236,15 @@ function getChunkDefinitionsFromManualChunks(
 	manualChunkAliasByEntry: ReadonlyMap<Module, string>,
 	isManualChunksFunctionForm: boolean,
 	onlyExplicitManualChunks: boolean
-): {
-	chunkDefinitions: ChunkDefinitions;
-	combinedManualChunkAliasMaskByModule: ReadonlyMap<Module, bigint>;
-	modulesInManualChunks: Set<Module>;
-} {
+): { chunkDefinitions: ChunkDefinitions; modulesInManualChunks: Set<Module> } {
 	const modulesInManualChunks = new Set(manualChunkAliasByEntry.keys());
 	const manualChunkModulesByAlias: Record<string, Module[]> = Object.create(null);
-	const combinedManualChunkAliasMaskByModule = new Map<Module, bigint>();
 	const sortedEntriesWithAlias = [...manualChunkAliasByEntry].sort(
 		([entryA], [entryB]) => entryA.execIndex - entryB.execIndex
 	);
-	let nextAliasMask = 1n;
-	const maskByAlias = new Map<string, bigint>();
 	for (const [entry, alias] of sortedEntriesWithAlias) {
 		if (isManualChunksFunctionForm && onlyExplicitManualChunks) {
 			(manualChunkModulesByAlias[alias] ||= []).push(entry);
-			traverseStaticDependencies(entry, modulesInManualChunks, (module: Module) => {
-				let aliasMask = maskByAlias.get(alias);
-				if (!aliasMask) {
-					aliasMask = nextAliasMask;
-					maskByAlias.set(alias, aliasMask);
-					nextAliasMask <<= 1n;
-				}
-				const combinedAliasMask = combinedManualChunkAliasMaskByModule.get(module);
-				combinedManualChunkAliasMaskByModule.set(
-					module,
-					combinedAliasMask ? combinedAliasMask | aliasMask : aliasMask
-				);
-			});
 		} else {
 			addStaticDependenciesToManualChunk(
 				entry,
@@ -286,11 +259,7 @@ function getChunkDefinitionsFromManualChunks(
 	for (const [alias, modules] of manualChunks) {
 		chunkDefinitions[index++] = { alias, modules };
 	}
-	return {
-		chunkDefinitions,
-		combinedManualChunkAliasMaskByModule,
-		modulesInManualChunks
-	};
+	return { chunkDefinitions, modulesInManualChunks };
 }
 
 function addStaticDependenciesToManualChunk(
@@ -310,51 +279,39 @@ function addStaticDependenciesToManualChunk(
 	}
 }
 
-function traverseStaticDependencies(
-	entry: Module,
-	manualChunkModules: Set<Module>,
-	handleStaticDependency: (module: Module) => void
-): void {
-	const modulesToHandle = new Set([entry]);
-	for (const module of modulesToHandle) {
-		for (const dependency of module.dependencies) {
-			if (
-				!(
-					dependency instanceof ExternalModule ||
-					manualChunkModules.has(dependency) ||
-					modulesToHandle.has(dependency)
-				)
-			) {
-				modulesToHandle.add(dependency);
-				handleStaticDependency(dependency);
-			}
-		}
-	}
-}
-
-function analyzeModuleGraph(entries: Iterable<Module>): {
-	allEntries: readonly Module[];
+function analyzeModuleGraph(
+	entries: readonly Module[],
+	manualChunkDefinitions: ChunkDefinitions
+): {
+	awaitedDynamicImportsByEntry: readonly ReadonlySet<number>[];
 	dependentEntriesByModule: Map<Module, Set<number>>;
 	dynamicImportsByEntry: readonly ReadonlySet<number>[];
-	dynamicallyDependentEntriesByDynamicEntry: Map<number, Set<number>>;
-	awaitedDynamicImportsByEntry: readonly ReadonlySet<number>[];
 	dynamicallyDependentEntriesByAwaitedDynamicEntry: Map<number, Set<number>>;
+	dynamicallyDependentEntriesByDynamicEntry: Map<number, Set<number>>;
+	entriesAndManualChunksCount: number;
 } {
 	const dynamicEntryModules = new Set<Module>();
 	const awaitedDynamicEntryModules = new Set<Module>();
 	const dependentEntriesByModule = new Map<Module, Set<number>>();
-	const allEntriesSet = new Set(entries);
-	const dynamicImportModulesByEntry: Set<Module>[] = new Array(allEntriesSet.size);
-	const awaitedDynamicImportModulesByEntry: Set<Module>[] = new Array(allEntriesSet.size);
-	let entryIndex = 0;
-	for (const currentEntry of allEntriesSet) {
+	const allEntriesSet = new Set<Module>(entries);
+	// Each entry is defined by its position in this array
+	const allEntriesAndManualChunks = entries
+		.map(module => [module])
+		.concat(manualChunkDefinitions.map(({ modules }) => modules));
+	const dynamicImportModulesByEntry: Set<Module>[] = new Array(allEntriesAndManualChunks.length);
+	const awaitedDynamicImportModulesByEntry: Set<Module>[] = new Array(
+		allEntriesAndManualChunks.length
+	);
+	let entryOrManualChunkIndex = 0;
+	for (const currentEntryModules of allEntriesAndManualChunks) {
 		const dynamicImportsForCurrentEntry = new Set<Module>();
 		const awaitedDynamicImportsForCurrentEntry = new Set<Module>();
-		dynamicImportModulesByEntry[entryIndex] = dynamicImportsForCurrentEntry;
-		awaitedDynamicImportModulesByEntry[entryIndex] = awaitedDynamicImportsForCurrentEntry;
-		const staticDependencies = new Set([currentEntry]);
+		dynamicImportModulesByEntry[entryOrManualChunkIndex] = dynamicImportsForCurrentEntry;
+		awaitedDynamicImportModulesByEntry[entryOrManualChunkIndex] =
+			awaitedDynamicImportsForCurrentEntry;
+		const staticDependencies = new Set(currentEntryModules);
 		for (const module of staticDependencies) {
-			getOrCreate(dependentEntriesByModule, module, getNewSet<number>).add(entryIndex);
+			getOrCreate(dependentEntriesByModule, module, getNewSet<number>).add(entryOrManualChunkIndex);
 			for (const dependency of module.getDependenciesToBeIncluded()) {
 				if (!(dependency instanceof ExternalModule)) {
 					staticDependencies.add(dependency);
@@ -370,6 +327,7 @@ function analyzeModuleGraph(entries: Iterable<Module>): {
 				) {
 					dynamicEntryModules.add(resolution);
 					allEntriesSet.add(resolution);
+					allEntriesAndManualChunks.push([resolution]);
 					dynamicImportsForCurrentEntry.add(resolution);
 					for (const includedTopLevelAwaitingDynamicImporter of resolution.includedTopLevelAwaitingDynamicImporters) {
 						if (staticDependencies.has(includedTopLevelAwaitingDynamicImporter)) {
@@ -384,46 +342,46 @@ function analyzeModuleGraph(entries: Iterable<Module>): {
 				if (!allEntriesSet.has(dependency)) {
 					dynamicEntryModules.add(dependency);
 					allEntriesSet.add(dependency);
+					allEntriesAndManualChunks.push([dependency]);
 				}
 			}
 		}
-		entryIndex++;
+		entryOrManualChunkIndex++;
 	}
-	const allEntries = [...allEntriesSet];
 	const {
 		awaitedDynamicEntries,
 		awaitedDynamicImportsByEntry,
 		dynamicEntries,
 		dynamicImportsByEntry
 	} = getDynamicEntries(
-		allEntries,
+		allEntriesAndManualChunks,
 		dynamicEntryModules,
 		dynamicImportModulesByEntry,
 		awaitedDynamicEntryModules,
 		awaitedDynamicImportModulesByEntry
 	);
 	return {
-		allEntries,
 		awaitedDynamicImportsByEntry,
 		dependentEntriesByModule,
 		dynamicallyDependentEntriesByAwaitedDynamicEntry: getDynamicallyDependentEntriesByDynamicEntry(
 			dependentEntriesByModule,
 			awaitedDynamicEntries,
-			allEntries,
+			allEntriesAndManualChunks,
 			dynamicEntry => dynamicEntry.includedTopLevelAwaitingDynamicImporters
 		),
 		dynamicallyDependentEntriesByDynamicEntry: getDynamicallyDependentEntriesByDynamicEntry(
 			dependentEntriesByModule,
 			dynamicEntries,
-			allEntries,
+			allEntriesAndManualChunks,
 			dynamicEntry => dynamicEntry.includedDynamicImporters
 		),
-		dynamicImportsByEntry
+		dynamicImportsByEntry,
+		entriesAndManualChunksCount: allEntriesAndManualChunks.length
 	};
 }
 
 function getDynamicEntries(
-	allEntries: Module[],
+	allEntriesAndManualChunks: Module[][],
 	dynamicEntryModules: Set<Module>,
 	dynamicImportModulesByEntry: Set<Module>[],
 	awaitedDynamicEntryModules: Set<Module>,
@@ -432,13 +390,15 @@ function getDynamicEntries(
 	const entryIndexByModule = new Map<Module, number>();
 	const dynamicEntries = new Set<number>();
 	const awaitedDynamicEntries = new Set<number>();
-	for (const [entryIndex, entry] of allEntries.entries()) {
-		entryIndexByModule.set(entry, entryIndex);
-		if (dynamicEntryModules.has(entry)) {
-			dynamicEntries.add(entryIndex);
-		}
-		if (awaitedDynamicEntryModules.has(entry)) {
-			awaitedDynamicEntries.add(entryIndex);
+	for (const [entryIndex, entryModules] of allEntriesAndManualChunks.entries()) {
+		for (const entryModule of entryModules) {
+			entryIndexByModule.set(entryModule, entryIndex);
+			if (dynamicEntryModules.has(entryModule)) {
+				dynamicEntries.add(entryIndex);
+			}
+			if (awaitedDynamicEntryModules.has(entryModule)) {
+				awaitedDynamicEntries.add(entryIndex);
+			}
 		}
 	}
 	const dynamicImportsByEntry = getDynamicImportsByEntry(
@@ -476,7 +436,7 @@ function getDynamicImportsByEntry(
 function getDynamicallyDependentEntriesByDynamicEntry(
 	dependentEntriesByModule: ReadonlyMap<Module, ReadonlySet<number>>,
 	dynamicEntries: ReadonlySet<number>,
-	allEntries: readonly Module[],
+	allEntriesAndManualChunks: readonly Module[][],
 	getDynamicImporters: (entry: Module) => Iterable<Module>
 ): Map<number, Set<number>> {
 	const dynamicallyDependentEntriesByDynamicEntry = new Map<number, Set<number>>();
@@ -486,17 +446,19 @@ function getDynamicallyDependentEntriesByDynamicEntry(
 			dynamicEntryIndex,
 			getNewSet<number>
 		);
-		const dynamicEntry = allEntries[dynamicEntryIndex];
-		for (const importer of concatLazy([
-			getDynamicImporters(dynamicEntry),
-			dynamicEntry.implicitlyLoadedAfter
-		])) {
-			const importerEntries = dependentEntriesByModule.get(importer);
-			if (!importerEntries) {
-				continue;
-			}
-			for (const entry of importerEntries) {
-				dynamicallyDependentEntries.add(entry);
+		const dynamicEntryModules = allEntriesAndManualChunks[dynamicEntryIndex];
+		for (const dynamicEntryModule of dynamicEntryModules) {
+			for (const importer of concatLazy([
+				getDynamicImporters(dynamicEntryModule),
+				dynamicEntryModule.implicitlyLoadedAfter
+			])) {
+				const importerEntries = dependentEntriesByModule.get(importer);
+				if (!importerEntries) {
+					continue;
+				}
+				for (const entry of importerEntries) {
+					dynamicallyDependentEntries.add(entry);
+				}
 			}
 		}
 	}
@@ -504,8 +466,7 @@ function getDynamicallyDependentEntriesByDynamicEntry(
 }
 
 function getChunksWithSameDependentEntries(
-	moduleWithDependentEntries: Iterable<ModuleWithDependentEntries>,
-	allEntriesSet: Set<Module>
+	moduleWithDependentEntries: Iterable<ModuleWithDependentEntries>
 ): ModulesWithDependentEntries[] {
 	const chunkModules: Record<string, ModulesWithDependentEntries> = Object.create(null);
 	for (const { dependentEntries, module } of moduleWithDependentEntries) {
@@ -513,13 +474,10 @@ function getChunksWithSameDependentEntries(
 		for (const entryIndex of dependentEntries) {
 			chunkSignature |= 1n << BigInt(entryIndex);
 		}
-		const atom = (chunkModules[String(chunkSignature)] ||= {
+		(chunkModules[String(chunkSignature)] ||= {
 			dependentEntries: new Set(dependentEntries),
-			hasEntryModule: false,
 			modules: []
-		});
-		atom.modules.push(module);
-		atom.hasEntryModule ||= allEntriesSet.has(module);
+		}).modules.push(module);
 	}
 	return Object.values(chunkModules);
 }
@@ -544,12 +502,12 @@ function* getModulesWithDependentEntriesAndHandleTLACycles(
 }
 
 function getStaticDependencyAtomsByEntry(
-	allEntries: readonly Module[],
+	entriesAndManualChunksCount: number,
 	chunkAtoms: ModulesWithDependentEntries[]
 ) {
 	// The indices correspond to the indices in allEntries. The atoms correspond
 	// to bits in the bigint values where chunk 0 is the lowest bit.
-	const staticDependencyAtomsByEntry: bigint[] = allEntries.map(() => 0n);
+	const staticDependencyAtomsByEntry: bigint[] = new Array(entriesAndManualChunksCount).fill(0n);
 
 	// This toggles the bits for each atom that is a dependency of an entry
 	let atomMask = 1n;
@@ -567,13 +525,14 @@ function getAlreadyLoadedAtomsByEntry(
 	staticDependencyAtomsByEntry: bigint[],
 	dynamicallyDependentEntriesByDynamicEntry: Map<number, Set<number>>,
 	dynamicImportsByEntry: readonly ReadonlySet<number>[],
-	allEntries: readonly Module[]
+	allEntriesCount: number
 ) {
 	// Dynamic entries have all atoms as already loaded initially because we then
 	// intersect with the static dependency atoms of all dynamic importers.
 	// Static entries cannot have already loaded atoms.
-	const alreadyLoadedAtomsByEntry: bigint[] = allEntries.map((_entry, entryIndex) =>
-		dynamicallyDependentEntriesByDynamicEntry.has(entryIndex) ? -1n : 0n
+	const alreadyLoadedAtomsByEntry: bigint[] = Array.from(
+		{ length: allEntriesCount },
+		(_entry, entryIndex) => (dynamicallyDependentEntriesByDynamicEntry.has(entryIndex) ? -1n : 0n)
 	);
 	for (const [
 		dynamicEntryIndex,
@@ -630,34 +589,6 @@ function removeUnnecessaryDependentEntries(
 			}
 		}
 		chunkMask <<= 1n;
-	}
-}
-
-function extractManualChunkStaticDependenciesFromEntryChunkAtoms(
-	chunkAtoms: ModulesWithDependentEntries[],
-	combinedManualChunkAliasMaskByModule: ReadonlyMap<Module, bigint>,
-	chunkDefinitions: ChunkDefinitions
-) {
-	for (const chunkAtom of chunkAtoms) {
-		const { modules, hasEntryModule } = chunkAtom;
-		if (!hasEntryModule) continue;
-		const extractedModules = new Set<Module>();
-		const modulesByCombinedManualChunkAliasMask = new Map<bigint, Module[]>();
-		for (const module of modules) {
-			const combinedAliasMask = combinedManualChunkAliasMaskByModule.get(module);
-			if (combinedAliasMask) {
-				getOrCreate(modulesByCombinedManualChunkAliasMask, combinedAliasMask, getNewArray).push(
-					module
-				);
-				extractedModules.add(module);
-			}
-		}
-		if (extractedModules.size > 0) {
-			chunkAtom.modules = chunkAtom.modules.filter(module => !extractedModules.has(module));
-		}
-		for (const [, modules] of modulesByCombinedManualChunkAliasMask) {
-			chunkDefinitions.push({ alias: null, modules });
-		}
 	}
 }
 

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -298,6 +298,12 @@ function analyzeModuleGraph(
 	const allEntriesAndManualChunks = entries
 		.map(module => [module])
 		.concat(manualChunkDefinitions.map(({ modules }) => modules));
+	const manualChunkMembersByModule = new Map<Module, Module[]>();
+	for (const { modules } of manualChunkDefinitions) {
+		for (const module of modules) {
+			manualChunkMembersByModule.set(module, modules);
+		}
+	}
 	const dynamicImportModulesByEntry: Set<Module>[] = new Array(allEntriesAndManualChunks.length);
 	const awaitedDynamicImportModulesByEntry: Set<Module>[] = new Array(
 		allEntriesAndManualChunks.length
@@ -311,6 +317,12 @@ function analyzeModuleGraph(
 			awaitedDynamicImportsForCurrentEntry;
 		const staticDependencies = new Set(currentEntryModules);
 		for (const module of staticDependencies) {
+			const manualChunkMembers = manualChunkMembersByModule.get(module);
+			if (manualChunkMembers) {
+				for (const manualChunkMember of manualChunkMembers) {
+					staticDependencies.add(manualChunkMember);
+				}
+			}
 			getOrCreate(dependentEntriesByModule, module, getNewSet<number>).add(entryOrManualChunkIndex);
 			for (const dependency of module.getDependenciesToBeIncluded()) {
 				if (!(dependency instanceof ExternalModule)) {

--- a/src/utils/chunkAssignment.ts
+++ b/src/utils/chunkAssignment.ts
@@ -167,11 +167,12 @@ export function getChunkAssignments(
 	isManualChunksFunctionForm: boolean,
 	onlyExplicitManualChunks: boolean
 ): ChunkDefinitions {
-	const { chunkDefinitions, modulesInManualChunks } = getChunkDefinitionsFromManualChunks(
-		manualChunkAliasByEntry,
-		isManualChunksFunctionForm,
-		onlyExplicitManualChunks
-	);
+	const { chunkDefinitions, manualChunkModules, manualChunkModulesByModule } =
+		getChunkDefinitionsFromManualChunks(
+			manualChunkAliasByEntry,
+			isManualChunksFunctionForm,
+			onlyExplicitManualChunks
+		);
 	const {
 		entriesAndManualChunksCount,
 		dependentEntriesByModule,
@@ -179,13 +180,13 @@ export function getChunkAssignments(
 		dynamicImportsByEntry,
 		dynamicallyDependentEntriesByAwaitedDynamicEntry,
 		awaitedDynamicImportsByEntry
-	} = analyzeModuleGraph(entries, chunkDefinitions);
+	} = analyzeModuleGraph(entries, manualChunkModules, manualChunkModulesByModule);
 
 	// Each chunk is identified by its position in this array
 	const chunkAtoms = getChunksWithSameDependentEntries(
 		getModulesWithDependentEntriesAndHandleTLACycles(
 			dependentEntriesByModule,
-			modulesInManualChunks,
+			manualChunkModulesByModule,
 			chunkDefinitions
 		)
 	);
@@ -236,30 +237,38 @@ function getChunkDefinitionsFromManualChunks(
 	manualChunkAliasByEntry: ReadonlyMap<Module, string>,
 	isManualChunksFunctionForm: boolean,
 	onlyExplicitManualChunks: boolean
-): { chunkDefinitions: ChunkDefinitions; modulesInManualChunks: Set<Module> } {
+): {
+	chunkDefinitions: ChunkDefinitions;
+	manualChunkModules: Module[][];
+	manualChunkModulesByModule: Map<Module, Module[]>;
+} {
 	const modulesInManualChunks = new Set(manualChunkAliasByEntry.keys());
 	const manualChunkModulesByAlias: Record<string, Module[]> = Object.create(null);
 	const sortedEntriesWithAlias = [...manualChunkAliasByEntry].sort(
 		([entryA], [entryB]) => entryA.execIndex - entryB.execIndex
 	);
 	for (const [entry, alias] of sortedEntriesWithAlias) {
+		const chunkModules = (manualChunkModulesByAlias[alias] ||= []);
 		if (isManualChunksFunctionForm && onlyExplicitManualChunks) {
-			(manualChunkModulesByAlias[alias] ||= []).push(entry);
+			chunkModules.push(entry);
 		} else {
-			addStaticDependenciesToManualChunk(
-				entry,
-				(manualChunkModulesByAlias[alias] ||= []),
-				modulesInManualChunks
-			);
+			addStaticDependenciesToManualChunk(entry, chunkModules, modulesInManualChunks);
 		}
 	}
 	const manualChunks = Object.entries(manualChunkModulesByAlias);
+	const manualChunkModules: Module[][] = new Array(manualChunks.length);
 	const chunkDefinitions: ChunkDefinitions = new Array(manualChunks.length);
+	const manualChunkModulesByModule = new Map<Module, Module[]>();
 	let index = 0;
 	for (const [alias, modules] of manualChunks) {
-		chunkDefinitions[index++] = { alias, modules };
+		chunkDefinitions[index] = { alias, modules };
+		manualChunkModules[index] = modules;
+		for (const module of modules) {
+			manualChunkModulesByModule.set(module, modules);
+		}
+		index++;
 	}
-	return { chunkDefinitions, modulesInManualChunks };
+	return { chunkDefinitions, manualChunkModules, manualChunkModulesByModule };
 }
 
 function addStaticDependenciesToManualChunk(
@@ -281,7 +290,8 @@ function addStaticDependenciesToManualChunk(
 
 function analyzeModuleGraph(
 	entries: readonly Module[],
-	manualChunkDefinitions: ChunkDefinitions
+	manualChunkModules: Module[][],
+	manualChunkModulesByModule: Map<Module, Module[]>
 ): {
 	awaitedDynamicImportsByEntry: readonly ReadonlySet<number>[];
 	dependentEntriesByModule: Map<Module, Set<number>>;
@@ -295,15 +305,8 @@ function analyzeModuleGraph(
 	const dependentEntriesByModule = new Map<Module, Set<number>>();
 	const allEntriesSet = new Set<Module>(entries);
 	// Each entry is defined by its position in this array
-	const allEntriesAndManualChunks = entries
-		.map(module => [module])
-		.concat(manualChunkDefinitions.map(({ modules }) => modules));
-	const manualChunkMembersByModule = new Map<Module, Module[]>();
-	for (const { modules } of manualChunkDefinitions) {
-		for (const module of modules) {
-			manualChunkMembersByModule.set(module, modules);
-		}
-	}
+	const allEntriesAndManualChunks = entries.map(module => [module]).concat(manualChunkModules);
+	// TODO Lukas add performance improvement for large module sets
 	const dynamicImportModulesByEntry: Set<Module>[] = new Array(allEntriesAndManualChunks.length);
 	const awaitedDynamicImportModulesByEntry: Set<Module>[] = new Array(
 		allEntriesAndManualChunks.length
@@ -317,13 +320,13 @@ function analyzeModuleGraph(
 			awaitedDynamicImportsForCurrentEntry;
 		const staticDependencies = new Set(currentEntryModules);
 		for (const module of staticDependencies) {
-			const manualChunkMembers = manualChunkMembersByModule.get(module);
+			getOrCreate(dependentEntriesByModule, module, getNewSet<number>).add(entryOrManualChunkIndex);
+			const manualChunkMembers = manualChunkModulesByModule.get(module);
 			if (manualChunkMembers) {
 				for (const manualChunkMember of manualChunkMembers) {
 					staticDependencies.add(manualChunkMember);
 				}
 			}
-			getOrCreate(dependentEntriesByModule, module, getNewSet<number>).add(entryOrManualChunkIndex);
 			for (const dependency of module.getDependenciesToBeIncluded()) {
 				if (!(dependency instanceof ExternalModule)) {
 					staticDependencies.add(dependency);
@@ -496,7 +499,7 @@ function getChunksWithSameDependentEntries(
 
 function* getModulesWithDependentEntriesAndHandleTLACycles(
 	dependentEntriesByModule: Map<Module, Set<number>>,
-	modulesInManualChunks: Set<Module>,
+	modulesInManualChunks: Map<Module, unknown>,
 	chunkDefinitions: ChunkDefinitions
 ) {
 	for (const [module, dependentEntries] of dependentEntriesByModule) {

--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -314,7 +314,7 @@ export function logCircularChunk(cyclePath: string[], isManualChunkConflict: boo
 		message: `Circular chunk: ${cyclePath.join(' -> ')}. ${
 			isManualChunkConflict
 				? `Please adjust the manual chunk logic for these chunks.`
-				: `Consider disabling the "output.onlyExplicitManualChunks" option, as enabling it causes the static dependencies of the manual chunk "${cyclePath.at(-2)}" to be bundled into the chunk "${cyclePath.at(-1)}".`
+				: `Please consider disabling the "output.onlyExplicitManualChunks" option, as enabling it causes modules located between the modules included in the manual chunk "${cyclePath.at(-2)}" to be extracted into the separate chunk "${cyclePath.at(-1)}".`
 		}`
 	};
 }

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_config.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_config.js
@@ -11,9 +11,9 @@ module.exports = defineTest({
 	expectedWarnings: ['CIRCULAR_CHUNK'],
 	logs: new Array(4).fill(null).map(() => ({
 		code: 'CIRCULAR_CHUNK',
-		ids: ['main', 'ac', 'main'],
+		ids: ['b', 'ac', 'b'],
 		level: 'warn',
 		message:
-			'Circular chunk: main -> ac -> main. Consider disabling the "output.onlyExplicitManualChunks" option, as enabling it causes the static dependencies of the manual chunk "ac" to be bundled into the chunk "main".'
+			'Circular chunk: b -> ac -> b. Please consider disabling the "output.onlyExplicitManualChunks" option, as enabling it causes modules located between the modules included in the manual chunk "ac" to be extracted into the separate chunk "b".'
 	}))
 });

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/generated-ac.js
@@ -1,10 +1,10 @@
-define(['exports', './main'], (function (exports, main) { 'use strict';
+define(['exports', './generated-b'], (function (exports, b) { 'use strict';
 
 	const c = 'c';
 	console.log(c);
 
 	const a = 'a';
-	console.log(a + main.b);
+	console.log(a + b.b);
 
 	exports.a = a;
 	exports.c = c;

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/generated-b.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-ac'], (function (exports, ac) { 'use strict';
+
+	const b = 'b';
+	console.log(b + ac.c);
+
+	exports.b = b;
+
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/amd/main.js
@@ -1,10 +1,5 @@
-define(['exports', './generated-ac', './main'], (function (exports, ac, main) { 'use strict';
-
-	const b = 'b';
-	console.log(b + ac.c);
+define(['./generated-ac', './generated-b'], (function (ac, b) { 'use strict';
 
 	console.log(ac.a);
-
-	exports.b = b;
 
 }));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/generated-ac.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var main = require('./main.js');
+var b = require('./generated-b.js');
 
 const c = 'c';
 console.log(c);
 
 const a = 'a';
-console.log(a + main.b);
+console.log(a + b.b);
 
 exports.a = a;
 exports.c = c;

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/cjs/generated-b.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var ac = require('./generated-ac.js');
-require('./generated-b.js');
 
-console.log(ac.a);
+const b = 'b';
+console.log(b + ac.c);
+
+exports.b = b;

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/generated-ac.js
@@ -1,4 +1,4 @@
-import { b } from './main.js';
+import { b } from './generated-b.js';
 
 const c = 'c';
 console.log(c);

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/generated-b.js
@@ -1,0 +1,6 @@
+import { c } from './generated-ac.js';
+
+const b = 'b';
+console.log(b + c);
+
+export { b };

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/es/main.js
@@ -1,9 +1,4 @@
-import { c, a } from './generated-ac.js';
-import './main.js';
-
-const b = 'b';
-console.log(b + c);
+import { a } from './generated-ac.js';
+import './generated-b.js';
 
 console.log(a);
-
-export { b };

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/generated-ac.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/generated-ac.js
@@ -1,4 +1,4 @@
-System.register(['./main.js'], (function (exports) {
+System.register(['./generated-b.js'], (function (exports) {
 	'use strict';
 	var b;
 	return {

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/generated-b.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/generated-b.js
@@ -1,0 +1,15 @@
+System.register(['./generated-ac.js'], (function (exports) {
+	'use strict';
+	var c;
+	return {
+		setters: [function (module) {
+			c = module.c;
+		}],
+		execute: (function () {
+
+			const b = exports("b", 'b');
+			console.log(b + c);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/circular-chunks-warning-caused-by-only-explicit-manual-chunks/_expected/system/main.js
@@ -1,15 +1,11 @@
-System.register(['./generated-ac.js', './main.js'], (function (exports) {
+System.register(['./generated-ac.js', './generated-b.js'], (function () {
 	'use strict';
-	var c, a;
+	var a;
 	return {
 		setters: [function (module) {
-			c = module.c;
 			a = module.a;
 		}, null],
 		execute: (function () {
-
-			const b = exports("b", 'b');
-			console.log(b + c);
 
 			console.log(a);
 

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-dep1.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-dep1.js
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	const dep1 = 'dep1';
+
+	exports.dep1 = dep1;
+
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/generated-dynamic.js
@@ -1,5 +1,5 @@
-define(['./main', './generated-manual'], (function (main, manual) { 'use strict';
+define(['./generated-dep1', './generated-manual'], (function (dep1, manual) { 'use strict';
 
-	console.log(main.dep1, manual.dep2);
+	console.log(dep1.dep1, manual.dep2);
 
 }));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/amd/main.js
@@ -1,9 +1,5 @@
-define(['exports', './generated-manual'], (function (exports, manual) { 'use strict';
+define(['./generated-dep1', './generated-manual'], (function (dep1, manual) { 'use strict';
 
-	const dep1 = 'dep1';
-
-	console.log(dep1);
-
-	exports.dep1 = dep1;
+	console.log(dep1.dep1);
 
 }));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-dep1.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-dep1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const dep1 = 'dep1';
+
+exports.dep1 = dep1;

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/generated-dynamic.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var main = require('./main.js');
+var dep1 = require('./generated-dep1.js');
 var manual = require('./generated-manual.js');
 
-console.log(main.dep1, manual.dep2);
+console.log(dep1.dep1, manual.dep2);

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/cjs/main.js
@@ -1,9 +1,6 @@
 'use strict';
 
+var dep1 = require('./generated-dep1.js');
 require('./generated-manual.js');
 
-const dep1 = 'dep1';
-
-console.log(dep1);
-
-exports.dep1 = dep1;
+console.log(dep1.dep1);

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-dep1.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-dep1.js
@@ -1,0 +1,3 @@
+const dep1 = 'dep1';
+
+export { dep1 as d };

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/generated-dynamic.js
@@ -1,4 +1,4 @@
-import { d as dep1 } from './main.js';
+import { d as dep1 } from './generated-dep1.js';
 import { d as dep2 } from './generated-manual.js';
 
 console.log(dep1, dep2);

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/es/main.js
@@ -1,7 +1,4 @@
+import { d as dep1 } from './generated-dep1.js';
 import './generated-manual.js';
 
-const dep1 = 'dep1';
-
 console.log(dep1);
-
-export { dep1 as d };

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-dep1.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-dep1.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const dep1 = exports("d", 'dep1');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-dynamic.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/generated-dynamic.js
@@ -1,4 +1,4 @@
-System.register(['./main.js', './generated-manual.js'], (function () {
+System.register(['./generated-dep1.js', './generated-manual.js'], (function () {
 	'use strict';
 	var dep1, dep2;
 	return {

--- a/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/main.js
+++ b/test/chunking-form/samples/dynamic-import-from-manual-chunk/_expected/system/main.js
@@ -1,10 +1,11 @@
-System.register(['./generated-manual.js'], (function (exports) {
+System.register(['./generated-dep1.js', './generated-manual.js'], (function () {
 	'use strict';
+	var dep1;
 	return {
-		setters: [null],
+		setters: [function (module) {
+			dep1 = module.d;
+		}, null],
 		execute: (function () {
-
-			const dep1 = exports("d", 'dep1');
 
 			console.log(dep1);
 

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_config.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_config.js
@@ -1,0 +1,14 @@
+module.exports = defineTest({
+	description: 'treats unrelated files in manual chunks as one file',
+	options: {
+		input: ['main1.js', 'main2.js'],
+		output: {
+			manualChunks(id) {
+				if (/manual\d/.test(id)) {
+					return 'manual';
+				}
+			},
+			onlyExplicitManualChunks: true
+		}
+	}
+});

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/generated-dep2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/generated-dep2.js
@@ -1,0 +1,12 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	// There is no reason for this to end up in a different chunk as the other dep
+	const dep$1 = 'dep1';
+
+	// There is no reason for this to end up in a different chunk as the other dep
+	const dep = 'dep2';
+
+	exports.dep = dep$1;
+	exports.dep$1 = dep;
+
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/generated-manual.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/generated-manual.js
@@ -1,0 +1,12 @@
+define(['exports', './generated-dep2'], (function (exports, dep2) { 'use strict';
+
+	console.log('manual1');
+	const manual$1 = 'manual1:' + dep2.dep;
+
+	console.log('manual2');
+	const manual = 'manual2:' + dep2.dep$1;
+
+	exports.manual = manual$1;
+	exports.manual$1 = manual;
+
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/main1.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/main1.js
@@ -1,0 +1,5 @@
+define(['./generated-manual', './generated-dep2'], (function (manual, dep2) { 'use strict';
+
+	console.log('main1', manual.manual);
+
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/main2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/amd/main2.js
@@ -1,0 +1,5 @@
+define(['./generated-manual', './generated-dep2'], (function (manual, dep2) { 'use strict';
+
+	console.log('main2', manual.manual$1);
+
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/generated-dep2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/generated-dep2.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// There is no reason for this to end up in a different chunk as the other dep
+const dep$1 = 'dep1';
+
+// There is no reason for this to end up in a different chunk as the other dep
+const dep = 'dep2';
+
+exports.dep = dep$1;
+exports.dep$1 = dep;

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/generated-manual.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/generated-manual.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var dep2 = require('./generated-dep2.js');
+
+console.log('manual1');
+const manual$1 = 'manual1:' + dep2.dep;
+
+console.log('manual2');
+const manual = 'manual2:' + dep2.dep$1;
+
+exports.manual = manual$1;
+exports.manual$1 = manual;

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/main1.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/main1.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var manual = require('./generated-manual.js');
+require('./generated-dep2.js');
+
+console.log('main1', manual.manual);

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/main2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/cjs/main2.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var manual = require('./generated-manual.js');
+require('./generated-dep2.js');
+
+console.log('main2', manual.manual$1);

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/generated-dep2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/generated-dep2.js
@@ -1,0 +1,7 @@
+// There is no reason for this to end up in a different chunk as the other dep
+const dep$1 = 'dep1';
+
+// There is no reason for this to end up in a different chunk as the other dep
+const dep = 'dep2';
+
+export { dep as a, dep$1 as d };

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/generated-manual.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/generated-manual.js
@@ -1,0 +1,9 @@
+import { d as dep, a as dep$1 } from './generated-dep2.js';
+
+console.log('manual1');
+const manual$1 = 'manual1:' + dep;
+
+console.log('manual2');
+const manual = 'manual2:' + dep$1;
+
+export { manual as a, manual$1 as m };

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/main1.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/main1.js
@@ -1,0 +1,4 @@
+import { m as manual } from './generated-manual.js';
+import './generated-dep2.js';
+
+console.log('main1', manual);

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/main2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/es/main2.js
@@ -1,0 +1,4 @@
+import { a as manual } from './generated-manual.js';
+import './generated-dep2.js';
+
+console.log('main2', manual);

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/generated-dep2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/generated-dep2.js
@@ -1,0 +1,14 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			// There is no reason for this to end up in a different chunk as the other dep
+			const dep$1 = exports("d", 'dep1');
+
+			// There is no reason for this to end up in a different chunk as the other dep
+			const dep = exports("a", 'dep2');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/generated-manual.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/generated-manual.js
@@ -1,0 +1,19 @@
+System.register(['./generated-dep2.js'], (function (exports) {
+	'use strict';
+	var dep, dep$1;
+	return {
+		setters: [function (module) {
+			dep = module.d;
+			dep$1 = module.a;
+		}],
+		execute: (function () {
+
+			console.log('manual1');
+			const manual$1 = exports("m", 'manual1:' + dep);
+
+			console.log('manual2');
+			const manual = exports("a", 'manual2:' + dep$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/main1.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/main1.js
@@ -1,0 +1,14 @@
+System.register(['./generated-manual.js', './generated-dep2.js'], (function () {
+	'use strict';
+	var manual;
+	return {
+		setters: [function (module) {
+			manual = module.m;
+		}, null],
+		execute: (function () {
+
+			console.log('main1', manual);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/main2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/_expected/system/main2.js
@@ -1,0 +1,14 @@
+System.register(['./generated-manual.js', './generated-dep2.js'], (function () {
+	'use strict';
+	var manual;
+	return {
+		setters: [function (module) {
+			manual = module.a;
+		}, null],
+		execute: (function () {
+
+			console.log('main2', manual);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/dep1.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/dep1.js
@@ -1,0 +1,2 @@
+// There is no reason for this to end up in a different chunk as the other dep
+export const dep = 'dep1';

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/dep2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/dep2.js
@@ -1,0 +1,2 @@
+// There is no reason for this to end up in a different chunk as the other dep
+export const dep = 'dep2';

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/main1.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/main1.js
@@ -1,0 +1,3 @@
+import { manual } from './manual1';
+
+console.log('main1', manual);

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/main2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/main2.js
@@ -1,0 +1,3 @@
+import { manual } from './manual2';
+
+console.log('main2', manual);

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/manual1.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/manual1.js
@@ -1,0 +1,4 @@
+import { dep } from './dep1';
+
+console.log('manual1');
+export const manual = 'manual1:' + dep;

--- a/test/chunking-form/samples/manual-chunk-with-unrelated-files/manual2.js
+++ b/test/chunking-form/samples/manual-chunk-with-unrelated-files/manual2.js
@@ -1,0 +1,4 @@
+import { dep } from './dep2';
+
+console.log('manual2');
+export const manual = 'manual2:' + dep;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_config.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_config.js
@@ -1,0 +1,12 @@
+module.exports = defineTest({
+	description: 'Does not produce circular chunk with onlyExplicitManualChunks',
+	options: {
+		output: {
+			manualChunks(id) {
+				if (id.includes('c.js')) return 'c';
+				if (id.includes('c3.js')) return 'c3';
+			},
+			onlyExplicitManualChunks: true
+		}
+	}
+});

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-a.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-a.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-c', './generated-c2', './generated-c3', './generated-c4', './generated-e'], (function (exports, c, c2, c3, c4, e) { 'use strict';
+
+	console.log('a');
+	const a = 'a' + c.c;
+
+	exports.a = a;
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-b.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-b.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-e'], (function (exports, e) { 'use strict';
+
+	console.log('b');
+	const b = 'b' + e.e;
+
+	exports.b = b;
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-c2'], (function (exports, c2) { 'use strict';
+
+	console.log('c');
+	const c = 'c' + c2.c2;
+
+	exports.c = c;
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c2.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c2.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-c3'], (function (exports, c3) { 'use strict';
+
+	console.log('c2');
+	const c2 = 'c2' + c3.c3;
+
+	exports.c2 = c2;
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c3.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c3.js
@@ -1,0 +1,8 @@
+define(['exports', './generated-c4'], (function (exports, c4) { 'use strict';
+
+	console.log('c3');
+	const c3 = 'c3' + c4.c4;
+
+	exports.c3 = c3;
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c4.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-c4.js
@@ -1,0 +1,11 @@
+define(['exports', './generated-e'], (function (exports, e) { 'use strict';
+
+	console.log('c5');
+	const c5 = 'c5' + e.e;
+
+	console.log('c4');
+	const c4 = 'c4' + c5;
+
+	exports.c4 = c4;
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-e.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/generated-e.js
@@ -1,0 +1,8 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	console.log('e');
+	const e = 'e';
+
+	exports.e = e;
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/main.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/amd/main.js
@@ -1,0 +1,6 @@
+define(['require'], (function (require) { 'use strict';
+
+	new Promise(function (resolve, reject) { require(['./generated-a'], resolve, reject); }).then(({a}) => console.log(a));
+	new Promise(function (resolve, reject) { require(['./generated-b'], resolve, reject); }).then(({b}) => console.log(b));
+
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-a.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-a.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var c = require('./generated-c.js');
+require('./generated-c2.js');
+require('./generated-c3.js');
+require('./generated-c4.js');
+require('./generated-e.js');
+
+console.log('a');
+const a = 'a' + c.c;
+
+exports.a = a;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-b.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-b.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var e = require('./generated-e.js');
+
+console.log('b');
+const b = 'b' + e.e;
+
+exports.b = b;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var c2 = require('./generated-c2.js');
+
+console.log('c');
+const c = 'c' + c2.c2;
+
+exports.c = c;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c2.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var c3 = require('./generated-c3.js');
+
+console.log('c2');
+const c2 = 'c2' + c3.c3;
+
+exports.c2 = c2;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c3.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c3.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var c4 = require('./generated-c4.js');
+
+console.log('c3');
+const c3 = 'c3' + c4.c4;
+
+exports.c3 = c3;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c4.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-c4.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var e = require('./generated-e.js');
+
+console.log('c5');
+const c5 = 'c5' + e.e;
+
+console.log('c4');
+const c4 = 'c4' + c5;
+
+exports.c4 = c4;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-e.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/generated-e.js
@@ -1,0 +1,6 @@
+'use strict';
+
+console.log('e');
+const e = 'e';
+
+exports.e = e;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/main.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/cjs/main.js
@@ -1,0 +1,4 @@
+'use strict';
+
+Promise.resolve().then(function () { return require('./generated-a.js'); }).then(({a}) => console.log(a));
+Promise.resolve().then(function () { return require('./generated-b.js'); }).then(({b}) => console.log(b));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-a.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-a.js
@@ -1,0 +1,10 @@
+import { c } from './generated-c.js';
+import './generated-c2.js';
+import './generated-c3.js';
+import './generated-c4.js';
+import './generated-e.js';
+
+console.log('a');
+const a = 'a' + c;
+
+export { a };

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-b.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-b.js
@@ -1,0 +1,6 @@
+import { e } from './generated-e.js';
+
+console.log('b');
+const b = 'b' + e;
+
+export { b };

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c.js
@@ -1,0 +1,6 @@
+import { c as c2 } from './generated-c2.js';
+
+console.log('c');
+const c = 'c' + c2;
+
+export { c };

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c2.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c2.js
@@ -1,0 +1,6 @@
+import { c as c3 } from './generated-c3.js';
+
+console.log('c2');
+const c2 = 'c2' + c3;
+
+export { c2 as c };

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c3.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c3.js
@@ -1,0 +1,6 @@
+import { c as c4 } from './generated-c4.js';
+
+console.log('c3');
+const c3 = 'c3' + c4;
+
+export { c3 as c };

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c4.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-c4.js
@@ -1,0 +1,9 @@
+import { e } from './generated-e.js';
+
+console.log('c5');
+const c5 = 'c5' + e;
+
+console.log('c4');
+const c4 = 'c4' + c5;
+
+export { c4 as c };

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-e.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/generated-e.js
@@ -1,0 +1,4 @@
+console.log('e');
+const e = 'e';
+
+export { e };

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/main.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/es/main.js
@@ -1,0 +1,2 @@
+import('./generated-a.js').then(({a}) => console.log(a));
+import('./generated-b.js').then(({b}) => console.log(b));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-a.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-a.js
@@ -1,0 +1,15 @@
+System.register(['./generated-c.js', './generated-c2.js', './generated-c3.js', './generated-c4.js', './generated-e.js'], (function (exports) {
+	'use strict';
+	var c;
+	return {
+		setters: [function (module) {
+			c = module.c;
+		}, null, null, null, null],
+		execute: (function () {
+
+			console.log('a');
+			const a = exports("a", 'a' + c);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-b.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-b.js
@@ -1,0 +1,15 @@
+System.register(['./generated-e.js'], (function (exports) {
+	'use strict';
+	var e;
+	return {
+		setters: [function (module) {
+			e = module.e;
+		}],
+		execute: (function () {
+
+			console.log('b');
+			const b = exports("b", 'b' + e);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c.js
@@ -1,0 +1,15 @@
+System.register(['./generated-c2.js'], (function (exports) {
+	'use strict';
+	var c2;
+	return {
+		setters: [function (module) {
+			c2 = module.c;
+		}],
+		execute: (function () {
+
+			console.log('c');
+			const c = exports("c", 'c' + c2);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c2.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c2.js
@@ -1,0 +1,15 @@
+System.register(['./generated-c3.js'], (function (exports) {
+	'use strict';
+	var c3;
+	return {
+		setters: [function (module) {
+			c3 = module.c;
+		}],
+		execute: (function () {
+
+			console.log('c2');
+			const c2 = exports("c", 'c2' + c3);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c3.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c3.js
@@ -1,0 +1,15 @@
+System.register(['./generated-c4.js'], (function (exports) {
+	'use strict';
+	var c4;
+	return {
+		setters: [function (module) {
+			c4 = module.c;
+		}],
+		execute: (function () {
+
+			console.log('c3');
+			const c3 = exports("c", 'c3' + c4);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c4.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-c4.js
@@ -1,0 +1,18 @@
+System.register(['./generated-e.js'], (function (exports) {
+	'use strict';
+	var e;
+	return {
+		setters: [function (module) {
+			e = module.e;
+		}],
+		execute: (function () {
+
+			console.log('c5');
+			const c5 = 'c5' + e;
+
+			console.log('c4');
+			const c4 = exports("c", 'c4' + c5);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-e.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/generated-e.js
@@ -1,0 +1,11 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			console.log('e');
+			const e = exports("e", 'e');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/_expected/system/main.js
@@ -1,0 +1,11 @@
+System.register([], (function (exports, module) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			module.import('./generated-a.js').then(({a}) => console.log(a));
+			module.import('./generated-b.js').then(({b}) => console.log(b));
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/a.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/a.js
@@ -1,0 +1,3 @@
+import { c } from './c.js';
+console.log('a');
+export const a = 'a' + c;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/b.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/b.js
@@ -1,0 +1,3 @@
+import { e } from './e.js';
+console.log('b');
+export const b = 'b' + e;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c.js
@@ -1,0 +1,3 @@
+import { c2 } from './c2.js';
+console.log('c');
+export const c = 'c' + c2;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c2.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c2.js
@@ -1,0 +1,3 @@
+import { c3 } from './c3.js';
+console.log('c2');
+export const c2 = 'c2' + c3;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c3.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c3.js
@@ -1,0 +1,3 @@
+import { c4 } from './c4.js';
+console.log('c3');
+export const c3 = 'c3' + c4;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c4.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c4.js
@@ -1,0 +1,3 @@
+import { c5 } from './c5.js';
+console.log('c4');
+export const c4 = 'c4' + c5;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c5.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/c5.js
@@ -1,0 +1,3 @@
+import { e } from './e.js';
+console.log('c5');
+export const c5 = 'c5' + e;

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/e.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/e.js
@@ -1,0 +1,2 @@
+console.log('e');
+export const e = 'e';

--- a/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/main.js
+++ b/test/chunking-form/samples/non-circular-chunk-with-only-explicit-manual-chunks/main.js
@@ -1,0 +1,2 @@
+import('./a.js').then(({a}) => console.log(a));
+import('./b.js').then(({b}) => console.log(b));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_config.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_config.js
@@ -1,0 +1,12 @@
+module.exports = defineTest({
+	description: 'extracts shared static dependency between manual chunks into a single chunk',
+	options: {
+		output: {
+			manualChunks(id) {
+				if (id.includes('manual1.js')) return 'manual1';
+				if (id.includes('manual2.js')) return 'manual2';
+			},
+			onlyExplicitManualChunks: true
+		}
+	}
+});

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/generated-manual1.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/generated-manual1.js
@@ -1,0 +1,5 @@
+define(['./generated-shared'], (function (shared) { 'use strict';
+
+	console.log('manual1', shared.shared);
+
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/generated-manual2.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/generated-manual2.js
@@ -1,0 +1,5 @@
+define(['./generated-shared'], (function (shared) { 'use strict';
+
+	console.log('manual2', shared.shared);
+
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/generated-shared.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/generated-shared.js
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	const shared = 'shared';
+
+	exports.shared = shared;
+
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/main.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/amd/main.js
@@ -1,0 +1,5 @@
+define(['./generated-manual1', './generated-manual2', './generated-shared'], (function (manual1, manual2, shared) { 'use strict';
+
+	console.log('main');
+
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/generated-manual1.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/generated-manual1.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var shared = require('./generated-shared.js');
+
+console.log('manual1', shared.shared);

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/generated-manual2.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/generated-manual2.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var shared = require('./generated-shared.js');
+
+console.log('manual2', shared.shared);

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/generated-shared.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/generated-shared.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const shared = 'shared';
+
+exports.shared = shared;

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/main.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/cjs/main.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('./generated-manual1.js');
+require('./generated-manual2.js');
+require('./generated-shared.js');
+
+console.log('main');

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/generated-manual1.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/generated-manual1.js
@@ -1,0 +1,3 @@
+import { s as shared } from './generated-shared.js';
+
+console.log('manual1', shared);

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/generated-manual2.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/generated-manual2.js
@@ -1,0 +1,3 @@
+import { s as shared } from './generated-shared.js';
+
+console.log('manual2', shared);

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/generated-shared.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/generated-shared.js
@@ -1,0 +1,3 @@
+const shared = 'shared';
+
+export { shared as s };

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/main.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/es/main.js
@@ -1,0 +1,5 @@
+import './generated-manual1.js';
+import './generated-manual2.js';
+import './generated-shared.js';
+
+console.log('main');

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/generated-manual1.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/generated-manual1.js
@@ -1,0 +1,14 @@
+System.register(['./generated-shared.js'], (function () {
+	'use strict';
+	var shared;
+	return {
+		setters: [function (module) {
+			shared = module.s;
+		}],
+		execute: (function () {
+
+			console.log('manual1', shared);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/generated-manual2.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/generated-manual2.js
@@ -1,0 +1,14 @@
+System.register(['./generated-shared.js'], (function () {
+	'use strict';
+	var shared;
+	return {
+		setters: [function (module) {
+			shared = module.s;
+		}],
+		execute: (function () {
+
+			console.log('manual2', shared);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/generated-shared.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/generated-shared.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			const shared = exports("s", 'shared');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/main.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/_expected/system/main.js
@@ -1,0 +1,11 @@
+System.register(['./generated-manual1.js', './generated-manual2.js', './generated-shared.js'], (function () {
+	'use strict';
+	return {
+		setters: [null, null, null],
+		execute: (function () {
+
+			console.log('main');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/main.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/main.js
@@ -1,0 +1,3 @@
+import './manual1.js';
+import './manual2.js';
+console.log('main');

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/manual1.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/manual1.js
@@ -1,0 +1,2 @@
+import { shared } from './shared.js';
+console.log('manual1', shared);

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/manual2.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/manual2.js
@@ -1,0 +1,2 @@
+import { shared } from './shared.js';
+console.log('manual2', shared);

--- a/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/shared.js
+++ b/test/chunking-form/samples/shared-static-dependency-between-manual-chunks/shared.js
@@ -1,0 +1,1 @@
+export const shared = 'shared';


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
This PR changes the `onlyExplicitManualChunks` behavior for the function form of `output.manualChunks`.

Static dependencies imported by manual chunks are now extracted into separate chunks instead of remaining in entry chunk atoms. This avoids an unnecessary circular chunk case.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
