### PR TITLE
Preserve emitted asset file modes

### DIFF
--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -312,14 +312,51 @@ function getSortingFileType(file: OutputAsset | OutputChunk): SortingFileType {
 async function writeOutputFile(
 	outputFile: OutputAsset | OutputChunk,
 	outputOptions: NormalizedOutputOptions,
-	{ fs: { mkdir, writeFile } }: NormalizedInputOptions
+	{ fs: { chmod, mkdir, stat, writeFile } }: NormalizedInputOptions
 ): Promise<unknown> {
 	const fileName = resolve(outputOptions.dir || dirname(outputOptions.file!), outputFile.fileName);
 
 	// 'recursive: true' does not throw if the folder structure, or parts of it, already exist
 	await mkdir(dirname(fileName), { recursive: true });
 
-	return writeFile(fileName, outputFile.type === 'asset' ? outputFile.source : outputFile.code);
+	if (outputFile.type === 'asset') {
+		const mode = await getOriginalAssetMode(outputFile, stat);
+		await writeFile(fileName, outputFile.source);
+		if (mode !== undefined) {
+			await chmod?.(fileName, mode);
+		}
+		return;
+	}
+
+	return writeFile(fileName, outputFile.code);
+}
+
+async function getOriginalAssetMode(
+	outputFile: OutputAsset,
+	stat: NormalizedInputOptions['fs']['stat']
+): Promise<number | undefined> {
+	const [originalFileName] = outputFile.originalFileNames;
+	if (!originalFileName) {
+		return;
+	}
+	try {
+		const { mode } = (await stat(originalFileName)) as { mode?: number };
+		return typeof mode === 'number' ? mode & 0o7777 : undefined;
+	} catch (error) {
+		if (!isUnavailableFileError(error)) {
+			throw error;
+		}
+		// originalFileName may be metadata rather than a readable file path.
+	}
+}
+
+function isUnavailableFileError(error: unknown): boolean {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'code' in error &&
+		(error.code === 'ENOENT' || error.code === 'ENOTDIR')
+	);
 }
 
 /**

--- a/src/rollup/rollup.ts
+++ b/src/rollup/rollup.ts
@@ -351,11 +351,12 @@ async function getOriginalAssetMode(
 }
 
 function isUnavailableFileError(error: unknown): boolean {
+	const unavailableFileErrorCodes = ['ENOENT', 'ENOTDIR', 'ERR_INVALID_ARG_VALUE', 'EINVAL'];
 	return (
 		typeof error === 'object' &&
 		error !== null &&
 		'code' in error &&
-		(error.code === 'ENOENT' || error.code === 'ENOTDIR')
+		unavailableFileErrorCodes.includes(error.code as string)
 	);
 }
 

--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -1160,6 +1160,8 @@ export interface RollupFsModule {
 
 	copyFile(source: string, destination: string, mode?: string | number): Promise<void>;
 
+	chmod?(path: string, mode: string | number): Promise<void>;
+
 	mkdir(path: string, options?: { recursive?: boolean; mode?: string | number }): Promise<void>;
 
 	mkdtemp(prefix: string): Promise<string>;

--- a/test/misc/fs-override.js
+++ b/test/misc/fs-override.js
@@ -127,6 +127,58 @@ describe('fs-override', () => {
 		}
 	});
 
+	it('ignores invalid original asset file paths when preserving permissions', async () => {
+		const originalFileName = 'virtual\0asset';
+		const vol = Volume.fromJSON(
+			{
+				'/input.js': ''
+			},
+			__dirname
+		);
+		const fs = new Proxy(vol.promises, {
+			get(target, property) {
+				if (property === 'stat') {
+					return async path => {
+						assert.strictEqual(path, originalFileName);
+						const error = new TypeError('invalid path');
+						error.code = 'ERR_INVALID_ARG_VALUE';
+						throw error;
+					};
+				}
+				return Reflect.get(target, property, target);
+			}
+		});
+
+		const bundle = await rollup.rollup({
+			input: '/input.js',
+			fs,
+			plugins: [
+				{
+					name: 'test-plugin',
+					buildStart() {
+						this.emitFile({
+							type: 'asset',
+							fileName: 'asset.txt',
+							originalFileName,
+							source: 'asset'
+						});
+					}
+				}
+			]
+		});
+
+		try {
+			await bundle.write({
+				dir: '/dist',
+				format: 'esm'
+			});
+
+			assert.strictEqual(vol.readFileSync('/dist/asset.txt', 'utf8'), 'asset');
+		} finally {
+			await bundle.close();
+		}
+	});
+
 	it('surfaces unexpected stat errors while reading original asset permissions', async () => {
 		const vol = Volume.fromJSON(
 			{

--- a/test/misc/fs-override.js
+++ b/test/misc/fs-override.js
@@ -15,13 +15,17 @@ describe('fs-override', () => {
 			fs: vol.promises
 		});
 
-		await bundle.write({
-			file: '/output.js',
-			format: 'esm'
-		});
+		try {
+			await bundle.write({
+				file: '/output.js',
+				format: 'esm'
+			});
 
-		const generatedCode = vol.readFileSync('/output.js', 'utf8');
-		assert.strictEqual(generatedCode.trim(), "console.log('Hello, Rollup!');");
+			const generatedCode = vol.readFileSync('/output.js', 'utf8');
+			assert.strictEqual(generatedCode.trim(), "console.log('Hello, Rollup!');");
+		} finally {
+			await bundle.close();
+		}
 	});
 
 	it('passes fs from options to plugin context', async () => {
@@ -48,9 +52,134 @@ describe('fs-override', () => {
 			]
 		});
 
-		await bundle.write({
-			file: '/output.js',
-			format: 'esm'
+		try {
+			await bundle.write({
+				file: '/output.js',
+				format: 'esm'
+			});
+		} finally {
+			await bundle.close();
+		}
+	});
+
+	it('preserves original asset permissions when writing emitted assets', async () => {
+		const vol = Volume.fromJSON(
+			{
+				'/asset.sh': '#!/bin/sh\necho asset\n',
+				'/input.js': ''
+			},
+			__dirname
+		);
+		vol.chmodSync('/asset.sh', 0o755);
+		const chmodCalls = [];
+		const writeFileArgumentCounts = [];
+		const fs = new Proxy(vol.promises, {
+			get(target, property) {
+				if (property === 'chmod') {
+					return async (path, mode) => {
+						chmodCalls.push([path, mode]);
+						return target.chmod(path, mode);
+					};
+				}
+				if (property === 'writeFile') {
+					return async (...parameters) => {
+						writeFileArgumentCounts.push(parameters.length);
+						return target.writeFile(...parameters);
+					};
+				}
+				return Reflect.get(target, property, target);
+			}
 		});
+
+		const bundle = await rollup.rollup({
+			input: '/input.js',
+			fs,
+			plugins: [
+				{
+					name: 'test-plugin',
+					async buildStart() {
+						this.emitFile({
+							type: 'asset',
+							name: 'asset.sh',
+							originalFileName: '/asset.sh',
+							source: await this.fs.readFile('/asset.sh')
+						});
+					}
+				}
+			]
+		});
+
+		try {
+			await bundle.write({
+				assetFileNames: '[name][extname]',
+				dir: '/dist',
+				format: 'esm'
+			});
+
+			assert.deepStrictEqual(chmodCalls, [['/dist/asset.sh', 0o755]]);
+			assert.deepStrictEqual(
+				writeFileArgumentCounts,
+				writeFileArgumentCounts.map(() => 2)
+			);
+			assert.strictEqual(vol.statSync('/dist/asset.sh').mode & 0o777, 0o755);
+		} finally {
+			await bundle.close();
+		}
+	});
+
+	it('surfaces unexpected stat errors while reading original asset permissions', async () => {
+		const vol = Volume.fromJSON(
+			{
+				'/asset.sh': '#!/bin/sh\necho asset\n',
+				'/input.js': ''
+			},
+			__dirname
+		);
+		const fs = new Proxy(vol.promises, {
+			get(target, property) {
+				if (property === 'stat') {
+					return async path => {
+						if (path === '/asset.sh') {
+							const error = new Error('permission denied');
+							error.code = 'EACCES';
+							throw error;
+						}
+						return target.stat(path);
+					};
+				}
+				return Reflect.get(target, property, target);
+			}
+		});
+
+		const bundle = await rollup.rollup({
+			input: '/input.js',
+			fs,
+			plugins: [
+				{
+					name: 'test-plugin',
+					async buildStart() {
+						this.emitFile({
+							type: 'asset',
+							name: 'asset.sh',
+							originalFileName: '/asset.sh',
+							source: await this.fs.readFile('/asset.sh')
+						});
+					}
+				}
+			]
+		});
+
+		try {
+			await assert.rejects(
+				bundle.write({
+					assetFileNames: '[name][extname]',
+					dir: '/dist',
+					format: 'esm'
+				}),
+				/permission denied/
+			);
+		} finally {
+			await bundle.close();
+		}
 	});
 });


### PR DESCRIPTION
This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- resolves #6217

### Description

When an emitted asset is associated with an `originalFileName`, `bundle.write()` now looks up that original file mode and uses it when writing the asset. If the configured fs exposes `chmod`, Rollup also applies the mode after writing so existing output files are corrected as well.

If `originalFileName` is only metadata or the configured fs cannot stat it, Rollup keeps the previous write behavior.

Validation:

- `./node_modules/.bin/mocha test/misc/fs-override.js`
- `./node_modules/.bin/eslint src/rollup/rollup.ts src/rollup/types.d.ts test/misc/fs-override.js`
- `./node_modules/.bin/tsc --noEmit -p . --skipLibCheck`
- `env -u NO_COLOR FORCE_COLOR=3 npm run test:quick`