### PR TITLE
docs: fix broken links

### DIFF
--- a/CHANGELOG-0.md
+++ b/CHANGELOG-0.md
@@ -1321,7 +1321,7 @@ _2017-08-27_
 
 - Prevent plugin-provided external IDs being normalised ([#630](https://github.com/rollup/rollup/issues/630), [#633](https://github.com/rollup/rollup/issues/633))
 - Throw if module exports/re-exports the same name twice, or has multiple default exports ([#679](https://github.com/rollup/rollup/issues/679))
-- Warn about `eval` security issue ([#675](<(https://github.com/rollup/rollup/issues/675)>))
+- Warn about `eval` security issue ([#675](https://github.com/rollup/rollup/issues/675))
 
 ## 0.26.3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ We also welcome financial contributions in full transparency on our [open collec
 
 ## Questions
 
-If you require technical assistance, [Stackoverflow](https://stackoverflow.com/questions/tagged/rollupjs) or [Discord](https://is.gd/rollup_chat) are usually the best places to start. You can also create an [issue](issue) ( protip: do a quick search first to see if someone else didn't ask the same question before!).
+If you require technical assistance, [Stackoverflow](https://stackoverflow.com/questions/tagged/rollupjs) or [Discord](https://is.gd/rollup_chat) are usually the best places to start. You can also create an [issue](https://github.com/rollup/rollup/issues/new/choose) ( protip: do a quick search first to see if someone else didn't ask the same question before!).
 
 ## Credits
 


### PR DESCRIPTION
## Summary

- update the contributing guide's issue link to the GitHub issue template chooser
- fix malformed Markdown around the `#675` changelog link

## Verification

- `npm run lint:markdown:nofix`
- `! rg -n -F '[issue](issue)' CONTRIBUTING.md`
- `! rg -n -F '[#675](<(https://github.com/rollup/rollup/issues/675)>)' CHANGELOG-0.md`

Note: `npm ci` installed enough dependencies to run the markdown check, but its prepare step attempted a native build and failed because `cmake` is not installed in this local environment.
