### PR TITLE
Remove the whole CRLF pair when suppressing ASI

### DIFF
--- a/src/utils/renderHelpers.ts
+++ b/src/utils/renderHelpers.ts
@@ -85,6 +85,15 @@ export function findLastWhiteSpaceReverse(code: string, start: number, end: numb
 	}
 }
 
+// A CRLF pair is one line break and must be removed as one. Removing only the
+// LF leaves the CR, which is still a line terminator, so ASI fires anyway and
+// the operand after a `return` or `throw` becomes dead code.
+function getLineBreakStart(code: string, lineBreakPos: number): number {
+	return lineBreakPos > 0 && code.charCodeAt(lineBreakPos - 1) === 13 /*"\r"*/
+		? lineBreakPos - 1
+		: lineBreakPos;
+}
+
 // This assumes "code" only contains white-space and comments
 // Returns position of line-comment if applicable
 export function findFirstLineBreakOutsideComment(code: string): [number, number] {
@@ -94,7 +103,8 @@ export function findFirstLineBreakOutsideComment(code: string): [number, number]
 	lineBreakPos = code.indexOf('\n', start);
 	while (true) {
 		start = code.indexOf('/', start);
-		if (start === -1 || start > lineBreakPos) return [lineBreakPos, lineBreakPos + 1];
+		if (start === -1 || start > lineBreakPos)
+			return [getLineBreakStart(code, lineBreakPos), lineBreakPos + 1];
 
 		// With our assumption, '/' always starts a comment. Determine comment type:
 		charCodeAfterSlash = code.charCodeAt(start + 1);

--- a/test/function/samples/preserve-asi-with-crlf-line-endings/_config.js
+++ b/test/function/samples/preserve-asi-with-crlf-line-endings/_config.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert');
+
+// The source is synthesised rather than checked in: .gitattributes normalises
+// every committed file to LF, so a CRLF fixture cannot survive in the tree.
+const source = [
+	'function withBlockComment() {',
+	'\treturn true &&',
+	'\t\t/* comment */',
+	'\t\t"block";',
+	'}',
+	'function withLineComment() {',
+	'\treturn true &&',
+	'\t\t// comment',
+	'\t\t"line";',
+	'}',
+	'function withoutComment() {',
+	'\treturn true &&',
+	'\t\t"plain";',
+	'}',
+	'export const block = withBlockComment();',
+	'export const line = withLineComment();',
+	'export const plain = withoutComment();',
+	''
+].join('\r\n');
+
+module.exports = defineTest({
+	description: 'does not leave a carriage return that triggers ASI after return',
+	options: {
+		input: 'main',
+		plugins: [
+			{
+				name: 'crlf-source',
+				resolveId: id => (id === 'main' ? id : null),
+				load: id => (id === 'main' ? source : null)
+			}
+		]
+	},
+	exports(exports) {
+		assert.strictEqual(exports.block, 'block');
+		assert.strictEqual(exports.line, 'line');
+		assert.strictEqual(exports.plain, 'plain');
+	}
+});


### PR DESCRIPTION
## Problem

`removeLineBreaks` exists so that when tree-shaking collapses an expression in an ASI-restricted position, no line break is left between the keyword and the surviving operand. It gets the range from `findFirstLineBreakOutsideComment`, which reports the break as the single character at the LF:

```ts
lineBreakPos = code.indexOf('\n', start);
...
if (start === -1 || start > lineBreakPos) return [lineBreakPos, lineBreakPos + 1];
```

On a CRLF source that removes the LF and leaves the CR. A lone CR is itself a line terminator, so ASI fires exactly as it would have.

## Effect

Measured against released rollup 4.63.2, feeding CRLF sources through `rollup()` with a memory plugin:

```
return true && /* comment */ "value";
  emitted : function f() {\r\n\treturn /* c */\r\t\t"value";\r\n}
  f()     : undefined            <- should be "value"

throw true && /* comment */ new Error("boom");
  emitted : function g() {\r\n\tthrow /* c */\r\t\tnew Error("boom");\r\n}
  loading : SyntaxError: Illegal newline after throw
```

The `return` case is the bad one: valid input, no error, no warning, and a bundle whose function silently returns `undefined`. The `throw` case produces a chunk that does not parse.

The equivalent LF sources are correct, and so are the CRLF cases with a line comment or no comment — the block-comment branch is the one that reaches the plain line-break return above.

## Fix

Extend the removal back over a preceding CR, so a CRLF pair is removed as the single line break it is.

```ts
function getLineBreakStart(code: string, lineBreakPos: number): number {
	return lineBreakPos > 0 && code.charCodeAt(lineBreakPos - 1) === 13 /*"\r"*/
		? lineBreakPos - 1
		: lineBreakPos;
}
```

LF-only sources take the same path they did before — the guard is false — so nothing in the existing snapshots moves. The line-comment branch already returned a range starting at the `//`, which covers any CR before the LF.

## Test plan

- Added `test/function/samples/preserve-asi-with-crlf-line-endings`. `.gitattributes` normalises committed files to LF, so the CRLF module is synthesised in the config's `load` hook rather than checked in. It covers a block comment, a line comment and no comment.
- Ran: `npm run build:quick` then `mocha test/test.js` → **5302 passing**, and the same run on an unmodified source tree gives **5301 passing**. Diffing the two failure lists, the only test that changes state is the new one; there are no regressions. (The remaining failures are identical in both runs and are unrelated to this change — they reproduce on a clean checkout here.)
- Checked: reverting only `renderHelpers.ts` fails the new test with `undefined` where `'block'` is expected.
- Ran: `eslint` on both touched files → clean.