### PR TITLE
ci: fix linux-gnu glibc regression and enforce glibc ≤ 2.28 compatibility

### DIFF
--- a/.github/actions/install-and-cache-node-deps/action.yml
+++ b/.github/actions/install-and-cache-node-deps/action.yml
@@ -38,13 +38,13 @@ runs:
       run: |
         set -e
         binding=node_modules/@napi-rs/lzma-linux-x64-gnu
-        if [ ! -d "$binding" ]; then
+        if [ ! -f "$binding/package.json" ]; then
           echo "Repairing missing @napi-rs/lzma-linux-x64-gnu from its pinned lockfile tarball (rollup#6461)."
+          rm -rf "$binding"
           url=$(node -p "require('./package-lock.json').packages['node_modules/@napi-rs/lzma-linux-x64-gnu'].resolved")
           integrity=$(node -p "require('./package-lock.json').packages['node_modules/@napi-rs/lzma-linux-x64-gnu'].integrity")
           curl -fsSL "$url" -o /tmp/lzma-binding.tgz
           node -e "
-            const {execSync} = require('node:child_process');
             const crypto = require('node:crypto');
             const fs = require('node:fs');
             const [algo, expected] = '$integrity'.split('-', 2);

--- a/.github/actions/install-and-cache-node-deps/action.yml
+++ b/.github/actions/install-and-cache-node-deps/action.yml
@@ -22,6 +22,43 @@ runs:
         fi
         npm ${{ github.ref == 'refs/heads/master' && 'ci' || 'install' }} --ignore-scripts && npm run prepare:patch
       shell: bash
+    # The @napi-rs/lzma-linux-x64-gnu platform binding (optional dependency of
+    # @napi-rs/cross-toolchain) must be present, otherwise `napi build
+    # --use-napi-cross` silently skips the cross toolchain and links against the
+    # host glibc, producing artifacts that require a newer glibc than the target
+    # (rollup#6461). Restored cache snapshots can be poisoned: their hidden
+    # lockfile claims the binding is installed while it is not, and npm trusts
+    # that lockfile - even an explicit `npm install <pkg>` is reconciled away
+    # instead of placing the files (npm/cli#4828). So repair at tarball level
+    # using the pinned URL + integrity from package-lock.json, then fail loudly
+    # if the binding is still absent.
+    - name: Ensure napi-rs cross-toolchain platform binding is present
+      if: runner.os == 'Linux' && runner.arch == 'X64'
+      shell: bash
+      run: |
+        set -e
+        binding=node_modules/@napi-rs/lzma-linux-x64-gnu
+        if [ ! -d "$binding" ]; then
+          echo "Repairing missing @napi-rs/lzma-linux-x64-gnu from its pinned lockfile tarball (rollup#6461)."
+          url=$(node -p "require('./package-lock.json').packages['node_modules/@napi-rs/lzma-linux-x64-gnu'].resolved")
+          integrity=$(node -p "require('./package-lock.json').packages['node_modules/@napi-rs/lzma-linux-x64-gnu'].integrity")
+          curl -fsSL "$url" -o /tmp/lzma-binding.tgz
+          node -e "
+            const {execSync} = require('node:child_process');
+            const crypto = require('node:crypto');
+            const fs = require('node:fs');
+            const [algo, expected] = '$integrity'.split('-', 2);
+            const actual = crypto.createHash(algo).update(fs.readFileSync('/tmp/lzma-binding.tgz')).digest('base64');
+            if (actual !== expected) { console.error('integrity mismatch'); process.exit(1); }
+          "
+          mkdir -p "$binding"
+          tar -xzf /tmp/lzma-binding.tgz -C "$binding" --strip-components=1
+          rm /tmp/lzma-binding.tgz
+        fi
+        if [ ! -f "$binding/package.json" ]; then
+          echo "::error::@napi-rs/lzma-linux-x64-gnu is missing from node_modules; the napi cross toolchain would be silently skipped (rollup#6461)."
+          exit 1
+        fi
     - name: Save Node dependencies cache
       if: steps.cache-node-modules.outputs.cache-hit != 'true' && github.ref == 'refs/heads/master'
       uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -287,6 +287,35 @@ jobs:
         run: npm run build:napi -- --release --target ${{ matrix.settings.target }} ${{ matrix.settings.cross == 'zig' && '-x' || matrix.settings.cross == 'napi' && '--use-napi-cross' || matrix.settings.cross == 'cross' && '--use-cross' || '' }} -- ${{ matrix.settings.build-std && '-Zbuild-std=std,core,alloc,panic_unwind -Zbuild-std-features=panic-unwind' || '' }}
         if: ${{ !matrix.settings.build }}
         shell: bash
+      - name: Check glibc symbol compatibility
+        # riscv64 and loongarch64 use classic apt cross-gcc toolchains whose glibc
+        # floor tracks the runner image (currently 2.34/2.36) rather than the
+        # manylinux-derived napi cross toolchain; pinning them to 2.28 would
+        # require a separate sysroot toolchain change.
+        if: ${{ !matrix.settings.is-wasm-build && contains(matrix.settings.target, 'linux-gnu') && !contains(matrix.settings.target, 'android') && !contains(matrix.settings.target, 'ohos') && !contains(matrix.settings.target, 'riscv64') && !contains(matrix.settings.target, 'loongarch64') }}
+        run: |
+          set -e
+          failed=0
+          for file in ${APP_NAME:-rollup}.*.node; do
+            [ -f "$file" ] || continue
+            echo "Checking $file for glibc symbol versions..."
+            # Extract highest required GLIBC version from the binary
+            max_glibc=$(objdump -T "$file" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -Vu | tail -1 || true)
+            if [ -n "$max_glibc" ]; then
+              echo "  Highest required GLIBC: $max_glibc"
+              # napi-cross sysroot is manylinux2014-based (glibc 2.17). Allow a small guard band
+              # up to 2.28 (the floor reported by users running RHEL8/Debian 11) to account for
+              # symbols the manylinux2014 sysroot itself legitimately references above 2.17.
+              if [ "$(printf '%s\n2.28\n' "$max_glibc" | sort -V | tail -1)" != "2.28" ]; then
+                echo "::error::$file requires GLIBC_$max_glibc, exceeding the supported floor of 2.28 (RHEL8/Debian 11)"
+                failed=1
+              fi
+            else
+              echo "  No GLIBC symbols found (statically linked or musl)."
+            fi
+          done
+          [ "$failed" = "0" ]
+        shell: bash
       - name: Save Cargo cache
         if: github.ref == 'refs/heads/master' && matrix.settings.cache-cargo != false
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/build-and-tests.yml
+++ b/.github/workflows/build-and-tests.yml
@@ -295,12 +295,15 @@ jobs:
         if: ${{ !matrix.settings.is-wasm-build && contains(matrix.settings.target, 'linux-gnu') && !contains(matrix.settings.target, 'android') && !contains(matrix.settings.target, 'ohos') && !contains(matrix.settings.target, 'riscv64') && !contains(matrix.settings.target, 'loongarch64') }}
         run: |
           set -e
+          set -o pipefail
           failed=0
+          checked=0
           for file in ${APP_NAME:-rollup}.*.node; do
             [ -f "$file" ] || continue
+            checked=$((checked + 1))
             echo "Checking $file for glibc symbol versions..."
             # Extract highest required GLIBC version from the binary
-            max_glibc=$(objdump -T "$file" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -Vu | tail -1 || true)
+            max_glibc=$(objdump -T "$file" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -Vu | tail -1 || true)
             if [ -n "$max_glibc" ]; then
               echo "  Highest required GLIBC: $max_glibc"
               # napi-cross sysroot is manylinux2014-based (glibc 2.17). Allow a small guard band
@@ -314,6 +317,10 @@ jobs:
               echo "  No GLIBC symbols found (statically linked or musl)."
             fi
           done
+          if [ "$checked" = "0" ]; then
+            echo "::error::No native .node artifacts found to check (pattern: ${APP_NAME:-rollup}.*.node)"
+            exit 1
+          fi
           [ "$failed" = "0" ]
         shell: bash
       - name: Save Cargo cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,6 +110,7 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -3497,7 +3498,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
   },
   "homepage": "https://rollupjs.org/",
   "optionalDependencies": {
+    "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
     "fsevents": "~2.3.2"
   },
   "dependencies": {
@@ -230,6 +231,7 @@
     "vue-tsc": "This is necessary so that prettier-plugin-organize-imports works correctly in Vue templatges",
     "@emnapi/core": "If missing this fails npm install for Linux ARM",
     "@emnapi/runtime": "If missing this fails npm install for Linux ARM",
+    "@napi-rs/lzma-linux-x64-gnu": "If missing, napi build --use-napi-cross silently skips the cross toolchain and links against the host glibc (#6461)",
     "react": "If missing this fails npm install for Linux ARM",
     "react-dom": "If missing this fails npm install for Linux ARM"
   },


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no — this PR only changes CI infrastructure, and the change *is* the test: the new "Check glibc symbol compatibility" build step. It was verified against real artifacts and in CI: it failed on this branch's x86_64-gnu build while the toolchain was degraded (`requires GLIBC_2.34, exceeding the supported floor of 2.28`), and passes now that the fix landed (`Highest required GLIBC: 2.14`).

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

- resolves #6461

### Description

## Problem

`@rollup/rollup-linux-x64-gnu@4.62.3` requires **GLIBC_2.34** (`pthread_getattr_np@GLIBC_2.32`, `fstat64/stat64@GLIBC_2.33`, `pthread_*@GLIBC_2.34`) whereas `4.62.2` required only **GLIBC_2.14** — breaking builds on RHEL 8 / CentOS 8-based images (2.28), Debian 11 bullseye (2.31), Amazon Linux 2, and AWS build environments (#6461).

## Root cause (confirmed via CI logs from this branch)

The linux-gnu x64 build intends to use `napi build --use-napi-cross`, which downloads a manylinux-derived gcc cross toolchain (glibc 2.17 sysroot) and drives both C compilation and linking through it:

1. The build jobs restore `node_modules` from an `actions/cache` snapshot. A snapshot **missing the optional platform package `@napi-rs/lzma-linux-x64-gnu`** got cached on master ([npm optional-dependency bug, npm/cli#4828](https://github.com/npm/cli/issues/4828)).
2. With that binding missing, `require('@napi-rs/cross-toolchain')` throws inside `napi build`, and the CLI **silently swallows it** (`debug`-only warning "Pick cross toolchain failed") and continues **without** `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER`, `TARGET_CC`, or `TARGET_SYSROOT`.
3. Cargo then falls back to the host `cc` and links against the ubuntu-24.04 runner's glibc 2.39 — producing the GLIBC 2.34 floor.
4. The poisoned snapshot **self-propagated** through the cache: its hidden lockfile claims the binding is installed, so `npm install` is a no-op, and even an explicit `npm install <pkg>` is reconciled away against the lying hidden lockfile. Verified in CI on this branch — npm printed "added 4 packages, removed 2 packages" and the binding was *still* absent afterwards.
5. Since the build was green, nothing surfaced this: the degradation only became visible in the published artifact's symbol table (PR #6451's lockfile refresh forced a cold rebuild and exposed it). Thanks to @yoyo837 for the precise bisect in #6461.

## Changes (two commits)

**1. `ci: ensure napi cross-toolchain binding is present for glibc-compatible builds`**

- Pin `@napi-rs/lzma-linux-x64-gnu` as an explicit `optionalDependency` so it's reliably installed on linux-x64-glibc hosts (not `devDependencies`: a regular dependency on a platform-restricted package breaks installs elsewhere with `EBADPLATFORM`). Mirrors the existing `@emnapi/*` workaround philosophy.
- After the regular node_modules restore/install flow in `install-and-cache-node-deps` (flow otherwise unchanged), **ensure** the binding is present on Linux/X64 runners: if missing, repair it at tarball level by downloading the exact pinned URL from `package-lock.json` and verifying its recorded integrity hash — bypassing npm's trust in the stale hidden lockfile. Fail loudly if it's still absent, so a degraded toolchain can never ship an incompatible artifact again.

**2. `ci: add glibc symbol compatibility check for linux-gnu builds`**

- New `Check glibc symbol compatibility` step in the `build` job: runs `objdump -T` on every native `*.node` artifact built via the napi cross toolchain (excluding android/ohos/musl/wasm), extracts the highest required `GLIBC_x.y`, and **fails the build if it exceeds 2.28** — the floor for the oldest commonly deployed targets reported in #6461 (RHEL 8 / Amazon Linux 2 era).
- `riscv64gc` and `loongarch64` gnu targets are excluded with a documented note: they use classic apt cross-gcc toolchains whose glibc floor tracks the runner image (currently 2.34/2.36) rather than the napi cross toolchain; pinning them lower is a separate toolchain change.
- The check inspects the *artifact*, not the runner, so it keeps working as `ubuntu-latest` evolves and cannot be masked by cache behavior.

## Verification

- Guard proven to catch the bug: this branch's first CI run (guard only, no fix) failed the x86_64-gnu build with `requires GLIBC_2.34, exceeding the supported floor of 2.28`.
- Root cause proven in CI: same run's logs contain `Pick cross toolchain failed … Cannot find module '@napi-rs/lzma-linux-x64-gnu'` right after a node_modules cache restore.
- Fix proven in CI: subsequent run — the repair step detected the missing binding in the poisoned restored snapshot, restored it from the pinned tarball (integrity-verified), the napi cross toolchain engaged, and the guard now reports `Highest required GLIBC: 2.14` on the x86_64-gnu artifact.
- Full CI green on the final branch, including the gnu matrix builds, tests on Node 18.20.0/24, coverage, additional tests, and the s390x smoke test.

## Open follow-ups (not blocking)

- Upstream: `@napi-rs/cli` treats a missing `--use-napi-cross` toolchain as a debug warning instead of a hard failure; worth fixing in napi-rs. Our guard and binding pin make this non-blocking for rollup.
- `riscv64`/`loongarch64` gnu floors (2.34/2.36) could be brought down via a sysroot-pinned toolchain if anyone needs it, but they were unaffected by this regression.
- Threshold 2.28 vs strict 2.17 (manylinux2014): the napi-cross sysroot legitimately references a few symbols above 2.17 (e.g. `statx`@2.28, `getrandom`@2.25, `log2`@2.29 from libm); 2.28 covers every distro family reported in #6461 while accommodating those.
