### PR TITLE
Prevent exponential growth in return value tracking

### DIFF
--- a/src/ast/nodes/shared/MultiExpression.ts
+++ b/src/ast/nodes/shared/MultiExpression.ts
@@ -7,7 +7,7 @@ import ReturnStatement from '../ReturnStatement';
 import {
 	ExpressionEntity,
 	type LiteralValueOrUnknown,
-	UNKNOWN_RETURN_EXPRESSION,
+	UNKNOWN_EXPRESSION,
 	UnknownFalsyValue,
 	UnknownTruthyValue,
 	UnknownValue
@@ -125,7 +125,7 @@ export class MultiExpression extends ExpressionEntity implements DeoptimizableEn
 			}
 		}
 
-		if (exceededTrackingLimit) return UNKNOWN_RETURN_EXPRESSION;
+		if (exceededTrackingLimit) return [UNKNOWN_EXPRESSION, pure];
 		const flattenedReturnExpressions = [...returnExpressions];
 		return [
 			flattenedReturnExpressions.length === 1

--- a/src/ast/nodes/shared/MultiExpression.ts
+++ b/src/ast/nodes/shared/MultiExpression.ts
@@ -7,10 +7,13 @@ import ReturnStatement from '../ReturnStatement';
 import {
 	ExpressionEntity,
 	type LiteralValueOrUnknown,
+	UNKNOWN_RETURN_EXPRESSION,
 	UnknownFalsyValue,
 	UnknownTruthyValue,
 	UnknownValue
 } from './Expression';
+
+const MAX_TRACKED_RETURN_EXPRESSIONS = 64;
 
 type Value = Exclude<LiteralValueOrUnknown, typeof UnknownValue>;
 
@@ -98,15 +101,36 @@ export class MultiExpression extends ExpressionEntity implements DeoptimizableEn
 		recursionTracker: EntityPathTracker,
 		origin: DeoptimizableEntity
 	): [expression: ExpressionEntity, isPure: boolean] {
-		const returnExpressions = this.expressions.map(expression =>
-			expression.getReturnExpressionWhenCalledAtPath(path, interaction, recursionTracker, origin)
-		);
-
+		const returnExpressions = new Set<ExpressionEntity>();
+		const visitedMultiExpressions = new Set<MultiExpression>();
+		let exceededTrackingLimit = false;
 		let pure = true;
+		for (const expression of this.expressions) {
+			const [returnExpression, isPure] = expression.getReturnExpressionWhenCalledAtPath(
+				path,
+				interaction,
+				recursionTracker,
+				origin
+			);
+			pure &&= isPure;
+			if (
+				!exceededTrackingLimit &&
+				!this.addFlattenedReturnExpression(
+					returnExpression,
+					returnExpressions,
+					visitedMultiExpressions
+				)
+			) {
+				exceededTrackingLimit = true;
+			}
+		}
+
+		if (exceededTrackingLimit) return UNKNOWN_RETURN_EXPRESSION;
+		const flattenedReturnExpressions = [...returnExpressions];
 		return [
-			new MultiExpression(
-				returnExpressions.map(expression => ((pure &&= expression[1]), expression[0]))
-			),
+			flattenedReturnExpressions.length === 1
+				? flattenedReturnExpressions[0]
+				: new MultiExpression(flattenedReturnExpressions),
 			pure
 		];
 	}
@@ -131,5 +155,31 @@ export class MultiExpression extends ExpressionEntity implements DeoptimizableEn
 		}
 
 		return false;
+	}
+
+	private addFlattenedReturnExpression(
+		expression: ExpressionEntity,
+		returnExpressions: Set<ExpressionEntity>,
+		visitedMultiExpressions: Set<MultiExpression>
+	): boolean {
+		if (!(expression instanceof MultiExpression)) {
+			returnExpressions.add(expression);
+			return returnExpressions.size <= MAX_TRACKED_RETURN_EXPRESSIONS;
+		}
+
+		if (visitedMultiExpressions.has(expression)) return true;
+		visitedMultiExpressions.add(expression);
+		for (const nestedExpression of expression.expressions) {
+			if (
+				!this.addFlattenedReturnExpression(
+					nestedExpression,
+					returnExpressions,
+					visitedMultiExpressions
+				)
+			) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/test/cli/samples/avoids-exponential-memory-usage-for-chained-calls/_config.js
+++ b/test/cli/samples/avoids-exponential-memory-usage-for-chained-calls/_config.js
@@ -1,0 +1,12 @@
+const assert = require('node:assert/strict');
+
+module.exports = defineTest({
+	description: 'avoids exponential memory usage when repeatedly calling a multi-return function',
+	env: { NODE_OPTIONS: '--max-old-space-size=64' },
+	execute: true,
+	spawnArgs: ['main.js', '--format', 'cjs', '--silent'],
+	stderr(errorOutput) {
+		assert.equal(errorOutput, '');
+		return true;
+	}
+});

--- a/test/cli/samples/avoids-exponential-memory-usage-for-chained-calls/main.js
+++ b/test/cli/samples/avoids-exponential-memory-usage-for-chained-calls/main.js
@@ -1,0 +1,12 @@
+let calls = 0;
+
+function getFunction() {
+	calls++;
+	if (globalThis.condition) return getFunction;
+	return getFunction;
+}
+
+const result = getFunction()()()()()()()()()()()()()()()()()()();
+
+assert.strictEqual(result, getFunction);
+assert.strictEqual(calls, 19);

--- a/test/form/samples/limits-return-expression-tracking-for-chained-calls/_config.js
+++ b/test/form/samples/limits-return-expression-tracking-for-chained-calls/_config.js
@@ -1,3 +1,8 @@
 module.exports = defineTest({
-	description: 'tracks at most 64 return expressions when calls are chained'
+	description: 'tracks at most 64 return expressions without losing call purity',
+	options: {
+		treeshake: {
+			manualPureFunctions: Array.from({ length: 65 }, (_, index) => `pure${index}`)
+		}
+	}
 });

--- a/test/form/samples/limits-return-expression-tracking-for-chained-calls/_config.js
+++ b/test/form/samples/limits-return-expression-tracking-for-chained-calls/_config.js
@@ -1,0 +1,3 @@
+module.exports = defineTest({
+	description: 'tracks at most 64 return expressions when calls are chained'
+});

--- a/test/form/samples/limits-return-expression-tracking-for-chained-calls/_expected.js
+++ b/test/form/samples/limits-return-expression-tracking-for-chained-calls/_expected.js
@@ -1,0 +1,72 @@
+function noop() {}
+
+const selectedCondition = condition;
+
+const functionOverLimit =
+	selectedCondition === 0 ? () => () => noop :
+	selectedCondition === 1 ? () => () => noop :
+	selectedCondition === 2 ? () => () => noop :
+	selectedCondition === 3 ? () => () => noop :
+	selectedCondition === 4 ? () => () => noop :
+	selectedCondition === 5 ? () => () => noop :
+	selectedCondition === 6 ? () => () => noop :
+	selectedCondition === 7 ? () => () => noop :
+	selectedCondition === 8 ? () => () => noop :
+	selectedCondition === 9 ? () => () => noop :
+	selectedCondition === 10 ? () => () => noop :
+	selectedCondition === 11 ? () => () => noop :
+	selectedCondition === 12 ? () => () => noop :
+	selectedCondition === 13 ? () => () => noop :
+	selectedCondition === 14 ? () => () => noop :
+	selectedCondition === 15 ? () => () => noop :
+	selectedCondition === 16 ? () => () => noop :
+	selectedCondition === 17 ? () => () => noop :
+	selectedCondition === 18 ? () => () => noop :
+	selectedCondition === 19 ? () => () => noop :
+	selectedCondition === 20 ? () => () => noop :
+	selectedCondition === 21 ? () => () => noop :
+	selectedCondition === 22 ? () => () => noop :
+	selectedCondition === 23 ? () => () => noop :
+	selectedCondition === 24 ? () => () => noop :
+	selectedCondition === 25 ? () => () => noop :
+	selectedCondition === 26 ? () => () => noop :
+	selectedCondition === 27 ? () => () => noop :
+	selectedCondition === 28 ? () => () => noop :
+	selectedCondition === 29 ? () => () => noop :
+	selectedCondition === 30 ? () => () => noop :
+	selectedCondition === 31 ? () => () => noop :
+	selectedCondition === 32 ? () => () => noop :
+	selectedCondition === 33 ? () => () => noop :
+	selectedCondition === 34 ? () => () => noop :
+	selectedCondition === 35 ? () => () => noop :
+	selectedCondition === 36 ? () => () => noop :
+	selectedCondition === 37 ? () => () => noop :
+	selectedCondition === 38 ? () => () => noop :
+	selectedCondition === 39 ? () => () => noop :
+	selectedCondition === 40 ? () => () => noop :
+	selectedCondition === 41 ? () => () => noop :
+	selectedCondition === 42 ? () => () => noop :
+	selectedCondition === 43 ? () => () => noop :
+	selectedCondition === 44 ? () => () => noop :
+	selectedCondition === 45 ? () => () => noop :
+	selectedCondition === 46 ? () => () => noop :
+	selectedCondition === 47 ? () => () => noop :
+	selectedCondition === 48 ? () => () => noop :
+	selectedCondition === 49 ? () => () => noop :
+	selectedCondition === 50 ? () => () => noop :
+	selectedCondition === 51 ? () => () => noop :
+	selectedCondition === 52 ? () => () => noop :
+	selectedCondition === 53 ? () => () => noop :
+	selectedCondition === 54 ? () => () => noop :
+	selectedCondition === 55 ? () => () => noop :
+	selectedCondition === 56 ? () => () => noop :
+	selectedCondition === 57 ? () => () => noop :
+	selectedCondition === 58 ? () => () => noop :
+	selectedCondition === 59 ? () => () => noop :
+	selectedCondition === 60 ? () => () => noop :
+	selectedCondition === 61 ? () => () => noop :
+	selectedCondition === 62 ? () => () => noop :
+	selectedCondition === 63 ? () => () => noop :
+	() => () => noop;
+
+functionOverLimit()()();

--- a/test/form/samples/limits-return-expression-tracking-for-chained-calls/main.js
+++ b/test/form/samples/limits-return-expression-tracking-for-chained-calls/main.js
@@ -138,3 +138,139 @@ const functionOverLimit =
 	() => () => noop;
 
 functionOverLimit()()();
+
+function pure0() { return () => {}; }
+function pure1() { return () => {}; }
+function pure2() { return () => {}; }
+function pure3() { return () => {}; }
+function pure4() { return () => {}; }
+function pure5() { return () => {}; }
+function pure6() { return () => {}; }
+function pure7() { return () => {}; }
+function pure8() { return () => {}; }
+function pure9() { return () => {}; }
+function pure10() { return () => {}; }
+function pure11() { return () => {}; }
+function pure12() { return () => {}; }
+function pure13() { return () => {}; }
+function pure14() { return () => {}; }
+function pure15() { return () => {}; }
+function pure16() { return () => {}; }
+function pure17() { return () => {}; }
+function pure18() { return () => {}; }
+function pure19() { return () => {}; }
+function pure20() { return () => {}; }
+function pure21() { return () => {}; }
+function pure22() { return () => {}; }
+function pure23() { return () => {}; }
+function pure24() { return () => {}; }
+function pure25() { return () => {}; }
+function pure26() { return () => {}; }
+function pure27() { return () => {}; }
+function pure28() { return () => {}; }
+function pure29() { return () => {}; }
+function pure30() { return () => {}; }
+function pure31() { return () => {}; }
+function pure32() { return () => {}; }
+function pure33() { return () => {}; }
+function pure34() { return () => {}; }
+function pure35() { return () => {}; }
+function pure36() { return () => {}; }
+function pure37() { return () => {}; }
+function pure38() { return () => {}; }
+function pure39() { return () => {}; }
+function pure40() { return () => {}; }
+function pure41() { return () => {}; }
+function pure42() { return () => {}; }
+function pure43() { return () => {}; }
+function pure44() { return () => {}; }
+function pure45() { return () => {}; }
+function pure46() { return () => {}; }
+function pure47() { return () => {}; }
+function pure48() { return () => {}; }
+function pure49() { return () => {}; }
+function pure50() { return () => {}; }
+function pure51() { return () => {}; }
+function pure52() { return () => {}; }
+function pure53() { return () => {}; }
+function pure54() { return () => {}; }
+function pure55() { return () => {}; }
+function pure56() { return () => {}; }
+function pure57() { return () => {}; }
+function pure58() { return () => {}; }
+function pure59() { return () => {}; }
+function pure60() { return () => {}; }
+function pure61() { return () => {}; }
+function pure62() { return () => {}; }
+function pure63() { return () => {}; }
+function pure64() { return () => {}; }
+
+function getPureFunction() {
+	if (selectedCondition === 0) return pure0;
+	if (selectedCondition === 1) return pure1;
+	if (selectedCondition === 2) return pure2;
+	if (selectedCondition === 3) return pure3;
+	if (selectedCondition === 4) return pure4;
+	if (selectedCondition === 5) return pure5;
+	if (selectedCondition === 6) return pure6;
+	if (selectedCondition === 7) return pure7;
+	if (selectedCondition === 8) return pure8;
+	if (selectedCondition === 9) return pure9;
+	if (selectedCondition === 10) return pure10;
+	if (selectedCondition === 11) return pure11;
+	if (selectedCondition === 12) return pure12;
+	if (selectedCondition === 13) return pure13;
+	if (selectedCondition === 14) return pure14;
+	if (selectedCondition === 15) return pure15;
+	if (selectedCondition === 16) return pure16;
+	if (selectedCondition === 17) return pure17;
+	if (selectedCondition === 18) return pure18;
+	if (selectedCondition === 19) return pure19;
+	if (selectedCondition === 20) return pure20;
+	if (selectedCondition === 21) return pure21;
+	if (selectedCondition === 22) return pure22;
+	if (selectedCondition === 23) return pure23;
+	if (selectedCondition === 24) return pure24;
+	if (selectedCondition === 25) return pure25;
+	if (selectedCondition === 26) return pure26;
+	if (selectedCondition === 27) return pure27;
+	if (selectedCondition === 28) return pure28;
+	if (selectedCondition === 29) return pure29;
+	if (selectedCondition === 30) return pure30;
+	if (selectedCondition === 31) return pure31;
+	if (selectedCondition === 32) return pure32;
+	if (selectedCondition === 33) return pure33;
+	if (selectedCondition === 34) return pure34;
+	if (selectedCondition === 35) return pure35;
+	if (selectedCondition === 36) return pure36;
+	if (selectedCondition === 37) return pure37;
+	if (selectedCondition === 38) return pure38;
+	if (selectedCondition === 39) return pure39;
+	if (selectedCondition === 40) return pure40;
+	if (selectedCondition === 41) return pure41;
+	if (selectedCondition === 42) return pure42;
+	if (selectedCondition === 43) return pure43;
+	if (selectedCondition === 44) return pure44;
+	if (selectedCondition === 45) return pure45;
+	if (selectedCondition === 46) return pure46;
+	if (selectedCondition === 47) return pure47;
+	if (selectedCondition === 48) return pure48;
+	if (selectedCondition === 49) return pure49;
+	if (selectedCondition === 50) return pure50;
+	if (selectedCondition === 51) return pure51;
+	if (selectedCondition === 52) return pure52;
+	if (selectedCondition === 53) return pure53;
+	if (selectedCondition === 54) return pure54;
+	if (selectedCondition === 55) return pure55;
+	if (selectedCondition === 56) return pure56;
+	if (selectedCondition === 57) return pure57;
+	if (selectedCondition === 58) return pure58;
+	if (selectedCondition === 59) return pure59;
+	if (selectedCondition === 60) return pure60;
+	if (selectedCondition === 61) return pure61;
+	if (selectedCondition === 62) return pure62;
+	if (selectedCondition === 63) return pure63;
+	return pure64;
+}
+
+getPureFunction()()();

--- a/test/form/samples/limits-return-expression-tracking-for-chained-calls/main.js
+++ b/test/form/samples/limits-return-expression-tracking-for-chained-calls/main.js
@@ -1,0 +1,140 @@
+function noop() {}
+
+const selectedCondition = condition;
+
+const functionAtLimit =
+	selectedCondition === 0 ? () => () => noop :
+	selectedCondition === 1 ? () => () => noop :
+	selectedCondition === 2 ? () => () => noop :
+	selectedCondition === 3 ? () => () => noop :
+	selectedCondition === 4 ? () => () => noop :
+	selectedCondition === 5 ? () => () => noop :
+	selectedCondition === 6 ? () => () => noop :
+	selectedCondition === 7 ? () => () => noop :
+	selectedCondition === 8 ? () => () => noop :
+	selectedCondition === 9 ? () => () => noop :
+	selectedCondition === 10 ? () => () => noop :
+	selectedCondition === 11 ? () => () => noop :
+	selectedCondition === 12 ? () => () => noop :
+	selectedCondition === 13 ? () => () => noop :
+	selectedCondition === 14 ? () => () => noop :
+	selectedCondition === 15 ? () => () => noop :
+	selectedCondition === 16 ? () => () => noop :
+	selectedCondition === 17 ? () => () => noop :
+	selectedCondition === 18 ? () => () => noop :
+	selectedCondition === 19 ? () => () => noop :
+	selectedCondition === 20 ? () => () => noop :
+	selectedCondition === 21 ? () => () => noop :
+	selectedCondition === 22 ? () => () => noop :
+	selectedCondition === 23 ? () => () => noop :
+	selectedCondition === 24 ? () => () => noop :
+	selectedCondition === 25 ? () => () => noop :
+	selectedCondition === 26 ? () => () => noop :
+	selectedCondition === 27 ? () => () => noop :
+	selectedCondition === 28 ? () => () => noop :
+	selectedCondition === 29 ? () => () => noop :
+	selectedCondition === 30 ? () => () => noop :
+	selectedCondition === 31 ? () => () => noop :
+	selectedCondition === 32 ? () => () => noop :
+	selectedCondition === 33 ? () => () => noop :
+	selectedCondition === 34 ? () => () => noop :
+	selectedCondition === 35 ? () => () => noop :
+	selectedCondition === 36 ? () => () => noop :
+	selectedCondition === 37 ? () => () => noop :
+	selectedCondition === 38 ? () => () => noop :
+	selectedCondition === 39 ? () => () => noop :
+	selectedCondition === 40 ? () => () => noop :
+	selectedCondition === 41 ? () => () => noop :
+	selectedCondition === 42 ? () => () => noop :
+	selectedCondition === 43 ? () => () => noop :
+	selectedCondition === 44 ? () => () => noop :
+	selectedCondition === 45 ? () => () => noop :
+	selectedCondition === 46 ? () => () => noop :
+	selectedCondition === 47 ? () => () => noop :
+	selectedCondition === 48 ? () => () => noop :
+	selectedCondition === 49 ? () => () => noop :
+	selectedCondition === 50 ? () => () => noop :
+	selectedCondition === 51 ? () => () => noop :
+	selectedCondition === 52 ? () => () => noop :
+	selectedCondition === 53 ? () => () => noop :
+	selectedCondition === 54 ? () => () => noop :
+	selectedCondition === 55 ? () => () => noop :
+	selectedCondition === 56 ? () => () => noop :
+	selectedCondition === 57 ? () => () => noop :
+	selectedCondition === 58 ? () => () => noop :
+	selectedCondition === 59 ? () => () => noop :
+	selectedCondition === 60 ? () => () => noop :
+	selectedCondition === 61 ? () => () => noop :
+	selectedCondition === 62 ? () => () => noop :
+	() => () => noop;
+
+functionAtLimit()()();
+
+const functionOverLimit =
+	selectedCondition === 0 ? () => () => noop :
+	selectedCondition === 1 ? () => () => noop :
+	selectedCondition === 2 ? () => () => noop :
+	selectedCondition === 3 ? () => () => noop :
+	selectedCondition === 4 ? () => () => noop :
+	selectedCondition === 5 ? () => () => noop :
+	selectedCondition === 6 ? () => () => noop :
+	selectedCondition === 7 ? () => () => noop :
+	selectedCondition === 8 ? () => () => noop :
+	selectedCondition === 9 ? () => () => noop :
+	selectedCondition === 10 ? () => () => noop :
+	selectedCondition === 11 ? () => () => noop :
+	selectedCondition === 12 ? () => () => noop :
+	selectedCondition === 13 ? () => () => noop :
+	selectedCondition === 14 ? () => () => noop :
+	selectedCondition === 15 ? () => () => noop :
+	selectedCondition === 16 ? () => () => noop :
+	selectedCondition === 17 ? () => () => noop :
+	selectedCondition === 18 ? () => () => noop :
+	selectedCondition === 19 ? () => () => noop :
+	selectedCondition === 20 ? () => () => noop :
+	selectedCondition === 21 ? () => () => noop :
+	selectedCondition === 22 ? () => () => noop :
+	selectedCondition === 23 ? () => () => noop :
+	selectedCondition === 24 ? () => () => noop :
+	selectedCondition === 25 ? () => () => noop :
+	selectedCondition === 26 ? () => () => noop :
+	selectedCondition === 27 ? () => () => noop :
+	selectedCondition === 28 ? () => () => noop :
+	selectedCondition === 29 ? () => () => noop :
+	selectedCondition === 30 ? () => () => noop :
+	selectedCondition === 31 ? () => () => noop :
+	selectedCondition === 32 ? () => () => noop :
+	selectedCondition === 33 ? () => () => noop :
+	selectedCondition === 34 ? () => () => noop :
+	selectedCondition === 35 ? () => () => noop :
+	selectedCondition === 36 ? () => () => noop :
+	selectedCondition === 37 ? () => () => noop :
+	selectedCondition === 38 ? () => () => noop :
+	selectedCondition === 39 ? () => () => noop :
+	selectedCondition === 40 ? () => () => noop :
+	selectedCondition === 41 ? () => () => noop :
+	selectedCondition === 42 ? () => () => noop :
+	selectedCondition === 43 ? () => () => noop :
+	selectedCondition === 44 ? () => () => noop :
+	selectedCondition === 45 ? () => () => noop :
+	selectedCondition === 46 ? () => () => noop :
+	selectedCondition === 47 ? () => () => noop :
+	selectedCondition === 48 ? () => () => noop :
+	selectedCondition === 49 ? () => () => noop :
+	selectedCondition === 50 ? () => () => noop :
+	selectedCondition === 51 ? () => () => noop :
+	selectedCondition === 52 ? () => () => noop :
+	selectedCondition === 53 ? () => () => noop :
+	selectedCondition === 54 ? () => () => noop :
+	selectedCondition === 55 ? () => () => noop :
+	selectedCondition === 56 ? () => () => noop :
+	selectedCondition === 57 ? () => () => noop :
+	selectedCondition === 58 ? () => () => noop :
+	selectedCondition === 59 ? () => () => noop :
+	selectedCondition === 60 ? () => () => noop :
+	selectedCondition === 61 ? () => () => noop :
+	selectedCondition === 62 ? () => () => noop :
+	selectedCondition === 63 ? () => () => noop :
+	() => () => noop;
+
+functionOverLimit()()();


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers:

<!--
If this PR resolves any issues, list them as

-  resolves #1234

where 1234 is the issue number. This will help us with house-keeping as Github will automatically add a note to those issues stating that a potential fix exists. Once the PR is merged, Github will automatically close those issues.

Starting each line with a dash "-" will cause GitHub to display the issue title inline.

If an issue is only solved partially or is relevant in some other way, just list the number without "resolves".
-->

### Description
Flattens and deduplicates nested `MultiExpression` return values to prevent exponential memory growth across chained calls. Falls back to an unknown return value after 64 candidates and adds regression tests.
<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
