### PR TITLE
docs: name the parameter runHook actually takes

### DIFF
--- a/src/utils/PluginDriver.ts
+++ b/src/utils/PluginDriver.ts
@@ -304,7 +304,7 @@ export class PluginDriver {
 	 * Run an async plugin hook and return the result.
 	 * @param hookName Name of the plugin hook. Must be either in `PluginHooks`
 	 *   or `OutputPluginValueHooks`.
-	 * @param args Arguments passed to the plugin hook.
+	 * @param parameters Arguments passed to the plugin hook.
 	 * @param plugin The actual pluginObject to run.
 	 * @param replaceContext When passed, the plugin context can be overridden.
 	 */
@@ -400,7 +400,7 @@ export class PluginDriver {
 	/**
 	 * Run a sync plugin hook and return the result.
 	 * @param hookName Name of the plugin hook. Must be in `PluginHooks`.
-	 * @param args Arguments passed to the plugin hook.
+	 * @param parameters Arguments passed to the plugin hook.
 	 * @param plugin The actual plugin
 	 * @param replaceContext When passed, the plugin context can be overridden.
 	 */


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

Both `runHook` and `runHookSync` document `@param args`, and both take `parameters`. I left the `replaceContext` tag in the first block alone: the block sits above the addon overload, which does not take it, but the two overloads below do.
