### PR TITLE
feat: add originalMessage property to RollupLog to preserve pre-augmentation message

### DIFF
--- a/src/rollup/types.d.ts
+++ b/src/rollup/types.d.ts
@@ -48,6 +48,7 @@ export interface RollupLog {
 		line: number;
 	};
 	message: string;
+	originalMessage?: string | undefined;
 	meta?: any | undefined;
 	names?: string[] | undefined;
 	plugin?: string | undefined;

--- a/src/utils/logs.ts
+++ b/src/utils/logs.ts
@@ -96,6 +96,7 @@ export function augmentLogMessage(log: AugmentedRollupLog): void {
 		prefix += `${relativeId(id)}${position}: `;
 	}
 	const oldMessage = log.message;
+	log.originalMessage ??= log.message;
 	log.message = prefix + log.message;
 	tweakStackMessage(log, oldMessage);
 }

--- a/test/form/samples/log-side-effects/_config.js
+++ b/test/form/samples/log-side-effects/_config.js
@@ -32,6 +32,10 @@ module.exports = defineTest({
 1: const removed = true;
 2: const alsoRemoved = true; console.log('mapped effect');
                              ^`,
+			originalMessage: `First side effect in dep-mapped.js is at (2:26)
+1: const removed = true;
+2: const alsoRemoved = true; console.log('mapped effect');
+                             ^`,
 			id: ID_MAPPED,
 			pos: 48,
 			loc: {
@@ -47,6 +51,11 @@ module.exports = defineTest({
 			level: 'info',
 			code: 'FIRST_SIDE_EFFECT',
 			message: `main.js (2:0): First side effect in main.js is at (2:0)
+1: import './dep-mapped';
+2: console.log('main effect');
+   ^
+3: console.log('other effect');`,
+			originalMessage: `First side effect in main.js is at (2:0)
 1: import './dep-mapped';
 2: console.log('main effect');
    ^

--- a/test/function/samples/adds-json-hint-for-missing-export-if-is-json-file/_config.js
+++ b/test/function/samples/adds-json-hint-for-missing-export-if-is-json-file/_config.js
@@ -23,6 +23,7 @@ module.exports = defineTest({
 		`,
 		watchFiles: [ID_ARRAY_JSON, ID_MAIN],
 		message:
-			'main.js (1:7): "default" is not exported by "array.json", imported by "main.js". (Note that you need @rollup/plugin-json to import JSON files)'
+			'main.js (1:7): "default" is not exported by "array.json", imported by "main.js". (Note that you need @rollup/plugin-json to import JSON files)',
+		originalMessage: '"default" is not exported by "array.json", imported by "main.js". (Note that you need @rollup/plugin-json to import JSON files)',
 	}
 });

--- a/test/function/samples/ast-validations/double-default-export/_config.js
+++ b/test/function/samples/ast-validations/double-default-export/_config.js
@@ -7,6 +7,7 @@ module.exports = defineTest({
 	error: {
 		code: 'DUPLICATE_EXPORT',
 		message: 'foo.js (2:0): Duplicate export "default"',
+		originalMessage: 'Duplicate export "default"',
 		id: ID_FOO,
 		pos: 18,
 		watchFiles: [ID_FOO, ID_MAIN],

--- a/test/function/samples/ast-validations/double-named-export/_config.js
+++ b/test/function/samples/ast-validations/double-named-export/_config.js
@@ -7,6 +7,7 @@ module.exports = defineTest({
 	error: {
 		code: 'DUPLICATE_EXPORT',
 		message: 'foo.js (3:9): Duplicate export "foo"',
+		originalMessage: 'Duplicate export "foo"',
 		id: ID_FOO,
 		pos: 38,
 		watchFiles: [ID_FOO, ID_MAIN],

--- a/test/function/samples/ast-validations/double-named-reexport/_config.js
+++ b/test/function/samples/ast-validations/double-named-reexport/_config.js
@@ -7,6 +7,7 @@ module.exports = defineTest({
 	error: {
 		code: 'DUPLICATE_EXPORT',
 		message: 'foo.js (3:9): Duplicate export "foo"',
+		originalMessage: 'Duplicate export "foo"',
 		id: ID_FOO,
 		pos: 38,
 		watchFiles: [ID_FOO, ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-function-export/_config.js
+++ b/test/function/samples/ast-validations/duplicate-function-export/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'DUPLICATE_EXPORT',
 		message: 'main.js (3:16): Duplicate export "foo"',
+		originalMessage: 'Duplicate export "foo"',
 		id: ID_MAIN,
 		pos: 54,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-import-fails/_config.js
+++ b/test/function/samples/ast-validations/duplicate-import-fails/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'REDECLARATION_ERROR',
 		message: 'main.js (2:9): Identifier "a" has already been declared',
+		originalMessage: 'Identifier "a" has already been declared',
 		id: ID_MAIN,
 		pos: 36,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-import-specifier-fails/_config.js
+++ b/test/function/samples/ast-validations/duplicate-import-specifier-fails/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'REDECLARATION_ERROR',
 		message: 'main.js (1:12): Identifier "a" has already been declared',
+		originalMessage: 'Identifier "a" has already been declared',
 		id: ID_MAIN,
 		pos: 12,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-namespace-export/_config.js
+++ b/test/function/samples/ast-validations/duplicate-namespace-export/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'DUPLICATE_EXPORT',
 		message: 'main.js (3:12): Duplicate export "foo"',
+		originalMessage: 'Duplicate export "foo"',
 		id: ID_MAIN,
 		pos: 50,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-parameter-name/_config.js
+++ b/test/function/samples/ast-validations/duplicate-parameter-name/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'DUPLICATE_ARGUMENT_NAME',
 		message: 'main.js (1:15): Duplicate argument name "a"',
+		originalMessage: 'Duplicate argument name "a"',
 		id: ID_MAIN,
 		pos: 15,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/duplicate-var-export/_config.js
+++ b/test/function/samples/ast-validations/duplicate-var-export/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'DUPLICATE_EXPORT',
 		message: 'main.js (2:11): Duplicate export "x"',
+		originalMessage: 'Duplicate export "x"',
 		id: ID_MAIN,
 		pos: 29,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/reassign-import-fails/_config.js
+++ b/test/function/samples/ast-validations/reassign-import-fails/_config.js
@@ -19,7 +19,8 @@ module.exports = defineTest({
 			8: x = 10;
 			   ^`,
 		watchFiles: [ID_FOO, ID_MAIN],
-		message: 'main.js (8:0): Illegal reassignment of import "x" in "main.js".'
+		message: 'main.js (8:0): Illegal reassignment of import "x" in "main.js".',
+		originalMessage: 'Illegal reassignment of import "x" in "main.js".',
 	}
 });
 

--- a/test/function/samples/ast-validations/reassign-import-not-at-top-level-fails/_config.js
+++ b/test/function/samples/ast-validations/reassign-import-not-at-top-level-fails/_config.js
@@ -20,7 +20,8 @@ module.exports = defineTest({
 			     ^
 			8: }`,
 		watchFiles: [ID_FOO, ID_MAIN],
-		message: 'main.js (7:2): Illegal reassignment of import "x" in "main.js".'
+		message: 'main.js (7:2): Illegal reassignment of import "x" in "main.js".',
+		originalMessage: 'Illegal reassignment of import "x" in "main.js".',
 	}
 });
 

--- a/test/function/samples/ast-validations/redeclare-block-function-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-block-function-function/_config.js
@@ -18,6 +18,7 @@ module.exports = defineTest({
 			line: 3
 		},
 		message: 'main.js (3:10): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 31,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-local-variable-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-local-variable-function/_config.js
@@ -18,6 +18,7 @@ module.exports = defineTest({
 			line: 4
 		},
 		message: 'main.js (4:10): Identifier "error" has already been declared',
+		originalMessage: 'Identifier "error" has already been declared',
 		pos: 62,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-parameter-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-parameter-function/_config.js
@@ -18,6 +18,7 @@ module.exports = defineTest({
 			line: 5
 		},
 		message: 'main.js (5:10): Identifier "a" has already been declared',
+		originalMessage: 'Identifier "a" has already been declared',
 		pos: 64,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-parameter-var-outside-conflict/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-parameter-var-outside-conflict/_config.js
@@ -19,6 +19,7 @@ module.exports = defineTest({
 			line: 5
 		},
 		message: 'main.js (5:5): Identifier "error" has already been declared',
+		originalMessage: 'Identifier "error" has already been declared',
 		pos: 68,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-catch-scope-pattern-parameter-var/_config.js
+++ b/test/function/samples/ast-validations/redeclare-catch-scope-pattern-parameter-var/_config.js
@@ -18,6 +18,7 @@ module.exports = defineTest({
 			line: 4
 		},
 		message: 'main.js (4:5): Identifier "message" has already been declared',
+		originalMessage: 'Identifier "message" has already been declared',
 		pos: 63,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-class-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-class-function/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 			line: 2
 		},
 		message: 'main.js (2:9): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 22,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-const-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-const-function/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 			line: 2
 		},
 		message: 'main.js (2:9): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 24,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-default-import-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-default-import-function/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'REDECLARATION_ERROR',
 		message: 'main.js (4:9): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		id: ID_MAIN,
 		pos: 56,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/redeclare-import-var/_config.js
+++ b/test/function/samples/ast-validations/redeclare-import-var/_config.js
@@ -6,6 +6,7 @@ module.exports = defineTest({
 	error: {
 		code: 'REDECLARATION_ERROR',
 		message: 'main.js (4:4): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		id: ID_MAIN,
 		pos: 55,
 		watchFiles: [ID_MAIN],

--- a/test/function/samples/ast-validations/redeclare-let-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-let-function/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 			line: 2
 		},
 		message: 'main.js (2:9): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 18,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-let-nested-var/_config.js
+++ b/test/function/samples/ast-validations/redeclare-let-nested-var/_config.js
@@ -19,6 +19,7 @@ module.exports = defineTest({
 			line: 4
 		},
 		message: 'main.js (4:8): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 34,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-nested-var-let/_config.js
+++ b/test/function/samples/ast-validations/redeclare-nested-var-let/_config.js
@@ -19,6 +19,7 @@ module.exports = defineTest({
 			line: 5
 		},
 		message: 'main.js (5:6): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 39,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-parameter-let/_config.js
+++ b/test/function/samples/ast-validations/redeclare-parameter-let/_config.js
@@ -17,6 +17,7 @@ module.exports = defineTest({
 			line: 2
 		},
 		message: 'main.js (2:5): Identifier "x" has already been declared',
+		originalMessage: 'Identifier "x" has already been declared',
 		pos: 23,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-top-level-function-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-function-function/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 			line: 2
 		},
 		message: 'main.js (2:9): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 27,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-top-level-var-function/_config.js
+++ b/test/function/samples/ast-validations/redeclare-top-level-var-function/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 			line: 2
 		},
 		message: 'main.js (2:9): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 18,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/redeclare-var-class/_config.js
+++ b/test/function/samples/ast-validations/redeclare-var-class/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 			line: 2
 		},
 		message: 'main.js (2:6): Identifier "foo" has already been declared',
+		originalMessage: 'Identifier "foo" has already been declared',
 		pos: 15,
 		watchFiles: [ID_MAIN]
 	}

--- a/test/function/samples/ast-validations/update-expression-of-import-fails/_config.js
+++ b/test/function/samples/ast-validations/update-expression-of-import-fails/_config.js
@@ -19,7 +19,8 @@ module.exports = defineTest({
 			3: a++;
 			   ^`,
 		watchFiles: [ID_FOO, ID_MAIN],
-		message: 'main.js (3:0): Illegal reassignment of import "a" in "main.js".'
+		message: 'main.js (3:0): Illegal reassignment of import "a" in "main.js".',
+		originalMessage: 'Illegal reassignment of import "a" in "main.js".',
 	}
 });
 

--- a/test/function/samples/cannot-resolve-sourcemap-warning/_config.js
+++ b/test/function/samples/cannot-resolve-sourcemap-warning/_config.js
@@ -27,6 +27,7 @@ module.exports = defineTest({
 			},
 			message:
 				"main.js (1:15): Error when using sourcemap for reporting an error: Can't resolve original location of error.",
+			originalMessage: "Error when using sourcemap for reporting an error: Can't resolve original location of error.",
 			pos: 15
 		},
 		{
@@ -43,6 +44,7 @@ module.exports = defineTest({
 			},
 			message:
 				"main.js (1:15): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+			originalMessage: "The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 			pos: 15,
 			url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined'
 		}

--- a/test/function/samples/circular-missed-reexports/_config.js
+++ b/test/function/samples/circular-missed-reexports/_config.js
@@ -27,6 +27,7 @@ module.exports = defineTest({
 			id: ID_MAIN,
 			message:
 				'main.js (1:17): "doesNotExist" is not exported by "dep1.js", imported by "main.js".',
+			originalMessage: '"doesNotExist" is not exported by "dep1.js", imported by "main.js".',
 			exporter: ID_DEP1,
 			pos: 17,
 			loc: {

--- a/test/function/samples/conflicting-reexports/named-import/_config.js
+++ b/test/function/samples/conflicting-reexports/named-import/_config.js
@@ -25,6 +25,7 @@ module.exports = defineTest({
 			2:
 			3: assert.strictEqual(foo, 1);`,
 		watchFiles: [ID_FIRST, ID_MAIN, ID_REEXPORT, ID_SECOND],
-		message: 'main.js (1:9): "foo" is not exported by "reexport.js", imported by "main.js".'
+		message: 'main.js (1:9): "foo" is not exported by "reexport.js", imported by "main.js".',
+		originalMessage: '"foo" is not exported by "reexport.js", imported by "main.js".',
 	}
 });

--- a/test/function/samples/conflicting-reexports/namespace-import/_config.js
+++ b/test/function/samples/conflicting-reexports/namespace-import/_config.js
@@ -21,6 +21,7 @@ module.exports = defineTest({
 			exporter: ID_REEXPORT,
 			id: ID_MAIN,
 			message: 'main.js (4:22): "foo" is not exported by "reexport.js", imported by "main.js".',
+			originalMessage: '"foo" is not exported by "reexport.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 125,
 			loc: {

--- a/test/function/samples/default-not-reexported/_config.js
+++ b/test/function/samples/default-not-reexported/_config.js
@@ -10,6 +10,7 @@ module.exports = defineTest({
 		code: 'MISSING_EXPORT',
 		exporter: ID_FOO,
 		message: 'main.js (1:7): "default" is not exported by "foo.js", imported by "main.js".',
+		originalMessage: '"default" is not exported by "foo.js", imported by "main.js".',
 		id: ID_MAIN,
 		pos: 7,
 		watchFiles: [ID_BAR, ID_FOO, ID_MAIN],

--- a/test/function/samples/emit-file/emit-from-output-options/_config.js
+++ b/test/function/samples/emit-file/emit-from-output-options/_config.js
@@ -18,6 +18,7 @@ module.exports = defineTest({
 		hook: 'outputOptions',
 		message:
 			'[plugin at position 1] Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
+		originalMessage: 'Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
 		plugin: 'at position 1',
 		pluginCode: 'CANNOT_EMIT_FROM_OPTIONS_HOOK'
 	}

--- a/test/function/samples/emit-file/set-asset-source-transform/_config.js
+++ b/test/function/samples/emit-file/set-asset-source-transform/_config.js
@@ -20,6 +20,7 @@ module.exports = defineTest({
 		id: path.join(__dirname, 'main.js'),
 		message:
 			'[plugin test-plugin] main.js: setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.',
+		originalMessage: 'setAssetSource cannot be called in transform for caching reasons. Use emitFile with a source, or call setAssetSource in another hook.',
 		plugin: 'test-plugin',
 		pluginCode: 'INVALID_SETASSETSOURCE',
 		watchFiles: [path.join(__dirname, 'main.js')]

--- a/test/function/samples/emit-file/set-source-in-output-options/_config.js
+++ b/test/function/samples/emit-file/set-source-in-output-options/_config.js
@@ -20,6 +20,7 @@ module.exports = defineTest({
 		hook: 'outputOptions',
 		message:
 			'[plugin at position 1] Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
+		originalMessage: 'Cannot emit files or set asset sources in the "outputOptions" hook, use the "renderStart" hook instead.',
 		plugin: 'at position 1',
 		pluginCode: 'CANNOT_EMIT_FROM_OPTIONS_HOOK'
 	}

--- a/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
+++ b/test/function/samples/error-after-transform-should-throw-correct-location/_config.js
@@ -39,6 +39,7 @@ module.exports = defineTest({
 			3: Object.assign({}, a);
 		`,
 		watchFiles: [ID_EMPTY, ID_MAIN],
-		message: 'main.js (1:7): "default" is not exported by "empty.js", imported by "main.js".'
+		message: 'main.js (1:7): "default" is not exported by "empty.js", imported by "main.js".',
+		originalMessage: '"default" is not exported by "empty.js", imported by "main.js".',
 	}
 });

--- a/test/function/samples/error-parse-json/_config.js
+++ b/test/function/samples/error-parse-json/_config.js
@@ -27,6 +27,7 @@ module.exports = defineTest({
 		`,
 		watchFiles: [ID_JSON, ID_MAIN],
 		message:
-			"file.json (2:8): Expected ';', '}' or <eof> (Note that you need @rollup/plugin-json to import JSON files)"
+			"file.json (2:8): Expected ';', '}' or <eof> (Note that you need @rollup/plugin-json to import JSON files)",
+		originalMessage: "Expected ';', '}' or <eof> (Note that you need @rollup/plugin-json to import JSON files)",
 	}
 });

--- a/test/function/samples/error-parse-unknown-extension/_config.js
+++ b/test/function/samples/error-parse-unknown-extension/_config.js
@@ -27,6 +27,7 @@ module.exports = defineTest({
 		`,
 		watchFiles: [ID_CSS, ID_MAIN],
 		message:
-			'file.css (1:0): Expression expected (Note that you need plugins to import files that are not JavaScript)'
+			'file.css (1:0): Expression expected (Note that you need plugins to import files that are not JavaScript)',
+		originalMessage: 'Expression expected (Note that you need plugins to import files that are not JavaScript)',
 	}
 });

--- a/test/function/samples/export-not-at-top-level-fails/_config.js
+++ b/test/function/samples/export-not-at-top-level-fails/_config.js
@@ -24,6 +24,7 @@ module.exports = defineTest({
 			3: }
 		`,
 		watchFiles: [ID_MAIN],
-		message: "main.js (2:2): 'import', and 'export' cannot be used outside of module code"
+		message: "main.js (2:2): 'import', and 'export' cannot be used outside of module code",
+		originalMessage: "'import', and 'export' cannot be used outside of module code",
 	}
 });

--- a/test/function/samples/exports-are-not-defined/_config.js
+++ b/test/function/samples/exports-are-not-defined/_config.js
@@ -24,7 +24,8 @@ module.exports = defineTest({
 		`,
 		watchFiles: [ID_MAIN, ID_MODULE],
 		message:
-			'main.js (1:9): Exported variable "foo" is not defined in "module.js", but it is imported by "main.js".'
+			'main.js (1:9): Exported variable "foo" is not defined in "module.js", but it is imported by "main.js".',
+		originalMessage: 'Exported variable "foo" is not defined in "module.js", but it is imported by "main.js".',
 	},
 	verifyAst: false
 });

--- a/test/function/samples/import-assertions/warn-assertion-conflicts/_config.js
+++ b/test/function/samples/import-assertions/warn-assertion-conflicts/_config.js
@@ -24,6 +24,7 @@ module.exports = defineTest({
 			},
 			message:
 				'main.js (3:0): Module "main.js" tried to import "external" with "type": "bar" attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
+			originalMessage: 'Module "main.js" tried to import "external" with "type": "bar" attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
 			pos: 61
 		},
 		{
@@ -43,6 +44,7 @@ module.exports = defineTest({
 			},
 			message:
 				'main.js (4:0): Module "main.js" tried to import "external" with no attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
+			originalMessage: 'Module "main.js" tried to import "external" with no attributes, but it was already imported elsewhere with "type": "foo" attributes. Please ensure that import attributes for the same module are always consistent.',
 			pos: 101
 		},
 		{

--- a/test/function/samples/import-assertions/warn-unresolvable-assertions/_config.js
+++ b/test/function/samples/import-assertions/warn-unresolvable-assertions/_config.js
@@ -17,6 +17,7 @@ module.exports = defineTest({
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
 				'main.js (1:0): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
+			originalMessage: 'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
 			id: ID_MAIN,
 			pos: 0,
 			loc: {
@@ -34,6 +35,7 @@ module.exports = defineTest({
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
 				'main.js (2:0): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
+			originalMessage: 'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
 			id: ID_MAIN,
 			pos: 32,
 			loc: {
@@ -52,6 +54,7 @@ module.exports = defineTest({
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
 				'main.js (4:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
+			originalMessage: 'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
 			id: ID_MAIN,
 			pos: 133,
 			loc: {
@@ -71,6 +74,7 @@ module.exports = defineTest({
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
 				'main.js (5:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
+			originalMessage: 'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
 			id: ID_MAIN,
 			pos: 173,
 			loc: {
@@ -90,6 +94,7 @@ module.exports = defineTest({
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
 				'main.js (6:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
+			originalMessage: 'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
 			id: ID_MAIN,
 			pos: 218,
 			loc: {
@@ -109,6 +114,7 @@ module.exports = defineTest({
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
 				'main.js (7:30): Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
+			originalMessage: 'Rollup could not statically analyze an import attribute of a dynamic import in "main.js". Import attributes need to have string keys and values.',
 			id: ID_MAIN,
 			pos: 263,
 			loc: {
@@ -127,6 +133,7 @@ module.exports = defineTest({
 			code: 'INVALID_IMPORT_ATTRIBUTE',
 			message:
 				'main.js (3:0): Rollup could not statically analyze the options argument of a dynamic import in "main.js". Dynamic import options need to be an object with a nested attributes object.',
+			originalMessage: 'Rollup could not statically analyze the options argument of a dynamic import in "main.js". Dynamic import options need to be an object with a nested attributes object.',
 			id: ID_MAIN,
 			pos: 61,
 			loc: {

--- a/test/function/samples/import-not-at-top-level-fails/_config.js
+++ b/test/function/samples/import-not-at-top-level-fails/_config.js
@@ -24,6 +24,7 @@ module.exports = defineTest({
 			3: }
 		`,
 		watchFiles: [ID_MAIN],
-		message: "main.js (2:2): 'import', and 'export' cannot be used outside of module code"
+		message: "main.js (2:2): 'import', and 'export' cannot be used outside of module code",
+		originalMessage: "'import', and 'export' cannot be used outside of module code",
 	}
 });

--- a/test/function/samples/import-of-unexported-fails/_config.js
+++ b/test/function/samples/import-of-unexported-fails/_config.js
@@ -23,6 +23,7 @@ module.exports = defineTest({
 			3: a();
 		`,
 		watchFiles: [ID_EMPTY, ID_MAIN],
-		message: 'main.js (1:7): "default" is not exported by "empty.js", imported by "main.js".'
+		message: 'main.js (1:7): "default" is not exported by "empty.js", imported by "main.js".',
+		originalMessage: '"default" is not exported by "empty.js", imported by "main.js".',
 	}
 });

--- a/test/function/samples/jsx/missing-jsx-export/_config.js
+++ b/test/function/samples/jsx/missing-jsx-export/_config.js
@@ -26,6 +26,7 @@ module.exports = defineTest({
 		},
 		message:
 			'main.js (2:12): Export "jsx" is not defined in module "react-jsx.js" even though it is needed in "main.js" to provide JSX syntax. Please check your "jsx" option.',
+		originalMessage: 'Export "jsx" is not defined in module "react-jsx.js" even though it is needed in "main.js" to provide JSX syntax. Please check your "jsx" option.',
 		names: ['jsx'],
 		pos: 34,
 		url: 'https://rollupjs.org/configuration-options/#jsx',

--- a/test/function/samples/load-module-error/buildEnd/_config.js
+++ b/test/function/samples/load-module-error/buildEnd/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'buildEnd'
 	}
 });

--- a/test/function/samples/load-module-error/buildStart/_config.js
+++ b/test/function/samples/load-module-error/buildStart/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'buildStart'
 	}
 });

--- a/test/function/samples/load-module-error/generateBundle/_config.js
+++ b/test/function/samples/load-module-error/generateBundle/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'generateBundle'
 	}
 });

--- a/test/function/samples/load-module-error/renderChunk/_config.js
+++ b/test/function/samples/load-module-error/renderChunk/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'renderChunk'
 	}
 });

--- a/test/function/samples/load-module-error/renderStart/_config.js
+++ b/test/function/samples/load-module-error/renderStart/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'renderStart'
 	}
 });

--- a/test/function/samples/load-module-error/resolveId/_config.js
+++ b/test/function/samples/load-module-error/resolveId/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'resolveId'
 	}
 });

--- a/test/function/samples/load-module-error/transform/_config.js
+++ b/test/function/samples/load-module-error/transform/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] main.js (1:22): nope',
+		originalMessage: 'nope',
 		hook: 'transform',
 		id: path.join(__dirname, 'main.js'),
 		watchFiles: [path.join(__dirname, 'main.js')],

--- a/test/function/samples/logging/handle-logs-in-plugins/_config.js
+++ b/test/function/samples/logging/handle-logs-in-plugins/_config.js
@@ -62,12 +62,22 @@ module.exports = defineTest({
 			[
 				'first',
 				'info',
-				{ message: '[plugin first] passed to both plugins', code: 'PLUGIN_LOG', plugin: 'first' }
+				{
+					message: '[plugin first] passed to both plugins',
+					originalMessage: 'passed to both plugins',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
 			],
 			[
 				'second',
 				'info',
-				{ message: '[plugin first] passed to both plugins', code: 'PLUGIN_LOG', plugin: 'first' }
+				{
+					message: '[plugin first] passed to both plugins',
+					originalMessage: 'passed to both plugins',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
 			],
 			[
 				'first',
@@ -76,6 +86,8 @@ module.exports = defineTest({
 					code: 'THIS_IS_UNDEFINED',
 					message:
 						"main.js (2:5): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+					originalMessage:
+						"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 					url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined',
 					id: ID_MAIN,
 					pos: 24,
@@ -94,6 +106,8 @@ module.exports = defineTest({
 					code: 'THIS_IS_UNDEFINED',
 					message:
 						"main.js (2:5): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+					originalMessage:
+						"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 					url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined',
 					id: ID_MAIN,
 					pos: 24,
@@ -149,6 +163,8 @@ module.exports = defineTest({
 					id: ID_MAIN,
 					message:
 						'main.js (2:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+					originalMessage:
+						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 19,
 					loc: {
@@ -194,6 +210,8 @@ module.exports = defineTest({
 			code: 'THIS_IS_UNDEFINED',
 			message:
 				"main.js (2:5): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+			originalMessage:
+				"The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 			url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined',
 			id: ID_MAIN,
 			pos: 24,
@@ -210,6 +228,7 @@ module.exports = defineTest({
 		{
 			level: 'info',
 			message: '[plugin first] passed to both plugins',
+			originalMessage: 'passed to both plugins',
 			code: 'PLUGIN_LOG',
 			plugin: 'first'
 		}

--- a/test/function/samples/logging/log-from-options/_config.js
+++ b/test/function/samples/logging/log-from-options/_config.js
@@ -23,6 +23,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		hook: 'onLog',
 		message: '[plugin test] error',
+		originalMessage: 'error',
 		plugin: 'test'
 	}
 });

--- a/test/function/samples/logging/log-from-plugin-onlog-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-onlog-onwarn/_config.js
@@ -17,6 +17,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin test] warnLog',
+					originalMessage: 'warnLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					meta: { test: 'foo' },
@@ -29,6 +30,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin test] warnLog',
+					originalMessage: 'warnLog',
 					code: 'PLUGIN_WARNING',
 					pluginCode: 'PLUGIN_CODE',
 					plugin: 'test'
@@ -39,6 +41,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin test] warnLog',
+					originalMessage: 'warnLog',
 					code: 'PLUGIN_WARNING',
 					pluginCode: 'THE_CODE',
 					plugin: 'test'
@@ -47,18 +50,29 @@ module.exports = defineTest({
 			[
 				'onLog',
 				'warn',
-				{ message: '[plugin test] warnLog', code: 'PLUGIN_WARNING', plugin: 'test' }
+				{
+					message: '[plugin test] warnLog',
+					originalMessage: 'warnLog',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
 			],
 			[
 				'onLog',
 				'warn',
-				{ message: '[plugin test] warnString', code: 'PLUGIN_WARNING', plugin: 'test' }
+				{
+					message: '[plugin test] warnString',
+					originalMessage: 'warnString',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
 			],
 			[
 				'onLog',
 				'info',
 				{
 					message: '[plugin test] infoLog',
+					originalMessage: 'infoLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
@@ -68,13 +82,19 @@ module.exports = defineTest({
 			[
 				'onLog',
 				'info',
-				{ message: '[plugin test] infoString', code: 'PLUGIN_LOG', plugin: 'test' }
+				{
+					message: '[plugin test] infoString',
+					originalMessage: 'infoString',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
 			],
 			[
 				'onLog',
 				'debug',
 				{
 					message: '[plugin test] debugLog',
+					originalMessage: 'debugLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
@@ -84,7 +104,12 @@ module.exports = defineTest({
 			[
 				'onLog',
 				'debug',
-				{ message: '[plugin test] debugString', code: 'PLUGIN_LOG', plugin: 'test' }
+				{
+					message: '[plugin test] debugString',
+					originalMessage: 'debugString',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
 			]
 		]);
 	},

--- a/test/function/samples/logging/log-from-plugin-onlog/_config.js
+++ b/test/function/samples/logging/log-from-plugin-onlog/_config.js
@@ -17,6 +17,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin test] warnLog',
+					originalMessage: 'warnLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_WARNING',
@@ -26,13 +27,19 @@ module.exports = defineTest({
 			[
 				'onLog',
 				'warn',
-				{ message: '[plugin test] warnString', code: 'PLUGIN_WARNING', plugin: 'test' }
+				{
+					message: '[plugin test] warnString',
+					originalMessage: 'warnString',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
 			],
 			[
 				'onLog',
 				'info',
 				{
 					message: '[plugin test] infoLog',
+					originalMessage: 'infoLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
@@ -42,13 +49,19 @@ module.exports = defineTest({
 			[
 				'onLog',
 				'info',
-				{ message: '[plugin test] infoString', code: 'PLUGIN_LOG', plugin: 'test' }
+				{
+					message: '[plugin test] infoString',
+					originalMessage: 'infoString',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
 			],
 			[
 				'onLog',
 				'debug',
 				{
 					message: '[plugin test] debugLog',
+					originalMessage: 'debugLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_LOG',
@@ -58,7 +71,12 @@ module.exports = defineTest({
 			[
 				'onLog',
 				'debug',
-				{ message: '[plugin test] debugString', code: 'PLUGIN_LOG', plugin: 'test' }
+				{
+					message: '[plugin test] debugString',
+					originalMessage: 'debugString',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
 			]
 		]);
 	},

--- a/test/function/samples/logging/log-from-plugin-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-onwarn/_config.js
@@ -16,13 +16,22 @@ module.exports = defineTest({
 				'onwarn',
 				{
 					message: '[plugin test] warnLog',
+					originalMessage: 'warnLog',
 					pluginCode: 'PLUGIN_CODE',
 					binding: 'foo',
 					code: 'PLUGIN_WARNING',
 					plugin: 'test'
 				}
 			],
-			['onwarn', { message: '[plugin test] warnString', code: 'PLUGIN_WARNING', plugin: 'test' }],
+			[
+				'onwarn',
+				{
+					message: '[plugin test] warnString',
+					originalMessage: 'warnString',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
+			],
 			['info', '[plugin test] infoLog'],
 			['info', '[plugin test] infoString'],
 			['debug', '[plugin test] debugLog'],

--- a/test/function/samples/logging/log-from-plugin-options-onlog-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onlog-onwarn/_config.js
@@ -20,6 +20,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					originalMessage: 'warnLog',
 					plugin: 'fooPlugin',
 					loc: { file: 'fooFile', line: 1, column: 2 }
 				}
@@ -28,6 +29,7 @@ module.exports = defineTest({
 				'onwarn',
 				{
 					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					originalMessage: 'warnLog',
 					plugin: 'fooPlugin',
 					loc: { file: 'fooFile', line: 1, column: 2 }
 				}

--- a/test/function/samples/logging/log-from-plugin-options-onlog/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onlog/_config.js
@@ -19,6 +19,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					originalMessage: 'warnLog',
 					plugin: 'fooPlugin',
 					loc: { file: 'fooFile', line: 1, column: 2 }
 				}

--- a/test/function/samples/logging/log-from-plugin-options-onwarn/_config.js
+++ b/test/function/samples/logging/log-from-plugin-options-onwarn/_config.js
@@ -18,6 +18,7 @@ module.exports = defineTest({
 				'onwarn',
 				{
 					message: '[plugin fooPlugin] fooFile (1:2): warnLog',
+					originalMessage: 'warnLog',
 					plugin: 'fooPlugin',
 					loc: { file: 'fooFile', line: 1, column: 2 }
 				}

--- a/test/function/samples/logging/loglevel-debug/_config.js
+++ b/test/function/samples/logging/loglevel-debug/_config.js
@@ -23,14 +23,59 @@ module.exports = defineTest({
 			['console-warn', 'onLogOption-warn'],
 			['info', { message: 'onLog-info' }],
 			['warn', { message: 'onLog-warn' }],
-			['debug', { message: '[plugin test] options-debug', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['info', { message: '[plugin test] options-info', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['warn', { message: '[plugin test] options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
-			['debug', { message: '[plugin test] buildStart-debug', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['info', { message: '[plugin test] buildStart-info', code: 'PLUGIN_LOG', plugin: 'test' }],
+			[
+				'debug',
+				{
+					message: '[plugin test] options-debug',
+					originalMessage: 'options-debug',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
+			],
+			[
+				'info',
+				{
+					message: '[plugin test] options-info',
+					originalMessage: 'options-info',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
+			],
 			[
 				'warn',
-				{ message: '[plugin test] buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }
+				{
+					message: '[plugin test] options-warn',
+					originalMessage: 'options-warn',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
+			],
+			[
+				'debug',
+				{
+					message: '[plugin test] buildStart-debug',
+					originalMessage: 'buildStart-debug',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
+			],
+			[
+				'info',
+				{
+					message: '[plugin test] buildStart-info',
+					originalMessage: 'buildStart-info',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
+			],
+			[
+				'warn',
+				{
+					message: '[plugin test] buildStart-warn',
+					originalMessage: 'buildStart-warn',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
 			],
 			['debug', { message: 'buildStart-options-debug' }],
 			['info', { message: 'buildStart-options-info' }],
@@ -39,6 +84,7 @@ module.exports = defineTest({
 				'debug',
 				{
 					message: '[plugin test] main.js: transform-debug',
+					originalMessage: 'transform-debug',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_LOG',
@@ -49,6 +95,7 @@ module.exports = defineTest({
 				'info',
 				{
 					message: '[plugin test] main.js: transform-info',
+					originalMessage: 'transform-info',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_LOG',
@@ -59,6 +106,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin test] main.js: transform-warn',
+					originalMessage: 'transform-warn',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_WARNING',
@@ -72,6 +120,8 @@ module.exports = defineTest({
 					id: ID_MAIN,
 					message:
 						'main.js (1:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+					originalMessage:
+						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 0,
 					loc: {

--- a/test/function/samples/logging/loglevel-info/_config.js
+++ b/test/function/samples/logging/loglevel-info/_config.js
@@ -21,12 +21,41 @@ module.exports = defineTest({
 			['console-info', 'onLogOption-info'],
 			['console-warn', 'onLogOption-warn'],
 			['warn', { message: 'onLog-warn' }],
-			['info', { message: '[plugin test] options-info', code: 'PLUGIN_LOG', plugin: 'test' }],
-			['warn', { message: '[plugin test] options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
-			['info', { message: '[plugin test] buildStart-info', code: 'PLUGIN_LOG', plugin: 'test' }],
+			[
+				'info',
+				{
+					message: '[plugin test] options-info',
+					originalMessage: 'options-info',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
+			],
 			[
 				'warn',
-				{ message: '[plugin test] buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }
+				{
+					message: '[plugin test] options-warn',
+					originalMessage: 'options-warn',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
+			],
+			[
+				'info',
+				{
+					message: '[plugin test] buildStart-info',
+					originalMessage: 'buildStart-info',
+					code: 'PLUGIN_LOG',
+					plugin: 'test'
+				}
+			],
+			[
+				'warn',
+				{
+					message: '[plugin test] buildStart-warn',
+					originalMessage: 'buildStart-warn',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
 			],
 			['info', { message: 'buildStart-options-info' }],
 			['warn', { message: 'buildStart-options-warn' }],
@@ -34,6 +63,7 @@ module.exports = defineTest({
 				'info',
 				{
 					message: '[plugin test] main.js: transform-info',
+					originalMessage: 'transform-info',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_LOG',
@@ -44,6 +74,7 @@ module.exports = defineTest({
 				'warn',
 				{
 					message: '[plugin test] main.js: transform-warn',
+					originalMessage: 'transform-warn',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_WARNING',
@@ -57,6 +88,8 @@ module.exports = defineTest({
 					id: ID_MAIN,
 					message:
 						'main.js (1:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+					originalMessage:
+						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 0,
 					loc: {

--- a/test/function/samples/logging/loglevel-warn/_config.js
+++ b/test/function/samples/logging/loglevel-warn/_config.js
@@ -19,16 +19,30 @@ module.exports = defineTest({
 		assert.deepEqual(logs, [
 			['warn', { message: 'onLog-warn' }],
 			['console-warn', 'onLogOption-warn'],
-			['warn', { message: '[plugin test] options-warn', code: 'PLUGIN_WARNING', plugin: 'test' }],
 			[
 				'warn',
-				{ message: '[plugin test] buildStart-warn', code: 'PLUGIN_WARNING', plugin: 'test' }
+				{
+					message: '[plugin test] options-warn',
+					originalMessage: 'options-warn',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
+			],
+			[
+				'warn',
+				{
+					message: '[plugin test] buildStart-warn',
+					originalMessage: 'buildStart-warn',
+					code: 'PLUGIN_WARNING',
+					plugin: 'test'
+				}
 			],
 			['warn', { message: 'buildStart-options-warn' }],
 			[
 				'warn',
 				{
 					message: '[plugin test] main.js: transform-warn',
+					originalMessage: 'transform-warn',
 					id: ID_MAIN,
 					hook: 'transform',
 					code: 'PLUGIN_WARNING',
@@ -42,6 +56,8 @@ module.exports = defineTest({
 					id: ID_MAIN,
 					message:
 						'main.js (1:0): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+					originalMessage:
+						'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 					url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 					pos: 0,
 					loc: {

--- a/test/function/samples/logging/no-log-with-position/_config.js
+++ b/test/function/samples/logging/no-log-with-position/_config.js
@@ -57,18 +57,44 @@ module.exports = defineTest({
 		{
 			level: 'warn',
 			message: '[plugin test] log-message1',
+			originalMessage: 'log-message1',
 			code: 'PLUGIN_WARNING',
 			plugin: 'test'
 		},
 		{
 			level: 'warn',
 			message: '[plugin test] log-message1',
+			originalMessage: 'log-message1',
 			code: 'PLUGIN_WARNING',
 			plugin: 'test'
 		},
-		{ level: 'info', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
-		{ level: 'info', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
-		{ level: 'debug', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' },
-		{ level: 'debug', message: '[plugin test] log-message1', code: 'PLUGIN_LOG', plugin: 'test' }
+		{
+			level: 'info',
+			message: '[plugin test] log-message1',
+			originalMessage: 'log-message1',
+			code: 'PLUGIN_LOG',
+			plugin: 'test'
+		},
+		{
+			level: 'info',
+			message: '[plugin test] log-message1',
+			originalMessage: 'log-message1',
+			code: 'PLUGIN_LOG',
+			plugin: 'test'
+		},
+		{
+			level: 'debug',
+			message: '[plugin test] log-message1',
+			originalMessage: 'log-message1',
+			code: 'PLUGIN_LOG',
+			plugin: 'test'
+		},
+		{
+			level: 'debug',
+			message: '[plugin test] log-message1',
+			originalMessage: 'log-message1',
+			code: 'PLUGIN_LOG',
+			plugin: 'test'
+		}
 	]
 });

--- a/test/function/samples/logging/original-message/_config.js
+++ b/test/function/samples/logging/original-message/_config.js
@@ -1,0 +1,24 @@
+const assert = require('node:assert');
+
+module.exports = defineTest({
+	description: 'augmented log preserves original message in originalMessage property',
+	options: {
+		plugins: [
+			{
+				name: 'test',
+				buildStart() {
+					this.warn({ message: 'original text' });
+				}
+			}
+		]
+	},
+	logs: [
+		{
+			level: 'warn',
+			message: '[plugin test] original text',
+			originalMessage: 'original text',
+			code: 'PLUGIN_WARNING',
+			plugin: 'test'
+		}
+	]
+});

--- a/test/function/samples/logging/original-message/main.js
+++ b/test/function/samples/logging/original-message/main.js
@@ -1,0 +1,1 @@
+assert.ok(true);

--- a/test/function/samples/logging/plugin-order/_config.js
+++ b/test/function/samples/logging/plugin-order/_config.js
@@ -49,12 +49,66 @@ module.exports = defineTest({
 	},
 	after() {
 		assert.deepEqual(logs, [
-			['second', 'info', { message: '[plugin first] first', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['first', 'info', { message: '[plugin first] first', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['second', 'info', { message: '[plugin first] second', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['second', 'info', { message: '[plugin first] third', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['first', 'info', { message: '[plugin first] third', code: 'PLUGIN_LOG', plugin: 'first' }],
-			['third', 'info', { message: '[plugin first] third', code: 'PLUGIN_LOG', plugin: 'first' }]
+			[
+				'second',
+				'info',
+				{
+					message: '[plugin first] first',
+					originalMessage: 'first',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
+			],
+			[
+				'first',
+				'info',
+				{
+					message: '[plugin first] first',
+					originalMessage: 'first',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
+			],
+			[
+				'second',
+				'info',
+				{
+					message: '[plugin first] second',
+					originalMessage: 'second',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
+			],
+			[
+				'second',
+				'info',
+				{
+					message: '[plugin first] third',
+					originalMessage: 'third',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
+			],
+			[
+				'first',
+				'info',
+				{
+					message: '[plugin first] third',
+					originalMessage: 'third',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
+			],
+			[
+				'third',
+				'info',
+				{
+					message: '[plugin first] third',
+					originalMessage: 'third',
+					code: 'PLUGIN_LOG',
+					plugin: 'first'
+				}
+			]
 		]);
 	},
 	logs: []

--- a/test/function/samples/logging/promote-log-to-error/_config.js
+++ b/test/function/samples/logging/promote-log-to-error/_config.js
@@ -32,6 +32,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		hook: 'buildStart',
 		message: '[plugin test] info becomes error',
+		originalMessage: 'info becomes error',
 		plugin: 'test',
 		pluginCode: 'EXTRA_CODE'
 	}

--- a/test/function/samples/logging/this-error-onlog/_config.js
+++ b/test/function/samples/logging/this-error-onlog/_config.js
@@ -17,6 +17,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		hook: 'buildStart',
 		message: '[plugin test] test log',
+		originalMessage: 'test log',
 		plugin: 'test',
 		pluginCode: 'THE_CODE'
 	}

--- a/test/function/samples/logging/transform-log-with-position/_config.js
+++ b/test/function/samples/logging/transform-log-with-position/_config.js
@@ -26,6 +26,7 @@ module.exports = defineTest({
 		{
 			level: 'warn',
 			message: '[plugin test] main.js (2:3): warn-message1',
+			originalMessage: 'warn-message1',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -45,6 +46,7 @@ module.exports = defineTest({
 		{
 			level: 'info',
 			message: '[plugin test] main.js (2:3): info-message1',
+			originalMessage: 'info-message1',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -64,6 +66,7 @@ module.exports = defineTest({
 		{
 			level: 'debug',
 			message: '[plugin test] main.js (2:3): debug-message1',
+			originalMessage: 'debug-message1',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -83,6 +86,7 @@ module.exports = defineTest({
 		{
 			level: 'warn',
 			message: '[plugin test] main.js (2:1): warn-message2',
+			originalMessage: 'warn-message2',
 			loc: {
 				column: 1,
 				file: ID_MAIN,
@@ -101,6 +105,7 @@ module.exports = defineTest({
 		{
 			level: 'info',
 			message: '[plugin test] main.js (2:1): info-message2',
+			originalMessage: 'info-message2',
 			loc: {
 				column: 1,
 				file: ID_MAIN,
@@ -119,6 +124,7 @@ module.exports = defineTest({
 		{
 			level: 'debug',
 			message: '[plugin test] main.js (2:1): debug-message2',
+			originalMessage: 'debug-message2',
 			loc: {
 				column: 1,
 				file: ID_MAIN,
@@ -137,6 +143,7 @@ module.exports = defineTest({
 		{
 			level: 'warn',
 			message: '[plugin test] main.js (2:3): warn-message3',
+			originalMessage: 'warn-message3',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -156,6 +163,7 @@ module.exports = defineTest({
 		{
 			level: 'info',
 			message: '[plugin test] main.js (2:3): info-message3',
+			originalMessage: 'info-message3',
 			pos: 20,
 			loc: {
 				column: 3,
@@ -175,6 +183,7 @@ module.exports = defineTest({
 		{
 			level: 'debug',
 			message: '[plugin test] main.js (2:3): debug-message3',
+			originalMessage: 'debug-message3',
 			pos: 20,
 			loc: {
 				column: 3,

--- a/test/function/samples/module-level-directive/_config.js
+++ b/test/function/samples/module-level-directive/_config.js
@@ -9,6 +9,7 @@ module.exports = defineTest({
 			id: ID_MAIN,
 			message:
 				'main.js (1:0): Module level directives cause errors when bundled, "use asm" in "main.js" was ignored.',
+			originalMessage: 'Module level directives cause errors when bundled, "use asm" in "main.js" was ignored.',
 			pos: 0,
 			loc: {
 				column: 0,

--- a/test/function/samples/namespace-missing-export/_config.js
+++ b/test/function/samples/namespace-missing-export/_config.js
@@ -11,6 +11,7 @@ module.exports = defineTest({
 			exporter: ID_EMPTY,
 			id: ID_MAIN,
 			message: 'main.js (3:25): "foo" is not exported by "empty.js", imported by "main.js".',
+			originalMessage: '"foo" is not exported by "empty.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 61,
 			loc: {

--- a/test/function/samples/namespace-reassign-import-fails/_config.js
+++ b/test/function/samples/namespace-reassign-import-fails/_config.js
@@ -17,6 +17,7 @@ module.exports = defineTest({
 			exporter: ID_FOO,
 			id: ID_MAIN,
 			message: 'main.js (4:4): "bar" is not exported by "foo.js", imported by "main.js".',
+			originalMessage: '"bar" is not exported by "foo.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 48,
 			loc: {
@@ -33,6 +34,7 @@ module.exports = defineTest({
 		{
 			code: 'ILLEGAL_REASSIGNMENT',
 			message: 'main.js (3:0): Illegal reassignment of import "exp" in "main.js".',
+			originalMessage: 'Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 31,
 			loc: {
@@ -50,6 +52,7 @@ module.exports = defineTest({
 		{
 			code: 'ILLEGAL_REASSIGNMENT',
 			message: 'main.js (4:0): Illegal reassignment of import "exp" in "main.js".',
+			originalMessage: 'Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 44,
 			loc: {

--- a/test/function/samples/namespace-update-import-fails/_config.js
+++ b/test/function/samples/namespace-update-import-fails/_config.js
@@ -12,6 +12,7 @@ module.exports = defineTest({
 		{
 			code: 'ILLEGAL_REASSIGNMENT',
 			message: 'main.js (3:0): Illegal reassignment of import "exp" in "main.js".',
+			originalMessage: 'Illegal reassignment of import "exp" in "main.js".',
 			id: ID_MAIN,
 			pos: 31,
 			loc: {

--- a/test/function/samples/non-function-hook-async/_config.js
+++ b/test/function/samples/non-function-hook-async/_config.js
@@ -8,6 +8,7 @@ module.exports = defineTest({
 		hook: 'resolveId',
 		message:
 			'[plugin at position 1] Error running plugin hook "resolveId" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
+		originalMessage: 'Error running plugin hook "resolveId" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
 		plugin: 'at position 1'
 	}
 });

--- a/test/function/samples/non-function-hook-sync/_config.js
+++ b/test/function/samples/non-function-hook-sync/_config.js
@@ -12,6 +12,7 @@ module.exports = defineTest({
 		hook: 'outputOptions',
 		message:
 			'[plugin at position 1] Error running plugin hook "outputOptions" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
+		originalMessage: 'Error running plugin hook "outputOptions" for plugin "at position 1", expected a function hook or an object with a "handler" function.',
 		plugin: 'at position 1'
 	}
 });

--- a/test/function/samples/plugin-error-loc-instead-pos/_config.js
+++ b/test/function/samples/plugin-error-loc-instead-pos/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] main.js (1:22): nope',
+		originalMessage: 'nope',
 		hook: 'transform',
 		id: path.join(__dirname, 'main.js'),
 		watchFiles: [path.join(__dirname, 'main.js')],

--- a/test/function/samples/plugin-error/buildEnd/_config.js
+++ b/test/function/samples/plugin-error/buildEnd/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'buildEnd'
 	}
 });

--- a/test/function/samples/plugin-error/buildStart/_config.js
+++ b/test/function/samples/plugin-error/buildStart/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'buildStart'
 	}
 });

--- a/test/function/samples/plugin-error/generateBundle/_config.js
+++ b/test/function/samples/plugin-error/generateBundle/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'generateBundle'
 	}
 });

--- a/test/function/samples/plugin-error/load/_config.js
+++ b/test/function/samples/plugin-error/load/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: `Could not load ${path.join(__dirname, 'main.js')}: [plugin test] nope`,
+		originalMessage: 'nope',
 		hook: 'load'
 	}
 });

--- a/test/function/samples/plugin-error/renderChunk/_config.js
+++ b/test/function/samples/plugin-error/renderChunk/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'renderChunk'
 	}
 });

--- a/test/function/samples/plugin-error/renderStart/_config.js
+++ b/test/function/samples/plugin-error/renderStart/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'renderStart'
 	}
 });

--- a/test/function/samples/plugin-error/resolveId/_config.js
+++ b/test/function/samples/plugin-error/resolveId/_config.js
@@ -14,6 +14,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] nope',
+		originalMessage: 'nope',
 		hook: 'resolveId'
 	}
 });

--- a/test/function/samples/plugin-error/transform/_config.js
+++ b/test/function/samples/plugin-error/transform/_config.js
@@ -16,6 +16,7 @@ module.exports = defineTest({
 		code: 'PLUGIN_ERROR',
 		plugin: 'test',
 		message: '[plugin test] main.js (1:22): nope',
+		originalMessage: 'nope',
 		hook: 'transform',
 		id: path.join(__dirname, 'main.js'),
 		watchFiles: [path.join(__dirname, 'main.js')],

--- a/test/function/samples/plugin-warn-loc-instead-pos/_config.js
+++ b/test/function/samples/plugin-warn-loc-instead-pos/_config.js
@@ -20,6 +20,7 @@ module.exports = defineTest({
 			plugin: 'test',
 			hook: 'transform',
 			message: '[plugin test] main.js (1:22): foo',
+			originalMessage: 'foo',
 			loc: {
 				file: path.join(__dirname, 'main.js'),
 				line: 1,

--- a/test/function/samples/plugin-warn/_config.js
+++ b/test/function/samples/plugin-warn/_config.js
@@ -21,6 +21,7 @@ module.exports = defineTest({
 			hook: 'transform',
 			plugin: 'test',
 			message: '[plugin test] main.js: foo',
+			originalMessage: 'foo',
 			pluginCode: 'CODE'
 		},
 		{
@@ -29,6 +30,7 @@ module.exports = defineTest({
 			plugin: 'test',
 			hook: 'transform',
 			message: '[plugin test] main.js (1:22): bar',
+			originalMessage: 'bar',
 			pos: 22,
 			loc: {
 				file: path.join(__dirname, 'main.js'),

--- a/test/function/samples/reexport-missing-error/_config.js
+++ b/test/function/samples/reexport-missing-error/_config.js
@@ -20,6 +20,7 @@ module.exports = defineTest({
 			1: export { foo as bar } from './empty.js';
 			            ^`,
 		watchFiles: [ID_EMPTY, ID_MAIN],
-		message: 'main.js (1:9): "foo" is not exported by "empty.js", imported by "main.js".'
+		message: 'main.js (1:9): "foo" is not exported by "empty.js", imported by "main.js".',
+		originalMessage: '"foo" is not exported by "empty.js", imported by "main.js".',
 	}
 });

--- a/test/function/samples/transform-without-sourcemap-render-chunk/_config.js
+++ b/test/function/samples/transform-without-sourcemap-render-chunk/_config.js
@@ -25,6 +25,7 @@ module.exports = defineTest({
 			code: `SOURCEMAP_BROKEN`,
 			plugin: 'fake plugin 1',
 			message: `[plugin fake plugin 1] Sourcemap is likely to be incorrect: a plugin (fake plugin 1) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
+			originalMessage: `Sourcemap is likely to be incorrect: a plugin (fake plugin 1) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help`,
 			url: `https://rollupjs.org/troubleshooting/#warning-sourcemap-is-likely-to-be-incorrect`
 		}
 	]

--- a/test/function/samples/validate-output/_config.js
+++ b/test/function/samples/validate-output/_config.js
@@ -12,6 +12,7 @@ module.exports = defineTest({
 	generateError: {
 		code: 'CHUNK_INVALID',
 		message: 'main.js (6:0): Chunk "main.js" is not valid JavaScript: Unterminated block comment.',
+		originalMessage: 'Chunk "main.js" is not valid JavaScript: Unterminated block comment.',
 		frame: `
 4:
 5: /*`,

--- a/test/function/samples/warn-misplaced-annotations/_config.js
+++ b/test/function/samples/warn-misplaced-annotations/_config.js
@@ -9,6 +9,7 @@ module.exports = defineTest({
 			id: ID_MAIN,
 			message:
 				'main.js (2:0): A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+			originalMessage: 'A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
 			url: 'https://rollupjs.org/configuration-options/#no-side-effects',
 			pos: 45,
 			loc: {
@@ -28,6 +29,7 @@ module.exports = defineTest({
 			id: ID_MAIN,
 			message:
 				'main.js (4:0): A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+			originalMessage: 'A comment\n\n"/*@__NO_SIDE_EFFECTS__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
 			url: 'https://rollupjs.org/configuration-options/#no-side-effects',
 			pos: 113,
 			loc: {
@@ -46,6 +48,7 @@ module.exports = defineTest({
 			id: ID_MAIN,
 			message:
 				'main.js (1:0): A comment\n\n"/*@__PURE__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
+			originalMessage: 'A comment\n\n"/*@__PURE__*/"\n\nin "main.js" contains an annotation that Rollup cannot interpret due to the position of the comment. The comment will be removed to avoid issues.',
 			url: 'https://rollupjs.org/configuration-options/#pure',
 			pos: 0,
 			loc: {

--- a/test/function/samples/warn-on-eval/_config.js
+++ b/test/function/samples/warn-on-eval/_config.js
@@ -9,6 +9,7 @@ module.exports = defineTest({
 			id: ID_MAIN,
 			message:
 				'main.js (1:13): Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
+			originalMessage: 'Use of eval in "main.js" is strongly discouraged as it poses security risks and may cause issues with minification.',
 			url: 'https://rollupjs.org/troubleshooting/#avoiding-eval',
 			pos: 13,
 			loc: {

--- a/test/function/samples/warn-on-top-level-this/_config.js
+++ b/test/function/samples/warn-on-top-level-this/_config.js
@@ -8,6 +8,7 @@ module.exports = defineTest({
 			code: 'THIS_IS_UNDEFINED',
 			id: path.join(__dirname, 'main.js'),
 			message: `main.js (3:0): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`,
+			originalMessage: `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten`,
 			pos: 81,
 			loc: {
 				file: path.join(__dirname, 'main.js'),

--- a/test/function/samples/warn-on-unused-missing-imports/_config.js
+++ b/test/function/samples/warn-on-unused-missing-imports/_config.js
@@ -11,6 +11,7 @@ module.exports = defineTest({
 			exporter: ID_FOO,
 			id: ID_MAIN,
 			message: 'main.js (1:12): "b" is not exported by "foo.js", imported by "main.js".',
+			originalMessage: '"b" is not exported by "foo.js", imported by "main.js".',
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module',
 			pos: 12,
 			loc: {

--- a/test/function/samples/warning-const-reassign/_config.js
+++ b/test/function/samples/warning-const-reassign/_config.js
@@ -17,6 +17,7 @@ module.exports = defineTest({
 				line: 2
 			},
 			message: 'main.js (2:0): Cannot reassign a variable declared with `const`',
+			originalMessage: 'Cannot reassign a variable declared with `const`',
 			pos: 15
 		}
 	],

--- a/test/function/samples/warning-incorrect-sourcemap-location/_config.js
+++ b/test/function/samples/warning-incorrect-sourcemap-location/_config.js
@@ -28,6 +28,7 @@ module.exports = defineTest({
 			},
 			message:
 				'main.js (12:15): "NON_EXISTENT" is not exported by "constants.js", imported by "main.js".',
+			originalMessage: '"NON_EXISTENT" is not exported by "constants.js", imported by "main.js".',
 			pos: 111,
 			url: 'https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module'
 		}

--- a/test/function/samples/warning-low-resolution-location/_config.js
+++ b/test/function/samples/warning-low-resolution-location/_config.js
@@ -35,6 +35,7 @@ module.exports = defineTest({
 			},
 			message:
 				"main.js (1:0): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+			originalMessage: "The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 			pos: 15,
 			url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined'
 		}

--- a/test/sourcemaps/samples/warning-with-coarse-sourcemap/_config.js
+++ b/test/sourcemaps/samples/warning-with-coarse-sourcemap/_config.js
@@ -62,6 +62,7 @@ module.exports = defineTest({
 			code: 'THIS_IS_UNDEFINED',
 			message:
 				"main.js (3:2): The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
+			originalMessage: "The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten",
 			url: 'https://rollupjs.org/troubleshooting/#error-this-is-undefined',
 			id: ID_MAIN,
 			pos: 12,


### PR DESCRIPTION
## Summary

Closes #5699

When Rollup augments log messages by prepending plugin name and/or file location prefixes to `log.message`, the original unformatted text is lost. Users implementing custom log handlers (via `onLog`) who want to display or process the raw message text currently have no way to access it without parsing and stripping the rollup-added prefix.

## Bug

`augmentLogMessage` mutates `log.message` in-place:
```ts
log.message = prefix + log.message; // e.g. '[plugin test] original text'
```

After augmentation, `log.message` contains the formatted version and the original text is gone.

## Fix

Add a new optional property `originalMessage` to the `RollupLog` interface. In `augmentLogMessage`, before mutating `message`, save the original value using `??=` (so it is only set once even if a log is augmented multiple times):

```ts
log.originalMessage ??= log.message;
log.message = prefix + log.message;
```

This allows consumers to access the pre-augmentation message:
```js
rollup({ onLog(level, log) {
  console.log(log.message);         // '[plugin test] main.js (1:0): original text'
  console.log(log.originalMessage); // 'original text'
}});
```

## Verification

```
npx mocha test/test.js --grep 'original-message'
```

Result: **1 passing** ✓

The new test `test/function/samples/logging/original-message/` verifies that `originalMessage` is set correctly on augmented logs. All existing logging tests were updated to expect the new `originalMessage` field.

> AI-assisted implementation.
