### PR TITLE
fix: don't match sibling directories that share preserveModulesRoot as a string prefix

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1162,7 +1162,7 @@ export default class Chunk {
 			? sanitizedId.slice(0, -extensionName.length)
 			: sanitizedId;
 		if (isAbsolute(idWithoutExtension)) {
-			if (preserveModulesRoot && resolve(idWithoutExtension).startsWith(preserveModulesRoot)) {
+			if (preserveModulesRoot && isModuleInRoot(resolve(idWithoutExtension), preserveModulesRoot)) {
 				return idWithoutExtension.slice(preserveModulesRoot.length).replace(/^[/\\]/, '');
 			} else {
 				// handle edge case in Windows
@@ -1606,6 +1606,18 @@ function getPredefinedChunkNameFromModule(module: Module): string {
 	return (
 		module.chunkNames.find(({ isUserDefined }) => isUserDefined)?.name ?? module.chunkNames[0]?.name
 	);
+}
+
+// Checks that `resolvedId` is the `root` directory itself or a path inside
+// it, as opposed to e.g. a sibling directory that merely shares `root` as a
+// string prefix (e.g. "/project/src-other" is not inside "/project/src").
+function isModuleInRoot(resolvedId: string, root: string): boolean {
+	if (!resolvedId.startsWith(root)) return false;
+	// A root that already ends in a separator is a filesystem root itself
+	// (e.g. "/" or "C:\\"), so anything starting with it is already inside.
+	if (root.endsWith('/') || root.endsWith('\\')) return true;
+	const nextChar = resolvedId[root.length];
+	return nextChar === undefined || nextChar === '/' || nextChar === '\\';
 }
 
 function getImportedBindingsPerDependency(

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_config.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_config.js
@@ -1,0 +1,11 @@
+module.exports = defineTest({
+	description:
+		'does not strip preserveModulesRoot from a module in a sibling directory that merely shares its name as a string prefix',
+	options: {
+		input: ['src/module.js', 'src-sibling/module.js'],
+		output: {
+			preserveModules: true,
+			preserveModulesRoot: 'src'
+		}
+	}
+});

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/amd/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/amd/module.js
@@ -1,0 +1,7 @@
+define((function () { 'use strict';
+
+	var module$1 = 'src module';
+
+	return module$1;
+
+}));

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/amd/src-sibling/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/amd/src-sibling/module.js
@@ -1,0 +1,7 @@
+define((function () { 'use strict';
+
+	var module$1 = 'src-sibling module';
+
+	return module$1;
+
+}));

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/cjs/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/cjs/module.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var module$1 = 'src module';
+
+module.exports = module$1;

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/cjs/src-sibling/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/cjs/src-sibling/module.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var module$1 = 'src-sibling module';
+
+module.exports = module$1;

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/es/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/es/module.js
@@ -1,0 +1,3 @@
+var module$1 = 'src module';
+
+export { module$1 as default };

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/es/src-sibling/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/es/src-sibling/module.js
@@ -1,0 +1,3 @@
+var module$1 = 'src-sibling module';
+
+export { module$1 as default };

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/system/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/system/module.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var module$1 = exports("default", 'src module');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/system/src-sibling/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/_expected/system/src-sibling/module.js
@@ -1,0 +1,10 @@
+System.register([], (function (exports) {
+	'use strict';
+	return {
+		execute: (function () {
+
+			var module$1 = exports("default", 'src-sibling module');
+
+		})
+	};
+}));

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/src-sibling/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/src-sibling/module.js
@@ -1,0 +1,1 @@
+export default 'src-sibling module';

--- a/test/chunking-form/samples/preserve-modules-root-sibling-dir/src/module.js
+++ b/test/chunking-form/samples/preserve-modules-root-sibling-dir/src/module.js
@@ -1,0 +1,1 @@
+export default 'src module';


### PR DESCRIPTION
getPreserveModulesChunkNameFromModule strips output.preserveModulesRoot off a module's path with a plain `.startsWith()` check, so a root of `src` also matches a sibling directory like `src-sibling` since it happens to start with the same characters. That produces a malformed output path for the sibling module instead of preserving its full relative path.

Added an `isModuleInRoot` helper that requires either an exact match or a `/`/`\` boundary right after the root, plus a chunking-form fixture with `src/module.js` and `src-sibling/module.js` as separate entry points to cover it. Existing `preserve-modules-root` fixture and the rest of the chunking-form suite still pass.