### PR TITLE
fix: insert conflict numbers before first extension in multi-extension filenames

### DIFF
--- a/src/utils/renderNamePattern.ts
+++ b/src/utils/renderNamePattern.ts
@@ -1,7 +1,6 @@
 import { error, logFailedValidation } from './logs';
 import type { OutputBundleWithPlaceholders } from './outputBundle';
 import { lowercaseBundleKeys } from './outputBundle';
-import { extname } from './path';
 import { isPathFragment } from './relativeId';
 
 export function renderNamePattern(
@@ -42,7 +41,7 @@ export function makeUnique(
 	{ [lowercaseBundleKeys]: reservedLowercaseBundleKeys }: OutputBundleWithPlaceholders
 ): string {
 	if (!reservedLowercaseBundleKeys.has(name.toLowerCase())) return name;
-	const extension = extname(name);
+	const extension = getFirstExtension(name);
 	name = name.slice(0, Math.max(0, name.length - extension.length));
 	let uniqueName: string,
 		uniqueIndex = 1;
@@ -50,4 +49,13 @@ export function makeUnique(
 		reservedLowercaseBundleKeys.has((uniqueName = name + ++uniqueIndex + extension).toLowerCase())
 	);
 	return uniqueName;
+}
+
+// Returns everything from the first dot onwards, treating files that start with
+// a dot (e.g. ".gitignore") as having no leading dot for extension purposes so
+// that ".env.local" yields ".local" rather than the full name.
+function getFirstExtension(name: string): string {
+	const startIndex = name.startsWith('.') ? 1 : 0;
+	const dotIndex = name.indexOf('.', startIndex);
+	return dotIndex === -1 ? '' : name.slice(dotIndex);
 }

--- a/src/utils/renderNamePattern.ts
+++ b/src/utils/renderNamePattern.ts
@@ -41,21 +41,13 @@ export function makeUnique(
 	{ [lowercaseBundleKeys]: reservedLowercaseBundleKeys }: OutputBundleWithPlaceholders
 ): string {
 	if (!reservedLowercaseBundleKeys.has(name.toLowerCase())) return name;
-	const extension = getFirstExtension(name);
-	name = name.slice(0, Math.max(0, name.length - extension.length));
+	const dotIndex = name.indexOf('.', 1);
+	const base = dotIndex === -1 ? name : name.slice(0, dotIndex);
+	const extension = dotIndex === -1 ? '' : name.slice(dotIndex);
 	let uniqueName: string,
 		uniqueIndex = 1;
 	while (
-		reservedLowercaseBundleKeys.has((uniqueName = name + ++uniqueIndex + extension).toLowerCase())
+		reservedLowercaseBundleKeys.has((uniqueName = base + ++uniqueIndex + extension).toLowerCase())
 	);
 	return uniqueName;
-}
-
-// Returns everything from the first dot onwards, treating files that start with
-// a dot (e.g. ".gitignore") as having no leading dot for extension purposes so
-// that ".env.local" yields ".local" rather than the full name.
-function getFirstExtension(name: string): string {
-	const startIndex = name.startsWith('.') ? 1 : 0;
-	const dotIndex = name.indexOf('.', startIndex);
-	return dotIndex === -1 ? '' : name.slice(dotIndex);
 }

--- a/src/utils/renderNamePattern.ts
+++ b/src/utils/renderNamePattern.ts
@@ -41,9 +41,13 @@ export function makeUnique(
 	{ [lowercaseBundleKeys]: reservedLowercaseBundleKeys }: OutputBundleWithPlaceholders
 ): string {
 	if (!reservedLowercaseBundleKeys.has(name.toLowerCase())) return name;
-	const dotIndex = name.indexOf('.', 1);
-	const base = dotIndex === -1 ? name : name.slice(0, dotIndex);
-	const extension = dotIndex === -1 ? '' : name.slice(dotIndex);
+	const slashIndex = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+	// This will also handle -1 correctly
+	const directory = name.slice(0, slashIndex + 1);
+	const fileName = name.slice(slashIndex + 1);
+	const dotIndex = fileName.indexOf('.', 1);
+	const base = directory + (dotIndex === -1 ? fileName : fileName.slice(0, dotIndex));
+	const extension = dotIndex === -1 ? '' : fileName.slice(dotIndex);
 	let uniqueName: string,
 		uniqueIndex = 1;
 	while (

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_config.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_config.js
@@ -1,0 +1,14 @@
+module.exports = defineTest({
+	description:
+		'preserves the leading dot of hidden file names when inserting conflict numbers before the first extension',
+	options: {
+		input: {
+			entryA: 'main1.js',
+			entryB: 'main2.js',
+			entryC: 'main3.js'
+		},
+		output: {
+			chunkFileNames: '.env.local'
+		}
+	}
+});

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/.env.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/.env.local
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 1;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/.env2.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/.env2.local
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 2;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/.env3.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/.env3.local
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 3;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/entryA.js
@@ -1,0 +1,5 @@
+define(['./.env.local', './.env2.local'], (function (dep1, dep2) { 'use strict';
+
+	console.log(dep1.num + dep2.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/entryB.js
@@ -1,0 +1,5 @@
+define(['./.env2.local', './.env3.local'], (function (dep2, dep3) { 'use strict';
+
+	console.log(dep2.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/amd/entryC.js
@@ -1,0 +1,5 @@
+define(['./.env.local', './.env3.local'], (function (dep1, dep3) { 'use strict';
+
+	console.log(dep1.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/.env.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/.env.local
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 1;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/.env2.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/.env2.local
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 2;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/.env3.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/.env3.local
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 3;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/entryA.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./.env.local');
+var dep2 = require('./.env2.local');
+
+console.log(dep1.num + dep2.num);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/entryB.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep2 = require('./.env2.local');
+var dep3 = require('./.env3.local');
+
+console.log(dep2.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/cjs/entryC.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./.env.local');
+var dep3 = require('./.env3.local');
+
+console.log(dep1.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/.env.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/.env.local
@@ -1,0 +1,3 @@
+var num = 1;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/.env2.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/.env2.local
@@ -1,0 +1,3 @@
+var num = 2;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/.env3.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/.env3.local
@@ -1,0 +1,3 @@
+var num = 3;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/entryA.js
@@ -1,0 +1,4 @@
+import { n as num } from './.env.local';
+import { n as num$1 } from './.env2.local';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/entryB.js
@@ -1,0 +1,4 @@
+import { n as num } from './.env2.local';
+import { n as num$1 } from './.env3.local';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/es/entryC.js
@@ -1,0 +1,4 @@
+import { n as num } from './.env.local';
+import { n as num$1 } from './.env3.local';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/.env.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/.env.local
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/.env2.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/.env2.local
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 2);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/.env3.local
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/.env3.local
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 3);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/entryA.js
@@ -1,0 +1,16 @@
+System.register(['./.env.local', './.env2.local'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/entryB.js
@@ -1,0 +1,16 @@
+System.register(['./.env2.local', './.env3.local'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/_expected/system/entryC.js
@@ -1,0 +1,16 @@
+System.register(['./.env.local', './.env3.local'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-hidden-file/dep1.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/dep1.js
@@ -1,0 +1,1 @@
+export var num = 1;

--- a/test/chunking-form/samples/chunk-naming-hidden-file/dep2.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/dep2.js
@@ -1,0 +1,1 @@
+export var num = 2;

--- a/test/chunking-form/samples/chunk-naming-hidden-file/dep3.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/dep3.js
@@ -1,0 +1,1 @@
+export var num = 3;

--- a/test/chunking-form/samples/chunk-naming-hidden-file/main1.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/main1.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep2';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/main2.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/main2.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep2';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-hidden-file/main3.js
+++ b/test/chunking-form/samples/chunk-naming-hidden-file/main3.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_config.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_config.js
@@ -1,0 +1,14 @@
+module.exports = defineTest({
+	description:
+		'conflict numbers are not inserted into directory segments containing dots in multi-extension file names',
+	options: {
+		input: {
+			entryA: 'main1.js',
+			entryB: 'main2.js',
+			entryC: 'main3.js'
+		},
+		output: {
+			chunkFileNames: 'v1.0/chunk.d.ts'
+		}
+	}
+});

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/entryA.js
@@ -1,0 +1,5 @@
+define(['./v1.0/chunk.d.ts', './v1.0/chunk2.d.ts'], (function (dep1, dep2) { 'use strict';
+
+	console.log(dep1.num + dep2.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/entryB.js
@@ -1,0 +1,5 @@
+define(['./v1.0/chunk2.d.ts', './v1.0/chunk3.d.ts'], (function (dep2, dep3) { 'use strict';
+
+	console.log(dep2.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/entryC.js
@@ -1,0 +1,5 @@
+define(['./v1.0/chunk.d.ts', './v1.0/chunk3.d.ts'], (function (dep1, dep3) { 'use strict';
+
+	console.log(dep1.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/v1.0/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/v1.0/chunk.d.ts
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 1;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/v1.0/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/v1.0/chunk2.d.ts
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 2;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/v1.0/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/amd/v1.0/chunk3.d.ts
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 3;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/entryA.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./v1.0/chunk.d.ts');
+var dep2 = require('./v1.0/chunk2.d.ts');
+
+console.log(dep1.num + dep2.num);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/entryB.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep2 = require('./v1.0/chunk2.d.ts');
+var dep3 = require('./v1.0/chunk3.d.ts');
+
+console.log(dep2.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/entryC.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./v1.0/chunk.d.ts');
+var dep3 = require('./v1.0/chunk3.d.ts');
+
+console.log(dep1.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/v1.0/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/v1.0/chunk.d.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 1;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/v1.0/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/v1.0/chunk2.d.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 2;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/v1.0/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/cjs/v1.0/chunk3.d.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 3;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/entryA.js
@@ -1,0 +1,4 @@
+import { n as num } from './v1.0/chunk.d.ts';
+import { n as num$1 } from './v1.0/chunk2.d.ts';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/entryB.js
@@ -1,0 +1,4 @@
+import { n as num } from './v1.0/chunk2.d.ts';
+import { n as num$1 } from './v1.0/chunk3.d.ts';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/entryC.js
@@ -1,0 +1,4 @@
+import { n as num } from './v1.0/chunk.d.ts';
+import { n as num$1 } from './v1.0/chunk3.d.ts';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/v1.0/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/v1.0/chunk.d.ts
@@ -1,0 +1,3 @@
+var num = 1;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/v1.0/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/v1.0/chunk2.d.ts
@@ -1,0 +1,3 @@
+var num = 2;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/v1.0/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/es/v1.0/chunk3.d.ts
@@ -1,0 +1,3 @@
+var num = 3;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/entryA.js
@@ -1,0 +1,16 @@
+System.register(['./v1.0/chunk.d.ts', './v1.0/chunk2.d.ts'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/entryB.js
@@ -1,0 +1,16 @@
+System.register(['./v1.0/chunk2.d.ts', './v1.0/chunk3.d.ts'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/entryC.js
@@ -1,0 +1,16 @@
+System.register(['./v1.0/chunk.d.ts', './v1.0/chunk3.d.ts'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/v1.0/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/v1.0/chunk.d.ts
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/v1.0/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/v1.0/chunk2.d.ts
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 2);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/v1.0/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/_expected/system/v1.0/chunk3.d.ts
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 3);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/dep1.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/dep1.js
@@ -1,0 +1,1 @@
+export var num = 1;

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/dep2.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/dep2.js
@@ -1,0 +1,1 @@
+export var num = 2;

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/dep3.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/dep3.js
@@ -1,0 +1,1 @@
+export var num = 3;

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/main1.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/main1.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep2';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/main2.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/main2.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep2';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/main3.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension-subdirectory/main3.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_config.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_config.js
@@ -1,5 +1,6 @@
 module.exports = defineTest({
-	description: 'conflict numbers are inserted before the first extension in multi-extension file names',
+	description:
+		'conflict numbers are inserted before the first extension in multi-extension file names',
 	options: {
 		input: {
 			entryA: 'main1.js',

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_config.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_config.js
@@ -1,0 +1,13 @@
+module.exports = defineTest({
+	description: 'conflict numbers are inserted before the first extension in multi-extension file names',
+	options: {
+		input: {
+			entryA: 'main1.js',
+			entryB: 'main2.js',
+			entryC: 'main3.js'
+		},
+		output: {
+			chunkFileNames: 'chunks/chunk.d.ts'
+		}
+	}
+});

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/chunks/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/chunks/chunk.d.ts
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 1;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/chunks/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/chunks/chunk2.d.ts
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 2;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/chunks/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/chunks/chunk3.d.ts
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 3;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/entryA.js
@@ -1,0 +1,5 @@
+define(['./chunks/chunk.d.ts', './chunks/chunk2.d.ts'], (function (dep1, dep2) { 'use strict';
+
+	console.log(dep1.num + dep2.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/entryB.js
@@ -1,0 +1,5 @@
+define(['./chunks/chunk2.d.ts', './chunks/chunk3.d.ts'], (function (dep2, dep3) { 'use strict';
+
+	console.log(dep2.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/amd/entryC.js
@@ -1,0 +1,5 @@
+define(['./chunks/chunk.d.ts', './chunks/chunk3.d.ts'], (function (dep1, dep3) { 'use strict';
+
+	console.log(dep1.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/chunks/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/chunks/chunk.d.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 1;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/chunks/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/chunks/chunk2.d.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 2;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/chunks/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/chunks/chunk3.d.ts
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 3;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/entryA.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./chunks/chunk.d.ts');
+var dep2 = require('./chunks/chunk2.d.ts');
+
+console.log(dep1.num + dep2.num);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/entryB.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep2 = require('./chunks/chunk2.d.ts');
+var dep3 = require('./chunks/chunk3.d.ts');
+
+console.log(dep2.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/cjs/entryC.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./chunks/chunk.d.ts');
+var dep3 = require('./chunks/chunk3.d.ts');
+
+console.log(dep1.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/chunks/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/chunks/chunk.d.ts
@@ -1,0 +1,3 @@
+var num = 1;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/chunks/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/chunks/chunk2.d.ts
@@ -1,0 +1,3 @@
+var num = 2;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/chunks/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/chunks/chunk3.d.ts
@@ -1,0 +1,3 @@
+var num = 3;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/entryA.js
@@ -1,0 +1,4 @@
+import { n as num } from './chunks/chunk.d.ts';
+import { n as num$1 } from './chunks/chunk2.d.ts';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/entryB.js
@@ -1,0 +1,4 @@
+import { n as num } from './chunks/chunk2.d.ts';
+import { n as num$1 } from './chunks/chunk3.d.ts';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/es/entryC.js
@@ -1,0 +1,4 @@
+import { n as num } from './chunks/chunk.d.ts';
+import { n as num$1 } from './chunks/chunk3.d.ts';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/chunks/chunk.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/chunks/chunk.d.ts
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/chunks/chunk2.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/chunks/chunk2.d.ts
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 2);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/chunks/chunk3.d.ts
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/chunks/chunk3.d.ts
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 3);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/entryA.js
@@ -1,0 +1,16 @@
+System.register(['./chunks/chunk.d.ts', './chunks/chunk2.d.ts'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/entryB.js
@@ -1,0 +1,16 @@
+System.register(['./chunks/chunk2.d.ts', './chunks/chunk3.d.ts'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/_expected/system/entryC.js
@@ -1,0 +1,16 @@
+System.register(['./chunks/chunk.d.ts', './chunks/chunk3.d.ts'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-multi-extension/dep1.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/dep1.js
@@ -1,0 +1,1 @@
+export var num = 1;

--- a/test/chunking-form/samples/chunk-naming-multi-extension/dep2.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/dep2.js
@@ -1,0 +1,1 @@
+export var num = 2;

--- a/test/chunking-form/samples/chunk-naming-multi-extension/dep3.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/dep3.js
@@ -1,0 +1,1 @@
+export var num = 3;

--- a/test/chunking-form/samples/chunk-naming-multi-extension/main1.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/main1.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep2';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/main2.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/main2.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep2';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-multi-extension/main3.js
+++ b/test/chunking-form/samples/chunk-naming-multi-extension/main3.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-no-extension/_config.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_config.js
@@ -1,0 +1,13 @@
+module.exports = defineTest({
+	description: 'inserts conflict numbers at the end of the file name when there is no extension',
+	options: {
+		input: {
+			entryA: 'main1.js',
+			entryB: 'main2.js',
+			entryC: 'main3.js'
+		},
+		output: {
+			chunkFileNames: 'chunk'
+		}
+	}
+});

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/chunk
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/chunk
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 1;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/chunk2
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/chunk2
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 2;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/chunk3
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/chunk3
@@ -1,0 +1,7 @@
+define(['exports'], (function (exports) { 'use strict';
+
+	var num = 3;
+
+	exports.num = num;
+
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/entryA.js
@@ -1,0 +1,5 @@
+define(['./chunk', './chunk2'], (function (dep1, dep2) { 'use strict';
+
+	console.log(dep1.num + dep2.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/entryB.js
@@ -1,0 +1,5 @@
+define(['./chunk2', './chunk3'], (function (dep2, dep3) { 'use strict';
+
+	console.log(dep2.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/amd/entryC.js
@@ -1,0 +1,5 @@
+define(['./chunk', './chunk3'], (function (dep1, dep3) { 'use strict';
+
+	console.log(dep1.num + dep3.num);
+
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/chunk
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/chunk
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 1;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/chunk2
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/chunk2
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 2;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/chunk3
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/chunk3
@@ -1,0 +1,5 @@
+'use strict';
+
+var num = 3;
+
+exports.num = num;

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/entryA.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./chunk');
+var dep2 = require('./chunk2');
+
+console.log(dep1.num + dep2.num);

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/entryB.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep2 = require('./chunk2');
+var dep3 = require('./chunk3');
+
+console.log(dep2.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/cjs/entryC.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var dep1 = require('./chunk');
+var dep3 = require('./chunk3');
+
+console.log(dep1.num + dep3.num);

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/chunk
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/chunk
@@ -1,0 +1,3 @@
+var num = 1;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/chunk2
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/chunk2
@@ -1,0 +1,3 @@
+var num = 2;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/chunk3
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/chunk3
@@ -1,0 +1,3 @@
+var num = 3;
+
+export { num as n };

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/entryA.js
@@ -1,0 +1,4 @@
+import { n as num } from './chunk';
+import { n as num$1 } from './chunk2';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/entryB.js
@@ -1,0 +1,4 @@
+import { n as num } from './chunk2';
+import { n as num$1 } from './chunk3';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/es/entryC.js
@@ -1,0 +1,4 @@
+import { n as num } from './chunk';
+import { n as num$1 } from './chunk3';
+
+console.log(num + num$1);

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/chunk
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/chunk
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/chunk2
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/chunk2
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 2);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/chunk3
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/chunk3
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var num = exports("n", 3);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/entryA.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/entryA.js
@@ -1,0 +1,16 @@
+System.register(['./chunk', './chunk2'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/entryB.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/entryB.js
@@ -1,0 +1,16 @@
+System.register(['./chunk2', './chunk3'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/entryC.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/_expected/system/entryC.js
@@ -1,0 +1,16 @@
+System.register(['./chunk', './chunk3'], (function () {
+	'use strict';
+	var num, num$1;
+	return {
+		setters: [function (module) {
+			num = module.n;
+		}, function (module) {
+			num$1 = module.n;
+		}],
+		execute: (function () {
+
+			console.log(num + num$1);
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/chunk-naming-no-extension/dep1.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/dep1.js
@@ -1,0 +1,1 @@
+export var num = 1;

--- a/test/chunking-form/samples/chunk-naming-no-extension/dep2.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/dep2.js
@@ -1,0 +1,1 @@
+export var num = 2;

--- a/test/chunking-form/samples/chunk-naming-no-extension/dep3.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/dep3.js
@@ -1,0 +1,1 @@
+export var num = 3;

--- a/test/chunking-form/samples/chunk-naming-no-extension/main1.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/main1.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep2';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-no-extension/main2.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/main2.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep2';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);

--- a/test/chunking-form/samples/chunk-naming-no-extension/main3.js
+++ b/test/chunking-form/samples/chunk-naming-no-extension/main3.js
@@ -1,0 +1,4 @@
+import { num as num1 } from './dep1';
+import { num as num2 } from './dep3';
+
+console.log(num1 + num2);


### PR DESCRIPTION
Closes #5822.

When rollup encounters a filename conflict it calls `makeUnique`, which
appended a counter just before the last file extension. For a
`chunkFileNames` pattern like `chunk.d.ts` that produced `chunk.d2.ts`
and `chunk.d3.ts` on subsequent conflicts instead of `chunk2.d.ts` and
`chunk3.d.ts`.

The problem is that `path.extname` only returns the last segment
(`.ts`), so the base after stripping becomes `chunk.d` and the number
lands in the wrong spot. TypeScript declaration files emitted by
rollup-plugin-dts are the most common case where this breaks things
because TypeScript's type resolver requires the `.d.ts` extension as a
whole.

The fix replaces the `extname` call with a small helper that scans for
the first dot in the filename (skipping a leading dot for hidden files
like `.env.local`) and treats everything from that position onwards as
the extension to preserve. Single-extension names are unaffected because
`chunk.js` has its first dot at the same position as its last dot.

A new chunking-form test verifies `chunk.d.ts` resolves conflicts as
`chunk2.d.ts` and `chunk3.d.ts` across all four output formats (es,
cjs, amd, system).