### PR TITLE
Fix build:docs after rollup update

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -54,6 +54,15 @@ export default defineConfig({
 				twoslashOptions: {
 					compilerOptions: {
 						moduleResolution: 100, // bundler
+						// Rollup uses an import assertion in the JavaScript part of the
+						// code for the package.json file. This triggers a bug in the
+						// TypeScript handling of Twoslash, which by default tries to
+						// include not only d.ts files but also any JavaScript files in the
+						// compilation.
+						// The solution here is to directly resolve rollup to its d.ts file.
+						paths: {
+							rollup: ['./node_modules/rollup/dist/rollup.d.ts']
+						},
 						types: ['node']
 					}
 				}


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description

In the latest version of Rollup, we have an import assertion in the JavaScript part of the code for the package.json file. This triggers a bug in the TypeScript handling of Twoslash, which by default tries to include not only d.ts files but also any JavaScript files in the compilation.
The solution here is to directly resolve rollup to its d.ts file.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
