### PR TITLE
fix: avoid spurious cycle warning for dynamic imports inside functions with TLA

### DIFF
--- a/src/utils/executionOrder.ts
+++ b/src/utils/executionOrder.ts
@@ -19,6 +19,28 @@ export function sortByExecutionOrder(units: OrderedExecutionUnit[]): void {
 // modules are executed before or after which other modules. THen the chunking
 // would need to take care that in each chunk, all modules are always executed
 // in the same sequence.
+
+// Check if an ImportExpression is at the top level of a module
+// (not nested inside any function)
+function isTopLevelImport(node: { parent: any }): boolean {
+	let parent = node.parent;
+	while (parent) {
+		// Check if parent is a function-like node by checking the type string
+		// This covers FunctionDeclaration, FunctionExpression, ArrowFunctionExpression,
+		// and class methods
+		const type = parent.type as string;
+		if (
+			type === 'FunctionDeclaration' ||
+			type === 'FunctionExpression' ||
+			type === 'ArrowFunctionExpression'
+		) {
+			return false;
+		}
+		parent = parent.parent;
+	}
+	return true;
+}
+
 export function analyseModuleExecution(entryModules: readonly Module[]): {
 	cyclePaths: string[][];
 	orderedModules: Module[];
@@ -50,14 +72,19 @@ export function analyseModuleExecution(entryModules: readonly Module[]): {
 			for (const dependency of module.implicitlyLoadedBefore) {
 				dynamicImports.add(dependency);
 			}
-			for (const {
-				node: { resolution, scope }
-			} of module.dynamicImports) {
-				if (resolution instanceof Module) {
-					if (scope.context.usesTopLevelAwait) {
-						handleSyncLoadedModule(resolution, module);
+			for (const dynamicImport of module.dynamicImports) {
+				if (dynamicImport.node.resolution instanceof Module) {
+					// Only treat dynamic imports as synchronous if the import
+					// expression is at the top level (not inside a function)
+					// of a module that uses top-level await. Dynamic imports
+					// inside functions are always async.
+					if (
+						isTopLevelImport(dynamicImport.node) &&
+						dynamicImport.node.scope.context.usesTopLevelAwait
+					) {
+						handleSyncLoadedModule(dynamicImport.node.resolution, module);
 					} else {
-						dynamicImports.add(resolution);
+						dynamicImports.add(dynamicImport.node.resolution);
 					}
 				}
 			}

--- a/test/form/samples/dynamic-import-tla-no-spurious-cycle/_config.js
+++ b/test/form/samples/dynamic-import-tla-no-spurious-cycle/_config.js
@@ -1,0 +1,10 @@
+module.exports = defineTest({
+description: 'dynamic import inside async function should not cause spurious cycle warning when module has top-level await',
+options: {
+output: {
+inlineDynamicImports: true
+}
+}
+// No expectedWarnings - the dynamic import is inside an async function,
+// not at the top level, so it should NOT be treated as synchronous
+});

--- a/test/form/samples/dynamic-import-tla-no-spurious-cycle/_expected.js
+++ b/test/form/samples/dynamic-import-tla-no-spurious-cycle/_expected.js
@@ -1,0 +1,36 @@
+await Promise.resolve();
+
+class B {
+async foo() {
+const foo = await Promise.resolve().then(function () { return foo2; });
+return new foo.Foo();
+}
+}
+
+class A extends B {}
+
+await Promise.resolve();
+
+let Foo$1 = class Foo extends A {
+async foo() {
+const foo = await Promise.resolve().then(function () { return foo2; });
+return new foo.Foo();
+}
+};
+
+class Bar extends A {
+bar() {
+return new Foo$1().foo();
+}
+}
+
+new Bar().bar();
+
+class Foo extends A {
+foo() { console.log('hello'); }
+}
+
+var foo2 = /*#__PURE__*/Object.freeze({
+	__proto__: null,
+	Foo: Foo
+});

--- a/test/form/samples/dynamic-import-tla-no-spurious-cycle/a.js
+++ b/test/form/samples/dynamic-import-tla-no-spurious-cycle/a.js
@@ -1,0 +1,3 @@
+import B from './b.js';
+
+export default class A extends B {}

--- a/test/form/samples/dynamic-import-tla-no-spurious-cycle/b.js
+++ b/test/form/samples/dynamic-import-tla-no-spurious-cycle/b.js
@@ -1,0 +1,8 @@
+await Promise.resolve();
+
+export default class B {
+async foo() {
+const foo = await import('./foo2.js');
+return new foo.Foo();
+}
+}

--- a/test/form/samples/dynamic-import-tla-no-spurious-cycle/foo.js
+++ b/test/form/samples/dynamic-import-tla-no-spurious-cycle/foo.js
@@ -1,0 +1,9 @@
+import A from './a.js';
+await Promise.resolve();
+
+export default class Foo extends A {
+async foo() {
+const foo = await import('./foo2.js');
+return new foo.Foo();
+}
+}

--- a/test/form/samples/dynamic-import-tla-no-spurious-cycle/foo2.js
+++ b/test/form/samples/dynamic-import-tla-no-spurious-cycle/foo2.js
@@ -1,0 +1,4 @@
+import A from './a.js';
+export class Foo extends A {
+foo() { console.log('hello'); }
+}

--- a/test/form/samples/dynamic-import-tla-no-spurious-cycle/main.js
+++ b/test/form/samples/dynamic-import-tla-no-spurious-cycle/main.js
@@ -1,0 +1,10 @@
+import A from './a.js';
+import Foo from './foo.js';
+
+class Bar extends A {
+bar() {
+return new Foo().foo();
+}
+}
+
+new Bar().bar();


### PR DESCRIPTION
## Summary

When a module uses top-level await (TLA), rollup was treating ALL dynamic imports from that module as synchronous dependencies, even if the import was inside a function. This caused false circular dependency warnings and incorrect module ordering.

See #6154 for the full reproduction.

## Root Cause

In `src/utils/executionOrder.ts`, the `analyseModuleExecution` function checks `scope.context.usesTopLevelAwait` for all dynamic imports in a module. If the module uses TLA, every dynamic import is treated as synchronous (added to the `parents` map for cycle detection). However, `usesTopLevelAwait` is a module-level flag — it doesn't distinguish between dynamic imports at the top level vs. inside functions.

## Fix

Added an `isTopLevelImport()` helper function that checks whether an ImportExpression is nested inside any function (FunctionDeclaration, FunctionExpression, or ArrowFunctionExpression). Dynamic imports are only treated as synchronous if:
1. The ImportExpression is at the top level (not inside any function), AND
2. The module uses top-level await

Dynamic imports inside functions are always async, regardless of the module's TLA status.

## Test

Added `test/form/samples/dynamic-import-tla-no-spurious-cycle/` which reproduces the issue from #6154. Without the fix, rollup produces a `CIRCULAR_DEPENDENCY` warning. With the fix, no warning is produced.

Also verified that the existing `cycles-dependency-with-TLA-await-import` test still passes, confirming that legitimate TLA cycles are still detected.
