### PR TITLE
Remove unused rendered module sources map

### DIFF
--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -1340,7 +1340,6 @@ export default class Chunk {
 		const usedModules: Module[] = [];
 		let hoistedSource = '';
 		const accessedGlobals = new Set<string>();
-		const renderedModuleSources = new Map<Module, MagicString>();
 
 		const renderOptions: RenderOptions = {
 			accessedDocumentCurrentScript: false,
@@ -1373,7 +1372,6 @@ export default class Chunk {
 				renderedLength = source.length();
 				if (renderedLength) {
 					if (compact && source.lastLine().includes('//')) source.append('\n');
-					renderedModuleSources.set(module, source);
 					magicString.addSource(source);
 					usedModules.push(module);
 				}


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

None.

### Description

`renderedModuleSources` is populated for every non-empty rendered module but is never read. The rendered sources are already added to the chunk's `MagicStringBundle`, so this removes unused bookkeeping without changing output. It avoids allocating an unused `Map` and inserting an entry for every non-empty rendered module.

No test was added because this is an internal, behavior-preserving deletion. Rollup's output suite exercises the affected rendering path.

Validation:

- `npm run update:js`
- `npm run lint:js:nofix`
- `env -u NO_COLOR TERM=xterm npm run test:only` (5,442 passing)
