### PR TITLE
fix: set report.excludeNetwork=true before getReport() to avoid blocking PTR lookups

### DIFF
--- a/native.js
+++ b/native.js
@@ -6,12 +6,18 @@ const { spawnSync } = require('node:child_process');
 const getReportHeader = () => {
 	try {
 		if (platform !== 'win32') {
-			return report.getReport().header;
+			// Avoid blocking reverse DNS (PTR) lookups on open TCP socket handles.
+			// See: https://github.com/nodejs/node/issues/55576
+			const previousExcludeNetwork = report.excludeNetwork;
+			report.excludeNetwork = true;
+			const header = report.getReport().header;
+			report.excludeNetwork = previousExcludeNetwork;
+			return header;
 		}
 
 		// This is needed because report.getReport() crashes the process on Windows sometimes.
 		const script =
-			"console.log(JSON.stringify(require('node:process').report.getReport().header));";
+			"const r=require('node:process').report;r.excludeNetwork=true;console.log(JSON.stringify(r.getReport().header));";
 		const child = spawnSync(process.execPath, ['-p', script], {
 			encoding: 'utf8',
 			timeout: 3000,

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -471,7 +471,10 @@ console.log(x);
 		assert.strictEqual(bundle.closed, true);
 	});
 
-	it('sets process.report.excludeNetwork=true during getReport() and restores the original value', () => {
+	it('sets process.report.excludeNetwork=true during getReport() and restores the original value (non-Windows)', () => {
+		// On Windows, getReport() runs inside a spawnSync child process and cannot
+		// be intercepted by mocking process.report.getReport in the current process.
+		if (process.platform === 'win32') return;
 		if (!('excludeNetwork' in process.report)) return;
 
 		const original = process.report.getReport.bind(process.report);

--- a/test/misc/misc.js
+++ b/test/misc/misc.js
@@ -470,4 +470,42 @@ console.log(x);
 		await bundle[Symbol.asyncDispose]();
 		assert.strictEqual(bundle.closed, true);
 	});
+
+	it('sets process.report.excludeNetwork=true during getReport() and restores the original value', () => {
+		if (!('excludeNetwork' in process.report)) return;
+
+		const original = process.report.getReport.bind(process.report);
+		const snapshots = [];
+		process.report.getReport = () => {
+			snapshots.push(process.report.excludeNetwork);
+			return original();
+		};
+
+		try {
+			for (const initial of [false, true]) {
+				process.report.excludeNetwork = initial;
+				snapshots.length = 0;
+				delete require.cache[require.resolve('../../dist/native.js')];
+				try {
+					require('../../dist/native.js');
+				} catch {
+					/* ignore binary load errors */
+				}
+				assert.ok(snapshots.length > 0, 'getReport() should have been called');
+				assert.ok(
+					snapshots.every(v => v === true),
+					'excludeNetwork must be true during getReport()'
+				);
+				assert.strictEqual(
+					process.report.excludeNetwork,
+					initial,
+					'excludeNetwork must be restored afterwards'
+				);
+			}
+		} finally {
+			process.report.getReport = original;
+			process.report.excludeNetwork = false;
+			delete require.cache[require.resolve('../../dist/native.js')];
+		}
+	});
 });


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
`native.js` calls `report.getReport()` during module initialization to detect the platform (`isMingw32`/`isMusl`). `report.getReport()` enumerates all libuv TCP handles and performs a reverse DNS (PTR) lookup on each one. When active TCP sockets are present and the remote IP's PTR query returns `SERVFAIL`, the call blocks until DNS times out.  

This affects projects where a plugin calls `fetch()` during a build, leaving a keep-alive socket in undici's pool, and a later plugin import triggers `native.js` to load.

Fix: set `report.excludeNetwork = true` before calling `report.getReport()` and restore the previous value afterwards. For the Windows `spawnSync` path, `excludeNetwork` is set inside the child script.

Ref: https://github.com/nodejs/node/issues/55576
Ref: https://github.com/nodejs/node/pull/55602