### PR TITLE
Skip side-effect-free external imports when hoisting is disabled

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1245,6 +1245,7 @@ export default class Chunk {
 		const importSpecifiers = this.getImportSpecifiers();
 		const reexportSpecifiers = this.getReexportSpecifiers();
 		const renderedDependencies = new Map<Chunk | ExternalChunk, ChunkDependency>();
+		const skippedDependencies: ExternalChunk[] = [];
 		const fileName = this.getFileName();
 		for (const dependency of this.dependencies) {
 			const imports = importSpecifiers.get(dependency) || null;
@@ -1254,14 +1255,14 @@ export default class Chunk {
 				reexports === null &&
 				dependency instanceof ExternalChunk &&
 				!dependency.moduleSideEffects &&
-				!this.outputOptions.hoistTransitiveImports
+				this.outputOptions.hoistTransitiveImports === false
 			) {
 				// A side-effect-free external dependency without imported or
 				// re-exported bindings can only be present because chunk assignment
 				// placed otherwise unrelated modules into this chunk. When transitive
 				// import hoisting is disabled, rendering it would emit a spurious
 				// side effect import, see https://github.com/rollup/rollup/issues/6111
-				this.dependencies.delete(dependency);
+				skippedDependencies.push(dependency);
 				continue;
 			}
 			const namedExportsMode =
@@ -1295,6 +1296,10 @@ export default class Chunk {
 				reexports,
 				sourcePhaseImport: sourcePhaseImport?.local
 			});
+		}
+
+		for (const dependency of skippedDependencies) {
+			this.dependencies.delete(dependency);
 		}
 
 		return (this.renderedDependencies = renderedDependencies);

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1249,6 +1249,21 @@ export default class Chunk {
 		for (const dependency of this.dependencies) {
 			const imports = importSpecifiers.get(dependency) || null;
 			const reexports = reexportSpecifiers.get(dependency) || null;
+			if (
+				imports === null &&
+				reexports === null &&
+				dependency instanceof ExternalChunk &&
+				!dependency.moduleSideEffects &&
+				!this.outputOptions.hoistTransitiveImports
+			) {
+				// A side-effect-free external dependency without imported or
+				// re-exported bindings can only be present because chunk assignment
+				// placed otherwise unrelated modules into this chunk. When transitive
+				// import hoisting is disabled, rendering it would emit a spurious
+				// side effect import, see https://github.com/rollup/rollup/issues/6111
+				this.dependencies.delete(dependency);
+				continue;
+			}
 			const namedExportsMode =
 				dependency instanceof ExternalChunk || dependency.exportMode !== 'default';
 			const importPath = dependency.getImportPath(fileName);

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -653,18 +653,15 @@ export default class Chunk {
 		if (this.renderedChunkInfo) {
 			return this.renderedChunkInfo;
 		}
+		const renderedDependencies = this.getRenderedDependencies();
 		return (this.renderedChunkInfo = {
 			...this.getPreRenderedChunkInfo(),
 			dynamicImports: this.getDynamicDependencies().map(resolveFileName),
 			fileName: this.getFileName(),
 
 			implicitlyLoadedBefore: Array.from(this.implicitlyLoadedBefore, resolveFileName),
-			importedBindings: getImportedBindingsPerDependency(
-				this.getRenderedDependencies(),
-				resolveFileName
-			),
-
-			imports: Array.from(this.dependencies, resolveFileName),
+			importedBindings: getImportedBindingsPerDependency(renderedDependencies, resolveFileName),
+			imports: Array.from(renderedDependencies.keys(), resolveFileName),
 			modules: this.renderedModules,
 			referencedFiles: this.getReferencedFiles()
 		});
@@ -1245,7 +1242,6 @@ export default class Chunk {
 		const importSpecifiers = this.getImportSpecifiers();
 		const reexportSpecifiers = this.getReexportSpecifiers();
 		const renderedDependencies = new Map<Chunk | ExternalChunk, ChunkDependency>();
-		const skippedDependencies: ExternalChunk[] = [];
 		const fileName = this.getFileName();
 		for (const dependency of this.dependencies) {
 			const imports = importSpecifiers.get(dependency) || null;
@@ -1255,14 +1251,13 @@ export default class Chunk {
 				reexports === null &&
 				dependency instanceof ExternalChunk &&
 				!dependency.moduleSideEffects &&
-				this.outputOptions.hoistTransitiveImports === false
+				!this.outputOptions.hoistTransitiveImports
 			) {
 				// A side-effect-free external dependency without imported or
 				// re-exported bindings can only be present because chunk assignment
 				// placed otherwise unrelated modules into this chunk. When transitive
 				// import hoisting is disabled, rendering it would emit a spurious
 				// side effect import, see https://github.com/rollup/rollup/issues/6111
-				skippedDependencies.push(dependency);
 				continue;
 			}
 			const namedExportsMode =
@@ -1296,10 +1291,6 @@ export default class Chunk {
 				reexports,
 				sourcePhaseImport: sourcePhaseImport?.local
 			});
-		}
-
-		for (const dependency of skippedDependencies) {
-			this.dependencies.delete(dependency);
 		}
 
 		return (this.renderedDependencies = renderedDependencies);

--- a/src/ExternalChunk.ts
+++ b/src/ExternalChunk.ts
@@ -28,6 +28,10 @@ export default class ExternalChunk {
 		this.suggestedVariableName = module.suggestedVariableName;
 	}
 
+	get moduleSideEffects(): boolean | 'no-treeshake' {
+		return this.moduleInfo.moduleSideEffects;
+	}
+
 	getFileName(): string {
 		if (this.fileName) {
 			return this.fileName;

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_config.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_config.js
@@ -1,0 +1,13 @@
+module.exports = defineTest({
+	description:
+		'does not emit side effect imports of side-effect-free externals when pure chunks are merged and hoisting is disabled (#6111)',
+	options: {
+		external: ['lib-main', 'lib-hooks-a', 'lib-hooks-b'],
+		input: ['main.js', 'hooks.js'],
+		output: {
+			hoistTransitiveImports: false
+		},
+		preserveEntrySignatures: 'strict',
+		treeshake: 'smallest'
+	}
+});

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/amd/hooks.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/amd/hooks.js
@@ -1,0 +1,14 @@
+define(['exports', 'lib-hooks-a', 'lib-hooks-b'], (function (exports, libHooksA, libHooksB) { 'use strict';
+
+
+
+	Object.defineProperty(exports, "hooksA", {
+		enumerable: true,
+		get: function () { return libHooksA.hooksA; }
+	});
+	Object.defineProperty(exports, "hooksB", {
+		enumerable: true,
+		get: function () { return libHooksB.hooksB; }
+	});
+
+}));

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/amd/main.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/amd/main.js
@@ -1,0 +1,10 @@
+define(['exports', 'lib-main'], (function (exports, libMain) { 'use strict';
+
+
+
+	Object.defineProperty(exports, "mainValue", {
+		enumerable: true,
+		get: function () { return libMain.mainValue; }
+	});
+
+}));

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/cjs/hooks.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/cjs/hooks.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var libHooksA = require('lib-hooks-a');
+var libHooksB = require('lib-hooks-b');
+
+
+
+Object.defineProperty(exports, "hooksA", {
+	enumerable: true,
+	get: function () { return libHooksA.hooksA; }
+});
+Object.defineProperty(exports, "hooksB", {
+	enumerable: true,
+	get: function () { return libHooksB.hooksB; }
+});

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/cjs/main.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/cjs/main.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var libMain = require('lib-main');
+
+
+
+Object.defineProperty(exports, "mainValue", {
+	enumerable: true,
+	get: function () { return libMain.mainValue; }
+});

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/es/hooks.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/es/hooks.js
@@ -1,0 +1,2 @@
+export { hooksA } from 'lib-hooks-a';
+export { hooksB } from 'lib-hooks-b';

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/es/main.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/es/main.js
@@ -1,0 +1,1 @@
+export { mainValue } from 'lib-main';

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/system/hooks.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/system/hooks.js
@@ -1,0 +1,15 @@
+System.register(['lib-hooks-a', 'lib-hooks-b'], (function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports("hooksA", module.hooksA);
+		}, function (module) {
+			exports("hooksB", module.hooksB);
+		}],
+		execute: (function () {
+
+
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/system/main.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/_expected/system/main.js
@@ -1,0 +1,13 @@
+System.register(['lib-main'], (function (exports) {
+	'use strict';
+	return {
+		setters: [function (module) {
+			exports("mainValue", module.mainValue);
+		}],
+		execute: (function () {
+
+
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/hooks.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/hooks.js
@@ -1,0 +1,2 @@
+export { hooksA } from 'lib-hooks-a';
+export { hooksB } from 'lib-hooks-b';

--- a/test/chunking-form/samples/no-side-effect-free-external-imports/main.js
+++ b/test/chunking-form/samples/no-side-effect-free-external-imports/main.js
@@ -1,0 +1,1 @@
+export { mainValue } from 'lib-main';


### PR DESCRIPTION
When `hoistTransitiveImports: false` is used with `experimentalMinChunkSize`, an entry chunk can pick up bare external imports from merged pure re-export chunks even though the entry never references those packages.
This keeps binding-less, side-effect-free external chunks out of the rendered imports when hoisting is disabled, and keeps `chunk.imports` in sync with the emitted code. The default hoisting path is left unchanged.
I added chunking-form coverage for ES, CJS, AMD, and System output. The focused sample goes red on the issue shape and green with the fix; I also ran the full suite, eslint, `tsc --noEmit`, and `git diff --check`.
Closes #6111