### PR TITLE
feat: assignment literal analysis and truthy functions

### DIFF
--- a/src/ast/nodes/AssignmentExpression.ts
+++ b/src/ast/nodes/AssignmentExpression.ts
@@ -14,18 +14,22 @@ import {
 	renderSystemExportFunction,
 	renderSystemExportSequenceAfterExpression
 } from '../../utils/systemJsRendering';
+import type { DeoptimizableEntity } from '../DeoptimizableEntity';
 import {
 	createHasEffectsContext,
 	type HasEffectsContext,
 	type InclusionContext
 } from '../ExecutionContext';
-import type { NodeInteraction } from '../NodeInteractions';
+import type { NodeInteraction, NodeInteractionCalled } from '../NodeInteractions';
 import { INTERACTION_ASSIGNED } from '../NodeInteractions';
+import type { EntityPathTracker } from '../utils/PathTracker';
 import { EMPTY_PATH, type ObjectPath, UNKNOWN_PATH } from '../utils/PathTracker';
 import type Variable from '../variables/Variable';
 import Identifier from './Identifier';
 import * as NodeType from './NodeType';
 import ObjectPattern from './ObjectPattern';
+import type { ExpressionEntity, LiteralValueOrUnknown } from './shared/Expression';
+import { UNKNOWN_RETURN_EXPRESSION, UnknownValue } from './shared/Expression';
 import { type ExpressionNode, type IncludeChildren, NodeBase } from './shared/Node';
 import type { PatternNode } from './shared/Pattern';
 
@@ -74,6 +78,27 @@ export default class AssignmentExpression extends NodeBase {
 			(interaction.type === INTERACTION_ASSIGNED && this.left.included) ||
 			this.right.hasEffectsOnInteractionAtPath(path, interaction, context)
 		);
+	}
+
+	getLiteralValueAtPath(
+		path: ObjectPath,
+		recursionTracker: EntityPathTracker,
+		origin: DeoptimizableEntity
+	): LiteralValueOrUnknown {
+		return this.operator === '='
+			? this.right.getLiteralValueAtPath(path, recursionTracker, origin)
+			: UnknownValue;
+	}
+
+	getReturnExpressionWhenCalledAtPath(
+		path: ObjectPath,
+		interaction: NodeInteractionCalled,
+		recursionTracker: EntityPathTracker,
+		origin: DeoptimizableEntity
+	): [expression: ExpressionEntity, isPure: boolean] {
+		return this.operator === '='
+			? this.right.getReturnExpressionWhenCalledAtPath(path, interaction, recursionTracker, origin)
+			: UNKNOWN_RETURN_EXPRESSION;
 	}
 
 	include(context: InclusionContext, includeChildrenRecursively: IncludeChildren): void {

--- a/src/ast/nodes/shared/ClassNode.ts
+++ b/src/ast/nodes/shared/ClassNode.ts
@@ -19,7 +19,11 @@ import Identifier from '../Identifier';
 import type Literal from '../Literal';
 import MethodDefinition from '../MethodDefinition';
 import { isStaticBlock } from '../StaticBlock';
-import { type ExpressionEntity, type LiteralValueOrUnknown } from './Expression';
+import {
+	type ExpressionEntity,
+	type LiteralValueOrUnknown,
+	UnknownTruthyValue
+} from './Expression';
 import { type ExpressionNode, type IncludeChildren, NodeBase, onlyIncludeSelf } from './Node';
 import { ObjectEntity, type ObjectProperty } from './ObjectEntity';
 import { ObjectMember } from './ObjectMember';
@@ -62,6 +66,7 @@ export default class ClassNode extends NodeBase implements DeoptimizableEntity {
 		recursionTracker: EntityPathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown {
+		if (!path.length) return UnknownTruthyValue;
 		return this.getObjectEntity().getLiteralValueAtPath(path, recursionTracker, origin);
 	}
 

--- a/src/ast/nodes/shared/FunctionBase.ts
+++ b/src/ast/nodes/shared/FunctionBase.ts
@@ -20,7 +20,7 @@ import RestElement from '../RestElement';
 import type VariableDeclarator from '../VariableDeclarator';
 import { Flag, isFlagSet, setFlag } from './BitFlags';
 import type { ExpressionEntity, LiteralValueOrUnknown } from './Expression';
-import { UNKNOWN_EXPRESSION, UNKNOWN_RETURN_EXPRESSION } from './Expression';
+import { UNKNOWN_EXPRESSION, UNKNOWN_RETURN_EXPRESSION, UnknownTruthyValue } from './Expression';
 import {
 	doNotDeoptimize,
 	type ExpressionNode,
@@ -100,6 +100,7 @@ export default abstract class FunctionBase extends NodeBase {
 		recursionTracker: EntityPathTracker,
 		origin: DeoptimizableEntity
 	): LiteralValueOrUnknown {
+		if (!path.length) return UnknownTruthyValue;
 		return this.getObjectEntity().getLiteralValueAtPath(path, recursionTracker, origin);
 	}
 

--- a/test/form/samples/tree-shake-if-statements/_expected.js
+++ b/test/form/samples/tree-shake-if-statements/_expected.js
@@ -43,3 +43,13 @@ if (console.log('effect'), false) ;
 if (console.log('effect'), false) ; else {
 	console.log('kept');
 }
+
+var a;
+if (a = false) ; else {
+	console.log('kept');
+}
+
+var d;
+if ((d = function () { return true })()) {
+	console.log('kept');
+}

--- a/test/form/samples/tree-shake-if-statements/main.js
+++ b/test/form/samples/tree-shake-if-statements/main.js
@@ -55,7 +55,7 @@ if (false) {
 
 if (false) {
 	console.log('removed');
-	var c;
+	var c; //
 }
 console.log(c);
 
@@ -75,4 +75,18 @@ if (console.log('effect'), false) {
 	console.log('removed');
 } else {
 	console.log('kept');
+}
+
+var a;
+if (a = false) {
+	console.log('removed');
+} else {
+	console.log('kept');
+}
+
+var d;
+if ((d = function () { return true })()) {
+	console.log('kept');
+} else {
+	console.log('removed');
 }

--- a/test/function/samples/deoptimize-object-assigned-via-destructuring/_config.js
+++ b/test/function/samples/deoptimize-object-assigned-via-destructuring/_config.js
@@ -1,0 +1,4 @@
+module.exports = defineTest({
+	description:
+		'does not treat an object mutated after being returned from an assignment expression as unmodified when the assignment target is a destructuring pattern'
+});

--- a/test/function/samples/deoptimize-object-assigned-via-destructuring/main.js
+++ b/test/function/samples/deoptimize-object-assigned-via-destructuring/main.js
@@ -1,0 +1,13 @@
+var y;
+const t = ({ y } = { z: 1 });
+t.z = 2;
+
+let branch;
+if (t.z === 1) {
+	branch = 'then';
+} else {
+	branch = 'else';
+}
+
+assert.equal(t.z, 2, 'mutation through the destructuring assignment value is lost');
+assert.equal(branch, 'else', 'the wrong branch was statically selected');


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

This PR addresses 2 shortcomings of Rollup currently:
- Assignment expressions are not walked through when it's a simple `=`. This unlocks analysis of e.g. `() => globalThis.value = true` as a side-effectful function returning `true`.
- Due to the TS enum bug, ObjectEntity is not considered truthy and so are functions and classes. I've made them act as truthy, which allowed Rollup to optimise core-js parts that the bundler considers always present (the optimisation gains are underwhelming due to the lack of advanced analysis of variable reassignment, which would allow Rollup to get rid of entire `requireXXX` blocks in core-js).