### PR TITLE
fix(watch): await the rerun so listener failures surface as ERROR events

### DIFF
--- a/src/watch/watch.ts
+++ b/src/watch/watch.ts
@@ -95,7 +95,7 @@ export class Watcher {
 				this.invalidatedIds.clear();
 				await this.emitter.emit('restart');
 				this.emitter.removeListenersForCurrentRun();
-				this.run();
+				await this.run();
 			} catch (error: any) {
 				this.invalidatedIds.clear();
 				await this.emitter.emit('event', {

--- a/test/watch/index.js
+++ b/test/watch/index.js
@@ -143,6 +143,44 @@ describe('rollup.watch', function () {
 		assert.deepStrictEqual([...events], ['START', 'BUNDLE_START', 'BUNDLE_END', 'END', undefined]);
 	});
 
+	it('emits an error event if a listener throws while re-running', async () => {
+		let bundleStarts = 0;
+		const codes = [];
+
+		await copy(path.join(SAMPLES_DIR, 'basic'), INPUT_DIR);
+		watcher = rollup.watch({
+			input: ENTRY_FILE,
+			output: {
+				file: BUNDLE_FILE,
+				format: 'cjs',
+				exports: 'auto'
+			}
+		});
+		const error = await new Promise((resolve, reject) => {
+			watcher.on('event', async event => {
+				codes.push(event.code);
+				if (event.code === 'BUNDLE_START' && ++bundleStarts === 2) {
+					// A listener that throws while the watcher is re-running must surface as an
+					// ERROR event, not as an unhandled rejection that skips ERROR and END.
+					throw new Error('listener failed');
+				}
+				if (event.code === 'BUNDLE_END') {
+					await event.result.close();
+					if (bundleStarts === 1) {
+						await wait(100);
+						atomicWriteFileSync(ENTRY_FILE, 'export default 44;');
+					}
+				}
+				if (event.code === 'ERROR') {
+					resolve(event.error);
+				}
+			});
+			setTimeout(() => reject(new Error('no ERROR event was emitted')), 10_000);
+		});
+		assert.strictEqual(error.message, 'listener failed');
+		assert.strictEqual(codes.at(-1), 'ERROR');
+	});
+
 	it('does not fail for virtual files', async () => {
 		await copy(path.join(SAMPLES_DIR, 'basic'), INPUT_DIR);
 		watcher = rollup.watch({


### PR DESCRIPTION
### What

`Watcher.invalidate()` schedules a rebuild, clears the listeners for the current run, and starts the next one. That call is not awaited, so anything the run rejects with escapes the surrounding `try`/`catch`: the ERROR and END events the catch exists to emit are never sent, and the rejection surfaces as an unhandled rejection instead.

### Steps to reproduce

An `event` listener that throws during a rebuild is enough. Against 4.63.1:

```js
const watcher = watch({ input: 'src/main.js', output: { dir: 'out', format: 'es' } });
let starts = 0;
watcher.on('event', event => {
  if (event.code === 'BUNDLE_END') event.result.close();
  if (event.code === 'BUNDLE_START' && ++starts === 2) throw new Error('handler blew up');
});
// then touch src/main.js
```

Before: `UNHANDLED REJECTION: handler blew up`, and no ERROR event arrives.
After: the ERROR event is emitted with that error and the watcher carries on.

The throw travels out of the `BUNDLE_START` emit in `Task.run` — which is outside that method's own `try` — up through `Watcher.run`, past the catch that was meant to handle it.

### Change

One `await` on the rerun, which puts the failure back inside the existing catch.

### Tests

Adds `emits an error event if a listener throws while re-running` to `test/watch/index.js`. It times out waiting for the ERROR event without the change and passes with it.

Full `mocha test/test.js`: 5442 passing. The single `plugin-hook-filters` failure also fails on unmodified `master` in my environment (I built with a prebuilt native binary rather than a local Rust build), so it is unrelated to this change.