### PR TITLE
Fix tree-shaking for pure annotated awaited imports

### DIFF
--- a/src/ast/nodes/AwaitExpression.ts
+++ b/src/ast/nodes/AwaitExpression.ts
@@ -1,4 +1,5 @@
-import type { InclusionContext } from '../ExecutionContext';
+import type { NormalizedTreeshakingOptions } from '../../rollup/types';
+import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import type { ObjectPath } from '../utils/PathTracker';
 import ArrowFunctionExpression from './ArrowFunctionExpression';
 import type * as NodeType from './NodeType';
@@ -7,19 +8,30 @@ import { type ExpressionNode, type IncludeChildren, type Node, NodeBase } from '
 
 export default class AwaitExpression extends NodeBase {
 	declare argument: ExpressionNode;
+	/** Marked with #__PURE__ annotation */
+	declare annotationPure?: boolean;
 	declare type: NodeType.tAwaitExpression;
 
 	deoptimizePath(path: ObjectPath) {
 		this.argument.deoptimizePath(path);
 	}
 
-	hasEffects(): boolean {
+	hasEffects(_context: HasEffectsContext): boolean {
 		if (!this.deoptimized) this.applyDeoptimizations();
+		if (this.annotationPure) {
+			return false;
+		}
 		return true;
 	}
 
 	initialise(): void {
 		super.initialise();
+		if (
+			this.annotations &&
+			(this.scope.context.options.treeshake as NormalizedTreeshakingOptions).annotations
+		) {
+			this.annotationPure = this.annotations.some(comment => comment.type === 'pure');
+		}
 		let parent = this.parent;
 		do {
 			if (parent instanceof FunctionNode || parent instanceof ArrowFunctionExpression) return;

--- a/src/ast/nodes/Program.ts
+++ b/src/ast/nodes/Program.ts
@@ -8,12 +8,16 @@ import {
 	type RenderOptions,
 	renderStatementList
 } from '../../utils/renderHelpers';
+import { childNodeKeys } from '../childNodeKeys';
 import type { HasEffectsContext, InclusionContext } from '../ExecutionContext';
 import { createHasEffectsContext } from '../ExecutionContext';
+import AwaitExpression from './AwaitExpression';
 import type * as NodeType from './NodeType';
 import {
 	doNotDeoptimize,
+	type GenericEsTreeNode,
 	type IncludeChildren,
+	type Node,
 	NodeBase,
 	onlyIncludeSelfNoDeoptimize,
 	type StatementNode
@@ -67,8 +71,12 @@ export default class Program extends NodeBase {
 	initialise() {
 		super.initialise();
 		if (this.invalidAnnotations)
-			for (const { start, end, type } of this.invalidAnnotations) {
+			for (const annotation of this.invalidAnnotations) {
+				const { start, end, type } = annotation;
 				this.scope.context.magicString.remove(start, end);
+				if (type === 'pure' && this.applyPureAnnotationToAwaitExpression(annotation)) {
+					continue;
+				}
 				if (type === 'pure' || type === 'noSideEffects') {
 					this.scope.context.log(
 						LOGLEVEL_WARN,
@@ -81,6 +89,43 @@ export default class Program extends NodeBase {
 					);
 				}
 			}
+	}
+
+	private applyPureAnnotationToAwaitExpression(annotation: RollupAnnotation): boolean {
+		const { code } = this.scope.context;
+		const findAnnotatedAwait = (node: Node): AwaitExpression | null => {
+			if (node.end < annotation.end) return null;
+			if (
+				node instanceof AwaitExpression &&
+				annotation.end <= node.start &&
+				code.slice(annotation.end, node.start).trim() === ''
+			) {
+				return node;
+			}
+			for (const key of childNodeKeys[node.type] || []) {
+				const value = (node as GenericEsTreeNode)[key];
+				if (Array.isArray(value)) {
+					for (const child of value) {
+						if (child) {
+							const annotatedAwait = findAnnotatedAwait(child);
+							if (annotatedAwait) return annotatedAwait;
+						}
+					}
+				} else if (value) {
+					const annotatedAwait = findAnnotatedAwait(value);
+					if (annotatedAwait) return annotatedAwait;
+				}
+			}
+			return null;
+		};
+		for (const node of this.body) {
+			const annotatedAwait = findAnnotatedAwait(node);
+			if (annotatedAwait) {
+				annotatedAwait.annotationPure = true;
+				return true;
+			}
+		}
+		return false;
 	}
 
 	render(code: MagicString, options: RenderOptions): void {

--- a/test/chunking-form/samples/pure-top-level-await-import-then/_config.js
+++ b/test/chunking-form/samples/pure-top-level-await-import-then/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description: 'tree-shakes pure annotated top-level await import.then expressions',
+	formats: ['es']
+});

--- a/test/chunking-form/samples/pure-top-level-await-import-then/_expected/es/generated-all.js
+++ b/test/chunking-form/samples/pure-top-level-await-import-then/_expected/es/generated-all.js
@@ -1,0 +1,4 @@
+const nativeA = 1;
+const shimA = 2;
+
+export { nativeA, shimA };

--- a/test/chunking-form/samples/pure-top-level-await-import-then/_expected/es/main.js
+++ b/test/chunking-form/samples/pure-top-level-await-import-then/_expected/es/main.js
@@ -1,0 +1,14 @@
+const a =  await import('./generated-all.js').then(({ nativeA, shimA }) =>
+	nativeA ? nativeA : shimA
+);
+function getThenable() {
+	return {
+		then(resolve) {
+			globalThis.awaitedThenable = true;
+			resolve('thenable');
+		}
+	};
+}
+await /*#__PURE__*/ getThenable();
+
+console.log(a);

--- a/test/chunking-form/samples/pure-top-level-await-import-then/all.js
+++ b/test/chunking-form/samples/pure-top-level-await-import-then/all.js
@@ -1,0 +1,5 @@
+export const nativeA = 1;
+export const shimA = 2;
+export const nativeB = 1;
+export const shimB = 2;
+export const other = 3;

--- a/test/chunking-form/samples/pure-top-level-await-import-then/main.js
+++ b/test/chunking-form/samples/pure-top-level-await-import-then/main.js
@@ -1,0 +1,3 @@
+import { a } from './mix.js';
+
+console.log(a);

--- a/test/chunking-form/samples/pure-top-level-await-import-then/mix.js
+++ b/test/chunking-form/samples/pure-top-level-await-import-then/mix.js
@@ -1,0 +1,15 @@
+export const a = /*#__PURE__*/ await import('./all.js').then(({ nativeA, shimA }) =>
+	nativeA ? nativeA : shimA
+);
+export const b = /*#__PURE__*/ await import('./all.js').then(({ nativeB, shimB }) =>
+	nativeB ? nativeB : shimB
+);
+function getThenable() {
+	return {
+		then(resolve) {
+			globalThis.awaitedThenable = true;
+			resolve('thenable');
+		}
+	};
+}
+export const c = await /*#__PURE__*/ getThenable();


### PR DESCRIPTION
### Description

Pure annotations placed immediately before a top-level `await import().then(...)` expression were treated as invalid, so an unused export initialized that way was still kept as a bare awaited dynamic import.

This applies that pure annotation to the following `AwaitExpression` and lets it opt out of the usual top-level-await side-effect check. The used awaited import is still preserved, while the unused pure one can be removed and its chunk exports can be tree-shaken.

Resolves #5948.

### Tests

- `npm run build:cjs`
- `npx mocha -b test/chunking-form/index.js --grep "top-level-await|dynamic-import-object-property-tree-shaking-then|pure-top-level-await-import-then"`
- `npx eslint --cache --concurrency auto src/ast/nodes/AwaitExpression.ts src/ast/nodes/Program.ts`
- `git diff --check`